### PR TITLE
Add basic validation of bucket name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "proptest-derive",
  "rand",
  "rand_chacha",
+ "regex",
  "serde_json",
  "sha2",
  "shuttle",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -21,6 +21,7 @@ hdrhistogram = { version = "7.5.2", default-features = false }
 libc = "0.2.126"
 metrics = "0.20.1"
 once_cell = "1.16.0"
+regex = "1.7.1"
 supports-color = "1.3.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -504,7 +504,7 @@ fn parse_bucket_name(bucket_name: &str) -> anyhow::Result<String> {
 
     // Actual bucket names must start/end with a letter, but bucket aliases can end with numbers
     // (-s3), so let's just naively check for invalid characters.
-    let bucket_regex = Regex::new(r"^[0-9a-zA-Z\-\.]+$").unwrap();
+    let bucket_regex = Regex::new(r"^[0-9a-zA-Z\-\._]+$").unwrap();
     if !bucket_regex.is_match(bucket_name) {
         return Err(anyhow!("bucket names can only contain letters, numbers, . and -"));
     }
@@ -563,7 +563,7 @@ mod tests {
     }
 
     #[test_case("test-bucket", true)]
-    #[test_case("test-123.bucket", true)]
+    #[test_case("test-123.buc_ket", true)]
     #[test_case("my-access-point-hrzrlukc5m36ft7okagglf3gmwluquse1b-s3alias", true)]
     #[test_case("my-object-lambda-acc-1a4n8yjrb3kda96f67zwrwiiuse1a--ol-s3", true)]
     #[test_case("s3://test-bucket", false)]

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -19,6 +19,7 @@ use mountpoint_s3_client::{
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use nix::sys::signal::Signal;
 use nix::unistd::ForkResult;
+use regex::Regex;
 use time::format_description::FormatItem;
 use time::macros;
 use time::OffsetDateTime;
@@ -86,7 +87,7 @@ const BUCKET_OPTIONS_HEADER: &str = "Bucket options";
 #[clap(about = "Mountpoint for Amazon S3", version = build_info::FULL_VERSION)]
 #[clap(group(ArgGroup::new("addressing-style").args(&["virtual_addressing", "path_addressing"])))]
 struct CliArgs {
-    #[clap(help = "Name of bucket to mount")]
+    #[clap(help = "Name of bucket to mount", value_parser = parse_bucket_name)]
     pub bucket_name: String,
 
     #[clap(help = "Mount point for file system")]
@@ -490,6 +491,27 @@ fn parse_perm_bits(perm_bit_str: &str) -> Result<u16, anyhow::Error> {
     }
 }
 
+/// Validate a bucket name. This isn't intended to be an exhaustive validation, just a quick filter
+/// to catch common CLI mistakes like using an S3 URI (`s3://bucket/`) or a path (`~/mnt`).
+fn parse_bucket_name(bucket_name: &str) -> anyhow::Result<String> {
+    if bucket_name.len() < 3 || bucket_name.len() > 255 {
+        return Err(anyhow!("bucket names must be 3-255 characters long"));
+    }
+
+    if bucket_name.contains("s3://") {
+        return Err(anyhow!("bucket name should not be an s3:// URI (provide the bare bucket name instead; use --prefix for prefix mounts)"));
+    }
+
+    // Actual bucket names must start/end with a letter, but bucket aliases can end with numbers
+    // (-s3), so let's just naively check for invalid characters.
+    let bucket_regex = Regex::new(r"^[0-9a-zA-Z\-\.]+$").unwrap();
+    if !bucket_regex.is_match(bucket_name) {
+        return Err(anyhow!("bucket names can only contain letters, numbers, . and -"));
+    }
+
+    Ok(bucket_name.to_owned())
+}
+
 fn calculate_network_throughput() -> anyhow::Result<f64> {
     let instance_type = retrieve_instance_type().context("failed to retrieve instance type")?;
     let throughput = get_maximum_network_throughput(&instance_type).context("failed to get network throughput")?;
@@ -524,7 +546,7 @@ fn get_maximum_network_throughput(ec2_instance_type: &str) -> anyhow::Result<f64
 
 #[cfg(test)]
 mod tests {
-    use super::get_maximum_network_throughput;
+    use super::*;
     use test_case::test_case;
 
     #[test_case("c4.large", None)] // We let "Moderate" fall through to default
@@ -538,5 +560,20 @@ mod tests {
     fn test_get_maximum_network_throughput(instance_type: &str, throughput: Option<f64>) {
         let actual = get_maximum_network_throughput(instance_type).ok();
         assert_eq!(actual, throughput);
+    }
+
+    #[test_case("test-bucket", true)]
+    #[test_case("test-123.bucket", true)]
+    #[test_case("my-access-point-hrzrlukc5m36ft7okagglf3gmwluquse1b-s3alias", true)]
+    #[test_case("my-object-lambda-acc-1a4n8yjrb3kda96f67zwrwiiuse1a--ol-s3", true)]
+    #[test_case("s3://test-bucket", false)]
+    #[test_case("~/mnt", false)]
+    fn validate_bucket_name(bucket_name: &str, valid: bool) {
+        let parsed = parse_bucket_name(bucket_name);
+        if valid {
+            assert_eq!(parsed.expect("valid bucket name"), bucket_name);
+        } else {
+            parsed.expect_err("invalid bucket name");
+        }
     }
 }

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -136,3 +136,25 @@ fn addressing_style_mutually_exclusive() -> Result<(), Box<dyn std::error::Error
 
     Ok(())
 }
+
+#[test]
+fn bucket_name_and_directory_swapped() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+
+    cmd.arg("test/dir").arg("my-bucket-name");
+    let error_message = "bucket names can only contain letters, numbers, . and -";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+#[test]
+fn s3_uri_as_bucket_name() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+
+    cmd.arg("s3://test-bucket/").arg("test/dir");
+    let error_message = "bucket name should not be an s3:// URI";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}


### PR DESCRIPTION
This will help catch common CLI errors like #203. Customers coming from
the AWS CLI might expect to be able to pass an s3:// URI as a bucket
name, which we don't support. It's also possible to accidentally swap
the bucket name and mount point arguments -- mount points will often be
invalid bucket names, so some validation helps us catch some of these
cases more quickly.

Arguably we could support parsing s3:// URIs, including using the key as
a prefix for the mount. But that would be a bigger feature and I'm not
totally sure it's the right thing, so for now some validation is better
than nothing.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
