### PR TITLE
Align GETs to multi-part object boundaries

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -9,7 +9,7 @@ use fuser::{FileAttr, KernelConfig};
 use mountpoint_s3_client::{ObjectClient, PutObjectParams};
 
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock};
-use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher};
+use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use crate::sync::{Arc, AsyncMutex, AsyncRwLock};
 
@@ -67,6 +67,8 @@ pub struct S3FilesystemConfig {
     pub dir_mode: u16,
     /// File permissions
     pub file_mode: u16,
+    /// Prefetcher configuration
+    pub prefetcher_config: PrefetcherConfig,
 }
 
 impl Default for S3FilesystemConfig {
@@ -84,6 +86,7 @@ impl Default for S3FilesystemConfig {
             gid,
             dir_mode: 0o755,
             file_mode: 0o644,
+            prefetcher_config: PrefetcherConfig::default(),
         }
     }
 }
@@ -118,7 +121,7 @@ where
 
         let client = Arc::new(client);
 
-        let prefetcher = Prefetcher::new(client.clone(), runtime, Default::default());
+        let prefetcher = Prefetcher::new(client.clone(), runtime, config.prefetcher_config);
 
         Self {
             config,

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -311,6 +311,9 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     if let Some(file_mode) = args.file_mode {
         filesystem_config.file_mode = file_mode;
     }
+    if let Some(part_size) = args.part_size {
+        filesystem_config.prefetcher_config.part_alignment = part_size as usize;
+    }
 
     let fs = S3FuseFilesystem::new(
         client,

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -39,6 +39,8 @@ pub struct PrefetcherConfig {
     pub sequential_prefetch_multiplier: usize,
     /// Timeout to wait for a part to become available
     pub read_timeout: Duration,
+    /// The size of the parts that GetObject will respond with
+    pub part_size: usize,
 }
 
 impl Default for PrefetcherConfig {
@@ -48,6 +50,7 @@ impl Default for PrefetcherConfig {
             max_request_size: 2 * 1024 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             read_timeout: Duration::from_secs(60),
+            part_size: 8 * 1024 * 1024,
         }
     }
 }
@@ -285,14 +288,50 @@ where
 
         // [read] will reset these if the reader stops making sequential requests
         self.next_request_offset += size;
-        self.next_request_size = (self.next_request_size * self.inner.config.sequential_prefetch_multiplier)
-            .min(self.inner.config.max_request_size);
+        self.next_request_size = Self::get_next_request_size(
+            self.next_request_offset,
+            self.next_request_size,
+            self.inner.config.sequential_prefetch_multiplier,
+            self.inner.config.max_request_size,
+            self.inner.config.part_size,
+        );
 
         Some(RequestTask {
             total_size: size as usize,
             remaining: size as usize,
             part_queue,
         })
+    }
+
+    /// Suggest next request size.
+    /// Normally, next request size is current request size multiply by sequential prefetch multiplier,
+    /// but if the request size is getting bigger than a part size we will try to align it to part boundaries.
+    fn get_next_request_size(
+        next_request_offset: u64,
+        current_request_size: usize,
+        multiplier: usize,
+        max_request_size: usize,
+        part_size: usize,
+    ) -> usize {
+        // calculate next request size
+        let next_request_size = (current_request_size * multiplier).min(max_request_size);
+
+        let offset_in_part = (next_request_offset % part_size as u64) as usize;
+        // if the offset is not at the start of the part we will drain all the bytes from that part first
+        if offset_in_part != 0 {
+            let remaining_in_part = part_size - offset_in_part;
+            return next_request_size.min(remaining_in_part);
+        }
+
+        // if the next request size is smaller than the part size, just return that value
+        if next_request_size < part_size {
+            return next_request_size;
+        }
+
+        // if it exceeds part boundaries, trim it to the part boundaries
+        let next_request_boundary = next_request_offset + next_request_size as u64;
+        let remainder = (next_request_boundary % part_size as u64) as usize;
+        next_request_size - remainder
     }
 }
 
@@ -332,6 +371,10 @@ mod tests {
     use proptest::strategy::{Just, Strategy};
     use proptest_derive::Arbitrary;
     use std::collections::HashMap;
+    use test_case::test_case;
+
+    const KB: usize = 1024;
+    const MB: usize = 1024 * 1024;
 
     #[derive(Debug, Arbitrary)]
     struct TestConfig {
@@ -359,6 +402,7 @@ mod tests {
             max_request_size: test_config.max_request_size,
             sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
             read_timeout: Duration::from_secs(5),
+            part_size: test_config.client_part_size,
         };
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
@@ -472,6 +516,31 @@ mod tests {
         );
 
         fail_sequential_read_test(1024 * 1024 + 111, 1024 * 1024, config, get_failures);
+    }
+
+    #[test_case(256 * KB, 256 * KB, 8, 100 * MB, 8 * MB, 2 * MB; "next request size is smaller than part size")]
+    #[test_case(7 * MB, 256 * KB, 8, 100 * MB, 8 * MB, 1 * MB; "next request size is remaining bytes in the part")]
+    #[test_case(9 * MB, (2 * MB) + 11, 11, 100 * MB, 9 * MB, 18 * MB; "next request size is trimmed to part boundaries")]
+    #[test_case(8 * MB, 2 * MB, 8, 100 * MB, 8 * MB, 16 * MB; "next request size is multiple of the part size")]
+    #[test_case(8 * MB, 2 * MB, 100, 20 * MB, 8 * MB, 16 * MB; "max request size is trimmed to part boundaries")]
+    #[test_case(8 * MB, 2 * MB, 100, 24 * MB, 8 * MB, 24 * MB; "max request size is multiple of the part size")]
+    #[test_case(8 * MB, 2 * MB, 8, 3 * MB, 8 * MB, 3 * MB; "max request size is less than part size")]
+    fn test_get_next_request_size(
+        next_request_offset: usize,
+        current_request_size: usize,
+        prefetch_multiplier: usize,
+        max_request_size: usize,
+        part_size: usize,
+        expected_size: usize,
+    ) {
+        let next_request_size = PrefetchGetObject::<MockClient, ThreadPool>::get_next_request_size(
+            next_request_offset as u64,
+            current_request_size,
+            prefetch_multiplier,
+            max_request_size,
+            part_size,
+        );
+        assert_eq!(next_request_size, expected_size);
     }
 
     proptest! {

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -39,8 +39,8 @@ pub struct PrefetcherConfig {
     pub sequential_prefetch_multiplier: usize,
     /// Timeout to wait for a part to become available
     pub read_timeout: Duration,
-    /// The size of the parts that GetObject will respond with
-    pub part_size: usize,
+    /// The size of the parts that the prefetcher is trying to align with
+    pub part_alignment: usize,
 }
 
 impl Default for PrefetcherConfig {
@@ -50,7 +50,7 @@ impl Default for PrefetcherConfig {
             max_request_size: 2 * 1024 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             read_timeout: Duration::from_secs(60),
-            part_size: 8 * 1024 * 1024,
+            part_alignment: 8 * 1024 * 1024,
         }
     }
 }
@@ -288,13 +288,7 @@ where
 
         // [read] will reset these if the reader stops making sequential requests
         self.next_request_offset += size;
-        self.next_request_size = Self::get_next_request_size(
-            self.next_request_offset,
-            self.next_request_size,
-            self.inner.config.sequential_prefetch_multiplier,
-            self.inner.config.max_request_size,
-            self.inner.config.part_size,
-        );
+        self.next_request_size = self.get_next_request_size();
 
         Some(RequestTask {
             total_size: size as usize,
@@ -306,32 +300,27 @@ where
     /// Suggest next request size.
     /// Normally, next request size is current request size multiply by sequential prefetch multiplier,
     /// but if the request size is getting bigger than a part size we will try to align it to part boundaries.
-    fn get_next_request_size(
-        next_request_offset: u64,
-        current_request_size: usize,
-        multiplier: usize,
-        max_request_size: usize,
-        part_size: usize,
-    ) -> usize {
+    fn get_next_request_size(&self) -> usize {
         // calculate next request size
-        let next_request_size = (current_request_size * multiplier).min(max_request_size);
+        let next_request_size = (self.next_request_size * self.inner.config.sequential_prefetch_multiplier)
+            .min(self.inner.config.max_request_size);
 
-        let offset_in_part = (next_request_offset % part_size as u64) as usize;
+        let offset_in_part = (self.next_request_offset % self.inner.config.part_alignment as u64) as usize;
         // if the offset is not at the start of the part we will drain all the bytes from that part first
         if offset_in_part != 0 {
-            let remaining_in_part = part_size - offset_in_part;
-            return next_request_size.min(remaining_in_part);
-        }
+            let remaining_in_part = self.inner.config.part_alignment - offset_in_part;
+            next_request_size.min(remaining_in_part)
+        } else {
+            // if the next request size is smaller than the part size, just return that value
+            if next_request_size < self.inner.config.part_alignment {
+                return next_request_size;
+            }
 
-        // if the next request size is smaller than the part size, just return that value
-        if next_request_size < part_size {
-            return next_request_size;
+            // if it exceeds part boundaries, trim it to the part boundaries
+            let next_request_boundary = self.next_request_offset + next_request_size as u64;
+            let remainder = (next_request_boundary % self.inner.config.part_alignment as u64) as usize;
+            next_request_size - remainder
         }
-
-        // if it exceeds part boundaries, trim it to the part boundaries
-        let next_request_boundary = next_request_offset + next_request_size as u64;
-        let remainder = (next_request_boundary % part_size as u64) as usize;
-        next_request_size - remainder
     }
 }
 
@@ -402,7 +391,7 @@ mod tests {
             max_request_size: test_config.max_request_size,
             sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
             read_timeout: Duration::from_secs(5),
-            part_size: test_config.client_part_size,
+            part_alignment: test_config.client_part_size,
         };
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
@@ -533,13 +522,29 @@ mod tests {
         part_size: usize,
         expected_size: usize,
     ) {
-        let next_request_size = PrefetchGetObject::<MockClient, ThreadPool>::get_next_request_size(
-            next_request_offset as u64,
-            current_request_size,
-            prefetch_multiplier,
-            max_request_size,
+        let object_size = 50 * 1024 * 1024;
+
+        let config = MockClientConfig {
+            bucket: "test-bucket".to_string(),
             part_size,
-        );
+        };
+        let client = MockClient::new(config);
+
+        let test_config = PrefetcherConfig {
+            first_request_size: 256 * 1024,
+            sequential_prefetch_multiplier: prefetch_multiplier,
+            max_request_size,
+            read_timeout: Duration::from_secs(60),
+            part_alignment: part_size,
+        };
+        let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
+        let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
+
+        let mut request = prefetcher.get("test-bucket", "hello", object_size);
+
+        request.next_request_offset = next_request_offset as u64;
+        request.next_request_size = current_request_size;
+        let next_request_size = request.get_next_request_size();
         assert_eq!(next_request_size, expected_size);
     }
 


### PR DESCRIPTION
It's an S3 performance best practice to align range GETs to multi-part upload boundaries. This is the first naive implementation to make the prefetcher aligns its requests to those boundaries by assuming that every multipart object has the same static part size.

Related to https://github.com/awslabs/mountpoint-s3/issues/73.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
