### PR TITLE
Add error handling for FUSE worker threads that panic

### DIFF
--- a/mountpoint-s3/src/fuse/session.rs
+++ b/mountpoint-s3/src/fuse/session.rs
@@ -52,11 +52,7 @@ impl FuseSession {
                 .name("fuse-worker-waiter".to_owned())
                 .spawn(move || {
                     for thd in workers {
-                        let thread_name = thd
-                            .thread()
-                            .name()
-                            .map(ToOwned::to_owned);
-
+                        let thread_name = thd.thread().name().map(ToOwned::to_owned);
                         match thd.join() {
                             Err(panic_param) => {
                                 // Try to downcast as &str or String to log


### PR DESCRIPTION
When encountering a panic in a FUSE operation, the filesystem was not exiting cleanly. We were not handling the panicking thread case before this change. With this change, we log at error and allow the unmount process to continue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
