### PR TITLE
Rename S3Client -> S3CrtClient

### DIFF
--- a/s3-client/examples/client_benchmark.rs
+++ b/s3-client/examples/client_benchmark.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
 use clap::{Arg, Command};
 use futures::StreamExt;
-use s3_client::{ObjectClient, S3Client, S3ClientConfig};
+use s3_client::{ObjectClient, S3ClientConfig, S3CrtClient};
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -67,7 +67,7 @@ fn main() {
         throughput_target_gbps,
         part_size,
     };
-    let client = Arc::new(S3Client::new(region, config).expect("couldn't create client"));
+    let client = Arc::new(S3CrtClient::new(region, config).expect("couldn't create client"));
 
     for i in 0..iterations.unwrap_or(1) {
         let received_size = Arc::new(AtomicU64::new(0));

--- a/s3-client/examples/download.rs
+++ b/s3-client/examples/download.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
 use clap::{Arg, Command};
 use futures::StreamExt;
-use s3_client::{ObjectClient, S3Client};
+use s3_client::{ObjectClient, S3CrtClient};
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -35,7 +35,7 @@ fn main() {
     let key = matches.get_one::<String>("key").unwrap();
     let region = matches.get_one::<String>("region").unwrap();
 
-    let client = S3Client::new(region, Default::default()).expect("couldn't create client");
+    let client = S3CrtClient::new(region, Default::default()).expect("couldn't create client");
 
     let last_offset = Arc::new(Mutex::new(None));
     let last_offset_clone = Arc::clone(&last_offset);

--- a/s3-client/examples/list.rs
+++ b/s3-client/examples/list.rs
@@ -1,5 +1,5 @@
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
-use s3_client::S3Client;
+use s3_client::S3CrtClient;
 
 use clap::{Arg, Command};
 use tracing_subscriber::fmt::Subscriber;
@@ -34,7 +34,7 @@ fn main() {
     let prefix = matches.get_one::<String>("prefix").unwrap();
     let region = matches.get_one::<String>("region").unwrap();
 
-    let client = S3Client::new(region, Default::default()).expect("couldn't create client");
+    let client = S3CrtClient::new(region, Default::default()).expect("couldn't create client");
 
     let result = futures::executor::block_on(client.list_objects(bucket, None, delimiter, 500, prefix)).unwrap();
 

--- a/s3-client/src/lib.rs
+++ b/s3-client/src/lib.rs
@@ -1,21 +1,21 @@
 pub mod failure_client;
 pub mod mock_client;
 mod object_client;
-mod s3_client;
+mod s3_crt_client;
 mod util;
 
 pub use object_client::{ListObjectsResult, ObjectClient};
-pub use s3_client::get_object::GetObjectError;
-pub use s3_client::head_bucket::HeadBucketError;
-pub use s3_client::list_objects::ListObjectsError;
-pub use s3_client::{S3Client, S3ClientConfig, S3RequestError};
+pub use s3_crt_client::get_object::GetObjectError;
+pub use s3_crt_client::head_bucket::HeadBucketError;
+pub use s3_crt_client::list_objects::ListObjectsError;
+pub use s3_crt_client::{S3ClientConfig, S3CrtClient, S3RequestError};
 
 #[cfg(test)]
 mod tests {
-    use crate::s3_client::S3Client;
+    use crate::s3_crt_client::S3CrtClient;
 
     #[test]
     fn smoke() {
-        let _client = S3Client::new("us-east-1", Default::default()).unwrap();
+        let _client = S3CrtClient::new("us-east-1", Default::default()).unwrap();
     }
 }

--- a/s3-client/src/s3_crt_client.rs
+++ b/s3-client/src/s3_crt_client.rs
@@ -24,10 +24,10 @@ use thiserror::Error;
 use tracing::{debug, error, trace, warn, Span};
 
 use crate::object_client::{HeadObjectResult, ListObjectsResult, ObjectClient, PutObjectParams, PutObjectResult};
-use crate::s3_client::get_object::{GetObjectError, GetObjectRequest};
-use crate::s3_client::head_object::HeadObjectError;
-use crate::s3_client::list_objects::ListObjectsError;
-use crate::s3_client::put_object::PutObjectError;
+use crate::s3_crt_client::get_object::{GetObjectError, GetObjectRequest};
+use crate::s3_crt_client::head_object::HeadObjectError;
+use crate::s3_crt_client::list_objects::ListObjectsError;
+use crate::s3_crt_client::put_object::PutObjectError;
 
 macro_rules! request_span {
     ($self:expr, $method:expr) => {{
@@ -49,7 +49,7 @@ pub struct S3ClientConfig {
 }
 
 #[derive(Debug)]
-pub struct S3Client {
+pub struct S3CrtClient {
     s3_client: Client,
     event_loop_group: EventLoopGroup,
     region: String,
@@ -57,7 +57,7 @@ pub struct S3Client {
     next_request_counter: AtomicU64,
 }
 
-impl S3Client {
+impl S3CrtClient {
     pub fn new(region: &str, config: S3ClientConfig) -> Result<Self, NewClientError> {
         let allocator = Allocator::default();
 
@@ -353,7 +353,7 @@ pub enum S3RequestError<E: std::error::Error> {
 }
 
 #[async_trait]
-impl ObjectClient for S3Client {
+impl ObjectClient for S3CrtClient {
     type GetObjectResult = GetObjectRequest;
     type GetObjectError = S3RequestError<GetObjectError>;
     type HeadObjectError = S3RequestError<HeadObjectError>;

--- a/s3-client/src/s3_crt_client/get_object.rs
+++ b/s3-client/src/s3_crt_client/get_object.rs
@@ -13,10 +13,10 @@ use thiserror::Error;
 use tracing::{debug, error};
 
 use crate::object_client::GetBodyPart;
-use crate::s3_client::S3HttpRequest;
-use crate::{S3Client, S3RequestError};
+use crate::s3_crt_client::S3HttpRequest;
+use crate::{S3CrtClient, S3RequestError};
 
-impl S3Client {
+impl S3CrtClient {
     /// Create and begin a new GetObject request. The returned [GetObjectRequest] is a [Stream] (for
     /// async users) or [Iterator} (for sync users) of body parts of the object, which will be
     /// delivered in order.

--- a/s3-client/src/s3_crt_client/head_bucket.rs
+++ b/s3-client/src/s3_crt_client/head_bucket.rs
@@ -1,4 +1,4 @@
-use crate::{S3Client, S3RequestError};
+use crate::{S3CrtClient, S3RequestError};
 use aws_crt_s3::s3::client::{MetaRequestResult, MetaRequestType};
 use thiserror::Error;
 use tracing::debug;
@@ -13,7 +13,7 @@ pub enum HeadBucketError {
     PermissionDenied(MetaRequestResult),
 }
 
-impl S3Client {
+impl S3CrtClient {
     pub async fn head_bucket(&self, bucket: &str) -> Result<(), S3RequestError<HeadBucketError>> {
         let body = {
             let mut message = self

--- a/s3-client/src/s3_crt_client/head_object.rs
+++ b/s3-client/src/s3_crt_client/head_object.rs
@@ -1,6 +1,6 @@
 use crate::object_client::{HeadObjectResult, ObjectInfo};
-use crate::s3_client::S3RequestError;
-use crate::S3Client;
+use crate::s3_crt_client::S3RequestError;
+use crate::S3CrtClient;
 use aws_crt_s3::http::request_response::{Headers, HeadersError};
 use aws_crt_s3::s3::client::MetaRequestType;
 use std::ffi::OsString;
@@ -62,7 +62,7 @@ impl HeadObjectResult {
     }
 }
 
-impl S3Client {
+impl S3CrtClient {
     pub async fn head_object(
         &self,
         bucket: &str,

--- a/s3-client/src/s3_crt_client/list_objects.rs
+++ b/s3-client/src/s3_crt_client/list_objects.rs
@@ -1,6 +1,6 @@
 use crate::object_client::{ListObjectsResult, ObjectInfo};
-use crate::s3_client::S3RequestError;
-use crate::S3Client;
+use crate::s3_crt_client::S3RequestError;
+use crate::S3CrtClient;
 use aws_crt_s3::s3::client::MetaRequestType;
 use std::str::FromStr;
 use thiserror::Error;
@@ -131,7 +131,7 @@ impl ObjectInfo {
     }
 }
 
-impl S3Client {
+impl S3CrtClient {
     pub async fn list_objects(
         &self,
         bucket: &str,

--- a/s3-client/src/s3_crt_client/put_object.rs
+++ b/s3-client/src/s3_crt_client/put_object.rs
@@ -1,5 +1,5 @@
 use crate::object_client::{PutObjectParams, PutObjectResult};
-use crate::{S3Client, S3RequestError};
+use crate::{S3CrtClient, S3RequestError};
 use aws_crt_s3::http::request_response::Header;
 use aws_crt_s3::io::stream::InputStream;
 use aws_crt_s3::s3::client::MetaRequestType;
@@ -11,7 +11,7 @@ use tracing::debug;
 #[non_exhaustive]
 pub enum PutObjectError {}
 
-impl S3Client {
+impl S3CrtClient {
     pub(super) async fn put_object(
         &self,
         bucket: &str,

--- a/s3-client/tests/common/mod.rs
+++ b/s3-client/tests/common/mod.rs
@@ -7,7 +7,7 @@ use futures::{pin_mut, Stream, StreamExt};
 use rand::rngs::OsRng;
 use rand::RngCore;
 use s3::Region;
-use s3_client::S3Client;
+use s3_client::S3CrtClient;
 use std::ops::Range;
 
 /// Enable tracing and CRT logging when running unit tests.
@@ -17,8 +17,8 @@ fn init_tracing_subscriber() {
     let _ = tracing_subscriber::fmt::try_init();
 }
 
-pub fn get_test_client() -> S3Client {
-    S3Client::new(&get_test_region(), Default::default()).expect("could not create test client")
+pub fn get_test_client() -> S3CrtClient {
+    S3CrtClient::new(&get_test_region(), Default::default()).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {

--- a/s3-client/tests/get_object.rs
+++ b/s3-client/tests/get_object.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::types::ByteStream;
 use bytes::Bytes;
 use common::*;
 use futures::stream::StreamExt;
-use s3_client::{ObjectClient, S3Client};
+use s3_client::{ObjectClient, S3CrtClient};
 
 #[tokio::test]
 async fn test_get_object() {
@@ -25,7 +25,7 @@ async fn test_get_object() {
         .await
         .unwrap();
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let result = client.get_object(&bucket, &key, None).await.expect("get_object failed");
     check_get_result(result, None, &body[..]).await;
@@ -47,7 +47,7 @@ async fn test_get_object_large() {
         .await
         .unwrap();
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let result = client.get_object(&bucket, &key, None).await.expect("get_object failed");
     check_get_result(result, None, &body[..]).await;
@@ -71,7 +71,7 @@ async fn test_get_object_404() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let mut result = client.get_object(&bucket, &key, None).await.expect("get_object failed");
     let next = StreamExt::next(&mut result).await.expect("stream needs to return Err");

--- a/s3-client/tests/head_bucket.rs
+++ b/s3-client/tests/head_bucket.rs
@@ -3,7 +3,7 @@
 pub mod common;
 
 use common::*;
-use s3_client::{HeadBucketError, S3Client, S3RequestError};
+use s3_client::{HeadBucketError, S3CrtClient, S3RequestError};
 
 #[tokio::test]
 async fn test_head_bucket_correct_region() {
@@ -15,7 +15,7 @@ async fn test_head_bucket_correct_region() {
 
 #[tokio::test]
 async fn test_head_bucket_wrong_region() {
-    let client = S3Client::new("ap-southeast-2", Default::default()).expect("could not create test client");
+    let client = S3CrtClient::new("ap-southeast-2", Default::default()).expect("could not create test client");
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let expected_region = get_test_region();
 

--- a/s3-client/tests/head_object.rs
+++ b/s3-client/tests/head_object.rs
@@ -5,7 +5,7 @@ pub mod common;
 use aws_sdk_s3::types::ByteStream;
 use bytes::Bytes;
 use common::*;
-use s3_client::S3Client;
+use s3_client::S3CrtClient;
 
 #[tokio::test]
 async fn test_head_object() {
@@ -23,7 +23,7 @@ async fn test_head_object() {
         .await
         .unwrap();
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
     let result = client.head_object(&bucket, &key).await.expect("get_object failed");
 
     assert_eq!(result.bucket, bucket);
@@ -37,7 +37,7 @@ async fn test_head_object_404() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let result = client.head_object(&bucket, &key).await;
     assert!(result.is_err());

--- a/s3-client/tests/list_objects.rs
+++ b/s3-client/tests/list_objects.rs
@@ -3,7 +3,7 @@
 pub mod common;
 
 use common::*;
-use s3_client::S3Client;
+use s3_client::S3CrtClient;
 
 #[tokio::test]
 async fn test_list_objects() {
@@ -11,7 +11,7 @@ async fn test_list_objects() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_list_objects");
     create_objects_for_test(&sdk_client, &bucket, &prefix, &["hello", "dir/a", "dir/b"]).await;
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let result = client
         .list_objects(&bucket, None, "/", 1000, &prefix)
@@ -43,7 +43,7 @@ async fn test_max_keys_continuation_token() {
     let keys: Vec<String> = (0..TOTAL_KEYS).map(|i| format!("object_{i}")).collect();
     create_objects_for_test(&sdk_client, &bucket, &prefix, &keys[..]).await;
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     let mut continuation_token: Option<String> = None;
     let mut keys_left = TOTAL_KEYS;
@@ -92,7 +92,7 @@ async fn test_max_keys_continuation_token() {
 async fn test_invalid_list_objects() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_invalid_list_objects");
 
-    let client: S3Client = get_test_client();
+    let client: S3CrtClient = get_test_client();
 
     // Make a ListObjects request using some made-up continuation token.
     let continuation_token = Some("Made-up invalid token here");

--- a/s3-file-connector/examples/fs_benchmark.rs
+++ b/s3-file-connector/examples/fs_benchmark.rs
@@ -1,7 +1,7 @@
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
 use clap::{Arg, Command};
 use fuser::{BackgroundSession, MountOption, Session};
-use s3_client::{S3Client, S3ClientConfig};
+use s3_client::{S3ClientConfig, S3CrtClient};
 use s3_file_connector::fuse::S3FuseFilesystem;
 use s3_file_connector::S3FilesystemConfig;
 use std::{
@@ -154,7 +154,7 @@ fn mount_file_system(bucket_name: &str, region: &str, throughput_target_gbps: Op
         throughput_target_gbps,
         part_size,
     };
-    let client = S3Client::new(region, config).expect("Failed to create S3 client");
+    let client = S3CrtClient::new(region, config).expect("Failed to create S3 client");
     let runtime = client.event_loop_group();
 
     let mut options = vec![MountOption::RO, MountOption::FSName("fuse_sync".to_string())];

--- a/s3-file-connector/examples/prefetch_benchmark.rs
+++ b/s3-file-connector/examples/prefetch_benchmark.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
 use clap::{Arg, Command};
 use futures::executor::ThreadPool;
-use s3_client::{S3Client, S3ClientConfig};
+use s3_client::{S3ClientConfig, S3CrtClient};
 use s3_file_connector::prefetch::Prefetcher;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -74,7 +74,7 @@ fn main() {
         throughput_target_gbps,
         part_size,
     };
-    let client = Arc::new(S3Client::new(region, config).expect("couldn't create client"));
+    let client = Arc::new(S3CrtClient::new(region, config).expect("couldn't create client"));
 
     for i in 0..iterations.unwrap_or(1) {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();

--- a/s3-file-connector/src/main.rs
+++ b/s3-file-connector/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::Context as _;
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
 use clap::Parser;
 use fuser::{BackgroundSession, MountOption, Session};
-use s3_client::{HeadBucketError, S3Client, S3ClientConfig, S3RequestError};
+use s3_client::{HeadBucketError, S3ClientConfig, S3CrtClient, S3RequestError};
 
 use s3_file_connector::fs::S3FilesystemConfig;
 use s3_file_connector::fuse::S3FuseFilesystem;
@@ -179,8 +179,8 @@ fn create_client_for_bucket(
     bucket: &str,
     supposed_region: &str,
     client_config: S3ClientConfig,
-) -> Result<S3Client, anyhow::Error> {
-    let client = S3Client::new(supposed_region, client_config.clone())?;
+) -> Result<S3CrtClient, anyhow::Error> {
+    let client = S3CrtClient::new(supposed_region, client_config.clone())?;
     let head_request = client.head_bucket(bucket);
     match futures::executor::block_on(head_request) {
         Ok(_) => Ok(client),
@@ -191,7 +191,7 @@ fn create_client_for_bucket(
                 region,
                 supposed_region
             );
-            let new_client = S3Client::new(&region, client_config)?;
+            let new_client = S3CrtClient::new(&region, client_config)?;
             let head_request = new_client.head_bucket(bucket);
             futures::executor::block_on(head_request)
                 .map(|_| new_client)

--- a/s3-file-connector/tests/fuse_tests/mod.rs
+++ b/s3-file-connector/tests/fuse_tests/mod.rs
@@ -74,7 +74,7 @@ mod s3_session {
     use aws_sdk_s3::Region;
     use rand::rngs::OsRng;
     use rand::RngCore as _;
-    use s3_client::{S3Client, S3ClientConfig};
+    use s3_client::{S3ClientConfig, S3CrtClient};
 
     /// Create a FUSE mount backed by a real S3 client
     pub fn new(test_name: &str, filesystem_config: S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn) {
@@ -84,7 +84,7 @@ mod s3_session {
         let region = get_test_region();
 
         let client_config: S3ClientConfig = Default::default();
-        let client = S3Client::new(&region, client_config).unwrap();
+        let client = S3CrtClient::new(&region, client_config).unwrap();
         let runtime = client.event_loop_group();
 
         let options = vec![


### PR DESCRIPTION
This gives us some room to experiment with other clients in the same tree. This change is a pure automated refactor, no other code changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
