### PR TITLE
Refactor ObjectClient error types (part 2/2)

### DIFF
--- a/s3-client/src/s3_crt_client/list_objects.rs
+++ b/s3-client/src/s3_crt_client/list_objects.rs
@@ -1,12 +1,16 @@
-use crate::object_client::{ListObjectsError, ListObjectsResult, ObjectClientError, ObjectClientResult, ObjectInfo};
-use crate::s3_crt_client::S3RequestError;
-use crate::S3CrtClient;
-use aws_crt_s3::s3::client::MetaRequestType;
+use std::ops::Deref;
+use std::os::unix::prelude::OsStrExt;
 use std::str::FromStr;
+
+use aws_crt_s3::s3::client::{MetaRequestResult, MetaRequestType};
 use thiserror::Error;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tracing::{debug, error};
+
+use crate::object_client::{ListObjectsError, ListObjectsResult, ObjectClientError, ObjectClientResult, ObjectInfo};
+use crate::s3_crt_client::S3RequestError;
+use crate::S3CrtClient;
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -165,7 +169,10 @@ impl S3CrtClient {
             });
 
             self.make_simple_http_request(message, MetaRequestType::Default, span, |result| {
-                ObjectClientError::ClientError(S3RequestError::ResponseError(result))
+                let parsed = parse_list_objects_error(&result);
+                parsed
+                    .map(ObjectClientError::ServiceError)
+                    .unwrap_or(ObjectClientError::ClientError(S3RequestError::ResponseError(result)))
             })?
         };
 
@@ -173,5 +180,55 @@ impl S3CrtClient {
 
         ListObjectsResult::parse_from_bytes(&body)
             .map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(e.into())))
+    }
+}
+
+fn parse_list_objects_error(result: &MetaRequestResult) -> Option<ListObjectsError> {
+    match result.response_status {
+        404 => {
+            let body = result.error_response_body.as_ref()?;
+            let root = xmltree::Element::parse(body.as_bytes()).ok()?;
+            let error_code = root.get_child("Code")?;
+            let error_str = error_code.get_text()?;
+            match error_str.deref() {
+                "NoSuchBucket" => Some(ListObjectsError::NoSuchBucket),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+
+    use super::*;
+
+    fn make_result(response_status: i32, body: impl Into<OsString>) -> MetaRequestResult {
+        MetaRequestResult {
+            response_status,
+            crt_error: 1i32.into(),
+            error_response_headers: None,
+            error_response_body: Some(body.into()),
+        }
+    }
+
+    #[test]
+    fn parse_404_no_such_bucket() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>DOC-EXAMPLE-BUCKET</BucketName><RequestId>4YAYHJ0E82DDDNF0</RequestId><HostId>Ajn9+i3d3VWQi339YrGqBbJqQlj5HaX2vplXp9IlDPAxsJ4vsIAsje0P2gJ0of/mTKKz/fv9pNy9RqhbLUBc/g==</HostId></Error>"#;
+        let result = make_result(404, OsStr::from_bytes(&body[..]));
+        let result = parse_list_objects_error(&result);
+        assert_eq!(result, Some(ListObjectsError::NoSuchBucket));
+    }
+
+    #[test]
+    fn parse_403_glacier_storage_class() {
+        // ListObjectsV2 can't actually fail with this XML, it's just a convenient body to use for
+        // the test
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidObjectState</Code><Message>The action is not valid for the object's storage class</Message><RequestId>9FEFFF118E15B86F</RequestId><HostId>WVQ5kzhiT+oiUfDCOiOYv8W4Tk9eNcxWi/MK+hTS/av34Xy4rBU3zsavf0aaaaa</HostId></Error>"#;
+        let result = make_result(403, OsStr::from_bytes(&body[..]));
+        let result = parse_list_objects_error(&result);
+        assert_eq!(result, None);
     }
 }

--- a/s3-client/tests/list_objects.rs
+++ b/s3-client/tests/list_objects.rs
@@ -3,7 +3,7 @@
 pub mod common;
 
 use common::*;
-use s3_client::S3CrtClient;
+use s3_client::{ListObjectsError, ObjectClientError, S3CrtClient};
 
 #[tokio::test]
 async fn test_list_objects() {
@@ -102,4 +102,19 @@ async fn test_invalid_list_objects() {
 
     let err = result.expect_err("this request should have failed: we made up an invalid continuation token");
     println!("{err}");
+}
+
+#[tokio::test]
+async fn test_list_objects_404_bucket() {
+    let (_bucket, prefix) = get_test_bucket_and_prefix("test_list_objects_404_bucket");
+
+    let client: S3CrtClient = get_test_client();
+
+    let result = client
+        .list_objects("DOC-EXAMPLE-BUCKET", None, "/", 1000, &prefix)
+        .await;
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ServiceError(ListObjectsError::NoSuchBucket))
+    ));
 }


### PR DESCRIPTION
Follows up on #76. The S3CrtClient now parses responses to identify service errors and returns them appropriately.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
