### PR TITLE
Use proper events to trigger benchmark CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,10 +3,8 @@ name: Benchmark
 on:
   push:
     branches: [ "main" ]
-  pull_request_target:
-    types: [labeled]
   pull_request:
-    types: [synchronize]
+    types: [labeled, opened, reopened, synchronize]
 
 env:
   # RUSTFLAGS: -Dwarnings
@@ -80,6 +78,6 @@ jobs:
         fail-on-alert: true
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Store the results and deploy GitHub pages automatically if the results are from main brancn
+        # Store the results and deploy GitHub pages automatically if the results are from main branch
         auto-push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && 'true' || 'false' }}
         comment-on-alert: true


### PR DESCRIPTION
The benchmark CI is now listen to `labeled` activity from `pull_request` event so that the workflow will always be running against new code. We can also add a label before opening a pull request, so we should listen to `opened` and `reopened` too.

Closes https://github.com/awslabs/mountpoint-s3/issues/137.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
