### PR TITLE
Split integration tests into a new CI workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,141 @@
+name: Integration tests
+
+# We use environments to require approval to run integration tests on PRs, but not on pushes to
+# `main` (which have been approved already since PRs are required for `main`).
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+      ref:
+        required: true
+        type: string
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  S3_BUCKET_NAME: s3-file-connector-github-test-bucket
+  S3_BUCKET_TEST_PREFIX: github-actions-tmp/run-${{ github.run_id }}/attempt-${{ github.run_attempt }}/
+  # A bucket our IAM role has no access to, but is in the right region, for permissions tests
+  S3_FORBIDDEN_BUCKET_NAME: s3-file-connector-github-test-bucket-forbidden
+  S3_REGION: us-east-1
+  RUST_FEATURES: fuse_tests,s3_tests
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-22.04
+
+    environment: ${{ inputs.environment }}
+
+    strategy:
+      matrix:
+        fuse: [fuse, fuse3]
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::360461222476:role/GitHub-Actions-Role
+        aws-region: us-east-1
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-integration-${{ matrix.fuse }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install fuse
+      run: sudo apt-get install ${{ matrix.fuse }} lib${{ matrix.fuse }}-dev
+    - name: Configure fuse
+      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+    - name: Run tests
+      run: cargo test --features $RUST_FEATURES
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR integration tests'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
+
+  asan:
+    name: Address sanitizer
+    runs-on: ubuntu-22.04
+
+    environment: ${{ inputs.environment }}
+
+    timeout-minutes: 60
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::360461222476:role/GitHub-Actions-Role
+        aws-region: us-east-1
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install nightly Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: rust-src
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-integration-asan-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install fuse
+      run: sudo apt-get install fuse3 libfuse3-dev
+    - name: Install llvm-dev
+      run: sudo apt-get install llvm-dev
+    - name: Configure fuse
+      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+    - name: Validate ASan is working
+      run: make test-asan-working
+    - name: Run tests
+      run: make test-asan
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR integration tests'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}

--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -1,0 +1,16 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  integration:
+    name: Integration
+    uses: ./.github/workflows/integration.yml
+    with:
+      ref: ${{ github.event.after }}

--- a/.github/workflows/integration_pr.yml
+++ b/.github/workflows/integration_pr.yml
@@ -1,0 +1,17 @@
+name: Integration tests (PR)
+
+on:
+  pull_request_target:
+    branches: [ "main" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  integration:
+    name: Integration
+    uses: ./.github/workflows/integration.yml
+    with:
+      environment: PR integration tests
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,16 @@
-name: CI
+name: Tests
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
 env:
-  # RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  S3_BUCKET_NAME: s3-file-connector-github-test-bucket
-  S3_BUCKET_TEST_PREFIX: github-actions-tmp/run-${{ github.run_id }}/attempt-${{ github.run_attempt }}/
-  # A bucket our IAM role has no access to, but is in the right region, for permissions tests
-  S3_FORBIDDEN_BUCKET_NAME: s3-file-connector-github-test-bucket-forbidden
-  S3_REGION: us-east-1
-  RUST_FEATURES: fuse_tests,s3_tests
+  RUST_FEATURES: fuse_tests
 
 jobs:
   test:
@@ -26,16 +21,7 @@ jobs:
       matrix:
         fuse: [fuse, fuse3]
 
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: arn:aws:iam::360461222476:role/GitHub-Actions-Role
-        aws-region: us-east-1
     - name: Checkout code
       uses: actions/checkout@v3
       with:
@@ -122,7 +108,7 @@ jobs:
     - name: Install fuse
       run: sudo apt-get install fuse libfuse-dev
     - name: Check all targets
-      run: cargo check --locked --all-targets --features $RUST_FEATURES
+      run: cargo check --locked --all-targets --all-features
 
   shuttle:
     name: Shuttle tests
@@ -152,51 +138,6 @@ jobs:
       run: sudo apt-get install fuse libfuse-dev
     - name: Run Shuttle tests
       run: cargo test -p mountpoint-s3 --features shuttle -- shuttle
-
-  asan:
-    name: Address sanitizer
-    runs-on: ubuntu-22.04
-
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: arn:aws:iam::360461222476:role/GitHub-Actions-Role
-        aws-region: us-east-1
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Install nightly Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        components: rust-src
-    - name: Cargo cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install fuse3 libfuse3-dev
-    - name: Install llvm-dev
-      run: sudo apt-get install llvm-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
-    - name: Validate ASan is working
-      run: make test-asan-working
-    - name: Run tests
-      run: make test-asan
 
   rustfmt:
     name: Formatting


### PR DESCRIPTION
Our integration tests are tricky to run because they require S3 credentials, which GitHub (quite rightly) makes difficult to access through a pull request from a fork repo. Even if we turn on GitHub's feature for requiring manual approval for a PR to run workflows, it still won't have access to the permissions it needs to get S3 credentials, because the `configure-aws-credentials` action needs `id_token: write` permissions, which fork PRs can never have.

This change makes our integration tests run using the `pull_request_target` event. This event runs in the context of the base repo rather than the PR, and so has access to the right permissions. That's dangerous, of course, so we want to manually approve runs of this workflow. But `pull_request_target` workflows are _automatically approved_, so the normal "require manual approval for a PR to run workflows" no longer works. Instead, we rig something up using deployment environments, which can be configured to require manual approval before deployments. The integration tests ask to be "deployed" to an environment with approval configured, and so won't run until someone with permission to approve those deployments clicks OK. Same effect as the normal PR approval mechanism, just a little more jury-rigged and with some confusing verbiage around "deployment".

Pushes to `main` also run the integration tests, but they ask for a null deployment, and so run as normal workflows. This is safe because pushes to `main` already require PR approvals.

Workflows on `pull_request_target` have a different security boundary [[1]], and in particular have two permissions normal `pull_request` workflows don't have:
1. Their GITHUB_TOKEN has write access to the repository. We explicitly downgrade the token to have only read access using the `permissions` field in integration test workflows.
2. They run in the context of the base repository, and so have access to secrets. We don't use any secrets. We also explicitly prevent the integration tests from storing cached artifacts if running from a PR, which could poison other users of the cache.

Since they run in the base context, `pull_request_target` workflows will always run with the workflow files from the base repo, ignoring any changes in the pull request. That means a PR can't change the workflow to undo these protections.

Fixes #143.

[1]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
