### PR TITLE
Update README for Amazon Linux 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ There are some notable restrictions in this first release:
 
 ## Getting started
 
-The alpha release of Mountpoint for Amazon S3 is only available by building from source, and only supports Linux. These instructions are for Amazon Linux 2, but other Linux distributions should be similar.
+The alpha release of Mountpoint for Amazon S3 is only available by building from source, and only supports Linux. These instructions are for Amazon Linux 2 and Amazon Linux 2023, but other Linux distributions should be similar.
 
 First, install dependencies, including the Rust compiler via [rustup](https://rustup.rs/):
 
-    sudo yum install fuse fuse-devel cmake3 clang-devel
+    sudo yum install fuse fuse-devel cmake3 clang-devel git
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    source "$HOME/.cargo/env"
 
 Now clone this repository and its submodules:
 


### PR DESCRIPTION
The only difference is that git needs to be manually installed. I also
added a missing step to source the Cargo environment variables, just in
case folks don't read the output of the Rustup installer.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
