### PR TITLE
Add get_object test with 1 byte range

### DIFF
--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -76,6 +76,32 @@ async fn test_get_object_large() {
 }
 
 #[tokio::test]
+async fn test_get_object_one_byte_range() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_one_byte_range");
+
+    // Create one object named "onebyte"
+    let key = format!("{prefix}/onebyte");
+    let body = b".";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let result = client
+        .get_object(&bucket, &key, Some(0..1), None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+}
+
+#[tokio::test]
 async fn test_get_object_404_key() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_404_key");
 


### PR DESCRIPTION
Demonstrate issue #218.

This test reproduces the underlying cause of the issue reported in #218, isolated on `mountpoint-s3-client`. 

Reproduction
* Make a GetObject request with a range of `bytes=0-0`

Expected
* response with body of size 1

Actual 
* response with empty body (but `Content-Length: 1`)


Investigation still in progress. Notes so far:

**mountpoint** 

Although the tests shows the issue on GetObject, we should also review the calling code in the prefetcher: can we detect the inconsistency and report an error rather than get stuck?

**CRT**

It looks like the issue is in CRT code:
* A similar problem was recently fixed here: [PR 272](https://github.com/awslabs/aws-c-s3/pull/272)
* We have updated `aws-c-s3` to `v0.2.8`, which includes the previous fix.
* Unfortunately, this does not seem to have fixed our issue - is it specific to range of `bytes=0-0`?


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
