### PR TITLE
Introduce crt imds client.

### DIFF
--- a/mountpoint-s3-client/src/imds_crt_client.rs
+++ b/mountpoint-s3-client/src/imds_crt_client.rs
@@ -1,0 +1,98 @@
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use futures::channel::oneshot;
+use futures::Future;
+use mountpoint_s3_crt::auth::imds_client::{ImdsClient, ImdsClientConfig};
+use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::common::error;
+use mountpoint_s3_crt::io::channel_bootstrap::{ClientBootstrap, ClientBootstrapOptions};
+use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
+use mountpoint_s3_crt::io::host_resolver::{HostResolver, HostResolverDefaultOptions};
+use pin_project::pin_project;
+use thiserror::Error;
+
+#[derive(Debug)]
+/// Instance Metadata Service (IMDS) client responsible for sending EC2 instance metadata query requests.
+pub struct ImdsCrtClient {
+    imds_client: ImdsClient,
+    #[allow(unused)]
+    event_loop_group: EventLoopGroup,
+    #[allow(unused)]
+    allocator: Allocator,
+}
+
+impl ImdsCrtClient {
+    pub fn new() -> Result<Self, error::Error> {
+        let allocator = Allocator::default();
+
+        let mut event_loop_group = EventLoopGroup::new_default(&allocator, None, || {}).unwrap();
+
+        let resolver_options = HostResolverDefaultOptions {
+            max_entries: 8,
+            event_loop_group: &mut event_loop_group,
+        };
+
+        let mut host_resolver = HostResolver::new_default(&allocator, &resolver_options).unwrap();
+
+        let bootstrap_options = ClientBootstrapOptions {
+            event_loop_group: &mut event_loop_group,
+            host_resolver: &mut host_resolver,
+        };
+
+        let client_bootstrap = ClientBootstrap::new(&allocator, &bootstrap_options).unwrap();
+
+        let mut client_config = ImdsClientConfig::new();
+        client_config.client_bootstrap(client_bootstrap);
+
+        let imds_client = ImdsClient::new(&allocator, client_config)?;
+
+        Ok(Self {
+            imds_client,
+            event_loop_group,
+            allocator,
+        })
+    }
+
+    /// Query the type of the EC2 instance this code is executed on.
+    pub fn make_instance_type_query(&self) -> Result<ImdsQueryRequest, ImdsQueryRequestError> {
+        let (tx, rx) = oneshot::channel();
+        self.imds_client.get_instance_type(move |result| {
+            let _ = tx.send(result.map_err(ImdsQueryRequestError::CrtError));
+        })?;
+
+        Ok(ImdsQueryRequest { receiver: rx })
+    }
+}
+
+#[derive(Debug)]
+#[pin_project]
+/// ImdsQueryRequest is a data encapsulation wrapper for asnychronous instance metadata query.
+pub struct ImdsQueryRequest {
+    #[pin]
+    receiver: oneshot::Receiver<Result<String, ImdsQueryRequestError>>,
+}
+
+impl Future for ImdsQueryRequest {
+    type Output = Result<String, ImdsQueryRequestError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.receiver
+            .poll(cx)
+            .map(|result| result.unwrap_or_else(|err| Err(ImdsQueryRequestError::InternalError(Box::new(err)))))
+    }
+}
+
+/// ImdsQueryRequestError is returned by an asynchronous query.
+#[derive(Error, Debug)]
+pub enum ImdsQueryRequestError {
+    /// An internal error from within the Imds client. The request may have been sent.
+    #[error("Internal Imds client error")]
+    InternalError(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// An internal error from within the AWS Common Runtime. The request may have been sent.
+    #[error("Unknown CRT error")]
+    CrtError(#[from] error::Error),
+}

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -1,11 +1,13 @@
 mod endpoint;
 pub mod failure_client;
+mod imds_crt_client;
 pub mod mock_client;
 mod object_client;
 mod s3_crt_client;
 mod util;
 
 pub use endpoint::{AddressingStyle, Endpoint};
+pub use imds_crt_client::ImdsCrtClient;
 pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
 pub use s3_crt_client::{S3ClientConfig, S3CrtClient, S3RequestError};

--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -28,6 +28,7 @@ const CRT_LIBRARIES: &[&str] = &[
 /// bindings for the stuff we (transitively) need, rather than everything.
 const CRT_HEADERS: &[&str] = &[
     "auth/credentials.h",
+    "auth/aws_imds_client.h",
     "checksums/crc.h",
     "common/atomics.h",
     "common/log_channel.h",

--- a/mountpoint-s3-crt/src/auth.rs
+++ b/mountpoint-s3-crt/src/auth.rs
@@ -7,6 +7,7 @@ use mountpoint_s3_crt_sys::aws_auth_library_init;
 use crate::common::allocator::Allocator;
 
 pub mod credentials;
+pub mod imds_client;
 pub mod signing_config;
 
 static AUTH_LIBRARY_INIT: Once = Once::new();

--- a/mountpoint-s3-crt/src/auth/imds_client.rs
+++ b/mountpoint-s3-crt/src/auth/imds_client.rs
@@ -1,0 +1,117 @@
+//! A client for retrieving ec2 instance metadata.
+
+use crate::auth::auth_library_init;
+use crate::common::allocator::Allocator;
+use crate::common::error::Error;
+use crate::io::channel_bootstrap::ClientBootstrap;
+use crate::io::retry_strategy::RetryStrategy;
+use crate::CrtError;
+use mountpoint_s3_crt_sys::{
+    aws_byte_buf, aws_imds_client, aws_imds_client_get_instance_type, aws_imds_client_new, aws_imds_client_options,
+    aws_imds_client_release,
+};
+use std::ptr::NonNull;
+
+/// A client for instance metadata query.
+#[derive(Debug)]
+pub struct ImdsClient {
+    /// A pointer to the underlying `aws_imds_client`
+    inner: NonNull<aws_imds_client>,
+}
+
+/// Configurations for creating a new [ImdsClient].
+#[derive(Debug, Default)]
+pub struct ImdsClientConfig {
+    /// The structure that can pass into the CRT's functions.
+    inner: aws_imds_client_options,
+
+    /// The [ClientBootstrap] to use to create connection to IMDS.
+    client_bootstrap: Option<ClientBootstrap>,
+
+    /// The [RetryStrategy] to use to reschedule failed requests to IMDS. This is reference counted,
+    /// so we only need to hold onto it until this [ImdsClientConfig] is consumed, at which point the
+    /// client will take ownership.
+    retry_strategy: Option<RetryStrategy>,
+}
+
+impl ImdsClientConfig {
+    /// Create a new [ImdsClientConfig] with default options.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Client bootstrap used for common staples such as event loop group, host resolver, etc.
+    pub fn client_bootstrap(&mut self, client_bootstrap: ClientBootstrap) -> &mut Self {
+        self.inner.bootstrap = client_bootstrap.inner.as_ptr();
+        self.client_bootstrap = Some(client_bootstrap);
+        self
+    }
+
+    /// Retry strategy used to reschedule failed requests
+    pub fn retry_strategy(&mut self, retry_strategy: RetryStrategy) -> &mut Self {
+        self.inner.retry_strategy = retry_strategy.inner.as_ptr();
+        self.retry_strategy = Some(retry_strategy);
+        self
+    }
+}
+
+impl ImdsClient {
+    /// Create a new [ImdsClient]
+    pub fn new(allocator: &Allocator, config: ImdsClientConfig) -> Result<Self, Error> {
+        auth_library_init(allocator);
+
+        // SAFETY: `aws_imds_client_new` copies what it needs out of `config`, so it's safe to pass only
+        // a reference and to drop it after this method completes.
+        let inner = unsafe { aws_imds_client_new(allocator.inner.as_ptr(), &config.inner).ok_or_last_error()? };
+        Ok(Self { inner })
+    }
+
+    /// Get the EC2 instance type.
+    pub fn get_instance_type<F>(&self, callback: F) -> Result<(), Error>
+    where
+        F: FnOnce(Result<String, Error>) + 'static,
+    {
+        let callback_wrapper = Box::new(ImdsClientGetResourceCallback(Box::new(callback)));
+        let callback_raw_ptr = Box::into_raw(callback_wrapper) as *mut libc::c_void;
+        let get_resource_callback_fn_ptr: Option<unsafe extern "C" fn(*const aws_byte_buf, i32, *mut libc::c_void)> =
+            Some(imds_client_get_resource_callback);
+
+        // SAFETY: `self.inner` is a valid `aws_imds_client`. `get_resource_callback_fn_ptr` is leaked by [Box::into_raw]
+        // and so will live until the `imds_client_get_resource_callback` function is invoked.
+        unsafe {
+            aws_imds_client_get_instance_type(self.inner.as_ptr(), get_resource_callback_fn_ptr, callback_raw_ptr)
+                .ok_or_last_error()
+        }
+    }
+}
+
+impl Drop for ImdsClient {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` always points to a valid underlying `aws_imds_client`.
+        unsafe { aws_imds_client_release(self.inner.as_ptr()) };
+    }
+}
+
+type OnGetResource = Box<dyn FnOnce(Result<String, Error>)>;
+struct ImdsClientGetResourceCallback(OnGetResource);
+
+/// Rust binding for CRT's callback function `aws_imds_client_on_get_resource_callback_fn`.
+unsafe extern "C" fn imds_client_get_resource_callback(
+    resource: *const aws_byte_buf,
+    error_code: i32,
+    user_data: *mut libc::c_void,
+) {
+    // SAFETY: `user_data` is a raw pointer to a `Box<ImdsClientGetResourceCallback>` created and leaked at query time.
+    // This function will be executed at most once, so the Box is still valid right now.
+    let callback = Box::from_raw(user_data as *mut ImdsClientGetResourceCallback).0;
+
+    let result = if 0 != error_code {
+        Err(error_code.into())
+    } else {
+        // SAFETY: The CRT guarantees `resource` is a valid `*const aws_byte_buf` if the IMDS query succeeded.
+        let resource = std::slice::from_raw_parts((*resource).buffer, (*resource).len).to_vec();
+        Ok(String::from_utf8(resource).expect("resource response should be encoded with utf8."))
+    };
+
+    callback(result)
+}


### PR DESCRIPTION
The main goal for using crt imds client is to query ec2 instance type mountpoint-s3 running on.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
