### PR TITLE
Speed up some slow unit tests

### DIFF
--- a/s3-client/src/mock_client.rs
+++ b/s3-client/src/mock_client.rs
@@ -21,7 +21,7 @@ use crate::ObjectClient;
 pub const RAMP_MODULUS: usize = 251; // Largest prime under 256
 static_assertions::const_assert!((RAMP_MODULUS > 0) && (RAMP_MODULUS <= 256));
 
-const RAMP_BUFFER_SIZE: usize = 16 * 1024 * RAMP_MODULUS; // around 4 MiB
+const RAMP_BUFFER_SIZE: usize = 4 * 1024 * RAMP_MODULUS; // around 1 MiB
 static_assertions::const_assert!(RAMP_BUFFER_SIZE % RAMP_MODULUS == 0);
 
 // Return a ramping pattern of bytes modulo RAMP_MODULUS.  The seed is the first byte.
@@ -574,7 +574,7 @@ mod tests {
     async fn test_put_object() {
         let mut rng = ChaChaRng::seed_from_u64(0x12345678);
 
-        let obj = MockObject::ramp(0xaa, RAMP_BUFFER_SIZE);
+        let obj = MockObject::ramp(0xaa, 2 * RAMP_BUFFER_SIZE);
 
         let client = MockClient::new(MockClientConfig {
             bucket: "test_bucket".to_string(),


### PR DESCRIPTION
We have a few slow unit tests that are pretty annoying. They're not slow
for any good reason -- the time is all spent moving large buffers around
rather than actually testing the logic. This change just makes all the
constants for these tests a bit smaller, so we're still testing the same
logic, just with fewer bytes to move around.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
