### PR TITLE
Make opened files visible in readdir

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -277,8 +277,7 @@ where
                 return Err(libc::EINVAL);
             }
 
-            let parent_lookup = self.superblock.getattr(&self.client, lookup.inode.parent()).await?;
-            lookup.inode.start_writing(&parent_lookup.inode)?;
+            lookup.inode.start_writing()?;
             FileHandleType::Write {
                 parts: Default::default(),
             }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -279,7 +279,6 @@ where
             }
 
             let inode_handle = self.superblock.write(&self.client, ino, lookup.inode.parent()).await?;
-            inode_handle.start_writing()?;
             FileHandleType::Write {
                 parts: Default::default(),
                 handle: inode_handle,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, trace};
 use fuser::{FileAttr, KernelConfig};
 use mountpoint_s3_client::{ObjectClient, PutObjectParams};
 
-use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock};
+use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, WriteHandle};
 use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
 use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -51,6 +51,7 @@ enum FileHandleType<Client: ObjectClient, Runtime> {
     },
     Write {
         parts: AsyncMutex<Vec<Box<[u8]>>>,
+        handle: WriteHandle,
     },
 }
 
@@ -277,9 +278,11 @@ where
                 return Err(libc::EINVAL);
             }
 
-            lookup.inode.start_writing()?;
+            let inode_handle = self.superblock.write(&self.client, ino, lookup.inode.parent()).await?;
+            inode_handle.start_writing()?;
             FileHandleType::Write {
                 parts: Default::default(),
+                handle: inode_handle,
             }
         } else {
             lookup.inode.start_reading()?;
@@ -394,7 +397,7 @@ where
             return Err(libc::EBADF);
         };
         let mut request = match &handle.typ {
-            FileHandleType::Write { parts } => parts.lock().await,
+            FileHandleType::Write { parts, .. } => parts.lock().await,
             FileHandleType::Read { .. } => return Err(libc::EBADF),
         };
 
@@ -512,18 +515,18 @@ where
         _lock_owner: Option<u64>,
         _flush: bool,
     ) -> Result<(), libc::c_int> {
-        let handle = {
+        let file_handle = {
             let mut file_handles = self.file_handles.write().await;
             file_handles.remove(&fh).ok_or(libc::EBADF)?
         };
 
-        match handle.typ {
-            FileHandleType::Write { parts } => {
+        match file_handle.typ {
+            FileHandleType::Write { parts, handle } => {
                 // TODO how do we make sure we didn't already handle this via `flush`?
                 let parts = parts.into_inner();
                 let size = parts.iter().map(|part| part.len()).sum::<usize>();
                 let stream = futures::stream::iter(parts);
-                let key = handle.full_key;
+                let key = file_handle.full_key;
 
                 let put = self
                     .client
@@ -542,14 +545,13 @@ where
                     }
                 };
 
-                let parent_lookup = self.superblock.getattr(&self.client, handle.inode.parent()).await?;
-                handle.inode.finish_writing(size, &parent_lookup.inode)?;
+                handle.finish_writing(size)?;
 
                 result
             }
             FileHandleType::Read { request: _ } => {
                 // TODO make sure we cancel the inflight PrefetchingGetRequest. is just dropping enough?
-                handle.inode.finish_reading()?;
+                file_handle.inode.finish_reading()?;
                 Ok(())
             }
         }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -277,7 +277,8 @@ where
                 return Err(libc::EINVAL);
             }
 
-            lookup.inode.start_writing()?;
+            let parent_lookup = self.superblock.getattr(&self.client, lookup.inode.parent()).await?;
+            lookup.inode.start_writing(&parent_lookup.inode)?;
             FileHandleType::Write {
                 parts: Default::default(),
             }
@@ -542,7 +543,8 @@ where
                     }
                 };
 
-                handle.inode.finish_writing(size)?;
+                let parent_lookup = self.superblock.getattr(&self.client, handle.inode.parent()).await?;
+                handle.inode.finish_writing(size, &parent_lookup.inode)?;
 
                 result
             }

--- a/mountpoint-s3/tests/fuse_tests/readdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/readdir_test.rs
@@ -1,9 +1,12 @@
 use crate::fuse_tests::PutObjectFn;
 use fuser::BackgroundSession;
 use mountpoint_s3::S3FilesystemConfig;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
+use test_case::test_case;
 
 // Unit Tests
 // Generate a filesystem with many entries
@@ -30,38 +33,107 @@ fn prepare_fs(mut put_object_fn: PutObjectFn, map: &HashMap<String, File>) {
     }
 }
 
-fn readdir_1<F>(creator_fn: F, prefix: &str)
+fn readdir<F>(creator_fn: F, prefix: &str)
 where
     F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
 {
-    let readdir_size = 5usize;
+    let readdir_size = 5;
     let filesystem_config = S3FilesystemConfig {
         readdir_size,
         ..Default::default()
     };
 
     let mut map = HashMap::new();
+    let mut expected_list = Vec::new();
     for i in 0..readdir_size * 4 {
-        map.insert(format!("file{i}"), File::new((i % 256) as u8, 10 * i));
+        let file_name = format!("file{i}");
+        map.insert(file_name.clone(), File::new((i % 256) as u8, 10 * i));
+        expected_list.push(file_name);
     }
+    expected_list.sort();
+
     let (mount_point, _session, put_object_fn) = creator_fn(prefix, filesystem_config);
 
     prepare_fs(put_object_fn, &map);
 
     let dir = fs::read_dir(mount_point.path()).unwrap();
-    let mut files: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        expected_list
+    );
+}
 
-    for f in files.drain(..) {
-        let path = f.path();
-        let name = path.file_name().unwrap().to_str().unwrap();
-        assert!(map.remove(name).is_some());
+fn readdir_while_writing<F>(creator_fn: F, prefix: &str, new_files: Vec<&str>)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
+{
+    let readdir_size = 5;
+    let filesystem_config = S3FilesystemConfig {
+        readdir_size,
+        ..Default::default()
+    };
+
+    let mut map = HashMap::new();
+    let mut expected_list = Vec::new();
+    for i in 0..readdir_size * 4 {
+        let file_name = format!("file{i}");
+        map.insert(file_name.clone(), File::new((i % 256) as u8, 10 * i));
+        expected_list.push(file_name);
     }
 
-    println!("... map is {map:?}");
-    assert!(map.is_empty());
+    let (mount_point, _session, put_object_fn) = creator_fn(prefix, filesystem_config);
+
+    prepare_fs(put_object_fn, &map);
+
+    const OBJECT_SIZE: usize = 1024;
+    let mut opened_files = Vec::new();
+    for file_name in new_files {
+        let path = mount_point.path().join(file_name);
+        let mut options = fs::File::options();
+        options.write(true);
+        options.create(true);
+        let f = options.open(path).unwrap();
+
+        let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
+        let mut body = vec![0u8; OBJECT_SIZE];
+        rng.fill(&mut body[..]);
+        opened_files.push(f);
+        map.insert(file_name.to_owned(), File::new(0, 0));
+        expected_list.push(file_name.to_owned());
+    }
+    expected_list.sort();
+
+    let dir = fs::read_dir(mount_point.path()).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        expected_list
+    );
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn readdir_s3() {
+    readdir(crate::fuse_tests::s3_session::new, "readdir_s3");
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(vec!["aaa", "file150", "file151", "zzz"]; "new files at various positions")]
+fn readdir_while_writing_s3(new_files: Vec<&str>) {
+    readdir_while_writing(crate::fuse_tests::s3_session::new, "readdir_s3", new_files);
 }
 
 #[test]
-fn readdir_1_mock() {
-    readdir_1(crate::fuse_tests::mock_session::new, "");
+fn readdir_mock() {
+    readdir(crate::fuse_tests::mock_session::new, "");
+}
+
+#[test_case(vec!["aaa", "file150", "file151", "zzz"]; "new files at various positions")]
+fn readdir_while_writing_mock(new_files: Vec<&str>) {
+    readdir_while_writing(crate::fuse_tests::mock_session::new, "readdir_s3", new_files);
 }

--- a/mountpoint-s3/tests/fuse_tests/readdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/readdir_test.rs
@@ -1,12 +1,12 @@
 use crate::fuse_tests::PutObjectFn;
 use fuser::BackgroundSession;
 use mountpoint_s3::S3FilesystemConfig;
+use rand::distributions::{Alphanumeric, DistString};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
-use test_case::test_case;
 
 // Unit Tests
 // Generate a filesystem with many entries
@@ -46,7 +46,8 @@ where
     let mut map = HashMap::new();
     let mut expected_list = Vec::new();
     for i in 0..readdir_size * 4 {
-        let file_name = format!("file{i}");
+        let random_str = Alphanumeric.sample_string(&mut rand::thread_rng(), 5);
+        let file_name = format!("file_{random_str}_{i}");
         map.insert(file_name.clone(), File::new((i % 256) as u8, 10 * i));
         expected_list.push(file_name);
     }
@@ -66,7 +67,7 @@ where
     );
 }
 
-fn readdir_while_writing<F>(creator_fn: F, prefix: &str, new_files: Vec<&str>)
+fn readdir_while_writing<F>(creator_fn: F, prefix: &str)
 where
     F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, PutObjectFn),
 {
@@ -79,7 +80,8 @@ where
     let mut map = HashMap::new();
     let mut expected_list = Vec::new();
     for i in 0..readdir_size * 4 {
-        let file_name = format!("file{i}");
+        let random_str = Alphanumeric.sample_string(&mut rand::thread_rng(), 5);
+        let file_name = format!("file_{random_str}_{i}");
         map.insert(file_name.clone(), File::new((i % 256) as u8, 10 * i));
         expected_list.push(file_name);
     }
@@ -89,9 +91,12 @@ where
     prepare_fs(put_object_fn, &map);
 
     const OBJECT_SIZE: usize = 1024;
+    // open some new files for write and leave it open
     let mut opened_files = Vec::new();
-    for file_name in new_files {
-        let path = mount_point.path().join(file_name);
+    for i in 0..readdir_size {
+        let random_str = Alphanumeric.sample_string(&mut rand::thread_rng(), 8);
+        let file_name = format!("file_{random_str}_{i}");
+        let path = mount_point.path().join(&file_name);
         let mut options = fs::File::options();
         options.write(true);
         options.create(true);
@@ -101,8 +106,8 @@ where
         let mut body = vec![0u8; OBJECT_SIZE];
         rng.fill(&mut body[..]);
         opened_files.push(f);
-        map.insert(file_name.to_owned(), File::new(0, 0));
-        expected_list.push(file_name.to_owned());
+        map.insert(file_name.clone(), File::new(0, 0));
+        expected_list.push(file_name);
     }
     expected_list.sort();
 
@@ -119,13 +124,13 @@ where
 #[cfg(feature = "s3_tests")]
 #[test]
 fn readdir_s3() {
-    readdir(crate::fuse_tests::s3_session::new, "readdir_s3");
+    readdir(crate::fuse_tests::s3_session::new, "");
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(vec!["aaa", "file150", "file151", "zzz"]; "new files at various positions")]
-fn readdir_while_writing_s3(new_files: Vec<&str>) {
-    readdir_while_writing(crate::fuse_tests::s3_session::new, "readdir_s3", new_files);
+#[test]
+fn readdir_while_writing_s3() {
+    readdir_while_writing(crate::fuse_tests::s3_session::new, "");
 }
 
 #[test]
@@ -133,7 +138,7 @@ fn readdir_mock() {
     readdir(crate::fuse_tests::mock_session::new, "");
 }
 
-#[test_case(vec!["aaa", "file150", "file151", "zzz"]; "new files at various positions")]
-fn readdir_while_writing_mock(new_files: Vec<&str>) {
-    readdir_while_writing(crate::fuse_tests::mock_session::new, "readdir_s3", new_files);
+#[test]
+fn readdir_while_writing_mock() {
+    readdir_while_writing(crate::fuse_tests::mock_session::new, "");
 }


### PR DESCRIPTION
Currently, new files that are opened for write will not be visible in the file system until they are closed and their contents are uploaded to S3, but we want them to be visible as soon as we open the files.

To do this, we will store inodes of the opened files in its parent state and remove them once we finish writing. Then, on readdir, we can append these inodes to the results we get from LIST API to make the opened files visible in the file system.

Another problem is results ordering. Previously, we're using a double-ended queue to store the sorted LIST results but it doesn't work well with newly created files since we don't know their exact positions in paginated results. In this commit, we will use two queues, one for local results, and another one for remote results. Each queue is sorted by file names, then we compare the first element in both lists to decide which to return next.

A part of https://github.com/awslabs/mountpoint-s3/issues/27.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
