### PR TITLE
Revert "Force direct IO for all files (#84)"

### DIFF
--- a/s3-file-connector/src/fs.rs
+++ b/s3-file-connector/src/fs.rs
@@ -255,12 +255,7 @@ where
         };
         self.file_handles.write().unwrap().insert(fh, handle);
 
-        Ok(Opened {
-            fh,
-            // TODO we currently force direct IO to avoid page caching; change when we adopt caching
-            // personalities
-            flags: fuser::consts::FOPEN_DIRECT_IO,
-        })
+        Ok(Opened { fh, flags: 0 })
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
This change is causing reads to sometimes return uninitialized memory. Our integration tests fail about 50% of the time with this change, and never with this change reverted. I don't think it's a bug on our side--the data we're writing to the FUSE device is correct--but I need to poke at it further. In the meantime, let's just revert until we understand it better.

This reverts commit c8296cb067f314b85d9b902d0724de04a82ca4ab.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
