### PR TITLE
Add support for AWS profile and unsigned requests as command line arguments

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -8,7 +8,9 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderChainDefaultOptions};
+use mountpoint_s3_crt::auth::credentials::{
+    CredentialsProvider, CredentialsProviderChainDefaultOptions, CredentialsProviderProfileOptions,
+};
 use mountpoint_s3_crt::common::allocator::Allocator;
 use mountpoint_s3_crt::common::uri::Uri;
 use mountpoint_s3_crt::http::request_response::{Header, Headers, Message};
@@ -43,12 +45,15 @@ pub(crate) mod delete_object;
 pub(crate) mod get_object;
 pub(crate) mod get_object_attributes;
 pub(crate) mod head_bucket;
+
 pub(crate) mod head_object;
 pub(crate) mod list_objects;
 pub(crate) mod put_object;
 
 #[derive(Debug, Clone, Default)]
 pub struct S3ClientConfig {
+    pub profile_name_override: Option<String>,
+    pub no_sign_request: bool,
     pub throughput_target_gbps: Option<f64>,
     pub part_size: Option<usize>,
     pub endpoint: Option<Endpoint>,
@@ -89,12 +94,7 @@ impl S3CrtClient {
 
         let mut client_bootstrap = ClientBootstrap::new(&allocator, &bootstrap_options).unwrap();
 
-        let creds_options = CredentialsProviderChainDefaultOptions {
-            bootstrap: &mut client_bootstrap,
-        };
-
-        let mut creds_provider = CredentialsProvider::new_chain_default(&allocator, &creds_options).unwrap();
-        let signing_config = init_default_signing_config(region, &mut creds_provider);
+        let mut client_config = ClientConfig::new();
 
         let mut retry_strategy_options = StandardRetryOptions::default(&mut event_loop_group);
         // Match the SDK "legacy" retry strategies
@@ -103,11 +103,29 @@ impl S3CrtClient {
         retry_strategy_options.backoff_retry_options.jitter_mode = ExponentialBackoffJitterMode::Full;
         let retry_strategy = RetryStrategy::standard(&allocator, &retry_strategy_options).unwrap();
 
-        let mut client_config = ClientConfig::new();
+        if !config.no_sign_request {
+            let credentials_provider = match config.profile_name_override {
+                Some(profile_name_override) => {
+                    let credentials_profile_options = CredentialsProviderProfileOptions {
+                        bootstrap: &mut client_bootstrap,
+                        profile_name_override: &profile_name_override,
+                    };
+                    CredentialsProvider::new_profile(&allocator, credentials_profile_options)
+                }
+                None => {
+                    let credentials_chain_default_options = CredentialsProviderChainDefaultOptions {
+                        bootstrap: &mut client_bootstrap,
+                    };
+                    CredentialsProvider::new_chain_default(&allocator, credentials_chain_default_options)
+                }
+            }
+            .map_err(NewClientError::ProviderFailure)?;
+            let signing_config = init_default_signing_config(region, credentials_provider);
+            client_config.signing_config(signing_config);
+        }
 
         client_config
             .client_bootstrap(client_bootstrap)
-            .signing_config(signing_config)
             .retry_strategy(retry_strategy);
 
         if let Some(throughput_target_gbps) = config.throughput_target_gbps {
@@ -465,6 +483,9 @@ pub enum NewClientError {
     /// Invalid S3 endpoint
     #[error("invalid S3 endpoint")]
     InvalidEndpoint(#[from] EndpointError),
+    /// Invalid AWS credentials
+    #[error("invalid AWS credentials")]
+    ProviderFailure(#[from] mountpoint_s3_crt::common::error::Error),
 }
 
 /// Failed S3 request results

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -1,11 +1,16 @@
 //! AWS credentials providers
 
+use mountpoint_s3_crt_sys::{
+    aws_credentials_provider, aws_credentials_provider_chain_default_options,
+    aws_credentials_provider_new_chain_default, aws_credentials_provider_new_profile,
+    aws_credentials_provider_profile_options, aws_credentials_provider_release,
+};
+
 use crate::auth::auth_library_init;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::io::channel_bootstrap::ClientBootstrap;
-use crate::CrtError as _;
-use mountpoint_s3_crt_sys::*;
+use crate::{CrtError as _, StringExt};
 use std::ptr::NonNull;
 
 /// Options for creating a default credentials provider
@@ -13,6 +18,15 @@ use std::ptr::NonNull;
 pub struct CredentialsProviderChainDefaultOptions<'a> {
     /// The client bootstrap this credentials provider should use to setup channels
     pub bootstrap: &'a mut ClientBootstrap,
+}
+
+/// Options for creating a profile credentials provider
+#[derive(Debug)]
+pub struct CredentialsProviderProfileOptions<'a> {
+    /// The client bootstrap this credentials provider should use to setup channels
+    pub bootstrap: &'a mut ClientBootstrap,
+    /// The name of profile to use.
+    pub profile_name_override: &'a str,
 }
 
 /// A credentials provider is an object that has an asynchronous query function for retrieving AWS
@@ -26,7 +40,7 @@ impl CredentialsProvider {
     /// Creates the default credential provider chain as used by most AWS SDKs
     pub fn new_chain_default(
         allocator: &Allocator,
-        options: &CredentialsProviderChainDefaultOptions,
+        options: CredentialsProviderChainDefaultOptions,
     ) -> Result<Self, Error> {
         auth_library_init(allocator);
 
@@ -38,6 +52,25 @@ impl CredentialsProvider {
         // SAFETY: aws_credentials_provider_new_chain_default makes a copy of the bootstrap options.
         let inner = unsafe {
             aws_credentials_provider_new_chain_default(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
+        };
+
+        Ok(Self { inner })
+    }
+
+    /// Creates the profile credential provider.
+    pub fn new_profile(allocator: &Allocator, options: CredentialsProviderProfileOptions) -> Result<Self, Error> {
+        auth_library_init(allocator);
+
+        // SAFETY: aws_credentials_provider_new_profile makes a copy of bootstrap
+        // and contents of profile_name_override.
+        let inner = unsafe {
+            let inner_options = aws_credentials_provider_profile_options {
+                bootstrap: options.bootstrap.inner.as_ptr(),
+                profile_name_override: options.profile_name_override.as_aws_byte_cursor(),
+                ..Default::default()
+            };
+
+            aws_credentials_provider_new_profile(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
         };
 
         Ok(Self { inner })

--- a/mountpoint-s3-crt/src/auth/signing_config.rs
+++ b/mountpoint-s3-crt/src/auth/signing_config.rs
@@ -1,19 +1,22 @@
 //! Configuration for signing requests to AWS APIs
 
-use mountpoint_s3_crt_sys::*;
+use crate::auth::credentials::CredentialsProvider;
+use mountpoint_s3_crt_sys::aws_signing_config_aws;
 use std::ffi::OsString;
 use std::fmt::Debug;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::sync::Arc;
 
-#[derive(Default)]
 pub(crate) struct SigningConfigInner {
     /// The raw `aws_signing_config` for this config
     pub(crate) inner: aws_signing_config_aws,
 
-    /// An owned copy of the region string, since the signing config holds a pointer to it
+    /// An owned copy of the region string, since the `aws_signing_config_aws` holds a pointer to it.
     pub(crate) region: OsString,
+
+    /// An owned CredentialProvider, since the holds `aws_signing_config_aws` a pointer to it inner.
+    pub(crate) credentials_provider: CredentialsProvider,
 
     /// This forces the struct to be !Unpin, because the signing config can contain pointers to itself
     pub(crate) _pinned: PhantomPinned,

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -206,7 +206,8 @@ struct CliArgs {
 
     #[clap(
         long,
-        help = "Do not sign requests. Credentials will not be loaded if this argument is provided."
+        help = "Do not sign requests. Credentials will not be loaded if this argument is provided.",
+        help_heading = AWS_CREDENTIALS
     )]
     pub no_sign_request: bool,
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -82,6 +82,7 @@ fn init_tracing_subscriber(is_foreground: bool, log_directory: Option<&Path>) ->
 const CLIENT_OPTIONS_HEADER: &str = "Client options";
 const MOUNT_OPTIONS_HEADER: &str = "Mount options";
 const BUCKET_OPTIONS_HEADER: &str = "Bucket options";
+const AWS_CREDENTIALS: &str = "AWS credentials options";
 
 #[derive(Parser)]
 #[clap(about = "Mountpoint for Amazon S3", version = build_info::FULL_VERSION)]
@@ -202,6 +203,15 @@ struct CliArgs {
 
     #[clap(short, long, help = "Run as foreground process")]
     pub foreground: bool,
+
+    #[clap(
+        long,
+        help = "Do not sign requests. Credentials will not be loaded if this argument is provided."
+    )]
+    pub no_sign_request: bool,
+
+    #[clap(long, help = "Use a specific profile from your credential file.", help_heading = AWS_CREDENTIALS)]
+    pub profile: Option<String>,
 }
 
 impl CliArgs {
@@ -358,6 +368,8 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     tracing::info!("target network throughput {throughput_target_gbps} Gbps");
 
     let client_config = S3ClientConfig {
+        profile_name_override: args.profile,
+        no_sign_request: args.no_sign_request,
         throughput_target_gbps: Some(throughput_target_gbps),
         part_size: args.part_size.map(|t| t as usize),
         endpoint,

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -158,3 +158,15 @@ fn s3_uri_as_bucket_name() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn invalid_profile() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+
+    cmd.arg("test-bucket").arg(dir.path()).arg("--profile").arg("INVALID");
+    let error_message = "invalid AWS credentials";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}


### PR DESCRIPTION
* Add option --profile for a specific profile in the AWS credentials file #151
* Add support for unsigned requests #181



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
