### PR TITLE
Force latest stable Rust version in CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,6 +40,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Update package list
       run: sudo apt-get update
     - name: Install dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Install fuse
       run: sudo apt-get install ${{ matrix.fuse }} lib${{ matrix.fuse }}-dev
     - name: Configure fuse
@@ -55,6 +60,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Install fuse
       run: sudo apt-get install fuse libfuse-dev
     - name: Check all targets
@@ -69,6 +79,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Install fuse
       run: sudo apt-get install fuse libfuse-dev
     - name: Run Shuttle tests
@@ -116,8 +131,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install rustfmt
-        run: rustup component add rustfmt
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
       - name: Check format
         run: make fmt-check
 
@@ -130,10 +149,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy
       - name: Install fuse
         run: sudo apt-get install fuse libfuse2 libfuse-dev
-      - name: Show Clippy version
-        run: cargo clippy --version
       - name: Run Clippy
         run: make clippy
 
@@ -146,6 +169,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Build CRT binding documentation
         run: cargo doc --no-deps -p aws-crt-s3
 
@@ -156,5 +184,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
In #42 we realized that we're inheriting the Rust version from the
GitHub Actions image, which means we get Rust version updates at some
random time after release. Instead, let's forcibly test on the latest
stable Rust version, so releases are more predictable.

We no longer need to explicitly print the Clippy version as it's included in the "Set up stable Rust" step.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
