### PR TITLE
Don't commit benchmark results for PRs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Run Benchmark
       run: s3-file-connector/scripts/fs_bench.sh
     - name: Store benchmark result
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
       uses: benchmark-action/github-action-benchmark@v1
       with:
         tool: 'customBiggerIsBetter'


### PR DESCRIPTION
The GitHub Pages page for benchmarks stores a linear history of benchmarks. We don't want to include pull requests in that list, since they might run many times.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
