### PR TITLE
Update S3 CRT client to to debug/warn on request failure based on status code

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -241,19 +241,9 @@ impl S3CrtClient {
                     let res_status_code = request_result.response_status;
                     if (res_status_code >= 200 && res_status_code <= 399) || res_status_code == 404 {
                         // Use debug level for less severe response codes.
-                        debug!(
-                            request_id,
-                            duration_us,
-                            ?request_result,
-                            "request failed"
-                        );
+                        debug!(request_id, duration_us, ?request_result, "request failed");
                     } else {
-                        warn!(
-                            request_id,
-                            duration_us,
-                            ?request_result,
-                            "request failed"
-                        );
+                        warn!(request_id, duration_us, ?request_result, "request failed");
                     }
 
                     // If it's not a real HTTP status, encode the CRT error instead
@@ -264,11 +254,7 @@ impl S3CrtClient {
                     };
                     metrics::counter!("s3.meta_request_failures", 1, "op" => op, "status" => format!("{error_status}"));
                 } else {
-                    debug!(
-                        request_id,
-                        duration_us,
-                        "request finished"
-                    );
+                    debug!(request_id, duration_us, "request finished");
                 }
 
                 let result = on_finish(request_result);

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -239,7 +239,7 @@ impl S3CrtClient {
                 let duration_us = start_time.elapsed().as_micros();
                 if request_result.is_err() {
                     let res_status_code = request_result.response_status;
-                    if (res_status_code >= 200 && res_status_code <= 399) || res_status_code == 404 {
+                    if (200..=399).contains(&res_status_code) || res_status_code == 404 {
                         // Use debug level for less severe response codes.
                         debug!(request_id, duration_us, ?request_result, "request failed");
                     } else {


### PR DESCRIPTION
Follows discussion in #201.

Some status codes are more severe than others for S3. We would like to warn on 4XX (excl. 404) and 5XX errors, while for the rest debug is fine.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
