### PR TITLE
Allow `mountpoint-s3-crt-sys` to link to an existing CRT installation

### DIFF
--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -1,13 +1,13 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use bindgen::{BindgenError, Bindings};
+use bindgen::BindgenError;
 use rustflags::Flag;
 
 /// Path to the CRT repos, relative to the crate root.
 const CRT_PATH: &str = "crt";
 
-/// On Linux, the CRT needs to build and link against Amazon's libcrypto. On Darwin it uses the
+/// On Linux, the CRT gets its TLS stack from AWS libcrypto and s2n. On Darwin it uses the
 /// platform's TLS stack instead.
 const CRT_CRYPTO_LIBRARIES: &[&str] = &["aws-lc", "s2n-tls"];
 
@@ -48,15 +48,70 @@ const CRT_HEADERS: &[&str] = &[
     "s3/s3_client.h",
 ];
 
-// The CRT needs cmake 3.x, but on AL2, the `cmake` binary is 2.x, and there's a separate `cmake3`.
-// If `cmake3` exists, let's use that as our CMAKE.
+/// Private CRT headers required for our build. These will always be read from the Git submodules
+/// even if we are linking against an existing CRT build, because these headers are not installed by
+/// the CRT. Paths are relative to [CRT_PATH].
+const PRIVATE_CRT_HEADERS: &[&str] = &[
+    // To access S3 client stats
+    "aws-c-s3/include/aws/s3/private/s3_client_impl.h",
+];
+
+/// Get the OS name we are compiling to
+fn get_target_os() -> String {
+    env::var("CARGO_CFG_TARGET_OS").expect("target OS not defined")
+}
+
+/// Read an environment variable and remember that it was accessed so that the build will rerun if
+/// its value is changed.
+fn get_env(var: &str) -> Option<String> {
+    println!("cargo:rerun-if-env-changed={var}");
+    match env::var(var) {
+        Ok(val) => Some(val),
+        Err(env::VarError::NotPresent) => None,
+        Err(e) => panic!("failed to read env var {var}: {e:?}"),
+    }
+}
+
+/// A single CRT library dependency. Some CRT libraries (aws-lc and s2n) have a different library
+/// name to their package name, so we record both.
+#[derive(Debug, Clone)]
+struct CrtLibrary {
+    package_name: String,
+    library_name: String,
+}
+
+/// Get a list of required CRT libraries for the given target OS.
+fn get_required_libraries(target_os: &str) -> Vec<CrtLibrary> {
+    let additional_libraries = (target_os == "linux").then_some(CRT_CRYPTO_LIBRARIES);
+    let libraries = additional_libraries.into_iter().flatten().chain(CRT_LIBRARIES.iter());
+    libraries
+        .map(|pkg| {
+            // aws-lc and s2n-tls have different lib names to their package name
+            let lib_name = match *pkg {
+                "aws-lc" => "crypto",
+                "s2n-tls" => "s2n",
+                lib => lib,
+            };
+            CrtLibrary {
+                package_name: pkg.to_string(),
+                library_name: lib_name.to_string(),
+            }
+        })
+        .collect()
+}
+
+/// The CRT needs cmake 3.x, but on AL2, the `cmake` binary is 2.x, and there's a separate `cmake3`.
+/// If `cmake3` exists, let's use that as our CMAKE.
 fn discover_cmake3() {
     if which::which("cmake3").is_ok() {
         std::env::set_var("CMAKE", "cmake3");
     }
 }
 
-fn generate_bindings(include_dir: &Path) -> Result<Bindings, BindgenError> {
+/// Generate `bindings.rs`, containing a Rust version of the CRT headers. The headers in
+/// [CRT_HEADERS] will be read from the given `include_dir`. The `bindings.rs` file will be written
+/// into the `output_path` directory.
+fn generate_bindings(include_dir: &Path, output_path: &Path) -> Result<(), BindgenError> {
     let mut builder = bindgen::Builder::default()
         // Get Default impls so we don't have to explicitly malloc/zero/ununit structs
         .derive_default(true)
@@ -87,7 +142,7 @@ fn generate_bindings(include_dir: &Path) -> Result<Bindings, BindgenError> {
         // they're linkable, but bindgen ignores inline functions by default, so we manually need to
         // mark them as exported.
         .clang_arg("-DAWS_STATIC_IMPL=")
-        .clang_args(&["-I", include_dir.to_str().unwrap(), "-I", "crt/aws-c-s3/include"]);
+        .clang_args(&["-I", include_dir.to_str().unwrap()]);
 
     for header in CRT_HEADERS {
         let header_path = include_dir.join("aws").join(header);
@@ -97,18 +152,34 @@ fn generate_bindings(include_dir: &Path) -> Result<Bindings, BindgenError> {
         builder = builder.header(header_path.to_str().unwrap());
     }
 
-    // We have to include this private API in order to access CRT client stats
-    builder = builder.header("crt/aws-c-s3/include/aws/s3/private/s3_client_impl.h");
+    for header in PRIVATE_CRT_HEADERS {
+        let header_path = Path::new(CRT_PATH).join(header);
+        if !header_path.exists() {
+            panic!(
+                "header file {} does not exist; perhaps you need to fetch git submodules",
+                header_path.display()
+            );
+        }
+        builder = builder.header(header_path.to_str().unwrap());
+    }
 
-    builder.generate()
+    let bindings = builder.generate()?;
+    bindings.write_to_file(output_path).expect("failed to write bindings");
+
+    Ok(())
 }
 
-/// Returns a path to the `include` directory for the CRT
-fn compile_crt_and_bindings() -> PathBuf {
+/// Compile the CRT from the Git submodule sources in this crate, and configure the Rust build to
+/// statically link them. Returns the path to the target directory the CRT was installed into by
+/// `cmake`.
+fn compile_crt(output_dir: &Path) -> PathBuf {
+    discover_cmake3();
+
     let source_dir = PathBuf::from(CRT_PATH);
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let build_dir = out_dir.join("build");
-    let target_dir = out_dir.join("target");
+
+    let build_dir = output_dir.join("build");
+    let target_dir = output_dir.join("target");
+    let target_os = get_target_os();
 
     if build_dir.exists() {
         fs::remove_dir_all(&build_dir).expect("failed to clean build directory");
@@ -121,17 +192,17 @@ fn compile_crt_and_bindings() -> PathBuf {
     fs::create_dir_all(&build_dir).expect("failed to create build directory");
     fs::create_dir_all(&target_dir).expect("failed to create target directory");
 
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let libraries = get_required_libraries(&target_os);
 
-    let additional_libraries = (target_os == "linux").then_some(CRT_CRYPTO_LIBRARIES);
-    let libraries = additional_libraries.into_iter().flatten().chain(CRT_LIBRARIES.iter());
-
-    for lib in libraries.clone() {
-        let lib_source_dir = source_dir.join(lib);
-        let lib_build_dir = build_dir.join(lib);
+    for lib in libraries.iter() {
+        let lib_source_dir = source_dir.join(&lib.package_name);
+        let lib_build_dir = build_dir.join(&lib.package_name);
 
         if !lib_source_dir.join("CMakeLists.txt").exists() {
-            panic!("missing library source for {lib}, perhaps you need to fetch git submodules");
+            panic!(
+                "missing library source for {}, perhaps you need to fetch git submodules",
+                lib.package_name
+            );
         }
         println!("cargo:rerun-if-changed={}", lib_source_dir.display());
 
@@ -145,7 +216,7 @@ fn compile_crt_and_bindings() -> PathBuf {
             .define("CMAKE_PREFIX_PATH", &target_dir)
             .define("BUILD_TESTING", "OFF");
 
-        if *lib == "aws-lc" {
+        if lib.package_name == "aws-lc" {
             builder.define("DISABLE_PERL", "ON");
             builder.define("DISABLE_GO", "ON");
         }
@@ -169,36 +240,25 @@ fn compile_crt_and_bindings() -> PathBuf {
 
     // Some Linuxes, notably AL2, install their library outputs in `lib64`
     for search_dir in ["lib", "lib64"] {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            target_dir.join(search_dir).display()
-        );
+        let lib_dir = target_dir.join(search_dir);
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
     }
 
-    // On macOS we need to link to some system frameworks
+    // On macOS we need to link to some system frameworks for TLS
     if target_os == "macos" {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=framework=Security");
     }
 
-    for lib in libraries {
-        // These libraries have names different to their repository name
-        let lib = match *lib {
-            "aws-lc" => "crypto",
-            "s2n-tls" => "s2n",
-            lib => lib,
-        };
-        println!("cargo:rustc-link-lib=static={lib}");
+    // Statically link all the compiled CRT libraries
+    for lib in libraries.iter() {
+        println!("cargo:rustc-link-lib=static={}", lib.library_name);
     }
 
-    let include_dir = target_dir.join("include");
-    let bindings = generate_bindings(include_dir.as_path()).expect("failed to generate bindings");
-    let bindings_path = out_dir.join("bindings.rs");
-    bindings.write_to_file(bindings_path).expect("failed to write bindings");
-
-    include_dir
+    target_dir
 }
 
+/// Compile the C shim for connecting CRT logging to Rust `tracing`
 fn compile_logging_shim(crt_include_dir: impl AsRef<Path>) {
     cc::Build::new()
         .file("src/logging_shim.c")
@@ -207,8 +267,44 @@ fn compile_logging_shim(crt_include_dir: impl AsRef<Path>) {
     println!("cargo:rerun-if-changed=src/logging_shim.c");
 }
 
+/// Build or link to the CRT.
+///
+/// By default, we build and statically link the CRT libraries embedded in this crate as Git
+/// submodules. However, if the `MOUNTPOINT_CRT_LIB_DIR` and `MOUNTPOINT_CRT_INCLUDE_DIR`
+/// environment variables are set, we don't build the CRT, and instead link to the CRT shared
+/// libraries expected to be in `MOUNTPOINT_CRT_LIB_DIR`. In this case, the
+/// `MOUNTPOINT_CRT_INCLUDE_DIR` variable must point to the directory the CRT headers were installed
+/// to. The build still needs access to the Git submodules for any private CRT headers we use, but
+/// the code from the submodules won't be compiled.
+///
+/// Note that `MOUNTPOINT_CRT_LIB_DIR` requires a compatible version of the CRT libraries. The CRT
+/// has no versioning mechanism for shared libraries right now, so customers configuring this
+/// variable are responsible for ensuring compatibility with the CRT versions embedded in this
+/// crate.
 fn main() {
-    discover_cmake3();
-    let include_dir = compile_crt_and_bindings();
+    let output_dir = PathBuf::from(env::var("OUT_DIR").expect("no OUT_DIR set"));
+
+    // Compile or link the CRT libraries
+    let include_dir = if let Some(path) = get_env("MOUNTPOINT_CRT_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={path}");
+
+        let libraries = get_required_libraries(&get_target_os());
+        for lib in libraries {
+            println!("cargo:rustc-link-lib=dylib={}", lib.library_name);
+        }
+
+        PathBuf::from(
+            get_env("MOUNTPOINT_CRT_INCLUDE_DIR")
+                .expect("MOUNTPOINT_CRT_INCLUDE_DIR must be set if MOUNTPOINT_CRT_LIB_DIR is used"),
+        )
+    } else {
+        let target_dir = compile_crt(&output_dir);
+        target_dir.join("include")
+    };
+
+    // Generate Rust bindings from the CRT headers
+    let bindings_path = output_dir.join("bindings.rs");
+    generate_bindings(&include_dir, &bindings_path).expect("failed to generate bindings");
+
     compile_logging_shim(include_dir);
 }


### PR DESCRIPTION
Some customers may already have a build of the CRT they'd like to use with Mountpoint rather than building the one we include; for example, one installed by their package manager. This change lets us specify environment variables pointing to an existing CRT build rather than always building it ourselves.

There's not a great versioning or compatibility story for CRT shared libraries, so this change should only be used when the customer can guarantee a suitable CRT version will be linked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
