### PR TITLE
Add clippy version info to CI output

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,8 @@ jobs:
           submodules: true
       - name: Install fuse
         run: sudo apt-get install fuse libfuse2 libfuse-dev
+      - name: Show Clippy version
+        run: cargo clippy --version
       - name: Run Clippy
         run: make clippy
 


### PR DESCRIPTION
Its not clear from the CI output which version of Clippy is running.

I understand that it should be a fixed version based on the Ubuntu image, however this will help ensure its obvious to readers of the CI logs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
