### PR TITLE
Send log outputs to file, Logs is recorded under path: logs/{chrono_time_stamp} for each run.

### DIFF
--- a/s3-file-connector/Cargo.toml
+++ b/s3-file-connector/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 nix = { version = "0.26.1", default-features = false, features = ["user"] }
 time = "0.3.17"
 const_format = "0.2.30"
+chrono = { version = "0.4.x", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.6"


### PR DESCRIPTION
Signed-off-by: Charles Zhang <zyaoshen@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
