### PR TITLE
Use cmake3 if it exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "log",
  "rustflags",
  "smallstr",
+ "which",
 ]
 
 [[package]]
@@ -2852,6 +2853,17 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/aws-crt-s3-sys/Cargo.toml
+++ b/aws-crt-s3-sys/Cargo.toml
@@ -10,6 +10,7 @@ bindgen = { version = "0.60.1", default-features = false, features = ["runtime"]
 cc = "1.0.73"
 cmake = "0.1.48"
 rustflags = "0.1.1"
+which = "4.3.0"
 
 [dependencies]
 libc = "0.2.126"

--- a/aws-crt-s3-sys/build.rs
+++ b/aws-crt-s3-sys/build.rs
@@ -46,6 +46,14 @@ const CRT_HEADERS: &[&str] = &[
     "s3/s3_client.h",
 ];
 
+// The CRT needs cmake 3.x, but on AL2, the `cmake` binary is 2.x, and there's a separate `cmake3`.
+// If `cmake3` exists, let's use that as our CMAKE.
+fn discover_cmake3() {
+    if which::which("cmake3").is_ok() {
+        std::env::set_var("CMAKE", "cmake3");
+    }
+}
+
 fn generate_bindings(include_dir: &Path) -> Result<Bindings, BindgenError> {
     let mut builder = bindgen::Builder::default()
         // Get Default impls so we don't have to explicitly malloc/zero/ununit structs
@@ -201,6 +209,7 @@ fn compile_logging_shim(crt_include_dir: impl AsRef<Path>) {
 }
 
 fn main() {
+    discover_cmake3();
     let include_dir = compile_crt_and_bindings();
     compile_logging_shim(include_dir);
 }


### PR DESCRIPTION
On AL2, `yum install cmake` gets you a 2.x version of cmake, but the CRT requires a 3.x version. AL2 has a 3.x version as a separate `cmake3` package and binary. If those exist, use them as the CMAKE so that users don't have to configure this manually.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
