### PR TITLE
Implement 'lookup count' tracking for `Inode`

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -305,7 +305,6 @@ where
 
         let full_key = lookup.inode.full_key().to_owned();
 
-        lookup.inode.inc_lookup_count();
         let fh = self.next_handle();
         let handle = FileHandle {
             inode: lookup.inode,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -578,10 +578,8 @@ where
             ) {
                 handle.handle.readd(next);
                 return Ok(reply);
-            } else {
-                if plus {
-                    next.inode.inc_lookup_count();
-                }
+            } else if plus {
+                next.inode.inc_lookup_count();
             }
             handle.next_offset();
         }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -483,11 +483,13 @@ where
         Ok(Opened { fh, flags: 0 })
     }
 
+    /// Implementation for both FUSE `readdir` and `readdirplus`.
     pub async fn readdir<R: DirectoryReplier>(
         &self,
         parent: InodeNo,
         fh: u64,
         offset: i64,
+        plus: bool,
         mut reply: R,
     ) -> Result<R, libc::c_int> {
         trace!("fs:readdir with ino {:?} fh {:?} offset {:?}", parent, fh, offset);
@@ -548,6 +550,10 @@ where
             ) {
                 handle.handle.readd(next);
                 return Ok(reply);
+            } else {
+                if plus {
+                    next.inode.inc_lookup_count();
+                }
             }
             handle.next_offset();
         }

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -1,3 +1,8 @@
+//! `fuser`-specific bindings, mostly wrapping the generic filesystem code in [crate::fs].
+//!
+//! Note that the purpose of this module is not necessarily to abstract away FUSE from a FileSystem,
+//! but instead to provide a thin wrapper between the `fuser` library and our filesystem handlers.
+
 use futures::executor::block_on;
 use futures::task::Spawn;
 use std::ffi::OsStr;

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -150,7 +150,7 @@ where
 
         let replier = ReplyDirectory { inner: &mut reply };
 
-        match block_on(self.fs.readdir(parent, fh, offset, replier).in_current_span()) {
+        match block_on(self.fs.readdir(parent, fh, offset, false, replier).in_current_span()) {
             Ok(_) => reply.ok(),
             Err(e) => reply.error(e),
         }
@@ -185,7 +185,7 @@ where
 
         let replier = ReplyDirectoryPlus { inner: &mut reply };
 
-        match block_on(self.fs.readdir(parent, fh, offset, replier).in_current_span()) {
+        match block_on(self.fs.readdir(parent, fh, offset, true, replier).in_current_span()) {
             Ok(_) => reply.ok(),
             Err(e) => reply.error(e),
         }

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -57,6 +57,11 @@ where
         }
     }
 
+    #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino, nlookup))]
+    fn forget(&self, _req: &Request<'_>, ino: u64, nlookup: u64) {
+        block_on(self.fs.forget(ino, nlookup));
+    }
+
     #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino))]
     fn open(&self, _req: &Request<'_>, ino: InodeNo, flags: i32, reply: ReplyOpen) {
         match block_on(self.fs.open(ino, flags).in_current_span()) {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -961,7 +961,12 @@ impl Inode {
         let mut state = self.inner.sync.write().unwrap();
         let lookup_count = &mut state.lookup_count;
         *lookup_count -= n;
-        trace!(ino = self.ino(), n, new_lookup_count = lookup_count, "decremented lookup count");
+        trace!(
+            ino = self.ino(),
+            n,
+            new_lookup_count = lookup_count,
+            "decremented lookup count"
+        );
         *lookup_count
     }
 

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -43,7 +43,7 @@ async fn test_read_dir_root(prefix: &str) {
     // Listing the root directory doesn't require resolving it first, can just opendir the root inode
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 3);
 
@@ -79,7 +79,7 @@ async fn test_read_dir_root(prefix: &str) {
 
     let mut reply = Default::default();
     let _reply = fs
-        .readdir(FUSE_ROOT_INODE, dir_handle, offset, &mut reply)
+        .readdir(FUSE_ROOT_INODE, dir_handle, offset, true, &mut reply)
         .await
         .unwrap();
     assert_eq!(reply.entries.len(), 0);
@@ -119,7 +119,7 @@ async fn test_read_dir_nested(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 2);
 
@@ -153,7 +153,7 @@ async fn test_read_dir_nested(prefix: &str) {
     assert!(offset > 0);
 
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, offset, &mut reply).await.unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, offset, true, &mut reply).await.unwrap();
     assert_eq!(reply.entries.len(), 0);
 
     // Not implemented
@@ -174,7 +174,7 @@ async fn test_random_read(object_size: usize) {
     // Find the object
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 
@@ -223,7 +223,7 @@ async fn test_implicit_directory_shadow(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -43,7 +43,7 @@ impl Harness {
             let mut keys = children.keys().cloned().collect::<HashSet<_>>();
 
             let mut reply = DirectoryReply::new(self.readdir_limit);
-            let _reply = self.fs.readdir(fs_dir, dir_handle, 0, &mut reply).await.unwrap();
+            let _reply = self.fs.readdir(fs_dir, dir_handle, 0, true, &mut reply).await.unwrap();
 
             // TODO `stat` on these needs to work
             let e0 = reply.entries.pop_front().unwrap();
@@ -53,7 +53,7 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
+                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, true, &mut reply).await.unwrap();
             }
 
             let e1 = reply.entries.pop_front().unwrap();
@@ -63,7 +63,7 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await;
+                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, true, &mut reply).await;
                 _reply.unwrap();
             }
 
@@ -103,7 +103,7 @@ impl Harness {
                     }
                 }
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
+                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, true, &mut reply).await.unwrap();
             }
 
             assert!(

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -53,7 +53,11 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, true, &mut reply).await.unwrap();
+                let _reply = self
+                    .fs
+                    .readdir(fs_dir, dir_handle, offset, true, &mut reply)
+                    .await
+                    .unwrap();
             }
 
             let e1 = reply.entries.pop_front().unwrap();
@@ -103,7 +107,11 @@ impl Harness {
                     }
                 }
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, true, &mut reply).await.unwrap();
+                let _reply = self
+                    .fs
+                    .readdir(fs_dir, dir_handle, offset, true, &mut reply)
+                    .await
+                    .unwrap();
             }
 
             assert!(


### PR DESCRIPTION
Early draft of tracking `lookup_count`, so that we know when we can drop from the superblock.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
