### PR TITLE
Add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,7 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for trying out the project and taking the time to fill out this report.
+        Thanks for taking the time to fill out a bug report.
+  - type: markdown
+    attributes:
+      value: |
+        **Note: security issues should not be reported here.**
+        Please follow the [security policy for this repository](https://github.com/awslabs/s3-file-connector/security/policy).
   - type: input
     id: project-version
     attributes:
@@ -21,7 +26,7 @@ body:
     attributes:
       label: AWS Region
       description: Which AWS region did you experience the bug in?
-      placeholder: ex. us-east-2
+      placeholder: us-east-1
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for trying out the project and taking the time to share ideas for new features.
+        Thanks for taking the time to share ideas for new features.
   - type: textarea
     id: feature-desc
     attributes:


### PR DESCRIPTION
This provides forms for bug reports and feature requests to gather specific information. It does not block the ability to create a blank issue, which shows at the end of the list of issue templates.

I have tested in a new repository to check forms work and look as expected.

This is the documentation on how issue templates work: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

Closes #43.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
