### PR TITLE
Fix dead code warning in integration tests

### DIFF
--- a/s3-file-connector/tests/mod.rs
+++ b/s3-file-connector/tests/mod.rs
@@ -1,5 +1,5 @@
+pub mod common;
+
 #[cfg(feature = "fuse_tests")]
 mod fuse_tests;
-
-mod common;
 mod reftests;


### PR DESCRIPTION
In #33 we saw weirdness adding code to `tests/common/mod.rs` creating
dead code warnings. This is because of Cargo's slightly funky rules for
compiling integration test modules
(https://github.com/rust-lang/rust/issues/46379). We can fix it by
claiming the module is public.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
