### PR TITLE
Fix URL encoding of request paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,6 +2207,7 @@ dependencies = [
  "libc",
  "libc-stdhandle",
  "metrics",
+ "percent-encoding",
  "pin-project",
  "proptest",
  "rand",
@@ -2219,7 +2220,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "urlencoding",
  "xmltree",
 ]
 

--- a/s3-client/Cargo.toml
+++ b/s3-client/Cargo.toml
@@ -16,13 +16,13 @@ lazy_static = "1.4.0"
 libc = "0.2.126"
 libc-stdhandle = "0.1.0"
 metrics = "0.20.1"
+percent-encoding = "2.2.0"
 pin-project = "1.0.12"
 regex = "1.7.1"
 static_assertions = "1.1.0"
 thiserror = "1.0.34"
 time = "0.3.14"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
-urlencoding = "2.1.2"
 xmltree = "0.10.3"
 
 [dev-dependencies]

--- a/s3-client/src/s3_crt_client/head_object.rs
+++ b/s3-client/src/s3_crt_client/head_object.rs
@@ -68,7 +68,6 @@ impl S3CrtClient {
                 .new_request_template("HEAD", bucket)
                 .map_err(S3RequestError::construction_failure)?;
 
-            // Don't URI encode the key, since "/" needs to be preserved
             let key = key.to_string();
             message
                 .set_request_path(format!("/{key}"))

--- a/s3-file-connector/tests/fuse_tests/lookup_test.rs
+++ b/s3-file-connector/tests/fuse_tests/lookup_test.rs
@@ -1,4 +1,4 @@
-use std::fs::{metadata, read_dir};
+use std::fs::{metadata, read_dir, read_to_string};
 
 use fuser::BackgroundSession;
 use s3_file_connector::S3FilesystemConfig;
@@ -46,4 +46,65 @@ fn lookup_directory_overlap_test_s3(subdir: &str) {
 #[test_case("lookup_dirrectory_overlap", "subdir/"; "prefix subdirectory")]
 fn lookup_directory_overlap_test_mock(prefix: &str, subdir: &str) {
     lookup_directory_overlap_test(crate::fuse_tests::mock_session::new, prefix, subdir);
+}
+
+fn lookup_weird_characters_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
+{
+    let (mount_point, _session, mut put_object_fn) = creator_fn(prefix, Default::default());
+
+    let keys = &[
+        "weird$dir name",
+        "weird$dir name/my 1st file~.jpg",
+        "weird$dir name/my 2nd file: the better one.jpg",
+        "weirder_.-@dir +name",
+        "weirder_.-@dir +name/",
+    ];
+
+    for (i, key) in keys.iter().enumerate() {
+        put_object_fn(key, format!("hello world {i}").as_bytes()).unwrap();
+    }
+
+    let test_dir = read_dir(mount_point.path()).unwrap();
+    let dirs: Vec<_> = test_dir.map(|f| f.unwrap()).collect();
+
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["weird$dir name", "weirder_.-@dir +name"]
+    );
+
+    let m = metadata(mount_point.path().join(keys[0])).unwrap();
+    assert!(m.file_type().is_dir());
+    let m = metadata(mount_point.path().join(keys[3])).unwrap();
+    assert!(m.file_type().is_dir());
+
+    let test_dir = read_dir(mount_point.path().join(keys[0])).unwrap();
+    let dirs: Vec<_> = test_dir.map(|f| f.unwrap()).collect();
+
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["my 1st file~.jpg", "my 2nd file: the better one.jpg"]
+    );
+
+    let f = read_to_string(mount_point.path().join(keys[1])).unwrap();
+    assert_eq!(f, "hello world 1");
+
+    let f = read_to_string(mount_point.path().join(keys[2])).unwrap();
+    assert_eq!(f, "hello world 2");
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn lookup_directory_weird_characters_s3() {
+    lookup_weird_characters_test(crate::fuse_tests::s3_session::new, "lookup_weird_characters_test");
+}
+
+#[test]
+fn lookup_directory_weird_characters_mock() {
+    lookup_weird_characters_test(crate::fuse_tests::mock_session::new, "lookup_weird_characters_test");
 }


### PR DESCRIPTION
We weren't correctly URL encoding paths before passing them to the CRT,
which expects them to already be encoded. This meant keys with weird
characters wouldn't work properly. The rules for encoding S3 keys aren't
explicit in the documentation, so this is my best attempt to match what
the Python SDK does (using `urllib.parse.quote`).

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
