### PR TITLE
Add S3 request failure metrics

### DIFF
--- a/aws-crt-s3/src/common/error.rs
+++ b/aws-crt-s3/src/common/error.rs
@@ -33,6 +33,11 @@ impl Error {
     pub fn is_err(&self) -> bool {
         self.0 != AWS_OP_SUCCESS
     }
+
+    /// Return the raw CRT error code
+    pub fn raw_error(&self) -> i32 {
+        self.0
+    }
 }
 
 /// Return a formatted description of this error suitable for debugging


### PR DESCRIPTION
Some simple metrics to keep track of succeeding and failing meta requests. We don't have any visibility into the individual S3 requests the CRT makes for us; we'll need to do that later.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
