### PR TITLE
Remove O_DIRECT from basic_read_test

### DIFF
--- a/s3-file-connector/tests/fuse_tests/mount_test.rs
+++ b/s3-file-connector/tests/fuse_tests/mount_test.rs
@@ -1,8 +1,5 @@
-use std::fs::{read_dir, File, OpenOptions};
+use std::fs::{read_dir, File};
 use std::io::{Read as _, Seek, SeekFrom};
-
-#[cfg(target_os = "linux")]
-use std::os::unix::fs::OpenOptionsExt;
 
 use fuser::BackgroundSession;
 use rand::RngCore;
@@ -45,13 +42,7 @@ where
 
     // We could do this with std::io::copy into the digest, but we'd like to control the buffer size
     // so we can make it weird.
-    let mut bin = {
-        let mut open = OpenOptions::new();
-        open.read(true);
-        #[cfg(target_os = "linux")]
-        open.custom_flags(libc::O_DIRECT);
-        open.open(files[1].path()).unwrap()
-    };
+    let mut bin = File::open(files[1].path()).unwrap();
     let mut two_mib_read = Vec::with_capacity(2 * 1024 * 1024);
     let mut bytes_read = 0usize;
     let mut buf = vec![0; 70000]; // weird size just to test alignment and the like


### PR DESCRIPTION
This test is failing sporadically in CI with corrupt data. I believe the cause is the same as why we reverted #84. Per the man page for `open(2)`, `O_DIRECT` is not safe to use concurrently with `fork` syscalls:

> O_DIRECT I/Os should never be run concurrently with the fork(2)
> system call, if the memory buffer is a private mapping (i.e., any
> mapping created with the mmap(2) MAP_PRIVATE flag; this includes
> memory allocated on the heap and statically allocated buffers).
> Any such I/Os, whether submitted via an asynchronous I/O
> interface or from another thread in the process, should be
> completed before fork(2) is called.  Failure to do so can result
> in data corruption and undefined behavior in parent and child
> processes.

Our test runner does a `fork` every time we mount a FUSE file system, since we don't run our tests as root, and so we need to execute the `fusermount3` utility to do the mount. Since tests run concurrently, that means we will sometimes do one of these forks at the same time as this test is doing an `O_DIRECT` read.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
