### PR TITLE
Refactor ObjectClient error types (part 1/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1618,14 +1618,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -2591,10 +2591,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -2701,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6a3b08b64e6dfad376fa2432c7b1f01522e37a623c3050bc95db2d3ff21583"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",

--- a/s3-client/src/lib.rs
+++ b/s3-client/src/lib.rs
@@ -6,10 +6,8 @@ mod s3_crt_client;
 mod util;
 
 pub use endpoint::{AddressingStyle, Endpoint};
-pub use object_client::{ListObjectsResult, ObjectClient};
-pub use s3_crt_client::get_object::GetObjectError;
+pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
-pub use s3_crt_client::list_objects::ListObjectsError;
 pub use s3_crt_client::{S3ClientConfig, S3CrtClient, S3RequestError};
 
 #[cfg(test)]

--- a/s3-client/src/object_client.rs
+++ b/s3-client/src/object_client.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use auto_impl::auto_impl;
 use futures::Stream;
 use std::ops::Range;
+use thiserror::Error;
 use time::OffsetDateTime;
 
 /// A single element of the [ObjectClient::get_object] response is a pair of offset within the
@@ -12,11 +13,8 @@ pub type GetBodyPart = (u64, Box<[u8]>);
 #[async_trait]
 #[auto_impl(Arc)]
 pub trait ObjectClient {
-    type GetObjectResult: Stream<Item = Result<GetBodyPart, Self::GetObjectError>> + Send;
-    type GetObjectError: std::error::Error + Send + Sync + 'static;
-    type HeadObjectError: std::error::Error + Send + Sync + 'static;
-    type ListObjectsError: std::error::Error + Send + Sync + 'static;
-    type PutObjectError: std::error::Error + Send + Sync + 'static;
+    type GetObjectResult: Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send;
+    type ClientError: std::error::Error + Send + Sync + 'static;
 
     /// Get an object from the object store. Returns a stream of body parts of the object. Parts are
     /// guaranteed to be returned by the stream in order and contiguously.
@@ -25,7 +23,7 @@ pub trait ObjectClient {
         bucket: &str,
         key: &str,
         range: Option<Range<u64>>,
-    ) -> Result<Self::GetObjectResult, Self::GetObjectError>;
+    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError>;
 
     /// List the objects in a bucket under a given prefix
     async fn list_objects(
@@ -35,10 +33,14 @@ pub trait ObjectClient {
         delimiter: &str,
         max_keys: usize,
         prefix: &str,
-    ) -> Result<ListObjectsResult, Self::ListObjectsError>;
+    ) -> ObjectClientResult<ListObjectsResult, ListObjectsError, Self::ClientError>;
 
     /// Retrieve object metadata without retrieving the object contents
-    async fn head_object(&self, bucket: &str, key: &str) -> Result<HeadObjectResult, Self::HeadObjectError>;
+    async fn head_object(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError>;
 
     /// Put an object into the object store.
     /// The contents are provided by the client as an async stream of buffers.
@@ -48,7 +50,41 @@ pub trait ObjectClient {
         key: &str,
         params: &PutObjectParams,
         contents: impl Stream<Item = impl AsRef<[u8]> + Send> + Send,
-    ) -> Result<PutObjectResult, Self::PutObjectError>;
+    ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError>;
+}
+
+/// Errors returned by calls to an [ObjectClient]. Errors that are explicitly modeled on a
+/// per-request-type basis are [ServiceError]s. Other generic or unhandled errors are
+/// [ClientError]s.
+///
+/// The distinction between these two types of error can sometimes be blurry. As a rough heuristic,
+/// [ServiceError]s are those that *any reasonable implementation* of an object client would be
+/// capable of experiencing, and [ClientError]s are anything else. For example, any object client
+/// could experience a "no such key" error, but only object clients that implement a permissions
+/// system could experience "permission denied" errors. When in doubt, we err towards *not* adding
+/// new [ServiceError]s, as they are public API for *every* object client.
+#[derive(Debug, Error)]
+pub enum ObjectClientError<S, C> {
+    /// An error returned by the service itself
+    #[error("Service error")]
+    ServiceError(#[source] S),
+
+    /// An error within the object client (for example, an unexpected response, or a failure to
+    /// construct the request).
+    #[error("Client error")]
+    ClientError(#[from] C),
+}
+
+pub type ObjectClientResult<T, S, C> = Result<T, ObjectClientError<S, C>>;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GetObjectError {
+    #[error("The bucket does not exist")]
+    NoSuchBucket,
+
+    #[error("The key does not exist")]
+    NoSuchKey,
 }
 
 /// Result of a [ObjectClient::list_objects] request
@@ -68,6 +104,13 @@ pub struct ListObjectsResult {
     pub next_continuation_token: Option<String>,
 }
 
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ListObjectsError {
+    #[error("The bucket does not exist")]
+    NoSuchBucket,
+}
+
 /// Result of a [ObjectClient::head_object] request
 #[derive(Debug)]
 pub struct HeadObjectResult {
@@ -76,6 +119,14 @@ pub struct HeadObjectResult {
 
     /// Object metadata
     pub object: ObjectInfo,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HeadObjectError {
+    /// Note that HeadObject cannot distinguish between NoSuchBucket and NoSuchKey errors
+    #[error("The object was not found")]
+    NotFound,
 }
 
 /// Parameters to a [ObjectClient::put_object] request
@@ -87,6 +138,13 @@ pub struct PutObjectParams {}
 /// TODO: Populate this struct with return fields from the S3 API, e.g., etag.
 #[derive(Debug)]
 pub struct PutObjectResult {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PutObjectError {
+    #[error("The bucket does not exist")]
+    NoSuchBucket,
+}
 
 /// Metadata about a single S3 object.
 /// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html for more details.

--- a/s3-client/tests/head_bucket.rs
+++ b/s3-client/tests/head_bucket.rs
@@ -3,7 +3,7 @@
 pub mod common;
 
 use common::*;
-use s3_client::{HeadBucketError, S3CrtClient, S3RequestError};
+use s3_client::{HeadBucketError, ObjectClientError, S3CrtClient};
 
 #[tokio::test]
 async fn test_head_bucket_correct_region() {
@@ -22,7 +22,7 @@ async fn test_head_bucket_wrong_region() {
     let result = client.head_bucket(&bucket).await;
 
     match result {
-        Err(S3RequestError::ServiceError(HeadBucketError::IncorrectRegion(actual_region))) => {
+        Err(ObjectClientError::ServiceError(HeadBucketError::IncorrectRegion(actual_region))) => {
             assert_eq!(actual_region, expected_region, "wrong region returned")
         }
         _ => panic!("incorrect result {result:?}"),
@@ -38,6 +38,6 @@ async fn test_head_bucket_forbidden() {
 
     assert!(matches!(
         result,
-        Err(S3RequestError::ServiceError(HeadBucketError::PermissionDenied(_)))
+        Err(ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(_)))
     ));
 }


### PR DESCRIPTION
Our current ObjectClient allows each implementer to provide its own error types for each request. This is nice and flexible, but prevents callers of an ObjectClient from being generic if they want to detect common service errors like NoSuchKey -- they must know the concrete error type of the particular client they're using to match on these errors. We've been getting away with this until #69, where we need to be able to distinguish (expected) 404 errors from other errors on HeadObject.

This change refactors ObjectClient to provide a common service error type for each operation. ObjectClients now return an error that is *either* a modeled service error like NoSuchKey *or* a client-specific error. This allows callers to be generic over the ObjectClient and still discriminate on the interesting error types, where by "interesting" I mean things I think it's likely a caller might want to know about.

The diff was getting pretty big so I'm splitting this into two commits. This is Part 1, which just does the refactoring, but doesn't change our S3CrtClient to return the new modeled service errors. That means this change shouldn't cause any functional change -- every error will be a client error, like it was before this commit.  I'll follow up with Part 2 that adds the service errors to S3CrtClient (so does XML parsing etc).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
