### PR TITLE
Make StorageClass optional in ListObjectsV2 result

### DIFF
--- a/s3-client/src/object_client.rs
+++ b/s3-client/src/object_client.rs
@@ -101,8 +101,8 @@ pub struct ObjectInfo {
     /// The time this object was last modified.
     pub last_modified: OffsetDateTime,
 
-    /// Storage class for this object.  Optional because head_object does not return
-    /// the storage class in its response.  See Examples here
+    /// Storage class for this object. Optional because head_object does not return
+    /// the storage class in its response. See examples here:
     /// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_Examples
     pub storage_class: Option<String>,
 

--- a/s3-client/src/s3_client/list_objects.rs
+++ b/s3-client/src/s3_client/list_objects.rs
@@ -114,11 +114,10 @@ impl ObjectInfo {
 
         // S3 appears to use RFC 3339 to encode this field, based on the API example here:
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
-
         let last_modified = OffsetDateTime::parse(&last_modified, &Rfc3339)
             .map_err(|e| ParseError::OffsetDateTime(e, "LastModified".to_string()))?;
 
-        let storage_class = Some(get_field(element, "StorageClass")?);
+        let storage_class = get_field(element, "StorageClass").ok();
 
         let etag = get_field(element, "ETag")?;
 


### PR DESCRIPTION
It's already optional in the `ObjectInfo`, but we should behave nicely
if it's not present.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
