### PR TITLE
Fixes for address sanitizer build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,9 +2353,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shuttle"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cf6e2264335cd79852f6aef04c675042084a74c048c1c66ecbd5249feb85af"
+checksum = "ae3516ebcc451de38f280f5d84de93ac871b7bb7590f34efccaa91e2c964d093"
 dependencies = [
  "bitvec",
  "generator",

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ test-asan:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
 	LSAN_OPTIONS=suppressions="$$(pwd)/lsan-suppressions.txt" \
 	RUSTFLAGS="-Zsanitizer=address" \
-	cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- --skip reftest_ --skip proptest_
+	cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- \
+	--skip reftest_ \
+	--skip proptest_ \
+	--skip sequential_read_large
 
 .PHONY: fmt
 fmt:

--- a/s3-client/src/mock_client.rs
+++ b/s3-client/src/mock_client.rs
@@ -359,7 +359,6 @@ mod tests {
 
     use super::*;
 
-    #[track_caller]
     async fn test_get_object(key: &str, size: usize, range: Option<Range<u64>>) {
         let mut rng = ChaChaRng::seed_from_u64(0x12345678);
 

--- a/s3-client/tests/get_object.rs
+++ b/s3-client/tests/get_object.rs
@@ -10,7 +10,6 @@ use futures::{pin_mut, Stream};
 use s3_client::{GetObjectError, ObjectClient, S3Client, S3RequestError};
 use std::ops::Range;
 
-#[track_caller]
 async fn check_get_result(
     result: impl Stream<Item = Result<(u64, Box<[u8]>), S3RequestError<GetObjectError>>>,
     range: Option<Range<u64>>,


### PR DESCRIPTION
`track_caller` is unstable and seems to now be guarded behind a feature flag: https://github.com/rust-lang/rust/issues/74042

We also have one test for large objects that is very slow under ASan.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
