### PR TITLE
Add time to first byte benchmark

### DIFF
--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -3,7 +3,7 @@ Currently, Mountpoint for Amazon S3 is an alpha release and we are focusing on d
 
 ### Workloads
 
-***read workload*** - there are two kinds of read we are testing, sequential read and random read. Each of the test is defined in a separate .fio file, and the file name indicates what is the test case for that file, for example `seq_read.fio` is the benchmark for sequential read. All of fio configuration files can be found at path [mountpoint-s3/scripts/fio/read/](../mountpoint-s3/scripts/fio/read).
+***read workload*** - we measure two aspects of the read operation, throughput and latency. For the first part, we use fio to simulate IO workloads for sequential read or random read for a specific duration then measure their throughput. On the latency side, we are using time to first byte as data points by running workloads that read one byte off of existing files on Mountpoint and measure the time it takes to complete the operation. Each of the test is defined in a separate .fio file, and the file name indicates what is the test case for that file, for example `seq_read.fio` is the benchmark for sequential read. All of fio configuration files can be found at path [mountpoint-s3/scripts/fio/read/](../mountpoint-s3/scripts/fio/read) and [mountpoint-s3/scripts/fio/read_latency/](../mountpoint-s3/scripts/fio/read_latency).
 
 In general, we run each IO operation for 30 seconds against a 100 GiB file. But there are some variants in configuration where we also want to test to see how Mountpoint would perform with these configurations. Here is the list of all the variants we have tested.
 

--- a/mountpoint-s3/scripts/fio/read_latency/ttfb.fio
+++ b/mountpoint-s3/scripts/fio/read_latency/ttfb.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_bench
+bs=1B
+
+[time_to_first_byte_read]
+size=1B
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+startdelay=30s
+loops=10

--- a/mountpoint-s3/scripts/fio/read_latency/ttfb_small.fio
+++ b/mountpoint-s3/scripts/fio/read_latency/ttfb_small.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_bench
+bs=1B
+
+[time_to_first_byte_read_small_file]
+size=1B
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+startdelay=30s
+loops=10


### PR DESCRIPTION
In this commit, we add a new type of benchmark to measure the latency aspect of the read operation.

We do this by running fio workloads that send one byte read request with one byte block size against existing files. The time it takes to complete this operation will be measured and recorded as time to first byte read.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
