### PR TITLE
S3Client: Implement a basic put_object

### DIFF
--- a/aws-crt-s3/src/http/request_response.rs
+++ b/aws-crt-s3/src/http/request_response.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::http::http_library_init;
+use crate::io::stream::InputStream;
 use crate::{aws_byte_cursor_as_slice, CrtError, StringExt};
 
 /// An HTTP header.
@@ -200,14 +201,17 @@ impl<'a> Iterator for HeadersIterator<'a> {
     }
 }
 
-/// A single HTTP message, initialized to be blank.
+/// A single HTTP message, initialized to be empty (i.e., no headers, no body).
 #[derive(Debug)]
-pub struct Message {
+pub struct Message<'a> {
     /// The pointer to the inner `aws_http_message`.
     pub(crate) inner: NonNull<aws_http_message>,
+
+    /// Input stream for the body of the http message, if present.
+    body_input_stream: Option<InputStream<'a>>,
 }
 
-impl Message {
+impl<'a> Message<'a> {
     /// Creates a new HTTP/1.1 request message.
     pub fn new_request(allocator: &mut Allocator) -> Result<Self, Error> {
         // TODO: figure out a better place to call this
@@ -216,7 +220,10 @@ impl Message {
         // SAFETY: `allocator.inner` is a valid `aws_allocator`.
         let inner = unsafe { aws_http_message_new_request(allocator.inner.as_ptr()).ok_or_last_error()? };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            body_input_stream: None,
+        })
     }
 
     /// Add a header to this message.
@@ -238,9 +245,31 @@ impl Message {
             aws_http_message_set_request_method(self.inner.as_ptr(), method.as_aws_byte_cursor()).ok_or_last_error()
         }
     }
+
+    /// Sets the body input stream for this message, and returns any previously set input stream.
+    /// If input_stream is None, unsets the body.
+    pub fn set_body_stream(&mut self, input_stream: Option<InputStream<'a>>) -> Option<InputStream<'a>> {
+        let old_input_stream = std::mem::replace(&mut self.body_input_stream, input_stream);
+
+        let new_input_stream_ptr = self
+            .body_input_stream
+            .as_ref()
+            .map(|s| s.inner.as_ptr())
+            .unwrap_or(std::ptr::null_mut());
+
+        // SAFETY: `aws_http_message_set_request_method` does _not_ take ownership of the underlying
+        // input stream. We take ownership of the input stream to make sure it doesn't get dropped
+        // while the CRT has a pointer to it. We also use lifetime parameters to enforce that this
+        // message does not outlive any data borrowed by the input stream.
+        unsafe {
+            aws_http_message_set_body_stream(self.inner.as_ptr(), new_input_stream_ptr);
+        }
+
+        old_input_stream
+    }
 }
 
-impl Drop for Message {
+impl<'a> Drop for Message<'a> {
     fn drop(&mut self) {
         // SAFETY: `self.inner` is a valid `aws_http_message`, and on Drop it's safe to decrement
         // the reference count since we won't use it again through `self.`

--- a/s3-client/src/s3_client/head_bucket.rs
+++ b/s3-client/src/s3_client/head_bucket.rs
@@ -1,7 +1,7 @@
 use crate::{S3Client, S3RequestError};
 use aws_crt_s3::common::allocator::Allocator;
 use aws_crt_s3::http::request_response::{Header, Message};
-use aws_crt_s3::s3::client::MetaRequestResult;
+use aws_crt_s3::s3::client::{MetaRequestResult, MetaRequestType};
 use thiserror::Error;
 use tracing::debug;
 
@@ -31,7 +31,7 @@ impl S3Client {
             let span = request_span!(self, "head_bucket");
             span.in_scope(|| debug!(?bucket, region = self.region, "new request"));
 
-            self.make_simple_http_request(message, span)?
+            self.make_simple_http_request(message, MetaRequestType::Default, span)?
         };
 
         body.await.map(|_| ()).map_err(|err| match err {

--- a/s3-client/src/s3_client/list_objects.rs
+++ b/s3-client/src/s3_client/list_objects.rs
@@ -3,6 +3,7 @@ use crate::s3_client::S3RequestError;
 use crate::S3Client;
 use aws_crt_s3::common::allocator::Allocator;
 use aws_crt_s3::http::request_response::{Header, Message};
+use aws_crt_s3::s3::client::MetaRequestType;
 use std::str::FromStr;
 use thiserror::Error;
 use time::format_description::well_known::Rfc3339;
@@ -174,7 +175,7 @@ impl S3Client {
                 )
             });
 
-            self.make_simple_http_request(message, span)?
+            self.make_simple_http_request(message, MetaRequestType::Default, span)?
         };
 
         let body = body.await?;

--- a/s3-client/src/s3_client/put_object.rs
+++ b/s3-client/src/s3_client/put_object.rs
@@ -1,0 +1,61 @@
+use crate::object_client::{PutObjectParams, PutObjectResult};
+use crate::{S3Client, S3RequestError};
+use aws_crt_s3::common::allocator::Allocator;
+use aws_crt_s3::http::request_response::{Header, Message};
+use aws_crt_s3::io::stream::InputStream;
+use aws_crt_s3::s3::client::MetaRequestType;
+use futures::{Stream, StreamExt};
+use std::ops::Deref;
+use thiserror::Error;
+use tracing::debug;
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum PutObjectError {}
+
+impl S3Client {
+    pub(super) async fn put_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        _params: &PutObjectParams,
+        contents: impl Stream<Item = impl Deref<Target = [u8]> + Send> + Send,
+    ) -> Result<PutObjectResult, S3RequestError<PutObjectError>> {
+        let mut buffer = vec![];
+
+        // Accumulate the stream contents into a buffer.
+        // TODO: Support streaming the data to the CRT.
+        contents
+            .for_each(|b| {
+                buffer.extend_from_slice(b.as_ref());
+                std::future::ready(())
+            })
+            .await;
+
+        let body = {
+            let endpoint = format!("{}.s3.{}.amazonaws.com", bucket, self.region);
+
+            let mut message = Message::new_request(&mut Allocator::default())?;
+            message.set_request_method("PUT")?;
+            message.add_header(&Header::new("Host", &endpoint))?;
+            message.add_header(&Header::new("Content-Length", &buffer.len().to_string()))?;
+            message.add_header(&Header::new("accept", "application/xml"))?;
+            message.add_header(&Header::new("user-agent", "aws-s3-crt-rust"))?;
+
+            let key = format!("/{}", key);
+            message.set_request_path(&key)?;
+
+            let body_input_stream = InputStream::new_from_slice(&mut Allocator::default(), &buffer)?;
+            message.set_body_stream(Some(body_input_stream));
+
+            let span = request_span!(self, "put_object");
+            span.in_scope(|| debug!(?bucket, ?key, "new request"));
+
+            self.make_simple_http_request(message, MetaRequestType::PutObject, span)?
+        };
+
+        body.await?;
+
+        Ok(PutObjectResult {})
+    }
+}

--- a/s3-client/tests/get_object.rs
+++ b/s3-client/tests/get_object.rs
@@ -6,26 +6,7 @@ use aws_sdk_s3::types::ByteStream;
 use bytes::Bytes;
 use common::*;
 use futures::stream::StreamExt;
-use futures::{pin_mut, Stream};
-use s3_client::{GetObjectError, ObjectClient, S3Client, S3RequestError};
-use std::ops::Range;
-
-async fn check_get_result(
-    result: impl Stream<Item = Result<(u64, Box<[u8]>), S3RequestError<GetObjectError>>>,
-    range: Option<Range<u64>>,
-    expected: &[u8],
-) {
-    let mut accum = vec![];
-    let mut next_offset = range.map(|r| r.start).unwrap_or(0);
-    pin_mut!(result);
-    while let Some(r) = result.next().await {
-        let (offset, body) = r.expect("get_object body part failed");
-        assert_eq!(offset, next_offset, "wrong body part offset");
-        next_offset += body.len() as u64;
-        accum.extend_from_slice(&body[..]);
-    }
-    assert_eq!(&accum[..], expected, "body does not match");
-}
+use s3_client::{ObjectClient, S3Client};
 
 #[tokio::test]
 async fn test_get_object() {

--- a/s3-client/tests/put_object.rs
+++ b/s3-client/tests/put_object.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use common::*;
+use futures::future;
+use futures::stream;
+use rand::Rng;
+use s3_client::ObjectClient;
+
+// Simple test for PUT object. Puts a single, small object as a single part and checks that the
+// contents are correct with a GET.
+async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str) {
+    let mut rng = rand::thread_rng();
+
+    let key = format!("{}/hello", prefix);
+
+    let mut contents = vec![0u8; 32];
+    rng.fill(&mut contents[..]);
+
+    client
+        .put_object(
+            bucket,
+            &key,
+            &Default::default(),
+            stream::once(future::ready(&contents[..])),
+        )
+        .await
+        .expect("put_object failed");
+
+    let result = client.get_object(bucket, &key, None).await.expect("get_object failed");
+    check_get_result(result, None, &contents[..]).await;
+}
+
+object_client_test!(test_put_object);
+
+// Test for multi-part PUT interface. Splits up a small object into a number of pieces, and streams
+// the pieces to the object client. Checks contents are correct using a GET.
+async fn test_put_object_multi_part(client: &impl ObjectClient, bucket: &str, prefix: &str) {
+    let mut rng = rand::thread_rng();
+
+    let key = format!("{}/hello", prefix);
+
+    let mut contents = vec![0u8; 32];
+    rng.fill(&mut contents[..]);
+
+    // Create a multi-part stream of contents by splitting up into four parts.
+    let contents_stream = stream::iter(contents.chunks(contents.len() / 4));
+
+    client
+        .put_object(bucket, &key, &Default::default(), contents_stream)
+        .await
+        .expect("put_object failed");
+
+    let result = client.get_object(bucket, &key, None).await.expect("get_object failed");
+    check_get_result(result, None, &contents[..]).await;
+}
+
+object_client_test!(test_put_object_multi_part);


### PR DESCRIPTION
For now, the implementation does not support streaming; it accumulates the entire object in memory before issuing the PUT request. Once the CRT supports multi-part PUT without requiring the Content-Length to be known ahead of time, this can be changed.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
