### PR TITLE
Basic property-based tests for writes

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -205,7 +205,7 @@ impl Superblock {
                     {
                         if result.objects[0].key == full_path_suffixed {
                             trace!(
-                                ?parent,
+                                parent = ?parent_ino,
                                 ?name,
                                 size = result.objects[0].size,
                                 "found a directory that shadows this name"
@@ -227,7 +227,7 @@ impl Superblock {
                     // We don't have to wait for the HeadObject to complete because in our
                     // semantics, directories always shadow files.
                     if found_directory {
-                        trace!(?parent, ?name, "lookup ListObjects found a directory");
+                        trace!(parent = ?parent_ino, ?name, "lookup ListObjects found a directory");
                         let stat = InodeStat::for_directory(self.inner.mount_time, Instant::now());
                         return Ok(Some(RemoteLookup { kind: InodeKind::Directory, stat }));
                     }
@@ -238,13 +238,13 @@ impl Superblock {
         // If we reach here, the ListObjects didn't find a shadowing directory, so we know we either
         // have a valid file, or both requests failed to find the object so the file must not exist remotely
         if let Some(stat) = file_state {
-            trace!(?parent, ?name, "found a regular file");
+            trace!(parent = ?parent_ino, ?name, "found a regular file");
             Ok(Some(RemoteLookup {
                 kind: InodeKind::File,
                 stat,
             }))
         } else {
-            trace!(?parent, ?name, "not found");
+            trace!(parent = ?parent_ino, ?name, "not found");
             Ok(None)
         }
     }
@@ -516,7 +516,7 @@ impl SuperblockInner {
             full_key.push('/');
         }
 
-        trace!(?parent, ?name, ?kind, new_ino=?next_ino, ?full_key, "creating new inode");
+        trace!(parent=?parent.ino(), ?name, ?kind, new_ino=?next_ino, ?full_key, "creating new inode");
 
         let inode = InodeInner {
             ino: next_ino,

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -1,6 +1,6 @@
 use crate::common::{make_test_filesystem, DirectoryReply, ReadReply};
-use crate::reftests::gen_tree::{flatten_tree, gen_tree, Content, FileSize, Name, TreeNode};
-use crate::reftests::reference::{build_reference, Node, Reference};
+use crate::reftests::generators::{flatten_tree, gen_tree, valid_name_strategy, FileContent, FileSize, Name, TreeNode};
+use crate::reftests::reference::{build_reference, File, Node, Reference};
 use fuser::FileType;
 use futures::executor::ThreadPool;
 use futures::future::{BoxFuture, FutureExt};
@@ -11,9 +11,41 @@ use mountpoint_s3::{
 };
 use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use proptest::prelude::*;
+use proptest_derive::Arbitrary;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
+use std::path::{Component, Path};
 use std::sync::Arc;
+use tracing::debug;
+
+/// Operations that the mutating proptests can perform on the file system.
+// TODO: mkdir, unlink
+// TODO: "reboot" (forget all the local inodes and re-bootstrap)
+// TODO: incremental writes (test partially written files)
+#[derive(Debug, Arbitrary)]
+pub enum Op {
+    WriteFile(
+        #[proptest(strategy = "valid_name_strategy()")] String,
+        DirectoryIndex,
+        FileContent,
+    ),
+}
+
+/// An index into the reference model's list of directories. We use this to randomly select an
+/// existing directory to operate on (for put, rmdir, etc).
+#[derive(Debug, Arbitrary)]
+pub struct DirectoryIndex(usize);
+
+impl DirectoryIndex {
+    /// Get the full path to the directory at the given index in the reference (wrapping around if
+    /// the index is larger than the number of directories)
+    fn get<'a>(&self, reference: &'a Reference) -> &'a str {
+        let directories = reference.directories();
+        assert!(!directories.is_empty(), "directories can never be empty");
+        let idx = self.0 % directories.len();
+        &directories[idx]
+    }
+}
 
 #[derive(Debug)]
 pub struct Harness {
@@ -23,11 +55,119 @@ pub struct Harness {
 }
 
 impl Harness {
-    fn new(fs: S3Filesystem<Arc<MockClient>, ThreadPool>, reference: Reference, readdir_limit: usize) -> Self {
+    /// Create a new test harness
+    pub fn new(fs: S3Filesystem<Arc<MockClient>, ThreadPool>, reference: Reference, readdir_limit: usize) -> Self {
         Self {
             readdir_limit,
             reference,
             fs,
+        }
+    }
+
+    /// Run a sequence of mutation operations on the test harness, checking equivalence between the
+    /// reference model and file system after each operation.
+    pub async fn run(&mut self, ops: Vec<Op>) {
+        for op in ops {
+            debug!(?op, "executing operation");
+            match &op {
+                Op::WriteFile(name, directory_index, contents) => {
+                    let dir = Path::new(directory_index.get(&self.reference));
+                    let full_path = format!("{}/{name}", dir.display());
+
+                    // Find the inode for the directory by walking the file system tree
+                    let mut components = dir.components();
+                    assert_eq!(components.next(), Some(Component::RootDir));
+                    let mut inode = FUSE_ROOT_INODE;
+                    for component in components {
+                        if let Component::Normal(folder) = component {
+                            inode = self
+                                .fs
+                                .lookup(inode, folder)
+                                .await
+                                .expect("directory must already exist")
+                                .attr
+                                .ino;
+                        } else {
+                            panic!("unexpected path component {component:?}");
+                        }
+                    }
+
+                    // Random paths can shadow existing ones, so we check that we aren't allowed to
+                    // overwrite an existing inode. The existing node could be either a file or
+                    // directory; we should fail the same way in both cases.
+                    // TODO we have to get pretty lucky to hit this path right now -- try to bias the
+                    // search in this direction a bit.
+                    let reference_lookup = self.reference.lookup(&full_path);
+                    if reference_lookup.is_some() {
+                        let mknod = self.fs.mknod(inode, name.as_ref(), libc::S_IFREG, 0, 0).await;
+                        assert!(
+                            matches!(mknod, Err(libc::EEXIST)),
+                            "can't overwrite existing file/directory"
+                        );
+                    } else {
+                        let mknod = self.fs.mknod(inode, name.as_ref(), libc::S_IFREG, 0, 0).await.unwrap();
+                        let open = self.fs.open(mknod.attr.ino, libc::O_WRONLY).await.unwrap();
+
+                        // TODO try testing more than one `write` call
+                        let bytes = contents.to_boxed_slice();
+                        let write = self
+                            .fs
+                            .write(mknod.attr.ino, open.fh, 0, &bytes, 0, 0, None)
+                            .await
+                            .unwrap();
+                        assert_eq!(write as usize, bytes.len());
+
+                        self.fs.release(mknod.attr.ino, open.fh, 0, None, false).await.unwrap();
+
+                        self.reference.add_file(&full_path, contents);
+                    }
+                }
+            }
+
+            debug!(?op, "checking contents");
+            self.compare_contents().await;
+        }
+    }
+
+    /// Walk the filesystem tree and check that at each level, contents match the reference
+    pub async fn compare_contents(&self) {
+        let root = self.reference.root();
+        self.compare_contents_recursive(FUSE_ROOT_INODE, FUSE_ROOT_INODE, root)
+            .await;
+    }
+
+    /// Walk a single path through the filesystem tree and ensure each node matches the reference.
+    /// Compared to [compare_contents], this avoids doing a `readdir` before `lookup`, and so tests
+    /// a different path through the inode code.
+    pub async fn compare_single_path(&self, idx: usize) {
+        let inodes = self.reference.list_recursive();
+        if inodes.is_empty() {
+            return;
+        }
+        let (path, node) = &inodes[idx % inodes.len()];
+
+        let mut parent = FUSE_ROOT_INODE;
+        let mut seen_inos = HashSet::from([FUSE_ROOT_INODE]);
+        for name in path.iter().take(path.len().saturating_sub(1)) {
+            let lookup = self.fs.lookup(parent, name.as_ref()).await.unwrap();
+            assert_eq!(lookup.attr.kind, FileType::Directory);
+            assert!(seen_inos.insert(lookup.attr.ino));
+            parent = lookup.attr.ino;
+        }
+
+        let lookup = self.fs.lookup(parent, path.last().unwrap().as_ref()).await.unwrap();
+        assert!(seen_inos.insert(lookup.attr.ino));
+        match node {
+            Node::Directory(_) => {
+                assert_eq!(lookup.attr.kind, FileType::Directory);
+            }
+            Node::File(content) => {
+                assert_eq!(lookup.attr.kind, FileType::RegularFile);
+                match content {
+                    File::Local(_) => unimplemented!(),
+                    File::Remote(object) => self.compare_file(lookup.attr.ino, object).await,
+                }
+            }
         }
     }
 
@@ -91,7 +231,10 @@ impl Harness {
                             );
                             if let Node::File(ref_object) = node {
                                 assert_eq!(attr.kind, FileType::RegularFile);
-                                self.compare_file(reply.ino, ref_object).await;
+                                match ref_object {
+                                    File::Local(_) => todo!("local files are not yet tested"),
+                                    File::Remote(object) => self.compare_file(reply.ino, object).await,
+                                }
                             } else {
                                 assert_eq!(attr.kind, FileType::Directory);
                                 // Recurse into directory
@@ -143,189 +286,248 @@ impl Harness {
             offset += num_bytes;
         }
     }
+}
 
-    /// Walk the filesystem tree and check that at each level, contents match the reference
-    async fn compare_contents(&self) {
-        let root = self.reference.root();
-        self.compare_contents_recursive(FUSE_ROOT_INODE, FUSE_ROOT_INODE, root)
-            .await;
+/// Read-only reftests that generate random S3 buckets and check the mapping from S3 keys to file
+/// paths is correct.
+mod read_only {
+    use super::*;
+
+    #[derive(Debug)]
+    enum CheckType {
+        /// Traverse the entire tree recursively with `readdir` and compare the results of every node
+        FullTree,
+        /// Do a lookup along a single path and compare the leaf node
+        SinglePath {
+            /// Index into the list of all nodes in the file system
+            path_index: usize,
+        },
     }
 
-    /// Walk a single path through the filesystem tree and ensure each node matches the reference.
-    /// Compared to [compare_contents], this avoids doing a `readdir` before `lookup`, and so tests
-    /// a different path through the inode code.
-    async fn compare_single_path(&self, idx: usize) {
-        let inodes = self.reference.list_recursive();
-        if inodes.is_empty() {
-            return;
-        }
-        let (path, node) = &inodes[idx % inodes.len()];
+    fn run_test(tree: TreeNode, check: CheckType, readdir_limit: usize) {
+        let test_prefix = Prefix::new("test_prefix/").expect("valid prefix");
+        let config = S3FilesystemConfig {
+            readdir_size: 5,
+            ..Default::default()
+        };
+        let (client, fs) = make_test_filesystem("harness", &test_prefix, config);
 
-        let mut parent = FUSE_ROOT_INODE;
-        let mut seen_inos = HashSet::from([FUSE_ROOT_INODE]);
-        for name in path.iter().take(path.len().saturating_sub(1)) {
-            let lookup = self.fs.lookup(parent, name.as_ref()).await.unwrap();
-            assert_eq!(lookup.attr.kind, FileType::Directory);
-            assert!(seen_inos.insert(lookup.attr.ino));
-            parent = lookup.attr.ino;
+        let namespace = flatten_tree(tree);
+        for (key, object) in namespace.iter() {
+            client.add_object(&format!("{test_prefix}{key}"), object.to_mock_object());
         }
 
-        let lookup = self.fs.lookup(parent, path.last().unwrap().as_ref()).await.unwrap();
-        assert!(seen_inos.insert(lookup.attr.ino));
-        match node {
-            Node::Directory(_) => {
-                assert_eq!(lookup.attr.kind, FileType::Directory);
+        let reference = build_reference(namespace);
+
+        let harness = Harness::new(fs, reference, readdir_limit);
+
+        futures::executor::block_on(async move {
+            match check {
+                CheckType::FullTree => harness.compare_contents().await,
+                CheckType::SinglePath { path_index } => harness.compare_single_path(path_index).await,
             }
-            Node::File(content) => {
-                assert_eq!(lookup.attr.kind, FileType::RegularFile);
-                self.compare_file(lookup.attr.ino, content).await;
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum CheckType {
-    /// Traverse the entire tree recursively with `readdir` and compare the results of every node
-    FullTree,
-    /// Do a lookup along a single path and compare the leaf node
-    SinglePath {
-        /// Index into the list of all nodes in the file system
-        path_index: usize,
-    },
-}
-
-fn run_test(tree: TreeNode, check: CheckType, readdir_limit: usize) {
-    let test_prefix = Prefix::new("test_prefix/").expect("valid prefix");
-    let config = S3FilesystemConfig {
-        readdir_size: 5,
-        ..Default::default()
-    };
-    let (client, fs) = make_test_filesystem("harness", &test_prefix, config);
-
-    let namespace = flatten_tree(tree);
-    for (key, object) in namespace.iter() {
-        client.add_object(&format!("{test_prefix}{key}"), object.to_mock_object());
+        });
     }
 
-    let reference = build_reference(namespace);
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
 
-    let harness = Harness::new(fs, reference, readdir_limit);
-
-    futures::executor::block_on(async move {
-        match check {
-            CheckType::FullTree => harness.compare_contents().await,
-            CheckType::SinglePath { path_index } => harness.compare_single_path(path_index).await,
+        #[test]
+        fn reftest_random_tree_full(readdir_limit in 0..10usize, tree in gen_tree(5, 100, 5, 20)) {
+            run_test(tree, CheckType::FullTree, readdir_limit);
         }
-    });
-}
 
-proptest! {
-    #![proptest_config(ProptestConfig {
-        failure_persistence: None,
-        .. ProptestConfig::default()
-    })]
-
-    #[test]
-    fn reftest_random_tree_full(readdir_limit in 0..10usize, tree in gen_tree(5, 100, 5, 20)) {
-        run_test(tree, CheckType::FullTree, readdir_limit);
+        #[test]
+        fn reftest_random_tree_single(tree in gen_tree(5, 100, 5, 20), path_index: usize) {
+            run_test(tree, CheckType::SinglePath { path_index }, 0);
+        }
     }
 
     #[test]
-    fn reftest_random_tree_single(tree in gen_tree(5, 100, 5, 20), path_index: usize) {
-        run_test(tree, CheckType::SinglePath { path_index }, 0);
-    }
-}
-
-#[test]
-fn random_tree_regression_basic() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([(
-            Name("-".to_string()),
+    fn random_tree_regression_basic() {
+        run_test(
             TreeNode::Directory(BTreeMap::from([(
                 Name("-".to_string()),
-                TreeNode::File(Content(0, FileSize::Small(0))),
-            )])),
-        )])),
-        CheckType::FullTree,
-        0,
-    );
-}
-
-#[test]
-fn random_tree_regression_directory_order() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([
-            (Name("-a-".to_string()), TreeNode::File(Content(0, FileSize::Small(0)))),
-            (
-                Name("-a".to_string()),
                 TreeNode::Directory(BTreeMap::from([(
                     Name("-".to_string()),
-                    TreeNode::File(Content(0, FileSize::Small(0))),
+                    TreeNode::File(FileContent(0, FileSize::Small(0))),
                 )])),
-            ),
-        ])),
-        CheckType::FullTree,
-        0,
-    );
-}
-
-#[test]
-fn random_tree_regression_invalid_name1() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([(
-            Name("-".to_string()),
-            TreeNode::Directory(BTreeMap::from([(
-                Name(".".to_string()),
-                TreeNode::File(Content(0, FileSize::Small(0))),
             )])),
-        )])),
-        CheckType::FullTree,
-        0,
-    );
-}
+            CheckType::FullTree,
+            0,
+        );
+    }
 
-#[test]
-fn random_tree_regression_invalid_name2() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([(
-            Name("-".to_string()),
+    #[test]
+    fn random_tree_regression_directory_order() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([
+                (
+                    Name("-a-".to_string()),
+                    TreeNode::File(FileContent(0, FileSize::Small(0))),
+                ),
+                (
+                    Name("-a".to_string()),
+                    TreeNode::Directory(BTreeMap::from([(
+                        Name("-".to_string()),
+                        TreeNode::File(FileContent(0, FileSize::Small(0))),
+                    )])),
+                ),
+            ])),
+            CheckType::FullTree,
+            0,
+        );
+    }
+
+    #[test]
+    fn random_tree_regression_invalid_name1() {
+        run_test(
             TreeNode::Directory(BTreeMap::from([(
-                Name("a/".to_string()),
-                TreeNode::File(Content(0, FileSize::Small(0))),
+                Name("-".to_string()),
+                TreeNode::Directory(BTreeMap::from([(
+                    Name(".".to_string()),
+                    TreeNode::File(FileContent(0, FileSize::Small(0))),
+                )])),
             )])),
-        )])),
-        CheckType::FullTree,
-        0,
-    )
+            CheckType::FullTree,
+            0,
+        );
+    }
+
+    #[test]
+    fn random_tree_regression_invalid_name2() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([(
+                Name("-".to_string()),
+                TreeNode::Directory(BTreeMap::from([(
+                    Name("a/".to_string()),
+                    TreeNode::File(FileContent(0, FileSize::Small(0))),
+                )])),
+            )])),
+            CheckType::FullTree,
+            0,
+        )
+    }
+
+    #[test]
+    fn random_tree_regression_directory_shadow() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([(
+                Name("a".to_string()),
+                TreeNode::Directory(BTreeMap::from([
+                    (
+                        Name("a/".to_string()),
+                        TreeNode::File(FileContent(0, FileSize::Small(0))),
+                    ),
+                    (
+                        Name("a".to_string()),
+                        TreeNode::File(FileContent(0, FileSize::Small(0))),
+                    ),
+                ])),
+            )])),
+            CheckType::FullTree,
+            0,
+        )
+    }
+
+    #[test]
+    fn random_tree_regression_directory_shadow_lookup() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([(
+                Name("a".to_string()),
+                TreeNode::Directory(BTreeMap::from([
+                    (
+                        Name("a/".to_string()),
+                        TreeNode::File(FileContent(0, FileSize::Small(0))),
+                    ),
+                    (
+                        Name("a".to_string()),
+                        TreeNode::File(FileContent(0, FileSize::Small(0))),
+                    ),
+                ])),
+            )])),
+            CheckType::SinglePath { path_index: 1 },
+            0,
+        )
+    }
 }
 
-#[test]
-fn random_tree_regression_directory_shadow() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([(
-            Name("a".to_string()),
-            TreeNode::Directory(BTreeMap::from([
-                (Name("a/".to_string()), TreeNode::File(Content(0, FileSize::Small(0)))),
-                (Name("a".to_string()), TreeNode::File(Content(0, FileSize::Small(0)))),
-            ])),
-        )])),
-        CheckType::FullTree,
-        0,
-    )
-}
+/// Mutation tests that run a sequence of mutations against a file system and check equivalence to
+/// the reference model.
+mod mutations {
+    use super::*;
+    use proptest::collection::vec;
 
-#[test]
-fn random_tree_regression_directory_shadow_lookup() {
-    run_test(
-        TreeNode::Directory(BTreeMap::from([(
-            Name("a".to_string()),
-            TreeNode::Directory(BTreeMap::from([
-                (Name("a/".to_string()), TreeNode::File(Content(0, FileSize::Small(0)))),
-                (Name("a".to_string()), TreeNode::File(Content(0, FileSize::Small(0)))),
-            ])),
-        )])),
-        CheckType::SinglePath { path_index: 1 },
-        0,
-    )
+    fn run_test(initial_tree: TreeNode, ops: Vec<Op>, readdir_limit: usize) {
+        let test_prefix = Prefix::new("test_prefix/").expect("valid prefix");
+        let config = S3FilesystemConfig {
+            readdir_size: 5,
+            ..Default::default()
+        };
+        let (client, fs) = make_test_filesystem("harness", &test_prefix, config);
+
+        let namespace = flatten_tree(initial_tree);
+        for (key, object) in namespace.iter() {
+            client.add_object(&format!("{test_prefix}{key}"), object.to_mock_object());
+        }
+
+        let reference = build_reference(namespace);
+
+        let mut harness = Harness::new(fs, reference, readdir_limit);
+
+        futures::executor::block_on(harness.run(ops));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
+
+        #[test]
+        fn reftest_random_tree(tree in gen_tree(5, 100, 5, 20), readdir_limit in 0..10usize, ops in vec(any::<Op>(), 1..10)) {
+            run_test(tree, ops, readdir_limit);
+        }
+    }
+
+    #[test]
+    fn regression_basic() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([(
+                Name("-".to_string()),
+                TreeNode::Directory(BTreeMap::from([(
+                    Name("-".to_string()),
+                    TreeNode::File(FileContent(0, FileSize::Small(0))),
+                )])),
+            )])),
+            vec![
+                Op::WriteFile(
+                    "a".to_string(),
+                    DirectoryIndex(0),
+                    FileContent(0x0a, FileSize::Small(50)),
+                ),
+                Op::WriteFile(
+                    "b".to_string(),
+                    DirectoryIndex(1),
+                    FileContent(0x0b, FileSize::Small(10)),
+                ),
+            ],
+            0,
+        );
+    }
+
+    #[test]
+    fn regression_overwrite() {
+        run_test(
+            TreeNode::File(FileContent(0, FileSize::Small(0))),
+            vec![
+                Op::WriteFile("-a".to_string(), DirectoryIndex(0), FileContent(0, FileSize::Small(0))),
+                Op::WriteFile("-a".to_string(), DirectoryIndex(0), FileContent(0, FileSize::Small(0))),
+            ],
+            0,
+        )
+    }
 }

--- a/mountpoint-s3/tests/reftests/mod.rs
+++ b/mountpoint-s3/tests/reftests/mod.rs
@@ -1,3 +1,3 @@
-mod gen_tree;
+mod generators;
 mod harness;
 mod reference;

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -236,7 +236,7 @@ pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
     }
 
     let mut directories = vec!["/".into()];
-    let root = convert(tree.take(), "", &mut directories);
+    let root = convert(tree.take(), "/", &mut directories);
     Reference {
         root: Node::Directory(root),
         directories,

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -1,18 +1,24 @@
 use fuser::FileType;
 use mountpoint_s3_client::mock_client::MockObject;
-use mountpoint_s3_client::ETag;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Component, Path};
 use std::rc::Rc;
 
-use crate::reftests::gen_tree::Content;
+use crate::reftests::generators::{FileContent, FileSize};
+
+#[derive(Debug)]
+pub enum File {
+    #[allow(unused)] // TODO when we test partially written files
+    Local(Vec<u8>),
+    Remote(MockObject),
+}
 
 #[derive(Debug)]
 pub enum Node {
     // TODO Also support hybrid nodes?
     Directory(BTreeMap<String, Node>),
-    File(MockObject),
+    File(File),
 }
 
 impl Node {
@@ -47,12 +53,21 @@ impl Node {
 #[derive(Debug)]
 pub struct Reference {
     root: Node,
+    /// Full path of all directories
+    directories: Vec<String>,
+    /// Full path of all inflight writes
+    #[allow(unused)] // TODO when we test partially written files
+    inflight_writes: Vec<String>,
 }
 
 impl Reference {
     pub fn new() -> Self {
         let root = Node::Directory(BTreeMap::new());
-        Self { root }
+        Self {
+            root,
+            directories: vec!["/".into()],
+            inflight_writes: vec![],
+        }
     }
 
     pub fn root(&self) -> &Node {
@@ -85,7 +100,7 @@ impl Reference {
     }
 
     // Add file to the reference, creating internal nodes as necessary
-    pub fn add_file(&mut self, path: &str, pattern: u8, length: usize) {
+    pub fn add_file(&mut self, path: &str, file: &FileContent) {
         let path = Path::new(path);
 
         let mut components = path.components().peekable();
@@ -98,7 +113,7 @@ impl Reference {
                     let dir = dir.as_os_str().to_str().unwrap().to_string();
                     if children.get(&dir).is_none() {
                         let data = if components.peek().is_none() {
-                            Node::File(MockObject::ramp(pattern, length, ETag::for_tests()))
+                            Node::File(File::Remote(file.to_mock_object()))
                         } else {
                             Node::Directory(BTreeMap::new())
                         };
@@ -110,6 +125,31 @@ impl Reference {
             };
         }
     }
+
+    /// Get a node from a full path, if it exists
+    pub fn lookup(&self, path: &str) -> Option<&Node> {
+        let path = Path::new(path);
+
+        let mut components = path.components().peekable();
+        assert_eq!(components.next(), Some(Component::RootDir));
+
+        let mut node = &self.root;
+        for dir in components {
+            node = match node {
+                Node::Directory(children) => {
+                    let dir = dir.as_os_str().to_str().unwrap().to_string();
+                    children.get(&dir)?
+                }
+                _ => panic!("unexpected internal file node"),
+            };
+        }
+
+        Some(node)
+    }
+
+    pub fn directories(&self) -> &[String] {
+        &self.directories
+    }
 }
 
 fn valid_inode_name(name: &str) -> bool {
@@ -119,11 +159,11 @@ fn valid_inode_name(name: &str) -> bool {
 /// Take an S3 namespace (list of keys) and create the expected reference file system tree. This is
 /// where all our semantics decisions about how to present a flat keyspace as a file system are
 /// made; we'll be testing the connector against the decisions made here.
-pub fn build_reference(flat: Vec<(String, Content)>) -> Reference {
+pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
     #[derive(Debug)]
     enum RefNode {
         Directory(Rc<RefCell<BTreeMap<String, RefNode>>>),
-        File(Content),
+        File(FileContent),
     }
 
     impl RefNode {
@@ -175,24 +215,29 @@ pub fn build_reference(flat: Vec<(String, Content)>) -> Reference {
         }
     }
 
-    fn convert(node: BTreeMap<String, RefNode>) -> BTreeMap<String, Node> {
+    fn convert(node: BTreeMap<String, RefNode>, path: String, directories: &mut Vec<String>) -> BTreeMap<String, Node> {
         let mut out = BTreeMap::new();
         for (key, node) in node {
             let node = match node {
                 RefNode::Directory(contents) => {
-                    let converted = convert(contents.take());
+                    let path = format!("{path}/{key}");
+                    directories.push(path.clone());
+                    let converted = convert(contents.take(), path, directories);
                     Node::Directory(converted)
                 }
-                RefNode::File(contents) => Node::File(contents.to_mock_object()),
+                RefNode::File(contents) => Node::File(File::Remote(contents.to_mock_object())),
             };
             out.insert(key, node);
         }
         out
     }
 
-    let root = convert(tree.take());
+    let mut directories = vec!["/".into()];
+    let root = convert(tree.take(), "".into(), &mut directories);
     Reference {
         root: Node::Directory(root),
+        directories,
+        inflight_writes: vec![],
     }
 }
 
@@ -202,7 +247,7 @@ fn depth_test() {
 
     assert_eq!(r.depth(), 0);
 
-    r.add_file("/a/b/c1", 0, 0);
-    r.add_file("/a/b/c2", 0, 0);
+    r.add_file("/a/b/c1", &FileContent(0xaa, FileSize::Small(0)));
+    r.add_file("/a/b/c2", &FileContent(0xbb, FileSize::Small(0)));
     assert_eq!(r.depth(), 3);
 }


### PR DESCRIPTION
This is the first step in property-based testing for the write path.
Right now, it tests scenarios where the entire write sequence happens at
once: mknod, open, write once, release. It generates a vector of such
operations, with random paths and random file contents/sizes. After each
operations, the test checks that the file system has the expected
contents.

I'm stopping this PR here because it's enough to get the testing off the
ground, but doesn't yet cover a lot of the interesting cases we'd like to
check. The focus here is getting the infrastructure in place to start
adding more complex operations to the `Op` structure in future PRs.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
