### PR TITLE
Enable ci for all branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The CI is disabled for non-main branches from the last PR, we might want to bring it back

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
