### PR TITLE
Correct default modes for files and directories

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -89,7 +89,7 @@ Synchronization operations (`fsync`) on directories are not supported.
 ### File and directory metadata and permissions
 
 Reading file metadata (`stat`, `fstatat`) is supported, but with some limitations:
-* File mode will be a default value (`0755` for files, `0644` for directories) unless you manually configure them with the `--file-mode` and `--dir-mode` command-line arguments.
+* File mode will be a default value (`0644` for files, `0755` for directories) unless you manually configure them with the `--file-mode` and `--dir-mode` command-line arguments.
 * File owner and group will default to the user/group that mounted the bucket unless you manually configure them with the `--uid` and `--gid` command-line arguments.
 * Last access time and last status change time will be the same as the last modified time.
 * Inode numbers are not stable and can change.

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -115,3 +115,4 @@ Mountpoint for Amazon S3 does not currently make any guarantees about the effect
 When Mountpoint for Amazon S3 detects that an object has been mutated in S3 while being read by the file client, it will cause future reads to the same file descriptor to return `EIO`. To read the new contents of the object, re-open the file.
 
 We have not yet [nailed down the exact semantics](https://github.com/awslabs/mountpoint-s3/issues/128) of concurrent mutations that affect the directory hierarchy (like creating a `foo/` key when `foo` already exists).
+


### PR DESCRIPTION
Files are not by default executable, directories are as per https://github.com/awslabs/mountpoint-s3/blob/b8363a4550b17e60c32d9e72968a61487279bf67/mountpoint-s3/src/fs.rs#L85



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
