### PR TITLE
Fix time dependency in mountpoint-s3-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,6 @@ dependencies = [
  "libc-stdhandle",
  "metrics",
  "mountpoint-s3-crt",
- "mountpoint-s3-crt-sys",
  "percent-encoding",
  "pin-project",
  "proptest",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt" }
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys" }
 
 async-trait = "0.1.57"
 auto_impl = "1.0.1"
@@ -21,7 +20,7 @@ pin-project = "1.0.12"
 regex = "1.7.1"
 static_assertions = "1.1.0"
 thiserror = "1.0.34"
-time = "0.3.14"
+time = { version = "0.3.17", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 xmltree = "0.10.3"
 


### PR DESCRIPTION
Just a tiny thing: this crate's use of `time` requires some features.
This isn't a problem for us because mountpoint-s3 pulls those features
in, so compilation still works, but it's a problem if someone wants to
take a direct dependency on mountpoint-s3-client. Also, there's no need
for the direct dependency on the -sys crate here.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
