### PR TITLE
Use real uid/gid/permission masks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix",
+ "nix 0.25.0",
  "winapi",
 ]
 
@@ -1535,6 +1535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2156,7 @@ dependencies = [
  "hdrhistogram",
  "libc",
  "metrics",
+ "nix 0.26.1",
  "once_cell",
  "predicates",
  "proptest",

--- a/s3-file-connector/Cargo.toml
+++ b/s3-file-connector/Cargo.toml
@@ -24,6 +24,7 @@ supports-color = "1.3.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
+nix = { version = "0.26.1", default-features = false, features = ["user"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/s3-file-connector/tests/cli.rs
+++ b/s3-file-connector/tests/cli.rs
@@ -27,3 +27,51 @@ fn mount_point_isnt_dir() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn max_dir_mode_exceeded() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+
+    cmd.arg("test-bucket").arg(dir.path()).arg("--dir-mode=7755");
+    let error_message = "'--dir-mode <DIR_MODE>': only user/group/other permissions are supported";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+#[test]
+fn invalid_dir_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+
+    cmd.arg("test-bucket").arg(dir.path()).arg("--dir-mode=800");
+    let error_message = "'--dir-mode <DIR_MODE>': must be a valid octal number";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+#[test]
+fn max_file_mode_exceeded() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+
+    cmd.arg("test-bucket").arg(dir.path()).arg("--file-mode=7644");
+    let error_message = "'--file-mode <FILE_MODE>': only user/group/other permissions are supported";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+#[test]
+fn invalid_file_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+
+    cmd.arg("test-bucket").arg(dir.path()).arg("--file-mode=900");
+    let error_message = "'--file-mode <FILE_MODE>': must be a valid octal number";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}

--- a/s3-file-connector/tests/common/mod.rs
+++ b/s3-file-connector/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
-use fuser::FileAttr;
+use fuser::{FileAttr, FileType};
 use futures::executor::ThreadPool;
 use s3_client::mock_client::{MockClient, MockClientConfig};
 use s3_file_connector::fs::{DirectoryReplier, ReadReplier};
@@ -25,6 +25,15 @@ pub fn make_test_filesystem(
     let fs = S3Filesystem::new(Arc::clone(&client), runtime, bucket, prefix, config);
 
     (client, fs)
+}
+
+#[track_caller]
+pub fn assert_attr(attr: FileAttr, ftype: FileType, size: u64, uid: u32, gid: u32, perm: u16) {
+    assert_eq!(attr.kind, ftype);
+    assert_eq!(attr.size, size);
+    assert_eq!(attr.uid, uid);
+    assert_eq!(attr.gid, gid);
+    assert_eq!(attr.perm, perm);
 }
 
 #[derive(Debug)]

--- a/s3-file-connector/tests/fuse_tests/mod.rs
+++ b/s3-file-connector/tests/fuse_tests/mod.rs
@@ -1,5 +1,6 @@
 mod lookup_test;
 mod mount_test;
+mod perm_test;
 mod readdir_test;
 
 use fuser::{BackgroundSession, MountOption, Session};
@@ -36,8 +37,10 @@ mod mock_session {
 
         let options = vec![
             MountOption::RO,
+            MountOption::DefaultPermissions,
             MountOption::FSName("s3_fuse".to_string()),
             MountOption::AutoUnmount,
+            MountOption::AllowOther,
         ];
 
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
@@ -86,8 +89,10 @@ mod s3_session {
 
         let options = vec![
             MountOption::RO,
+            MountOption::DefaultPermissions,
             MountOption::FSName("s3_fuse".to_string()),
             MountOption::AutoUnmount,
+            MountOption::AllowOther,
         ];
 
         let session = Session::new(

--- a/s3-file-connector/tests/fuse_tests/perm_test.rs
+++ b/s3-file-connector/tests/fuse_tests/perm_test.rs
@@ -1,0 +1,198 @@
+use std::{
+    fs::{self, metadata, Metadata},
+    io,
+    os::unix::prelude::{MetadataExt, PermissionsExt},
+};
+
+use fuser::BackgroundSession;
+use nix::unistd::{getgid, getuid};
+use s3_file_connector::S3FilesystemConfig;
+use tempfile::TempDir;
+use test_case::test_case;
+
+use crate::fuse_tests::PutObjectFn;
+
+fn perm_test<F>(creator_fn: F, uid: Option<u32>, gid: Option<u32>, dir_mode: Option<u16>, file_mode: Option<u16>)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
+{
+    let mut config = S3FilesystemConfig::default();
+    if let Some(id) = uid {
+        config.uid = id;
+    }
+    if let Some(id) = gid {
+        config.gid = id;
+    }
+    if let Some(mode) = dir_mode {
+        config.dir_mode = mode;
+    }
+    if let Some(mode) = file_mode {
+        config.file_mode = mode;
+    }
+
+    let (mount_point, _session, mut put_object_fn) = creator_fn("", config);
+
+    // expected values
+    let uid = uid.unwrap_or_else(|| getuid().into());
+    let gid = gid.unwrap_or_else(|| getgid().into());
+    let dir_mode = dir_mode.unwrap_or(0o755) as u32;
+    let file_mode = file_mode.unwrap_or(0o644) as u32;
+
+    // verify mount point metadata
+    let m = metadata(mount_point.path()).unwrap();
+    assert!(m.file_type().is_dir());
+    assert_perm(m, uid, gid, dir_mode);
+
+    put_object_fn("file1.txt", b"hello world").unwrap();
+    put_object_fn("dir/file2.txt", b"hello world").unwrap();
+
+    // verify readdir works on mount point
+    let dir = fs::read_dir(&mount_point).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["dir", "file1.txt"]
+    );
+
+    // verify inner directory metadata
+    let m = metadata(mount_point.path().join("dir")).unwrap();
+    assert!(m.file_type().is_dir());
+    assert_perm(m, uid, gid, dir_mode);
+
+    // verify readdir works
+    let dir = fs::read_dir(mount_point.path().join("dir")).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["file2.txt"]
+    );
+
+    // verify file metadata
+    let m = metadata(mount_point.path().join("file1.txt")).unwrap();
+    assert!(m.file_type().is_file());
+    assert_perm(m, uid, gid, file_mode);
+
+    let m = metadata(mount_point.path().join("dir/file2.txt")).unwrap();
+    assert!(m.file_type().is_file());
+    assert_perm(m, uid, gid, file_mode);
+
+    // verify read file works
+    let file_content = fs::read_to_string(mount_point.path().join("file1.txt")).unwrap();
+    assert_eq!(file_content, "hello world");
+
+    let file_content = fs::read_to_string(mount_point.path().join("dir/file2.txt")).unwrap();
+    assert_eq!(file_content, "hello world");
+}
+
+fn perm_test_negative<F>(
+    creator_fn: F,
+    uid: Option<u32>,
+    gid: Option<u32>,
+    dir_mode: Option<u16>,
+    file_mode: Option<u16>,
+) where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
+{
+    let mut config = S3FilesystemConfig::default();
+    if let Some(id) = uid {
+        config.uid = id;
+    }
+    if let Some(id) = gid {
+        config.gid = id;
+    }
+    if let Some(mode) = dir_mode {
+        config.dir_mode = mode;
+    }
+    if let Some(mode) = file_mode {
+        config.file_mode = mode;
+    }
+
+    let (mount_point, _session, mut put_object_fn) = creator_fn("", config);
+
+    // expected values
+    let uid = uid.unwrap_or_else(|| getuid().into());
+    let gid = gid.unwrap_or_else(|| getgid().into());
+    let dir_mode = dir_mode.unwrap_or(0o755) as u32;
+
+    // verify mount point metadata
+    let m = metadata(mount_point.path()).unwrap();
+    assert!(m.file_type().is_dir());
+    assert_perm(m, uid, gid, dir_mode);
+
+    put_object_fn("file1.txt", b"hello world").unwrap();
+    put_object_fn("dir/file2.txt", b"hello world").unwrap();
+
+    // verify readdir returns permission denied on mount point
+    let readdir_result = fs::read_dir(&mount_point).map_err(|e| e.kind());
+    assert!(readdir_result.is_err());
+    assert_eq!(io::ErrorKind::PermissionDenied, readdir_result.unwrap_err());
+
+    // verify access control works on inner directories
+    let metadata_result = metadata(mount_point.path().join("dir")).map_err(|e| e.kind());
+    assert!(metadata_result.is_err());
+    assert_eq!(io::ErrorKind::PermissionDenied, metadata_result.unwrap_err());
+    let readdir_result = fs::read_dir(mount_point.path().join("dir")).map_err(|e| e.kind());
+    assert_eq!(io::ErrorKind::PermissionDenied, readdir_result.unwrap_err());
+
+    // verify access control works on files
+    let metadata_result = metadata(mount_point.path().join("file1.txt")).map_err(|e| e.kind());
+    assert!(metadata_result.is_err());
+    assert_eq!(io::ErrorKind::PermissionDenied, metadata_result.unwrap_err());
+    let read_result = fs::read_to_string(mount_point.path().join("file1.txt")).map_err(|e| e.kind());
+    assert!(read_result.is_err());
+    assert_eq!(io::ErrorKind::PermissionDenied, read_result.unwrap_err());
+}
+
+fn assert_perm(m: Metadata, uid: u32, gid: u32, perm: u32) {
+    assert_eq!(uid, m.uid());
+    assert_eq!(gid, m.gid());
+    // mask with 0o7777 to get only permission bits
+    let actual_perm = m.permissions().mode() & 0o7777;
+    assert_eq!(perm, actual_perm);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(None, None, None, None; "default config")]
+#[test_case(None, None, Some(0o700), Some(0o600); "non default permissions")]
+#[test_case(None, None, Some(0o777), Some(0o777); "full permissions")]
+#[test_case(Some(500), Some(20), None, None; "non default gid and uid")]
+#[test_case(Some(500), Some(20), Some(0o555), Some(0o444); "non default gid, uid and permissions")]
+fn permission_config_test_s3(uid: Option<u32>, gid: Option<u32>, dir_mode: Option<u16>, file_mode: Option<u16>) {
+    perm_test(crate::fuse_tests::s3_session::new, uid, gid, dir_mode, file_mode);
+}
+
+#[test_case(None, None, None, None; "default config")]
+#[test_case(None, None, Some(0o700), Some(0o600); "non default permissions")]
+#[test_case(None, None, Some(0o777), Some(0o777); "full permissions")]
+#[test_case(Some(500), Some(20), None, None; "non default gid and uid")]
+#[test_case(Some(500), Some(20), Some(0o555), Some(0o444); "non default gid, uid and permissions")]
+fn permission_config_test_mock(uid: Option<u32>, gid: Option<u32>, dir_mode: Option<u16>, file_mode: Option<u16>) {
+    perm_test(crate::fuse_tests::mock_session::new, uid, gid, dir_mode, file_mode);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(None, None, Some(0o000), Some(0o000); "no permissions")]
+#[test_case(Some(500), Some(20), Some(0o700), Some(0o600); "no permissions as other users")]
+fn permission_config_test_negative_s3(
+    uid: Option<u32>,
+    gid: Option<u32>,
+    dir_mode: Option<u16>,
+    file_mode: Option<u16>,
+) {
+    perm_test_negative(crate::fuse_tests::s3_session::new, uid, gid, dir_mode, file_mode);
+}
+
+#[test_case(None, None, Some(0o000), Some(0o000); "no permissions")]
+#[test_case(Some(500), Some(20), Some(0o700), Some(0o600); "no permissions as other users")]
+fn permission_config_test_negative_mock(
+    uid: Option<u32>,
+    gid: Option<u32>,
+    dir_mode: Option<u16>,
+    file_mode: Option<u16>,
+) {
+    perm_test_negative(crate::fuse_tests::mock_session::new, uid, gid, dir_mode, file_mode);
+}


### PR DESCRIPTION
Implement https://github.com/awslabs/s3-file-connector/issues/9
- Use real UID and GID of the calling process as default owner
- Use 0755, 0644 as default permissions masks
- Add cli arguments to configure these values

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
