### PR TITLE
Implement mkdir

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -78,6 +78,12 @@ Space allocation (`fallocate`, `posix_fallocate`) are not supported.
 
 Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported.
 
+Creating directories (`mkdir`) is not currently supported, but will be [in the future](https://github.com/awslabs/mountpoint-s3/issues/77):
+
+* `mkdir` will create a new empty directory in the file system, but not affect the S3 bucket.
+* Note that this is different from e.g. the S3 Console, which creates "directory markers" (i.e. zero-byte objects with `<directory-name>/` key) in the bucket.
+* If a file is created under the new (or a nested) directory and committed to S3, Mountpoint for Amazon S3 will revert to using the default mapping of S3 object keys. This implies that the directory will be visible as long as there are keys which contain it as a prefix.
+
 Renaming files and directories (`rename`, `renameat`) is not currently supported.
 
 File deletion (`unlink`) is not currently supported, but will be [in the future](https://github.com/awslabs/mountpoint-s3/issues/78).

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -74,6 +74,17 @@ impl MockClient {
     pub fn remove_object(&self, key: &str) {
         self.objects.write().unwrap().remove(key);
     }
+
+    /// Returns `true` if this mock client's bucket contains the specified key
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.objects.read().unwrap().contains_key(key)
+    }
+
+    /// Returns `true` if this mock client's bucket contains the specified common prefix
+    pub fn contains_prefix(&self, prefix: &str) -> bool {
+        let prefix = format!("{prefix}/");
+        self.objects.read().unwrap().keys().any(|k| k.starts_with(&prefix))
+    }
 }
 
 pub struct MockObject {

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -373,7 +373,30 @@ where
             return Err(libc::EINVAL);
         }
 
-        let lookup = self.superblock.create(&self.client, parent, name).await?;
+        let lookup = self
+            .superblock
+            .create(&self.client, parent, name, InodeKind::File)
+            .await?;
+        let attr = self.make_attr(&lookup);
+
+        Ok(Entry {
+            ttl: self.config.stat_ttl,
+            attr,
+            generation: 0,
+        })
+    }
+
+    pub async fn mkdir(
+        &self,
+        parent: InodeNo,
+        name: &OsStr,
+        _mode: libc::mode_t,
+        _umask: u32,
+    ) -> Result<Entry, libc::c_int> {
+        let lookup = self
+            .superblock
+            .create(&self.client, parent, name, InodeKind::Directory)
+            .await?;
         let attr = self.make_attr(&lookup);
 
         Ok(Entry {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -80,10 +80,7 @@ impl Superblock {
             sync: RwLock::new(InodeState {
                 stat: InodeStat::for_directory(mount_time, Instant::now()), // TODO expiry
                 write_status: WriteStatus::Remote,
-                kind_data: InodeKindData::Directory {
-                    children: Default::default(),
-                    writing_children: Default::default(),
-                },
+                kind_data: InodeKindData::default_for(InodeKind::Directory),
             }),
         };
         let root = Inode { inner: Arc::new(root) };
@@ -312,12 +309,13 @@ impl Superblock {
         })
     }
 
-    /// Create a new regular file inode ready to be opened in write-only mode
+    /// Create a new regular file or directory inode ready to be opened in write-only mode
     pub async fn create<OC: ObjectClient>(
         &self,
         client: &OC,
         dir: InodeNo,
         name: &OsStr,
+        kind: InodeKind,
     ) -> Result<LookedUp, InodeError> {
         trace!(parent=?dir, ?name, "create");
 
@@ -347,15 +345,16 @@ impl Superblock {
         }
 
         let expiry = Instant::now(); // TODO local inode stats never expire?
-                                     // Objects don't have an ETag until they are uploaded to S3
-        let stat = InodeStat::for_file(0, OffsetDateTime::now_utc(), expiry, None);
-        let kind = InodeKind::File;
+        let datetime = OffsetDateTime::now_utc();
+        let stat = match kind {
+            InodeKind::File => InodeStat::for_file(0, datetime, expiry, None), // Objects don't have an ETag until they are uploaded to S3
+            InodeKind::Directory => InodeStat::for_directory(datetime, expiry),
+        };
         let state = InodeState {
             stat: stat.clone(),
-            kind_data: InodeKindData::File {},
+            kind_data: InodeKindData::default_for(kind),
             write_status: WriteStatus::LocalUnopened,
         };
-
         let inode = self
             .inner
             .create_inode_locked(&parent_inode, &mut parent_state, name, kind, state, true)?;
@@ -427,17 +426,9 @@ impl SuperblockInner {
                 }
             }
             UpdateStatus::RemoteKey(RemoteLookup { stat, kind }) => {
-                let kind_data = match kind {
-                    InodeKind::File => InodeKindData::File {},
-                    InodeKind::Directory => InodeKindData::Directory {
-                        children: Default::default(),
-                        writing_children: Default::default(),
-                    },
-                };
-
                 let state = InodeState {
                     stat: stat.clone(),
-                    kind_data,
+                    kind_data: InodeKindData::default_for(kind),
                     write_status: WriteStatus::Remote,
                 };
                 self.create_inode_locked(&parent, &mut parent_state, name, kind, state, false)
@@ -624,6 +615,18 @@ impl WriteHandle {
 
     /// Update status of the inode and its parent
     pub fn finish_writing(self, object_size: usize) -> Result<(), InodeError> {
+        fn remove_from_writing_children(parent_state_data: &mut InodeKindData, ino: &InodeNo) {
+            match parent_state_data {
+                InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
+                InodeKindData::Directory {
+                    children: _,
+                    writing_children,
+                } => {
+                    writing_children.remove(ino);
+                }
+            }
+        }
+
         let inode = self.inner.get(self.ino)?;
         let parent = self.inner.get(self.parent_ino)?;
 
@@ -634,13 +637,22 @@ impl WriteHandle {
             WriteStatus::LocalOpen => {
                 state.write_status = WriteStatus::Remote;
                 state.stat.size = object_size;
-                match &mut parent_state.kind_data {
-                    InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
-                    InodeKindData::Directory {
-                        children: _,
-                        writing_children,
-                    } => {
-                        writing_children.remove(&inode.ino());
+                remove_from_writing_children(&mut parent_state.kind_data, &inode.ino());
+                if parent_state.write_status != WriteStatus::Remote {
+                    parent_state.write_status = WriteStatus::Remote;
+
+                    let mut ancestor_ino = parent.inner.parent;
+                    let mut child_ino = parent.ino();
+                    loop {
+                        let ancestor = self.inner.get(ancestor_ino)?;
+                        let mut ancestor_state = ancestor.inner.sync.write().unwrap();
+                        remove_from_writing_children(&mut ancestor_state.kind_data, &child_ino);
+                        if ancestor_ino == ROOT_INODE_NO || ancestor_state.write_status == WriteStatus::Remote {
+                            break;
+                        }
+                        ancestor_state.write_status = WriteStatus::Remote;
+                        child_ino = ancestor_ino;
+                        ancestor_ino = ancestor.inner.parent;
                     }
                 }
                 // TODO force the file to be revalidated the next time it's `stat`ed?
@@ -941,6 +953,18 @@ enum InodeKindData {
         /// A set of inode numbers that have been opened for write but not completed yet.
         writing_children: HashSet<InodeNo>,
     },
+}
+
+impl InodeKindData {
+    fn default_for(kind: InodeKind) -> Self {
+        match kind {
+            InodeKind::File => Self::File {},
+            InodeKind::Directory => Self::Directory {
+                children: Default::default(),
+                writing_children: Default::default(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1246,7 +1270,12 @@ mod tests {
         for i in 0..5 {
             let filename = format!("file{i}.txt");
             let new_inode = superblock
-                .create(&client, FUSE_ROOT_INODE, OsStr::from_bytes(filename.as_bytes()))
+                .create(
+                    &client,
+                    FUSE_ROOT_INODE,
+                    OsStr::from_bytes(filename.as_bytes()),
+                    InodeKind::File,
+                )
                 .await
                 .unwrap();
             superblock
@@ -1297,7 +1326,12 @@ mod tests {
         for i in 0..5 {
             let filename = format!("newfile{i}.txt");
             let new_inode = superblock
-                .create(&client, FUSE_ROOT_INODE, OsStr::from_bytes(filename.as_bytes()))
+                .create(
+                    &client,
+                    FUSE_ROOT_INODE,
+                    OsStr::from_bytes(filename.as_bytes()),
+                    InodeKind::File,
+                )
                 .await
                 .unwrap();
             superblock
@@ -1316,6 +1350,101 @@ mod tests {
                 expected_list
             );
         }
+    }
+
+    #[test_case(""; "unprefixed")]
+    #[test_case("test_prefix/"; "prefixed")]
+    #[tokio::test]
+    async fn test_create_local_dir(prefix: &str) {
+        let client_config = MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024 * 1024,
+        };
+        let client = Arc::new(MockClient::new(client_config));
+        let prefix = Prefix::new(prefix).expect("valid prefix");
+        let superblock = Superblock::new("test_bucket", &prefix);
+
+        // Create local directory
+        let dirname = "local_dir";
+        superblock
+            .create(&client, FUSE_ROOT_INODE, dirname.as_ref(), InodeKind::Directory)
+            .await
+            .unwrap();
+
+        let lookedup = superblock
+            .lookup(&client, FUSE_ROOT_INODE, dirname.as_ref())
+            .await
+            .expect("lookup should succeed on local dirs");
+        assert_eq!(
+            lookedup.inode.inner.sync.read().unwrap().write_status,
+            WriteStatus::LocalUnopened
+        );
+
+        let dir_handle = superblock.readdir(&client, FUSE_ROOT_INODE, 2).await.unwrap();
+        let entries = dir_handle.collect(&client).await.unwrap();
+        assert_eq!(
+            entries.iter().map(|entry| entry.inode.name()).collect::<Vec<_>>(),
+            vec![dirname]
+        );
+
+        // Check that local directories are not present in the client
+        let prefix = format!("{prefix}{dirname}");
+        assert!(!client.contains_prefix(&prefix));
+    }
+
+    #[tokio::test]
+    async fn test_finish_writing_convert_parent_local_dirs_to_remote() {
+        let client_config = MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024 * 1024,
+        };
+        let client = Arc::new(MockClient::new(client_config));
+        let superblock = Superblock::new("test_bucket", &Default::default());
+
+        let nested_dirs = (0..5).map(|i| format!("level{i}")).collect::<Vec<_>>();
+        let leaf_dir_ino = {
+            let mut parent_dir_ino = FUSE_ROOT_INODE;
+            for dirname in &nested_dirs {
+                let dir_lookedup = superblock
+                    .create(&client, parent_dir_ino, dirname.as_ref(), InodeKind::Directory)
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    dir_lookedup.inode.inner.sync.read().unwrap().write_status,
+                    WriteStatus::LocalUnopened
+                );
+
+                parent_dir_ino = dir_lookedup.inode.ino();
+            }
+            parent_dir_ino
+        };
+
+        // Create object under leaf dir
+        let filename = "newfile.txt";
+        let new_inode = superblock
+            .create(
+                &client,
+                leaf_dir_ino,
+                OsStr::from_bytes(filename.as_bytes()),
+                InodeKind::File,
+            )
+            .await
+            .unwrap();
+
+        let writehandle = superblock
+            .write(&client, new_inode.inode.ino(), leaf_dir_ino)
+            .await
+            .unwrap();
+
+        // Invoke [finish_writing], without actually adding the
+        // object to the client
+        writehandle.finish_writing(0).unwrap();
+
+        // All nested dirs disappear
+        let dirname = nested_dirs.first().unwrap();
+        let lookedup = superblock.lookup(&client, FUSE_ROOT_INODE, dirname.as_ref()).await;
+        assert!(matches!(lookedup, Err(InodeError::FileDoesNotExist)));
     }
 
     #[tokio::test]

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -345,10 +345,9 @@ impl Superblock {
         }
 
         let expiry = Instant::now(); // TODO local inode stats never expire?
-        let datetime = OffsetDateTime::now_utc();
         let stat = match kind {
-            InodeKind::File => InodeStat::for_file(0, datetime, expiry, None), // Objects don't have an ETag until they are uploaded to S3
-            InodeKind::Directory => InodeStat::for_directory(datetime, expiry),
+            InodeKind::File => InodeStat::for_file(0, OffsetDateTime::now_utc(), expiry, None), // Objects don't have an ETag until they are uploaded to S3
+            InodeKind::Directory => InodeStat::for_directory(self.inner.mount_time, expiry),
         };
         let state = InodeState {
             stat: stat.clone(),

--- a/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
@@ -1,0 +1,64 @@
+use std::{
+    fs::{self, metadata, read_dir, DirBuilder},
+    time::Duration,
+};
+
+use fuser::BackgroundSession;
+use mountpoint_s3::S3FilesystemConfig;
+use tempfile::TempDir;
+use test_case::test_case;
+
+use crate::fuse_tests::TestClientBox;
+
+fn mkdir_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Create local directory
+    let dirname = "local_dir";
+    let dirpath = mount_point.path().join(dirname);
+
+    DirBuilder::new().recursive(true).create(&dirpath).unwrap();
+
+    assert!(!test_client.contains_dir(dirname).unwrap());
+
+    let m = metadata(&dirpath).unwrap();
+    assert!(m.file_type().is_dir());
+
+    // Write an object into the directory
+    let filename = "nested_file";
+    let filepath = dirpath.join(filename);
+    fs::write(filepath, "").unwrap();
+
+    // The kernel doesn't guarantee to flush the data as soon as the file is closed, so we
+    // need to wait to be sure it is committed to the client, or the remove will fail.
+    // TODO we can remove this when we implement fsync
+    std::thread::sleep(Duration::from_secs(5));
+
+    // Remove the new object from the client
+    test_client.remove_object(&format!("{dirname}/{filename}")).unwrap();
+
+    // Verify that the directory disappeared
+    let dir = read_dir(mount_point.path()).unwrap();
+    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    assert_eq!(
+        dirs.iter()
+            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        Vec::<String>::new()
+    );
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn mkdir_test_s3() {
+    mkdir_test(crate::fuse_tests::s3_session::new, "mkdir_test");
+}
+
+#[test_case(""; "unprefixed")]
+#[test_case("test_prefix/"; "prefixed")]
+fn mkdir_test_mock(prefix: &str) {
+    mkdir_test(crate::fuse_tests::mock_session::new, prefix);
+}


### PR DESCRIPTION
Address #77 by creating local-only directories:
* `mkdir` will create a new empty directory in the file system, but not affect the content of the bucket (i.e. no "directory marker" is created in the bucket).
* If a file is created under the new directory or a nested directory, the local directory will revert to a normal, implicit directory.

The new behavior is implemented using the same mechanism for writing files: a directory is created with a `WriteStatus::LocalUnopened` state and added to parent's `writing_files` set. When a new file is uploaded and its state transition to `Remote` in `finish_writing`, we also traverse its ancestors to transition local directories to `Remote`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
