### PR TITLE
Add --locked flag to Cargo check CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install fuse
       run: sudo apt-get install fuse libfuse-dev
     - name: Check all targets
-      run: cargo check --all-targets --features $RUST_FEATURES
+      run: cargo check --locked --all-targets --features $RUST_FEATURES
 
   shuttle:
     name: Shuttle tests


### PR DESCRIPTION
This will fail the job if an outdated Cargo.lock is part of the repository.

Tested on an outdated Cargo.lock:

```
❯ cargo check --locked --all-targets
    Updating crates.io index
error: the lock file /Users/djonesoa/devel/s3-file-connector/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

Closes #103.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
