### PR TITLE
Added logic to include port number in host header

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -547,6 +547,18 @@ impl ObjectClient for S3CrtClient {
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         self.put_object(bucket, key, params, contents).await
     }
+
+    async fn get_object_attributes(
+        &self,
+        bucket: &str,
+        key: &str,
+        max_parts: Option<usize>,
+        part_number_marker: Option<usize>,
+        object_attributes: &[ObjectAttribute],
+    ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
+        self.get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -155,7 +155,7 @@ impl S3CrtClient {
         let hostname_header = if port > 0 {
             format!("{}:{}", hostname, port)
         } else {
-            format!("{}", hostname)
+            hostname.to_string()
         };
 
         let mut message = Message::new_request(&self.allocator)?;

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -41,6 +41,7 @@ macro_rules! request_span {
 
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
+pub(crate) mod get_object_attributes;
 pub(crate) mod head_bucket;
 pub(crate) mod head_object;
 pub(crate) mod list_objects;
@@ -151,10 +152,11 @@ impl S3CrtClient {
         let (uri, path_prefix) = self.endpoint.for_bucket(bucket)?;
         let hostname = uri.host_name().to_str().unwrap();
         let port = uri.host_port();
-        let mut hostname_header = format!("{}", hostname);
-        if port > 0 {
-            hostname_header = format!("{}:{}", hostname, port);
-        }
+        let hostname_header = if port > 0 {
+            format!("{}:{}", hostname, port)
+        } else {
+            format!("{}", hostname)
+        };
 
         let mut message = Message::new_request(&self.allocator)?;
         message.set_request_method(method)?;

--- a/mountpoint-s3-crt/src/common/uri.rs
+++ b/mountpoint-s3-crt/src/common/uri.rs
@@ -6,7 +6,7 @@ use std::os::unix::prelude::OsStrExt;
 
 use mountpoint_s3_crt_sys::{
     aws_byte_cursor_from_buf, aws_uri, aws_uri_authority, aws_uri_clean_up, aws_uri_host_name, aws_uri_init_parse,
-    aws_uri_path, aws_uri_query_string, aws_uri_scheme, aws_uri_port
+    aws_uri_path, aws_uri_port, aws_uri_query_string, aws_uri_scheme,
 };
 
 use crate::common::allocator::Allocator;
@@ -68,9 +68,7 @@ impl Uri {
     pub fn host_port(&self) -> u16 {
         // SAFETY: `inner` is a valid `aws_uri` since it's owned by this struct, and the lifetime of
         // the returned slice will be tied to &self.
-        unsafe {
-            aws_uri_port(self.to_inner_ptr())
-        }
+        unsafe { aws_uri_port(self.to_inner_ptr()) }
     }
 
     /// Return the path portion of the URI, including any leading "/".

--- a/mountpoint-s3-crt/src/common/uri.rs
+++ b/mountpoint-s3-crt/src/common/uri.rs
@@ -69,8 +69,7 @@ impl Uri {
         // SAFETY: `inner` is a valid `aws_uri` since it's owned by this struct, and the lifetime of
         // the returned slice will be tied to &self.
         unsafe {
-            let cursor = aws_uri_port(self.to_inner_ptr());
-            cursor
+            aws_uri_port(self.to_inner_ptr())
         }
     }
 

--- a/mountpoint-s3-crt/src/common/uri.rs
+++ b/mountpoint-s3-crt/src/common/uri.rs
@@ -6,7 +6,7 @@ use std::os::unix::prelude::OsStrExt;
 
 use mountpoint_s3_crt_sys::{
     aws_byte_cursor_from_buf, aws_uri, aws_uri_authority, aws_uri_clean_up, aws_uri_host_name, aws_uri_init_parse,
-    aws_uri_path, aws_uri_query_string, aws_uri_scheme,
+    aws_uri_path, aws_uri_query_string, aws_uri_scheme, aws_uri_port
 };
 
 use crate::common::allocator::Allocator;
@@ -61,6 +61,16 @@ impl Uri {
         unsafe {
             let cursor = aws_uri_host_name(self.to_inner_ptr()).as_ref().unwrap();
             OsStr::from_bytes(aws_byte_cursor_as_slice(cursor))
+        }
+    }
+
+    /// Return the host port portion of the URI. If no port was present, returns 0
+    pub fn host_port(&self) -> u16 {
+        // SAFETY: `inner` is a valid `aws_uri` since it's owned by this struct, and the lifetime of
+        // the returned slice will be tied to &self.
+        unsafe {
+            let cursor = aws_uri_port(self.to_inner_ptr());
+            cursor
         }
     }
 


### PR DESCRIPTION
We can use other object storage systems like MinIO in backend. In dev mode the --endpoint-url value passed could be of form host[:port] While sending the host header we should include port number as well if its present and send header in the form `host:port`

Fixes: https://github.com/awslabs/mountpoint-s3/issues/159

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
