### PR TITLE
Send log to file

### DIFF
--- a/s3-file-connector/Cargo.toml
+++ b/s3-file-connector/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 nix = { version = "0.26.1", default-features = false, features = ["user"] }
 time = "0.3.17"
 const_format = "0.2.30"
+chrono = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/s3-file-connector/src/main.rs
+++ b/s3-file-connector/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Context as _};
 use aws_crt_s3::common::rust_log_adapter::RustLogAdapter;
@@ -16,7 +16,20 @@ use tracing_subscriber::Layer;
 mod build_info;
 
 fn init_tracing_subscriber() {
+    const LOG_FOLDER: &str = "logs";
+
     RustLogAdapter::try_init().expect("unable to install CRT log adapter");
+
+    match fs::create_dir_all(LOG_FOLDER) {
+        Ok(_) => (),
+        Err(error) => panic!("Failed to create log folder: {:?}", error),
+    };
+
+    let utc_time = chrono::UTC::now().to_rfc3339();
+    let file = match fs::File::create(format!("{}/{}", LOG_FOLDER, utc_time)) {
+        Ok(file) => file,
+        Err(error) => panic!("Failed to create log file: {:?}", error),
+    };
 
     // Brutal hack because tracing-subscriber doesn't allow us to specify *multiple* default
     // directives -- we want warning-level logging except for the CRT, which is very spammy.
@@ -25,7 +38,8 @@ fn init_tracing_subscriber() {
     }
 
     let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_ansi(supports_color::on(supports_color::Stream::Stdout).is_some())
+        .with_ansi(false)
+        .with_writer(Arc::new(file))
         .with_filter(tracing_subscriber::filter::EnvFilter::from_default_env());
 
     tracing_subscriber::registry()


### PR DESCRIPTION
Logs is recorded under path: logs/{chrono_time_stamp} for each run.

Signed-off-by: Charles Zhang <zyaoshen@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
