### PR TITLE
Send log outputs to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2253,7 @@ dependencies = [
  "fuser",
  "futures",
  "hdrhistogram",
+ "home",
  "libc",
  "metrics",
  "nix",
@@ -2607,6 +2617,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
  "time-macros",

--- a/aws-crt-s3/src/common/logging.rs
+++ b/aws-crt-s3/src/common/logging.rs
@@ -81,10 +81,11 @@ impl Logger {
 }
 
 /// Errors returned by methods that install [`Logger`]s
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LoggerInitError {
     /// A logger has already been initialized. Only one logger can be initialized for the lifetime
     /// of the program.
+    #[error("logger was already initialized")]
     AlreadyInitialized,
 }
 

--- a/s3-file-connector/Cargo.toml
+++ b/s3-file-connector/Cargo.toml
@@ -25,8 +25,9 @@ thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 nix = "0.26.2"
-time = "0.3.17"
+time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
+home = "0.5.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"


### PR DESCRIPTION
Logs is recorded under path: logs/{chrono_time_stamp} for each run.

Signed-off-by: Charles Zhang <zyaoshen@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
