### PR TITLE
Add value_hint for mount_point arg

### DIFF
--- a/s3-file-connector/src/main.rs
+++ b/s3-file-connector/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use anyhow::Context as _;
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use fuser::{BackgroundSession, MountOption, Session};
 use s3_client::{HeadBucketError, S3Client, S3ClientConfig, S3RequestError};
 
@@ -39,7 +39,7 @@ struct CliArgs {
     #[clap(help = "Name of bucket to mount")]
     pub bucket_name: String,
 
-    #[clap(help = "Mount point for file system")]
+    #[clap(help = "Mount point for file system", value_hint = ValueHint::DirPath)]
     pub mount_point: PathBuf,
 
     #[clap(


### PR DESCRIPTION
This adds the hint to the shell that the mount point takes an existing directory as an argument. Note: the default for the shell is normally any existing path, so by setting this we exclude files.

I'm not aware of any other arguments that would benefit from the value hint being set at this time.

Closes #47.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
