### PR TITLE
Make opened file visible in lookup

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -230,7 +230,7 @@ impl Superblock {
         }
 
         // If we reach here, the ListObjects didn't find a shadowing directory, so we know we either
-        // have a valid file, or both requests failed to find the object so it must not exist
+        // have a valid file, or both requests failed to find the object so the file must not exist remotely
         if let Some(stat) = file_state {
             trace!(?parent, ?name, "found a regular file");
             let inode = self
@@ -250,13 +250,10 @@ impl Superblock {
                         if writing_children.contains(&inode.ino()) {
                             let inode = inode.clone();
                             let stat = inode.inner.sync.read().unwrap().stat.clone();
-                            Ok(LookedUp { inode, stat })
-                        } else {
-                            Err(InodeError::FileDoesNotExist)
+                            return Ok(LookedUp { inode, stat });
                         }
-                    } else {
-                        Err(InodeError::FileDoesNotExist)
                     }
+                    Err(InodeError::FileDoesNotExist)
                 }
             }
         }

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -41,7 +41,7 @@ where
     let mut f = open_for_write(&path, append).unwrap();
 
     // The file is visible with size 0 as soon as we open it for write
-    let m = metadata(&subdir).unwrap();
+    let m = metadata(&path).unwrap();
     assert_eq!(m.len(), 0);
 
     // verify the new file is visible in readdir


### PR DESCRIPTION
We have implemented this in readdir but missed it in lookup. We want the new files to be visible there as well. There might be two options here, 1/ We can lookup locally first and return immediately when the item we want is an uncommitted inode and we don't have to call any S3 APIs since it should not exist in S3 yet, or 2/ we can lookup remotely first then fall back to local. In this commit, we go with the second option because there is a possibility that someone could make a change remotely like creating a directory marker that shadow the uncommitted file.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
