### PR TITLE
Add file connector version to user agent string

### DIFF
--- a/s3-file-connector/src/main.rs
+++ b/s3-file-connector/src/main.rs
@@ -161,7 +161,7 @@ fn main() -> anyhow::Result<()> {
         throughput_target_gbps,
         part_size: args.part_size.map(|t| t as usize),
         endpoint,
-        user_agent_prefix: Some("s3-file-connector".to_owned()),
+        user_agent_prefix: Some(format!("s3-file-connector/{}", build_info::FULL_VERSION)),
     };
 
     let _metrics = MetricsSink::init();


### PR DESCRIPTION
Adding in the build version to the user agent. Nice and straight forward with the implementation from #60.

Example user agent from my local repo:

```
User-Agent: s3-file-connector/0.1.0-a7990bb aws-s3-crt-rust CRTS3NativeClient/0.1.x
```

Closes #79.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
