### PR TITLE
Support running in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,8 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset",
+ "pin-utils",
  "static_assertions",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test-asan:
 	cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- \
 	--skip reftest_ \
 	--skip proptest_ \
+	--skip fork_test \
 	--skip sequential_read_large
 
 .PHONY: fmt

--- a/s3-file-connector/Cargo.toml
+++ b/s3-file-connector/Cargo.toml
@@ -24,7 +24,7 @@ supports-color = "1.3.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
-nix = { version = "0.26.1", default-features = false, features = ["user"] }
+nix = "0.26.2"
 time = "0.3.17"
 const_format = "0.2.30"
 

--- a/s3-file-connector/tests/fuse_tests/fork_test.rs
+++ b/s3-file-connector/tests/fuse_tests/fork_test.rs
@@ -1,0 +1,276 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::process::Stdio;
+use std::{path::PathBuf, process::Command}; // Run programs
+
+use crate::common::{create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region};
+
+const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[cfg(feature = "fuse_tests")]
+#[test]
+fn run_in_background() -> Result<(), Box<dyn std::error::Error>> {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_run_in_background");
+    let region = get_test_region();
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut child = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match child.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status and mount entry
+    assert!(exit_status.success());
+    assert!(mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()));
+
+    test_read_files(&bucket, &prefix, &region, &mount_point.to_path_buf());
+
+    Ok(())
+}
+
+#[cfg(feature = "fuse_tests")]
+#[test]
+fn run_in_foreground() -> Result<(), Box<dyn std::error::Error>> {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_run_in_foreground");
+    let region = get_test_region();
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut child = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .arg("--foreground")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        if mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // verify that process is still alive
+    let child_status = child.try_wait().unwrap();
+    assert_eq!(None, child_status);
+
+    assert!(mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()));
+
+    test_read_files(&bucket, &prefix, &region, &mount_point.to_path_buf());
+
+    Ok(())
+}
+
+#[cfg(feature = "fuse_tests")]
+#[test]
+fn run_in_background_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
+    // the mount would fail from error 403 on HeadBucket
+    let bucket = get_test_bucket_forbidden();
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut child = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg("--auto-unmount")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match child.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status and mount entry
+    assert!(!exit_status.success());
+    assert!(!mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()));
+
+    Ok(())
+}
+
+#[cfg(feature = "fuse_tests")]
+#[test]
+fn run_in_foreground_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
+    // the mount would fail from error 403 on HeadBucket
+    let bucket = get_test_bucket_forbidden();
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut child = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg("--auto-unmount")
+        .arg("--foreground")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match child.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status and mount entry
+    assert!(!exit_status.success());
+    assert!(!mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()));
+
+    Ok(())
+}
+
+#[cfg(feature = "fuse_tests")]
+#[test]
+fn run_fail_on_duplicate_mount() -> Result<(), Box<dyn std::error::Error>> {
+    let (bucket, prefix) = get_test_bucket_and_prefix("run_fail_on_duplicate_mount");
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut first_mount = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match first_mount.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status and mount entry
+    assert!(exit_status.success());
+    assert!(mount_exists("s3-file-connector", mount_point.path().to_str().unwrap()));
+
+    let mut cmd = Command::cargo_bin("s3-file-connector")?;
+    let mut second_mount = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match second_mount.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status
+    assert!(!exit_status.success());
+
+    Ok(())
+}
+
+fn test_read_files(bucket: &str, prefix: &str, region: &str, mount_point: &PathBuf) {
+    // create objects for test
+    create_objects(bucket, prefix, region, "file1.txt", b"hello world");
+    create_objects(bucket, prefix, region, "dir/file2.txt", b"hello world");
+
+    // verify readdir works on mount point
+    let dir = fs::read_dir(mount_point).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["dir", "file1.txt"]
+    );
+
+    // verify readdir works
+    let dir = fs::read_dir(mount_point.as_path().join("dir")).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["file2.txt"]
+    );
+
+    // verify read file works
+    let file_content = fs::read_to_string(mount_point.as_path().join("file1.txt")).unwrap();
+    assert_eq!(file_content, "hello world");
+
+    let file_content = fs::read_to_string(mount_point.as_path().join("dir/file2.txt")).unwrap();
+    assert_eq!(file_content, "hello world");
+}
+
+/// Read all mount records in the system and find the one that matches given arguments.
+/// # Arguments
+///
+/// * `source` - name of the file system.
+/// * `mount_point` - path to the mount point.
+fn mount_exists(source: &str, mount_point: &str) -> bool {
+    // macOS wrap its temp directory under /private but it's not visible to users
+    #[cfg(target_os = "macos")]
+    let mount_point = format!("/private{}", mount_point);
+
+    let mut cmd = Command::new("mount");
+    #[cfg(target_os = "linux")]
+    cmd.arg("-l");
+    let mut cmd = cmd.stdout(Stdio::piped()).spawn().expect("Unable to spawn mount tool");
+
+    let stdout = cmd.stdout.as_mut().unwrap();
+    let stdout_reader = BufReader::new(stdout);
+    let stdout_lines = stdout_reader.lines();
+
+    for line in stdout_lines.flatten() {
+        let str: Vec<&str> = line.split_whitespace().collect();
+        let source_rec = str[0];
+        let mount_point_rec = str[2];
+        if source_rec == source && mount_point_rec == mount_point {
+            return true;
+        }
+    }
+    false
+}

--- a/s3-file-connector/tests/fuse_tests/mod.rs
+++ b/s3-file-connector/tests/fuse_tests/mod.rs
@@ -1,3 +1,4 @@
+mod fork_test;
 mod lookup_test;
 mod mount_test;
 mod perm_test;
@@ -66,14 +67,14 @@ mod mock_session {
 
 #[cfg(feature = "s3_tests")]
 mod s3_session {
+    use crate::common::{get_test_bucket_and_prefix, get_test_region};
+
     use super::*;
 
     use std::future::Future;
 
     use aws_sdk_s3::types::ByteStream;
     use aws_sdk_s3::Region;
-    use rand::rngs::OsRng;
-    use rand::RngCore as _;
     use s3_client::{S3ClientConfig, S3CrtClient};
 
     /// Create a FUSE mount backed by a real S3 client
@@ -120,26 +121,6 @@ mod s3_session {
         };
 
         (mount_dir, session, Box::new(put_object))
-    }
-
-    fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-        let bucket = std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests");
-
-        // Generate a random nonce to make sure this prefix is truly unique
-        let nonce = OsRng.next_u64();
-
-        // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
-        let prefix =
-            std::env::var("S3_BUCKET_TEST_PREFIX").expect("Set S3_BUCKET_TEST_PREFIX to run integration tests");
-        assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
-
-        let prefix = format!("{prefix}{test_name}/{nonce}/");
-
-        (bucket, prefix)
-    }
-
-    fn get_test_region() -> String {
-        std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
     }
 
     async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {


### PR DESCRIPTION
This change allows the file connector to run in background and it will be running there by default. Users can change this behavior by passing in mount option `--foreground` or `-f` to run it in foreground instead.

I'm still figuring out how we can create some tests for this change. Any ideas are welcome. Another thing is that the logs are currently writing to the stdout directly even if the process is running in background. It's a bit annoying but I think that would be a part of PR that addresses https://github.com/awslabs/s3-file-connector/issues/39.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
