### PR TITLE
Validate and document `--prefix` argument

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -95,7 +95,8 @@ struct CliArgs {
 
     #[clap(
         long,
-        help = "Prefix inside the bucket to mount [default: mount the entire bucket]",
+        help = "Prefix inside the bucket to mount, ending in '/' [default: mount the entire bucket]",
+        value_parser = parse_prefix,
         help_heading = BUCKET_OPTIONS_HEADER
     )]
     pub prefix: Option<String>,
@@ -477,5 +478,13 @@ fn parse_perm_bits(perm_bit_str: &str) -> Result<u16, anyhow::Error> {
         Err(anyhow!("only user/group/other permissions are supported"))
     } else {
         Ok(perm)
+    }
+}
+
+fn parse_prefix(prefix: &str) -> Result<String, anyhow::Error> {
+    if !(prefix.is_empty() || prefix.ends_with('/')) {
+        Err(anyhow!("must end in '/'"))
+    } else {
+        Ok(prefix.to_owned())
     }
 }

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -34,6 +34,22 @@ fn mount_point_isnt_dir() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn prefix_doesnt_end_in_slash() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+
+    let prefix = "foo";
+    cmd.arg("test-bucket").arg(dir.path()).arg(format!("--prefix={}", prefix));
+    let error_message = format!(
+        "error: invalid value '{}' for '--prefix <PREFIX>': must end in '/'",
+        prefix
+    );
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+#[test]
 fn max_dir_mode_exceeded() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;
     let mut cmd = Command::cargo_bin("mount-s3")?;


### PR DESCRIPTION
Addresses #162. Validates that the `--prefix` argument is either empty or ending in `/` and returns a meaningful error if not.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
