### PR TITLE
Skip FIPS endpoint integration tests on non-FIPS regions

### DIFF
--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -72,19 +72,35 @@ async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) 
 #[test_case(AddressingStyle::Virtual)]
 #[tokio::test]
 async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
+    if should_skip_fips() {
+        eprintln!("Skipping test, region does not have FIPS endpoint");
+        return;
+    }
+
     run_test(|region| {
         let uri = format!("https://s3-fips.{region}.amazonaws.com");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
 }
+
 // FIPS endpoints can only be used with virtual-hosted-style addressing
 #[test_case(AddressingStyle::Virtual)]
 #[tokio::test]
 async fn test_addressing_style_uri_fips_dualstack(addressing_style: AddressingStyle) {
+    if should_skip_fips() {
+        eprintln!("Skipping test, region does not have FIPS endpoint");
+        return;
+    }
+
     run_test(|region| {
         let uri = format!("https://s3-fips.dualstack.{region}.amazonaws.com");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
+}
+
+fn should_skip_fips() -> bool {
+    let region = get_test_region();
+    !region.starts_with("us-") && !region.starts_with("ca-")
 }


### PR DESCRIPTION
Fixes #156. This change short-cicuits the tests to pass when pointed to non-FIPS regions (currently US and Canadian regions).

With the basic Rust test runner, there is no concept of 'skipping' a test. There is a message written to the STDERR of the test, but this is not output by default. Leaving in in case we change test runner.

This change (along with some experimental CI changes) was tested here: https://github.com/dannycjones/mountpoint-s3/actions/runs/4440020376/jobs/7793272517

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
