### PR TITLE
Arrange CLI arguments into groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,8 +773,7 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
@@ -783,10 +782,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "9a9d6ada83c1edcce028902ea27dd929069c70df4c7600b131b4d9a1ad2879cc"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.3",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -800,6 +814,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -895,7 +918,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.23",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -1125,7 +1148,7 @@ name = "fuser"
 version = "0.12.0"
 dependencies = [
  "bincode",
- "clap",
+ "clap 3.2.23",
  "env_logger",
  "libc",
  "log",
@@ -1393,6 +1416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1577,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -1778,7 +1819,7 @@ dependencies = [
  "base16ct",
  "built",
  "bytes",
- "clap",
+ "clap 4.1.9",
  "const_format",
  "ctor",
  "ctrlc",
@@ -1819,7 +1860,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "bytes",
- "clap",
+ "clap 3.2.23",
  "ctor",
  "futures",
  "lazy_static",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "1.8.0"
 async-lock = "2.6.0"
 bytes = "1.2.1"
-clap = { version = "3.2.12", features = ["derive"] }
+clap = { version = "4.1.9", features = ["derive"] }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }

--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 use fuser::{BackgroundSession, MountOption, Session};
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::S3FilesystemConfig;
@@ -47,26 +47,23 @@ fn main() -> io::Result<()> {
         .arg(
             Arg::new("buffer-capacity-kb")
                 .long("buffer-capacity-kb")
-                .help("Buffer reader capacity in KB")
-                .takes_value(true),
+                .help("Buffer reader capacity in KB"),
         )
         .arg(
             Arg::new("direct")
                 .long("direct")
                 .help("Open file with O_DIRECT option")
-                .takes_value(false),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("throughput-target-gbps")
                 .long("throughput-target-gbps")
-                .help("Desired throughput in Gbps")
-                .takes_value(true),
+                .help("Desired throughput in Gbps"),
         )
         .arg(
             Arg::new("iterations")
                 .long("iterations")
-                .help("Number of times to download")
-                .takes_value(true),
+                .help("Number of times to download"),
         )
         .arg(Arg::new("region").long("region").default_value("us-east-1"))
         .get_matches();
@@ -76,7 +73,7 @@ fn main() -> io::Result<()> {
     let buffer_capacity = matches
         .get_one::<String>("buffer-capacity-kb")
         .map(|s| s.parse::<usize>().expect("buffer capacity must be a number"));
-    let direct = matches.is_present("direct");
+    let direct = matches.get_flag("direct");
     let throughput_target_gbps = matches
         .get_one::<String>("throughput-target-gbps")
         .map(|s| s.parse::<f64>().expect("throughput target must be an f64"));

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -34,20 +34,17 @@ fn main() {
         .arg(
             Arg::new("throughput-target-gbps")
                 .long("throughput-target-gbps")
-                .help("Desired throughput in Gbps")
-                .takes_value(true),
+                .help("Desired throughput in Gbps"),
         )
         .arg(
             Arg::new("part-size")
                 .long("part-size")
-                .help("Part size for multi-part GET and PUT")
-                .takes_value(true),
+                .help("Part size for multi-part GET and PUT"),
         )
         .arg(
             Arg::new("iterations")
                 .long("iterations")
-                .help("Number of times to download")
-                .takes_value(true),
+                .help("Number of times to download"),
         )
         .arg(Arg::new("region").long("region").default_value("us-east-1"))
         .get_matches();

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -144,7 +144,7 @@ struct CliArgs {
     pub throughput_target_gbps: Option<u64>,
 
     #[clap(
-        long, 
+        long,
         help = "Number of FUSE daemon threads",
         value_name = "N",
         default_value = "1",

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -76,6 +76,10 @@ fn init_tracing_subscriber(is_foreground: bool, log_directory: Option<&Path>) ->
     Ok(())
 }
 
+const CLIENT_OPTIONS_HEADER: &str = "Client options";
+const MOUNT_OPTIONS_HEADER: &str = "Mount options";
+const BUCKET_OPTIONS_HEADER: &str = "Bucket options";
+
 #[derive(Parser)]
 #[clap(about = "Mountpoint for Amazon S3", version = build_info::FULL_VERSION)]
 #[clap(group(ArgGroup::new("addressing-style").args(&["virtual_addressing", "path_addressing"])))]
@@ -92,62 +96,102 @@ struct CliArgs {
     #[clap(
         long,
         help = "Prefix inside the bucket to mount [default: mount the entire bucket]",
-        help_heading = "Bucket options"
+        help_heading = BUCKET_OPTIONS_HEADER
     )]
     pub prefix: Option<String>,
 
     #[clap(
         long,
         help = "AWS region of the bucket [default: auto-detect region]",
-        help_heading = "Bucket options"
+        help_heading = BUCKET_OPTIONS_HEADER
     )]
     pub region: Option<String>,
 
     #[clap(
         long,
         help = "S3 endpoint URL [default: auto-detect endpoint]",
-        help_heading = "Bucket options"
+        help_heading = BUCKET_OPTIONS_HEADER
     )]
     pub endpoint_url: Option<String>,
 
-    #[clap(long, help = "Force virtual-host-style addressing", help_heading = "Bucket options")]
+    #[clap(long, help = "Force virtual-host-style addressing", help_heading = BUCKET_OPTIONS_HEADER)]
     pub virtual_addressing: bool,
 
-    #[clap(long, help = "Force path-style addressing", help_heading = "Bucket options")]
+    #[clap(long, help = "Force path-style addressing", help_heading = BUCKET_OPTIONS_HEADER)]
     pub path_addressing: bool,
 
-    #[clap(long, help = "Automatically unmount on exit", help_heading = "Mount options")]
+    #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
     pub auto_unmount: bool,
 
-    #[clap(long, help = "Allow root user to access file system", help_heading = "Mount options")]
+    #[clap(long, help = "Allow root user to access file system", help_heading = MOUNT_OPTIONS_HEADER)]
     pub allow_root: bool,
 
     #[clap(
         long,
         help = "Allow other non-root users to access file system",
-        help_heading = "Mount options"
+        help_heading = MOUNT_OPTIONS_HEADER
     )]
     pub allow_other: bool,
 
-    #[clap(long, help = "Desired throughput in Gbps", value_name = "N", default_value = "10", value_parser = value_parser!(u64).range(1..), help_heading = "Client options")]
+    #[clap(
+        long,
+        help = "Desired throughput in Gbps",
+        value_name = "N",
+        default_value = "10",
+        value_parser = value_parser!(u64).range(1..),
+        help_heading = CLIENT_OPTIONS_HEADER
+    )]
     pub throughput_target_gbps: Option<u64>,
 
-    #[clap(long, help = "Number of FUSE daemon threads", value_name = "N", default_value = "1", value_parser = value_parser!(u64).range(1..), help_heading = "Client options")]
+    #[clap(
+        long, 
+        help = "Number of FUSE daemon threads",
+        value_name = "N",
+        default_value = "1",
+        value_parser = value_parser!(u64).range(1..),
+        help_heading = CLIENT_OPTIONS_HEADER
+    )]
     pub thread_count: Option<u64>,
 
-    #[clap(long, help = "Part size for multi-part GET and PUT", default_value = "8388608", value_parser = value_parser!(u64).range(1..), help_heading = "Client options")]
+    #[clap(
+        long,
+        help = "Part size for multi-part GET and PUT",
+        default_value = "8388608",
+        value_parser = value_parser!(u64).range(1..),
+        help_heading = CLIENT_OPTIONS_HEADER
+    )]
     pub part_size: Option<u64>,
 
-    #[clap(long, help = "Owner UID [default: current user's UID]", value_parser = value_parser!(u32).range(1..), help_heading = "Mount options")]
+    #[clap(
+        long,
+        help = "Owner UID [default: current user's UID]",
+        value_parser = value_parser!(u32).range(1..),
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
     pub uid: Option<u32>,
 
-    #[clap(long, help = "Owner GID [default: current user's GID]", value_parser = value_parser!(u32).range(1..), help_heading = "Mount options")]
+    #[clap(
+        long,
+        help = "Owner GID [default: current user's GID]",
+        value_parser = value_parser!(u32).range(1..),
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
     pub gid: Option<u32>,
 
-    #[clap(long, help = "Directory permissions [default: 0755]", value_parser = parse_perm_bits, help_heading = "Mount options")]
+    #[clap(
+        long,
+        help = "Directory permissions [default: 0755]",
+        value_parser = parse_perm_bits,
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
     pub dir_mode: Option<u16>,
 
-    #[clap(long, help = "File permissions [default: 0644]", value_parser = parse_perm_bits, help_heading = "Mount options")]
+    #[clap(
+        long,
+        help = "File permissions [default: 0644]",
+        value_parser = parse_perm_bits,
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
     pub file_mode: Option<u16>,
 
     #[clap(short, long, help = "Run as foreground process")]

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -113,7 +113,7 @@ fn addressing_style_mutually_exclusive() -> Result<(), Box<dyn std::error::Error
         .arg("test/dir")
         .arg("--virtual-addressing")
         .arg("--path-addressing");
-    let error_message = "The argument '--virtual-addressing' cannot be used with '--path-addressing'";
+    let error_message = "the argument '--virtual-addressing' cannot be used with '--path-addressing'";
     cmd.assert().failure().stderr(predicate::str::contains(error_message));
 
     Ok(())


### PR DESCRIPTION
Our arguments are getting pretty unwieldly. This change updates to clap
v4 and then adds help headings so that `-h` is easier to parse.

With this change, the output looks like this:

```
[18:21:41] ~/c/mountpoint-s3 (clap-headings|✔) $ target/debug/mount-s3 -h
Mountpoint for Amazon S3

Usage: mount-s3 [OPTIONS] <BUCKET_NAME> <MOUNT_POINT>

Arguments:
  <BUCKET_NAME>  Name of bucket to mount
  <MOUNT_POINT>  Mount point for file system

Options:
  -l, --log-directory <LOG_DIRECTORY>  Log file directory [default: $HOME/.mountpoint-s3]
  -f, --foreground                     Run as foreground process
  -h, --help                           Print help
  -V, --version                        Print version

Bucket options:
      --prefix <PREFIX>              Prefix inside the bucket to mount [default: mount the entire bucket]
      --region <REGION>              AWS region of the bucket [default: auto-detect region]
      --endpoint-url <ENDPOINT_URL>  S3 endpoint URL [default: auto-detect endpoint]
      --virtual-addressing           Force virtual-host-style addressing
      --path-addressing              Force path-style addressing

Mount options:
      --auto-unmount           Automatically unmount on exit
      --allow-root             Allow root user to access file system
      --allow-other            Allow other non-root users to access file system
      --uid <UID>              Owner UID [default: current user's UID]
      --gid <GID>              Owner GID [default: current user's GID]
      --dir-mode <DIR_MODE>    Directory permissions [default: 0755]
      --file-mode <FILE_MODE>  File permissions [default: 0644]

Client options:
      --throughput-target-gbps <N>  Desired throughput in Gbps [default: 10]
      --thread-count <N>            Number of FUSE daemon threads [default: 1]
      --part-size <PART_SIZE>       Part size for multi-part GET and PUT [default: 8388608]
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
