### PR TITLE
Implement GetObjectAttributes in mountpoint-s3-client

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -127,10 +127,14 @@ where
         &self,
         bucket: &str,
         key: &str,
-        object_attributes: Vec<ObjectAttribute>,
+        max_parts: Option<usize>,
+        part_number_marker: Option<usize>,
+        object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
         // TODO failure hook for get_object_attributes
-        self.client.get_object_attributes(bucket, key, object_attributes).await
+        self.client
+            .get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
+            .await
     }
 }
 

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -10,10 +10,11 @@ use futures::Stream;
 use pin_project::pin_project;
 
 use crate::object_client::{
-    DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectError, HeadObjectError, HeadObjectResult,
-    ListObjectsError, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult,
+    DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
+    GetObjectError, HeadObjectError, HeadObjectResult, ListObjectsError, ObjectClientError, ObjectClientResult,
+    PutObjectError, PutObjectParams, PutObjectResult,
 };
-use crate::{ListObjectsResult, ObjectClient};
+use crate::{ListObjectsResult, ObjectAttribute, ObjectClient};
 
 // Wrapper for injecting failures into a get stream
 pub struct FailureGetWrapper<Client: ObjectClient, GetWrapperState> {
@@ -120,6 +121,16 @@ where
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         // TODO Add put fault injection hooks
         self.client.put_object(bucket, key, params, contents).await
+    }
+
+    async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        object_attributes: Vec<ObjectAttribute>,
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
+        // TODO failure hook for get_object_attributes
+        self.client.get_object_attributes(bucket, key, object_attributes).await
     }
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -430,7 +430,7 @@ impl ObjectClient for MockClient {
         trace!(bucket, key, "GetObjectAttributes");
 
         if bucket != self.config.bucket {
-            return Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound));
+            return Err(ObjectClientError::ServiceError(GetObjectAttributesError::NoSuchBucket));
         }
 
         let objects = self.objects.read().unwrap();
@@ -454,7 +454,7 @@ impl ObjectClient for MockClient {
             }
             Ok(result)
         } else {
-            Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound))
+            Err(ObjectClientError::ServiceError(GetObjectAttributesError::NoSuchKey))
         }
     }
 }

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -13,11 +13,11 @@ use time::OffsetDateTime;
 use tracing::trace;
 
 use crate::object_client::{
-    DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectError, HeadObjectError, HeadObjectResult,
-    ListObjectsError, ListObjectsResult, ObjectClientError, ObjectClientResult, ObjectInfo, PutObjectError,
-    PutObjectParams, PutObjectResult,
+    DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
+    GetObjectError, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectClient,
+    ObjectClientError, ObjectClientResult, ObjectInfo, PutObjectError, PutObjectParams, PutObjectResult,
 };
-use crate::ObjectClient;
+use crate::{Checksum, ObjectAttribute};
 
 pub const RAMP_MODULUS: usize = 251; // Largest prime under 256
 static_assertions::const_assert!((RAMP_MODULUS > 0) && (RAMP_MODULUS <= 256));
@@ -79,6 +79,8 @@ impl MockClient {
 pub struct MockObject {
     generator: Box<dyn Fn(u64, usize) -> Box<[u8]> + Send + Sync>,
     size: usize,
+    // TODO Set storage class from [MockClient::put_object]
+    storage_class: String,
     pub last_modified: OffsetDateTime,
 }
 
@@ -93,6 +95,7 @@ impl MockObject {
         Self {
             size: bytes.len(),
             generator: Box::new(move |offset, size| bytes[offset as usize..offset as usize + size].into()),
+            storage_class: "STANDARD".to_owned(),
             last_modified: OffsetDateTime::now_utc(),
         }
     }
@@ -101,6 +104,7 @@ impl MockObject {
         Self {
             generator: Box::new(move |_offset, size| vec![v; size].into_boxed_slice()),
             size,
+            storage_class: "STANDARD".to_owned(),
             last_modified: OffsetDateTime::now_utc(),
         }
     }
@@ -119,6 +123,7 @@ impl MockObject {
                 vec.into_boxed_slice()
             }),
             size,
+            storage_class: "STANDARD".to_owned(),
             last_modified: OffsetDateTime::now_utc(),
         }
     }
@@ -414,6 +419,43 @@ impl ObjectClient for MockClient {
         self.add_object(key, buffer.into());
 
         Ok(PutObjectResult {})
+    }
+
+    async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        object_attributes: Vec<ObjectAttribute>,
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
+        trace!(bucket, key, "GetObjectAttributes");
+
+        if bucket != self.config.bucket {
+            return Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound));
+        }
+
+        let objects = self.objects.read().unwrap();
+        if let Some(object) = objects.get(key) {
+            let mut result = GetObjectAttributesResult::default();
+            for attribute in object_attributes.iter() {
+                match attribute {
+                    ObjectAttribute::ETag => result.etag = Some("TODO".to_owned()),
+                    ObjectAttribute::Checksum => {
+                        result.checksum = Some(Checksum {
+                            checksum_crc32: Some("TODO".to_owned()),
+                            checksum_crc32c: Some("TODO".to_owned()),
+                            checksum_sha1: Some("TODO".to_owned()),
+                            checksum_sha256: Some("TODO".to_owned()),
+                        })
+                    }
+                    ObjectAttribute::ObjectParts => todo!("Support multipart mock object"),
+                    ObjectAttribute::StorageClass => result.storage_class = Some(object.storage_class.clone()),
+                    ObjectAttribute::ObjectSize => result.object_size = Some(object.size as u64),
+                }
+            }
+            Ok(result)
+        } else {
+            Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound))
+        }
     }
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -425,7 +425,9 @@ impl ObjectClient for MockClient {
         &self,
         bucket: &str,
         key: &str,
-        object_attributes: Vec<ObjectAttribute>,
+        _max_parts: Option<usize>,
+        _part_number_marker: Option<usize>,
+        object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
         trace!(bucket, key, "GetObjectAttributes");
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -66,7 +66,9 @@ pub trait ObjectClient {
         &self,
         bucket: &str,
         key: &str,
-        object_attributes: Vec<ObjectAttribute>,
+        max_parts: Option<usize>,
+        part_number_marker: Option<usize>,
+        object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError>;
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -60,6 +60,14 @@ pub trait ObjectClient {
         params: &PutObjectParams,
         contents: impl Stream<Item = impl AsRef<[u8]> + Send> + Send,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError>;
+
+    /// Retrieves all the metadata from an object without returning the object contents.
+    async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        object_attributes: Vec<ObjectAttribute>,
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError>;
 }
 
 /// Errors returned by calls to an [ObjectClient]. Errors that are explicitly modeled on a
@@ -156,6 +164,32 @@ pub enum DeleteObjectError {
     NoSuchBucket,
 }
 
+/// Result of a [ObjectClient::get_object_attributes] request
+#[derive(Debug, Default)]
+pub struct GetObjectAttributesResult {
+    /// ETag of the object
+    pub etag: Option<String>,
+
+    /// Checksum for the object
+    pub checksum: Option<Checksum>,
+
+    /// Object parts metadata for multi part object
+    pub object_parts: Option<GetObjectAttributesParts>,
+
+    /// Storage class of the object
+    pub storage_class: Option<String>,
+
+    /// Object size
+    pub object_size: Option<u64>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GetObjectAttributesError {
+    #[error("The object was not found")]
+    NotFound,
+}
+
 /// Parameters to a [ObjectClient::put_object] request
 /// TODO: Populate this struct with parameters from the S3 API, e.g., storage class, encryption.
 #[derive(Debug, Default)]
@@ -195,4 +229,88 @@ pub struct ObjectInfo {
 
     /// Entity tag of this object.
     pub etag: String,
+}
+
+/// All possible object attributes that can be retrived from [ObjectClient::get_object_attributes].
+pub enum ObjectAttribute {
+    ETag,
+    Checksum,
+    ObjectParts,
+    StorageClass,
+    ObjectSize,
+}
+
+impl ToString for ObjectAttribute {
+    fn to_string(&self) -> String {
+        match self {
+            ObjectAttribute::ETag => "ETag".to_owned(),
+            ObjectAttribute::Checksum => "Checksum".to_owned(),
+            ObjectAttribute::ObjectParts => "ObjectParts".to_owned(),
+            ObjectAttribute::StorageClass => "StorageClass".to_owned(),
+            ObjectAttribute::ObjectSize => "ObjectSize".to_owned(),
+        }
+    }
+}
+
+/// Metadata about object checksum.
+/// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_Checksum.html for more details.
+#[derive(Debug)]
+pub struct Checksum {
+    /// Base64-encoded, 32-bit CRC32 checksum of the object
+    pub checksum_crc32: Option<String>,
+
+    /// Base64-encoded, 32-bit CRC32C checksum of the object
+    pub checksum_crc32c: Option<String>,
+
+    /// Base64-encoded, 160-bit SHA-1 digest of the object
+    pub checksum_sha1: Option<String>,
+
+    /// Base64-encoded, 256-bit SHA-256 digest of the object
+    pub checksum_sha256: Option<String>,
+}
+
+/// Metadata about object parts from GetObjectAttributes API.
+/// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributesParts.html for more details.
+#[derive(Debug)]
+pub struct GetObjectAttributesParts {
+    /// Indicates whether the returned list of parts is truncated
+    pub is_truncated: bool,
+
+    /// Maximum number of parts allowed in the response
+    pub max_parts: usize,
+
+    /// When a list is truncated, this element specifies the next marker
+    pub next_part_number_marker: usize,
+
+    /// The marker for the current part
+    pub part_number_marker: usize,
+
+    /// Array of metadata for particular parts
+    pub parts: Vec<ObjectPart>,
+
+    /// Total number of parts
+    pub total_parts_count: usize,
+}
+
+/// Metadata for an individual object part.
+/// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectPart.html for more details.
+#[derive(Debug)]
+pub struct ObjectPart {
+    /// Base64-encoded, 32-bit CRC32 checksum of the object
+    pub checksum_crc32: Option<String>,
+
+    /// Base64-encoded, 32-bit CRC32C checksum of the object
+    pub checksum_crc32c: Option<String>,
+
+    /// Base64-encoded, 160-bit SHA-1 digest of the object
+    pub checksum_sha1: Option<String>,
+
+    /// Base64-encoded, 256-bit SHA-256 digest of the object
+    pub checksum_sha256: Option<String>,
+
+    /// Number of the part, this value is a positive integer between 1 and 10,000
+    pub part_number: usize,
+
+    // Size of the part in bytes
+    pub size: usize,
 }

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -548,9 +548,12 @@ impl ObjectClient for S3CrtClient {
         &self,
         bucket: &str,
         key: &str,
-        object_attributes: Vec<ObjectAttribute>,
+        max_parts: Option<usize>,
+        part_number_marker: Option<usize>,
+        object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
-        self.get_object_attributes(bucket, key, object_attributes).await
+        self.get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
+            .await
     }
 }
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -41,6 +41,7 @@ macro_rules! request_span {
 
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
+pub(crate) mod get_object_attributes;
 pub(crate) mod head_bucket;
 pub(crate) mod head_object;
 pub(crate) mod list_objects;
@@ -541,6 +542,15 @@ impl ObjectClient for S3CrtClient {
         contents: impl futures::Stream<Item = impl AsRef<[u8]> + Send> + Send,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         self.put_object(bucket, key, params, contents).await
+    }
+
+    async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        object_attributes: Vec<ObjectAttribute>,
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
+        self.get_object_attributes(bucket, key, object_attributes).await
     }
 }
 

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -1,0 +1,267 @@
+use std::{fmt, str::FromStr};
+
+use mountpoint_s3_crt::{
+    http::request_response::Header,
+    s3::client::{MetaRequestResult, MetaRequestType},
+};
+use thiserror::Error;
+use tracing::debug;
+
+use crate::{
+    Checksum, GetObjectAttributesError, GetObjectAttributesParts, GetObjectAttributesResult, ObjectAttribute,
+    ObjectClientError, ObjectClientResult, ObjectPart, S3CrtClient, S3RequestError,
+};
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum ParseError {
+    #[error("XML response was not valid: problem = {1}, xml node = {0:?}")]
+    InvalidResponse(xmltree::Element, String),
+
+    #[error("XML parsing error: {0:?}")]
+    Xml(#[from] xmltree::ParseError),
+
+    #[error("Missing field {1} from XML element {0:?}")]
+    MissingField(xmltree::Element, String),
+
+    #[error("Failed to parse field {0} from string")]
+    FromStr(String),
+}
+
+impl GetObjectAttributesResult {
+    fn parse_from_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
+        Self::parse_from_xml(&mut xmltree::Element::parse(bytes)?)
+    }
+
+    fn parse_from_xml(element: &mut xmltree::Element) -> Result<Self, ParseError> {
+        let etag = get_field_or_none(element, "ETag")?;
+        let storage_class = get_field_or_none(element, "StorageClass")?;
+        let object_size = get_field_or_none(element, "ObjectSize")?;
+
+        let mut checksum = None;
+        if let Some(checksum_elem) = element.take_child("Checksum") {
+            let checksum_crc32 = get_field_or_none(&checksum_elem, "ChecksumCRC32")?;
+            let checksum_crc32c = get_field_or_none(&checksum_elem, "ChecksumCRC32C")?;
+            let checksum_sha1 = get_field_or_none(&checksum_elem, "ChecksumSHA1")?;
+            let checksum_sha256 = get_field_or_none(&checksum_elem, "ChecksumSHA256")?;
+
+            checksum = Some(Checksum {
+                checksum_crc32,
+                checksum_crc32c,
+                checksum_sha1,
+                checksum_sha256,
+            })
+        }
+
+        let mut object_parts = None;
+        if let Some(mut object_parts_elem) = element.take_child("ObjectParts") {
+            let is_truncated = get_field(&object_parts_elem, "IsTruncated")?;
+            let max_parts = get_field(&object_parts_elem, "MaxParts")?;
+            let next_part_number_marker = get_field(&object_parts_elem, "NextPartNumberMarker")?;
+            let part_number_marker = get_field(&object_parts_elem, "PartNumberMarker")?;
+            let parts_count = get_field(&object_parts_elem, "PartsCount")?;
+
+            let mut parts = Vec::new();
+            while let Some(part_elem) = object_parts_elem.take_child("Part") {
+                let checksum_crc32 = get_field_or_none(&part_elem, "ChecksumCRC32")?;
+                let checksum_crc32c = get_field_or_none(&part_elem, "ChecksumCRC32C")?;
+                let checksum_sha1 = get_field_or_none(&part_elem, "ChecksumSHA1")?;
+                let checksum_sha256 = get_field_or_none(&part_elem, "ChecksumSHA256")?;
+
+                let part_number = get_field(&part_elem, "PartNumber")?;
+                let size = get_field(&part_elem, "Size")?;
+
+                let part = ObjectPart {
+                    checksum_crc32,
+                    checksum_crc32c,
+                    checksum_sha1,
+                    checksum_sha256,
+                    part_number: part_number.parse().unwrap(),
+                    size: size.parse().unwrap(),
+                };
+                parts.push(part);
+            }
+
+            object_parts = Some(GetObjectAttributesParts {
+                is_truncated: is_truncated.parse().unwrap(),
+                max_parts: max_parts.parse().unwrap(),
+                next_part_number_marker: next_part_number_marker.parse().unwrap(),
+                part_number_marker: part_number_marker.parse().unwrap(),
+                parts,
+                total_parts_count: parts_count.parse().unwrap(),
+            });
+        }
+
+        Ok(Self {
+            etag,
+            checksum,
+            object_parts,
+            storage_class,
+            object_size,
+        })
+    }
+}
+
+impl S3CrtClient {
+    pub async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        object_attributes: Vec<ObjectAttribute>,
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, S3RequestError> {
+        let body = {
+            let mut message = self
+                .new_request_template("GET", bucket)
+                .map_err(S3RequestError::construction_failure)?;
+
+            let query = vec![("attributes", "")];
+
+            let path = format!("/{key}");
+            message
+                .set_request_path_and_query(path, query)
+                .map_err(S3RequestError::construction_failure)?;
+
+            let object_attributes: Vec<String> = object_attributes.iter().map(|attr| attr.to_string()).collect();
+            message
+                .add_header(&Header::new("x-amz-object-attributes", object_attributes.join(",")))
+                .map_err(S3RequestError::construction_failure)?;
+
+            let span = request_span!(self, "get_object_attributes");
+            span.in_scope(|| debug!(?bucket, ?key, "new request"));
+
+            self.make_simple_http_request(message, MetaRequestType::Default, span, |result| {
+                let parsed = parse_get_object_attributes_error(&result);
+                parsed
+                    .map(ObjectClientError::ServiceError)
+                    .unwrap_or(ObjectClientError::ClientError(S3RequestError::ResponseError(result)))
+            })?
+        };
+
+        let body = body.await?;
+
+        GetObjectAttributesResult::parse_from_bytes(&body)
+            .map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(e.into())))
+    }
+}
+
+fn parse_get_object_attributes_error(result: &MetaRequestResult) -> Option<GetObjectAttributesError> {
+    match result.response_status {
+        404 => Some(GetObjectAttributesError::NotFound),
+        _ => None,
+    }
+}
+
+/// Copy text out of an XML element, with the right error type.
+fn get_text(element: &xmltree::Element) -> Result<String, ParseError> {
+    Ok(element
+        .get_text()
+        .ok_or_else(|| ParseError::InvalidResponse(element.clone(), "field has no text".to_string()))?
+        .to_string())
+}
+
+/// Wrapper to get child with some name out of an XML element, with the right error type.
+fn get_child<'a>(element: &'a xmltree::Element, name: &str) -> Result<&'a xmltree::Element, ParseError> {
+    element
+        .get_child(name)
+        .ok_or_else(|| ParseError::MissingField(element.clone(), name.to_string()))
+}
+
+/// Get the text out of a child node, with the right error type.
+fn get_field(element: &xmltree::Element, name: &str) -> Result<String, ParseError> {
+    get_text(get_child(element, name)?)
+}
+
+/// Get the value out of a child node, return [None] if the child node is missing.
+fn get_field_or_none<T>(element: &xmltree::Element, name: &str) -> Result<Option<T>, ParseError>
+where
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Debug,
+{
+    match get_field(element, name) {
+        Ok(str) => match str.parse::<T>() {
+            Ok(value) => Ok(Some(value)),
+            Err(_) => Err(ParseError::FromStr(name.to_string())),
+        },
+        Err(ParseError::MissingField(_, _)) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+
+    fn make_result(response_status: i32, body: impl Into<OsString>) -> MetaRequestResult {
+        MetaRequestResult {
+            response_status,
+            crt_error: 1i32.into(),
+            error_response_headers: None,
+            error_response_body: Some(body.into()),
+        }
+    }
+
+    #[test]
+    fn parse_404_object_not_found() {
+        let result = make_result(404, "");
+        let result = parse_get_object_attributes_error(&result);
+        assert_eq!(result, Some(GetObjectAttributesError::NotFound));
+    }
+
+    #[test]
+    fn parse_403() {
+        let result = make_result(403, "");
+        let result = parse_get_object_attributes_error(&result);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_string() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><GetObjectAttributesResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>fc3ff98e8c6a0d3087d515c0473f8677</ETag><IsTruncated>false</IsTruncated><ObjectSize>1024</ObjectSize></GetObjectAttributesResponse>"#;
+        let result: Result<Option<String>, ParseError> =
+            get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "ETag");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some("fc3ff98e8c6a0d3087d515c0473f8677".to_owned()));
+    }
+
+    #[test]
+    fn get_boolean() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><GetObjectAttributesResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>fc3ff98e8c6a0d3087d515c0473f8677</ETag><IsTruncated>false</IsTruncated><ObjectSize>1024</ObjectSize></GetObjectAttributesResponse>"#;
+        let result: Result<Option<bool>, ParseError> =
+            get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "IsTruncated");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(false));
+    }
+
+    #[test]
+    fn get_integer() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><GetObjectAttributesResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>fc3ff98e8c6a0d3087d515c0473f8677</ETag><IsTruncated>false</IsTruncated><ObjectSize>1024</ObjectSize></GetObjectAttributesResponse>"#;
+        let result: Result<Option<usize>, ParseError> =
+            get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "ObjectSize");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(1024));
+    }
+
+    #[test]
+    fn get_none() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><GetObjectAttributesResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>fc3ff98e8c6a0d3087d515c0473f8677</ETag><IsTruncated>false</IsTruncated><ObjectSize>1024</ObjectSize></GetObjectAttributesResponse>"#;
+        let result: Result<Option<usize>, ParseError> =
+            get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "PartNumber");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn get_parse_error() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><GetObjectAttributesResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>fc3ff98e8c6a0d3087d515c0473f8677</ETag><IsTruncated>false</IsTruncated><ObjectSize>1024</ObjectSize></GetObjectAttributesResponse>"#;
+        let result: Result<Option<usize>, ParseError> =
+            get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "IsTruncated");
+
+        assert!(result.is_err());
+    }
+}

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -246,7 +246,7 @@ mod tests {
         let result: bool = get_field_or_none(&xmltree::Element::parse(&body[..]).unwrap(), "IsTruncated")
             .unwrap()
             .unwrap();
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]

--- a/mountpoint-s3-client/tests/get_object_attributes.rs
+++ b/mountpoint-s3-client/tests/get_object_attributes.rs
@@ -3,11 +3,91 @@
 pub mod common;
 
 use aws_sdk_s3::model::{ChecksumAlgorithm, CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::output::CompleteMultipartUploadOutput;
 use aws_sdk_s3::types::ByteStream;
 use bytes::Bytes;
 use common::*;
 use mountpoint_s3_client::{GetObjectAttributesError, ObjectAttribute, ObjectClientError, S3CrtClient, S3RequestError};
 use test_case::test_case;
+
+async fn create_mpu_object(
+    bucket: &String,
+    key: &String,
+    parts_size: &Vec<usize>,
+    checksum_algorithm: Option<ChecksumAlgorithm>,
+) -> (Vec<CompletedPart>, CompleteMultipartUploadOutput) {
+    let sdk_client = get_test_sdk_client().await;
+
+    let mut create_mpu = sdk_client.create_multipart_upload().bucket(bucket).key(key);
+    if let Some(algorithm) = &checksum_algorithm {
+        create_mpu = create_mpu.checksum_algorithm(algorithm.to_owned());
+    }
+
+    let create_mpu_output = create_mpu.send().await.unwrap();
+    let upload_id = create_mpu_output.upload_id().unwrap();
+
+    let mut completed_parts: Vec<CompletedPart> = Vec::new();
+
+    for (part_index, part_size) in parts_size.iter().enumerate() {
+        let part_body = vec![0; part_size.to_owned()];
+        let part_num = (part_index + 1) as i32;
+
+        let mut upload_part = sdk_client
+            .upload_part()
+            .bucket(bucket)
+            .key(key)
+            .part_number(part_num)
+            .upload_id(upload_id)
+            .body(ByteStream::from(part_body.to_vec()));
+        if let Some(algorithm) = &checksum_algorithm {
+            upload_part = upload_part.checksum_algorithm(algorithm.to_owned());
+        }
+
+        let upload_part_output = upload_part.send().await.unwrap();
+
+        let mut completed_part_builder = CompletedPart::builder()
+            .e_tag(upload_part_output.e_tag.as_ref().unwrap())
+            .part_number(part_num);
+        if let Some(algorithm) = &checksum_algorithm {
+            match algorithm {
+                ChecksumAlgorithm::Crc32 => {
+                    completed_part_builder =
+                        completed_part_builder.checksum_crc32(upload_part_output.checksum_crc32().unwrap())
+                }
+                ChecksumAlgorithm::Crc32C => {
+                    completed_part_builder =
+                        completed_part_builder.checksum_crc32_c(upload_part_output.checksum_crc32_c().unwrap())
+                }
+                ChecksumAlgorithm::Sha1 => {
+                    completed_part_builder =
+                        completed_part_builder.checksum_sha1(upload_part_output.checksum_sha1().unwrap())
+                }
+                ChecksumAlgorithm::Sha256 => {
+                    completed_part_builder =
+                        completed_part_builder.checksum_sha256(upload_part_output.checksum_sha256().unwrap())
+                }
+                _ => unimplemented!("This algorithm is not supported"),
+            }
+        }
+        completed_parts.push(completed_part_builder.build());
+    }
+
+    let completed_mpu = CompletedMultipartUpload::builder()
+        .set_parts(Some(completed_parts.clone()))
+        .build();
+
+    let complete_mpu_output = sdk_client
+        .complete_multipart_upload()
+        .bucket(bucket)
+        .key(key)
+        .upload_id(upload_id)
+        .multipart_upload(completed_mpu)
+        .send()
+        .await
+        .unwrap();
+
+    (completed_parts, complete_mpu_output)
+}
 
 async fn test_with_checksum(checksum_algorithm: ChecksumAlgorithm) {
     let sdk_client = get_test_sdk_client().await;
@@ -17,7 +97,7 @@ async fn test_with_checksum(checksum_algorithm: ChecksumAlgorithm) {
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
 
-    sdk_client
+    let put_object_output = sdk_client
         .put_object()
         .bucket(&bucket)
         .key(&key)
@@ -39,18 +119,30 @@ async fn test_with_checksum(checksum_algorithm: ChecksumAlgorithm) {
 
     let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
 
-    assert!(result.is_ok());
-
     let result = result.unwrap();
-    assert!(result.etag.is_some());
+    assert_eq!(
+        result.etag,
+        put_object_output.e_tag().map(|s| s.trim_matches('"').to_string())
+    );
 
-    assert!(result.checksum.is_some());
     let checksum = result.checksum.unwrap();
     match checksum_algorithm {
-        ChecksumAlgorithm::Crc32 => assert!(checksum.checksum_crc32.is_some()),
-        ChecksumAlgorithm::Crc32C => assert!(checksum.checksum_crc32c.is_some()),
-        ChecksumAlgorithm::Sha1 => assert!(checksum.checksum_sha1.is_some()),
-        ChecksumAlgorithm::Sha256 => assert!(checksum.checksum_sha256.is_some()),
+        ChecksumAlgorithm::Crc32 => assert_eq!(
+            checksum.checksum_crc32,
+            put_object_output.checksum_crc32().map(|s| s.to_string())
+        ),
+        ChecksumAlgorithm::Crc32C => assert_eq!(
+            checksum.checksum_crc32c,
+            put_object_output.checksum_crc32_c().map(|s| s.to_string())
+        ),
+        ChecksumAlgorithm::Sha1 => assert_eq!(
+            checksum.checksum_sha1,
+            put_object_output.checksum_sha1().map(|s| s.to_string())
+        ),
+        ChecksumAlgorithm::Sha256 => assert_eq!(
+            checksum.checksum_sha256,
+            put_object_output.checksum_sha256().map(|s| s.to_string())
+        ),
         _ => unimplemented!("This algorithm is not supported"),
     }
 
@@ -67,7 +159,7 @@ async fn test_get_attributes() {
     // Create one object named "hello"
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
-    sdk_client
+    let put_object_output = sdk_client
         .put_object()
         .bucket(&bucket)
         .key(&key)
@@ -88,10 +180,11 @@ async fn test_get_attributes() {
 
     let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
 
-    assert!(result.is_ok());
-
     let result = result.unwrap();
-    assert!(result.etag.is_some());
+    assert_eq!(
+        result.etag,
+        put_object_output.e_tag().map(|s| s.trim_matches('"').to_string())
+    );
     assert!(result.checksum.is_none());
     assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
     assert_eq!(result.object_size, Some(body.len() as u64));
@@ -103,7 +196,7 @@ async fn test_get_attributes() {
 #[test_case(ChecksumAlgorithm::Sha1; "Checksum SHA1")]
 #[test_case(ChecksumAlgorithm::Sha256; "Checksum SHA256")]
 #[tokio::test]
-async fn test_get_attributes_checksum(checksum_algorithm: ChecksumAlgorithm) {
+async fn test_get_attributes_with_checksum(checksum_algorithm: ChecksumAlgorithm) {
     test_with_checksum(checksum_algorithm).await;
 }
 
@@ -131,8 +224,6 @@ async fn test_get_attributes_all_none() {
 
     let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
 
-    assert!(result.is_ok());
-
     let result = result.unwrap();
     assert!(result.etag.is_none());
     assert!(result.checksum.is_none());
@@ -143,78 +234,14 @@ async fn test_get_attributes_all_none() {
 
 #[tokio::test]
 async fn test_get_attributes_mpu() {
-    let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_mpu");
 
     // Create one object named "hello"
     let key = format!("{prefix}/hello");
+    let parts_size: Vec<usize> = vec![5 * 1024 * 1024, 1024];
+    let object_size = parts_size.iter().sum::<usize>() as u64;
 
-    let create_mpu_output = sdk_client
-        .create_multipart_upload()
-        .bucket(&bucket)
-        .key(&key)
-        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
-        .send()
-        .await
-        .unwrap();
-    let upload_id = create_mpu_output.upload_id().unwrap();
-
-    let mut completed_parts: Vec<CompletedPart> = Vec::new();
-    let five_mib_body = vec![0; 5 * 1024 * 1024];
-    let one_mib_body = vec![0; 1024 * 1024];
-    let object_size = (five_mib_body.len() + one_mib_body.len()) as u64;
-
-    let upload_part_output1 = sdk_client
-        .upload_part()
-        .bucket(&bucket)
-        .key(&key)
-        .part_number(1)
-        .upload_id(upload_id)
-        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
-        .body(ByteStream::from(five_mib_body.to_vec()))
-        .send()
-        .await
-        .unwrap();
-    completed_parts.push(
-        CompletedPart::builder()
-            .e_tag(upload_part_output1.e_tag.as_ref().unwrap())
-            .checksum_crc32_c(upload_part_output1.checksum_crc32_c().unwrap())
-            .part_number(1)
-            .build(),
-    );
-
-    let upload_part_output2 = sdk_client
-        .upload_part()
-        .bucket(&bucket)
-        .key(&key)
-        .part_number(2)
-        .upload_id(upload_id)
-        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
-        .body(ByteStream::from(one_mib_body.to_vec()))
-        .send()
-        .await
-        .unwrap();
-    completed_parts.push(
-        CompletedPart::builder()
-            .e_tag(upload_part_output2.e_tag.as_ref().unwrap())
-            .checksum_crc32_c(upload_part_output2.checksum_crc32_c().unwrap())
-            .part_number(2)
-            .build(),
-    );
-
-    let completed_mpu = CompletedMultipartUpload::builder()
-        .set_parts(Some(completed_parts))
-        .build();
-
-    sdk_client
-        .complete_multipart_upload()
-        .bucket(&bucket)
-        .key(&key)
-        .upload_id(upload_id)
-        .multipart_upload(completed_mpu)
-        .send()
-        .await
-        .unwrap();
+    let (_completed_parts, complete_mpu_output) = create_mpu_object(&bucket, &key, &parts_size, None).await;
 
     let client: S3CrtClient = get_test_client();
 
@@ -228,39 +255,94 @@ async fn test_get_attributes_mpu() {
 
     let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
 
-    assert!(result.is_ok());
-
     let result = result.unwrap();
-    assert!(result.etag.is_some());
+    assert_eq!(
+        result.etag,
+        complete_mpu_output.e_tag().map(|s| s.trim_matches('"').to_string())
+    );
     assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
     assert_eq!(result.object_size, Some(object_size));
 
-    assert!(result.checksum.is_some());
-    let checksum = result.checksum.unwrap();
-    assert!(checksum.checksum_crc32c.is_some());
+    assert!(result.checksum.is_none());
 
-    assert!(result.object_parts.is_some());
+    // object_parts is returned only if the object is using additional checksums.
     let object_parts = result.object_parts.unwrap();
-    assert!(!object_parts.is_truncated);
-    assert!(object_parts.max_parts > 0);
-    assert_eq!(object_parts.part_number_marker, 0);
-    assert_eq!(object_parts.next_part_number_marker, 2);
-    assert_eq!(object_parts.total_parts_count, 2);
-    assert_eq!(object_parts.parts.len(), 2);
-
-    let part1 = &object_parts.parts[0];
-    assert!(part1.checksum_crc32c.is_some());
-    assert_eq!(part1.part_number, 1);
-    assert_eq!(part1.size, five_mib_body.len());
-
-    let part2 = &object_parts.parts[1];
-    assert!(part2.checksum_crc32c.is_some());
-    assert_eq!(part2.part_number, 2);
-    assert_eq!(part2.size, one_mib_body.len());
+    assert_eq!(object_parts.total_parts_count.unwrap(), 2);
+    assert!(object_parts.is_truncated.is_none());
+    assert!(object_parts.max_parts.is_none());
+    assert!(object_parts.next_part_number_marker.is_none());
+    assert!(object_parts.part_number_marker.is_none());
+    assert!(object_parts.parts.is_none());
 }
 
 #[tokio::test]
-async fn test_get_attributes_404() {
+async fn test_get_attributes_mpu_with_checksum() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_mpu_with_checksum");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let parts_size: Vec<usize> = vec![5 * 1024 * 1024, 1024];
+    let object_size = parts_size.iter().sum::<usize>() as u64;
+
+    let (completed_parts, complete_mpu_output) =
+        create_mpu_object(&bucket, &key, &parts_size, Some(ChecksumAlgorithm::Crc32C)).await;
+
+    let client: S3CrtClient = get_test_client();
+
+    let object_attributes = vec![
+        ObjectAttribute::ETag,
+        ObjectAttribute::Checksum,
+        ObjectAttribute::ObjectParts,
+        ObjectAttribute::StorageClass,
+        ObjectAttribute::ObjectSize,
+    ];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    let result = result.unwrap();
+    assert_eq!(
+        result.etag,
+        complete_mpu_output.e_tag().map(|s| s.trim_matches('"').to_string())
+    );
+    assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
+    assert_eq!(result.object_size, Some(object_size));
+
+    let checksum = result.checksum.unwrap();
+    assert_eq!(
+        checksum
+            .checksum_crc32c
+            .map(|s| format!("{}-{}", s, completed_parts.len())),
+        complete_mpu_output.checksum_crc32_c().map(|s| s.to_string())
+    );
+
+    let object_parts = result.object_parts.unwrap();
+    assert!(!object_parts.is_truncated.unwrap());
+    assert!(object_parts.max_parts.unwrap() > 0);
+    assert_eq!(object_parts.part_number_marker.unwrap(), 0);
+    assert_eq!(object_parts.next_part_number_marker.unwrap(), 2);
+    assert_eq!(object_parts.total_parts_count.unwrap(), 2);
+    assert_eq!(object_parts.parts.as_ref().unwrap().len(), 2);
+
+    let parts = object_parts.parts.unwrap();
+    let part1 = &parts[0];
+    assert_eq!(
+        &part1.checksum.as_ref().unwrap().checksum_crc32c,
+        &completed_parts[0].checksum_crc32_c().map(|s| s.to_string())
+    );
+    assert_eq!(part1.part_number, 1);
+    assert_eq!(part1.size, parts_size[0]);
+
+    let part2 = &parts[1];
+    assert_eq!(
+        &part2.checksum.as_ref().unwrap().checksum_crc32c,
+        &completed_parts[1].checksum_crc32_c().map(|s| s.to_string())
+    );
+    assert_eq!(part2.part_number, 2);
+    assert_eq!(part2.size, parts_size[1]);
+}
+
+#[tokio::test]
+async fn test_get_attributes_404_key() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_404");
 
     let key = format!("{prefix}/nonexistent_key");
@@ -271,7 +353,25 @@ async fn test_get_attributes_404() {
     let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
     assert!(matches!(
         result,
-        Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound))
+        Err(ObjectClientError::ServiceError(GetObjectAttributesError::NoSuchKey))
+    ));
+}
+
+#[tokio::test]
+async fn test_get_attributes_404_bucket() {
+    let (_bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_404");
+
+    let key = format!("{prefix}/nonexistent_key");
+
+    let client: S3CrtClient = get_test_client();
+    let object_attributes = vec![ObjectAttribute::ETag];
+
+    let result = client
+        .get_object_attributes("nonexistent_bucket", &key, object_attributes)
+        .await;
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ServiceError(GetObjectAttributesError::NoSuchBucket))
     ));
 }
 

--- a/mountpoint-s3-client/tests/get_object_attributes.rs
+++ b/mountpoint-s3-client/tests/get_object_attributes.rs
@@ -1,0 +1,295 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use aws_sdk_s3::model::{ChecksumAlgorithm, CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::types::ByteStream;
+use bytes::Bytes;
+use common::*;
+use mountpoint_s3_client::{GetObjectAttributesError, ObjectAttribute, ObjectClientError, S3CrtClient, S3RequestError};
+use test_case::test_case;
+
+async fn test_with_checksum(checksum_algorithm: ChecksumAlgorithm) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_checksum");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .checksum_algorithm(checksum_algorithm.clone())
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let object_attributes = vec![
+        ObjectAttribute::ETag,
+        ObjectAttribute::Checksum,
+        ObjectAttribute::ObjectParts,
+        ObjectAttribute::StorageClass,
+        ObjectAttribute::ObjectSize,
+    ];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+    assert!(result.etag.is_some());
+
+    assert!(result.checksum.is_some());
+    let checksum = result.checksum.unwrap();
+    match checksum_algorithm {
+        ChecksumAlgorithm::Crc32 => assert!(checksum.checksum_crc32.is_some()),
+        ChecksumAlgorithm::Crc32C => assert!(checksum.checksum_crc32c.is_some()),
+        ChecksumAlgorithm::Sha1 => assert!(checksum.checksum_sha1.is_some()),
+        ChecksumAlgorithm::Sha256 => assert!(checksum.checksum_sha256.is_some()),
+        _ => unimplemented!("This algorithm is not supported"),
+    }
+
+    assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
+    assert_eq!(result.object_size, Some(body.len() as u64));
+    assert!(result.object_parts.is_none());
+}
+
+#[tokio::test]
+async fn test_get_attributes() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let object_attributes = vec![
+        ObjectAttribute::ETag,
+        ObjectAttribute::Checksum,
+        ObjectAttribute::ObjectParts,
+        ObjectAttribute::StorageClass,
+        ObjectAttribute::ObjectSize,
+    ];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+    assert!(result.etag.is_some());
+    assert!(result.checksum.is_none());
+    assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
+    assert_eq!(result.object_size, Some(body.len() as u64));
+    assert!(result.object_parts.is_none());
+}
+
+#[test_case(ChecksumAlgorithm::Crc32; "Checksum CRC32")]
+#[test_case(ChecksumAlgorithm::Crc32C; "Checksum CRC32C")]
+#[test_case(ChecksumAlgorithm::Sha1; "Checksum SHA1")]
+#[test_case(ChecksumAlgorithm::Sha256; "Checksum SHA256")]
+#[tokio::test]
+async fn test_get_attributes_checksum(checksum_algorithm: ChecksumAlgorithm) {
+    test_with_checksum(checksum_algorithm).await;
+}
+
+#[tokio::test]
+async fn test_get_attributes_all_none() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_all_none");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let object_attributes = vec![ObjectAttribute::ObjectParts];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+    assert!(result.etag.is_none());
+    assert!(result.checksum.is_none());
+    assert!(result.object_parts.is_none());
+    assert!(result.storage_class.is_none());
+    assert!(result.object_size.is_none());
+}
+
+#[tokio::test]
+async fn test_get_attributes_mpu() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_mpu");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+
+    let create_mpu_output = sdk_client
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(&key)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create_mpu_output.upload_id().unwrap();
+
+    let mut completed_parts: Vec<CompletedPart> = Vec::new();
+    let five_mib_body = vec![0; 5 * 1024 * 1024];
+    let one_mib_body = vec![0; 1024 * 1024];
+    let object_size = (five_mib_body.len() + one_mib_body.len()) as u64;
+
+    let upload_part_output1 = sdk_client
+        .upload_part()
+        .bucket(&bucket)
+        .key(&key)
+        .part_number(1)
+        .upload_id(upload_id)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+        .body(ByteStream::from(five_mib_body.to_vec()))
+        .send()
+        .await
+        .unwrap();
+    completed_parts.push(
+        CompletedPart::builder()
+            .e_tag(upload_part_output1.e_tag.as_ref().unwrap())
+            .checksum_crc32_c(upload_part_output1.checksum_crc32_c().unwrap())
+            .part_number(1)
+            .build(),
+    );
+
+    let upload_part_output2 = sdk_client
+        .upload_part()
+        .bucket(&bucket)
+        .key(&key)
+        .part_number(2)
+        .upload_id(upload_id)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+        .body(ByteStream::from(one_mib_body.to_vec()))
+        .send()
+        .await
+        .unwrap();
+    completed_parts.push(
+        CompletedPart::builder()
+            .e_tag(upload_part_output2.e_tag.as_ref().unwrap())
+            .checksum_crc32_c(upload_part_output2.checksum_crc32_c().unwrap())
+            .part_number(2)
+            .build(),
+    );
+
+    let completed_mpu = CompletedMultipartUpload::builder()
+        .set_parts(Some(completed_parts))
+        .build();
+
+    sdk_client
+        .complete_multipart_upload()
+        .bucket(&bucket)
+        .key(&key)
+        .upload_id(upload_id)
+        .multipart_upload(completed_mpu)
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let object_attributes = vec![
+        ObjectAttribute::ETag,
+        ObjectAttribute::Checksum,
+        ObjectAttribute::ObjectParts,
+        ObjectAttribute::StorageClass,
+        ObjectAttribute::ObjectSize,
+    ];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+    assert!(result.etag.is_some());
+    assert_eq!(result.storage_class, Some("STANDARD".to_owned()));
+    assert_eq!(result.object_size, Some(object_size));
+
+    assert!(result.checksum.is_some());
+    let checksum = result.checksum.unwrap();
+    assert!(checksum.checksum_crc32c.is_some());
+
+    assert!(result.object_parts.is_some());
+    let object_parts = result.object_parts.unwrap();
+    assert!(!object_parts.is_truncated);
+    assert!(object_parts.max_parts > 0);
+    assert_eq!(object_parts.part_number_marker, 0);
+    assert_eq!(object_parts.next_part_number_marker, 2);
+    assert_eq!(object_parts.total_parts_count, 2);
+    assert_eq!(object_parts.parts.len(), 2);
+
+    let part1 = &object_parts.parts[0];
+    assert!(part1.checksum_crc32c.is_some());
+    assert_eq!(part1.part_number, 1);
+    assert_eq!(part1.size, five_mib_body.len());
+
+    let part2 = &object_parts.parts[1];
+    assert!(part2.checksum_crc32c.is_some());
+    assert_eq!(part2.part_number, 2);
+    assert_eq!(part2.size, one_mib_body.len());
+}
+
+#[tokio::test]
+async fn test_get_attributes_404() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_404");
+
+    let key = format!("{prefix}/nonexistent_key");
+
+    let client: S3CrtClient = get_test_client();
+    let object_attributes = vec![ObjectAttribute::ETag];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ServiceError(GetObjectAttributesError::NotFound))
+    ));
+}
+
+#[tokio::test]
+async fn test_get_attributes_no_perm() {
+    let (_bucket, prefix) = get_test_bucket_and_prefix("test_get_attributes_no_perm");
+    let bucket = get_test_bucket_without_permissions();
+
+    let key = format!("{prefix}/some_key");
+
+    let client: S3CrtClient = get_test_client();
+    let object_attributes = vec![ObjectAttribute::ETag];
+
+    let result = client.get_object_attributes(&bucket, &key, object_attributes).await;
+
+    if let Err(ObjectClientError::ClientError(S3RequestError::ResponseError(err))) = &result {
+        assert!(err.response_status == 403);
+    } else {
+        panic!("Unexpected result, expected a ResponseError with 403 if there's no permission");
+    }
+}

--- a/mountpoint-s3-client/tests/get_object_attributes.rs
+++ b/mountpoint-s3-client/tests/get_object_attributes.rs
@@ -13,7 +13,7 @@ use test_case::test_case;
 async fn create_mpu_object(
     bucket: &String,
     key: &String,
-    parts_size: &Vec<usize>,
+    parts_size: &[usize],
     checksum_algorithm: Option<ChecksumAlgorithm>,
 ) -> (Vec<CompletedPart>, CompleteMultipartUploadOutput) {
     let sdk_client = get_test_sdk_client().await;


### PR DESCRIPTION
This PR implement [GetObjectAttributes](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributes.html) for our S3CrtClient.

I leave the failure client unimplemented for now since some other operations are also not implemented, so I think we might want to refactor the failure client and implement them in another PR.

Closes https://github.com/awslabs/mountpoint-s3/issues/115.

---

By submitting this pull request,
I confirm that my contribution is made under the terms of the Apache 2.0 license
and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
