### PR TITLE
Introduce crt imds client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .cargo/
+TAGS

--- a/mountpoint-s3-client/src/imds_crt_client.rs
+++ b/mountpoint-s3-client/src/imds_crt_client.rs
@@ -1,0 +1,69 @@
+use std::ffi::OsString;
+use std::time::Duration;
+
+use futures::channel::oneshot;
+use mountpoint_s3_crt::auth::imds_client::ImdsClient;
+use mountpoint_s3_crt::auth::imds_client::ImdsClientConfig;
+use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::common::error;
+use mountpoint_s3_crt::io::channel_bootstrap::{ClientBootstrap, ClientBootstrapOptions};
+use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
+use mountpoint_s3_crt::io::host_resolver::{HostResolver, HostResolverDefaultOptions};
+use mountpoint_s3_crt::io::retry_strategy::{ExponentialBackoffJitterMode, RetryStrategy, StandardRetryOptions};
+
+#[derive(Debug)]
+pub struct ImdsCrtClient {
+    imds_client: ImdsClient,
+    event_loop_group: EventLoopGroup,
+    allocator: Allocator,
+}
+
+impl ImdsCrtClient {
+    pub fn new() -> Result<Self, error::Error> {
+        let allocator = Allocator::default();
+
+        let mut event_loop_group = EventLoopGroup::new_default(&allocator, None, || {}).unwrap();
+
+        let resolver_options = HostResolverDefaultOptions {
+            max_entries: 8,
+            event_loop_group: &mut event_loop_group,
+        };
+
+        let mut host_resolver = HostResolver::new_default(&allocator, &resolver_options).unwrap();
+
+        let bootstrap_options = ClientBootstrapOptions {
+            event_loop_group: &mut event_loop_group,
+            host_resolver: &mut host_resolver,
+        };
+
+        let client_bootstrap = ClientBootstrap::new(&allocator, &bootstrap_options).unwrap();
+
+        let mut retry_strategy_options = StandardRetryOptions::default(&mut event_loop_group);
+        retry_strategy_options.backoff_retry_options.max_retries = 3;
+        retry_strategy_options.backoff_retry_options.backoff_scale_factor = Duration::from_millis(500);
+        retry_strategy_options.backoff_retry_options.jitter_mode = ExponentialBackoffJitterMode::Full;
+        let retry_strategy = RetryStrategy::standard(&allocator, &retry_strategy_options).unwrap();
+
+        let mut client_config = ImdsClientConfig::new();
+
+        client_config
+            .client_bootstrap(client_bootstrap)
+            .retry_strategy(retry_strategy);
+
+        let imds_client = ImdsClient::new(&allocator, client_config).unwrap();
+
+        Ok(Self {
+            imds_client,
+            event_loop_group,
+            allocator,
+        })
+    }
+
+    pub fn make_instance_type_query(&self) -> oneshot::Receiver<Result<OsString, error::Error>> {
+        let (tx, rx) = oneshot::channel::<Result<OsString, error::Error>>();
+        let _ = self.imds_client.get_instance_type(move |result| {
+            let _ = tx.send(result);
+        });
+        rx
+    }
+}

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -1,11 +1,13 @@
 mod endpoint;
 pub mod failure_client;
+mod imds_crt_client;
 pub mod mock_client;
 mod object_client;
 mod s3_crt_client;
 mod util;
 
 pub use endpoint::{AddressingStyle, Endpoint};
+pub use imds_crt_client::ImdsCrtClient;
 pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
 pub use s3_crt_client::{S3ClientConfig, S3CrtClient, S3RequestError};

--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -28,6 +28,7 @@ const CRT_LIBRARIES: &[&str] = &[
 /// bindings for the stuff we (transitively) need, rather than everything.
 const CRT_HEADERS: &[&str] = &[
     "auth/credentials.h",
+    "auth/aws_imds_client.h",
     "checksums/crc.h",
     "common/atomics.h",
     "common/log_channel.h",

--- a/mountpoint-s3-crt/src/auth.rs
+++ b/mountpoint-s3-crt/src/auth.rs
@@ -7,6 +7,7 @@ use mountpoint_s3_crt_sys::aws_auth_library_init;
 use crate::common::allocator::Allocator;
 
 pub mod credentials;
+pub mod imds_client;
 pub mod signing_config;
 
 static AUTH_LIBRARY_INIT: Once = Once::new();

--- a/mountpoint-s3-crt/src/auth/imds_client.rs
+++ b/mountpoint-s3-crt/src/auth/imds_client.rs
@@ -1,0 +1,127 @@
+//! A client for retrieving ec2 instance metadata.
+
+use crate::auth::auth_library_init;
+use crate::common::allocator::Allocator;
+use crate::common::error::Error;
+use crate::io::channel_bootstrap::ClientBootstrap;
+use crate::io::retry_strategy::RetryStrategy;
+use crate::CrtError;
+use mountpoint_s3_crt_sys::{
+    aws_byte_buf, aws_imds_client, aws_imds_client_get_instance_type, aws_imds_client_new, aws_imds_client_options,
+    aws_imds_client_release,
+};
+use std::ffi::{OsStr, OsString};
+use std::os::unix::prelude::OsStrExt;
+use std::ptr::NonNull;
+
+/// A client for instance metadata query.
+#[derive(Debug)]
+pub struct ImdsClient {
+    /// A pointer to the underlying `aws_imds_client`
+    inner: NonNull<aws_imds_client>,
+}
+
+///Configurations for creating a new [ImdsClient].
+#[derive(Debug, Default)]
+pub struct ImdsClientConfig {
+    /// The structure that can pass into the CRT's functions.
+    inner: aws_imds_client_options,
+
+    /// The [ClientBootstrap] to use to create connection to IMDS.
+    client_bootstrap: Option<ClientBootstrap>,
+
+    /// The [RetryStrategy] to use to reschedule failed requests to IMDS. This is reference counted,
+    /// so we only need to hold onto it until this [ImdsClientConfig] is consumed, at which point the
+    /// client will take ownership.
+    retry_strategy: Option<RetryStrategy>,
+}
+
+impl ImdsClient {
+    /// Create a new [ImdsClient]
+    pub fn new(allocator: &Allocator, config: ImdsClientConfig) -> Result<Self, Error> {
+        auth_library_init(allocator);
+
+        // SAFETY: `config` is moved into the [ImdsClient] on success, so `config.inner` (and the values
+        // inside) are guaranteed to live at least as long as this [Client] does. `allocator` is
+        // guaranteed to be a valid allocator because of the type-safe wrapper.
+        let inner = unsafe { aws_imds_client_new(allocator.inner.as_ptr(), &config.inner).ok_or_last_error()? };
+
+        Ok(Self { inner })
+    }
+
+    /// closure passed in.
+    pub fn get_instance_type<F>(&self, callback: F) -> Result<i32, Error>
+    where
+        F: FnOnce(Result<OsString, Error>) + 'static,
+    {
+        let callback_closure: OnGetResource = Box::new(callback);
+        let callback_wrapper: Box<ImdsClientGetResourceCallback> =
+            Box::new(ImdsClientGetResourceCallback(Box::new(callback_closure)));
+        let callback_wrapper: &mut ImdsClientGetResourceCallback = Box::leak(callback_wrapper);
+        // callback_wrapper is safe so the raw pointer referring to that is safe as well.
+        let callback_raw_ptr: *mut libc::c_void =
+            callback_wrapper as *mut ImdsClientGetResourceCallback as *mut libc::c_void;
+        let get_resource_callback_fn_ptr: Option<unsafe extern "C" fn(*const aws_byte_buf, i32, *mut libc::c_void)> =
+            Some(imds_client_get_resource_callback);
+
+        // Safety: move the reference where the data store in memory out of box potential leaks memory,
+        // however, the binding callback function will drop it once the corresponding crt function finished the execution.
+        // See `extern "C" fn imds_client_get_resource_callback`.
+        unsafe {
+            let result =
+                aws_imds_client_get_instance_type(self.inner.as_ptr(), get_resource_callback_fn_ptr, callback_raw_ptr);
+            Ok(result)
+        }
+    }
+}
+
+impl Drop for ImdsClient {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` points to a valid aws_imds_client, and when this [ImdsClient] is dropped, it's
+        // safe to decrement the reference counter by one.
+        unsafe { aws_imds_client_release(self.inner.as_ptr()) };
+    }
+}
+
+impl ImdsClientConfig {
+    /// Create a new [ImdsClientConfig] with default options.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Client bootstrap used for common staples such as event loop group, host resolver, etc.
+    pub fn client_bootstrap(&mut self, client_bootstrap: ClientBootstrap) -> &mut Self {
+        self.inner.bootstrap = client_bootstrap.inner.as_ptr();
+        self.client_bootstrap = Some(client_bootstrap);
+        self
+    }
+
+    /// Retry strategy used to reschedule failed requests
+    pub fn retry_strategy(&mut self, retry_strategy: RetryStrategy) -> &mut Self {
+        self.inner.retry_strategy = retry_strategy.inner.as_ptr();
+        self.retry_strategy = Some(retry_strategy);
+        self
+    }
+}
+
+/// Callback trait for when finished getting ec2 instance type.
+type OnGetResource = Box<dyn FnOnce(Result<OsString, Error>)>;
+struct ImdsClientGetResourceCallback(OnGetResource);
+
+/// Rust binding for CRT's callback function `aws_imds_client_on_get_resource_callback_fn`.
+unsafe extern "C" fn imds_client_get_resource_callback(
+    resource: *const aws_byte_buf,
+    error_code: i32,
+    user_data: *mut libc::c_void,
+) {
+    let resource_slice = std::slice::from_raw_parts((*resource).buffer, (*resource).len);
+    let resource = OsStr::from_bytes(resource_slice).to_os_string();
+    let callback = Box::from_raw(user_data as *mut ImdsClientGetResourceCallback).0;
+    let result = if 0 != error_code {
+        Err(Error::from(error_code))
+    } else {
+        Ok(resource)
+    };
+
+    callback(result);
+}


### PR DESCRIPTION
The main goal for using crt imds client is to query ec2 instance type mountpoint-s3 running on.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
