### PR TITLE
Add macOS CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,39 @@ jobs:
     - name: Run tests
       run: cargo test --features $RUST_FEATURES
 
+  macos-test:
+    name: Tests (MacOS)
+    runs-on: macos-12
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install dependencies
+      run: |
+        brew update > /dev/null && brew install pkg-config
+    - name: Install fuse
+      run: |
+        brew install --cask macfuse
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Cargo cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run tests
+      run: cargo test -- --skip=mnt::test::mount_unmount
+
   check:
     name: Check all targets
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Add a new Actions job to build and test our code in macOS. We can only run unit tests for now because of permissions problem on macOS 11+ https://github.com/actions/runner-images/issues/4731, but at least we can be sure that new PRs will not break macOS build.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
