### PR TITLE
Force direct IO for all files

### DIFF
--- a/s3-file-connector/src/fs.rs
+++ b/s3-file-connector/src/fs.rs
@@ -255,7 +255,12 @@ where
         };
         self.file_handles.write().unwrap().insert(fh, handle);
 
-        Ok(Opened { fh, flags: 0 })
+        Ok(Opened {
+            fh,
+            // TODO we currently force direct IO to avoid page caching; change when we adopt caching
+            // personalities
+            flags: fuser::consts::FOPEN_DIRECT_IO,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
We're currently building a no-caching connector, and so we should make sure the page cache doesn't enter the picture. We'll revisit this once we start thinking about personalities that do use caching, but for now, this default makes the experience consistent.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
