### PR TITLE
Fix benchmark script

### DIFF
--- a/s3-file-connector/scripts/fs_bench.sh
+++ b/s3-file-connector/scripts/fs_bench.sh
@@ -52,7 +52,7 @@ for job_file in "${jobs_dir}"/*.fio; do
   timeout_seconds=30
   # wait for file system to be ready
   while true; do
-    mount_rec=`findmnt -rncv -S fuse_sync -T ${mount_dir} -o SOURCE,TARGET`
+    mount_rec=`findmnt -rncv -S s3-file-connector -T ${mount_dir} -o SOURCE,TARGET`
     # file system is ready when the mount record exists
     if [ -n "${mount_rec}" ]; then
       break


### PR DESCRIPTION
After #72, we have changed the FS name to `s3-file-connector` and our file connector will be running in background by default. This breaks the benchmark clean up process because we're now using the wrong pid to kill the process after unmount.

Technically, running in background should not be a problem but because of #93 we will have to use `--foreground` flag until we have it fixed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
