### PR TITLE
Implement `unlink` operation for remote files

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -74,6 +74,19 @@ Synchronization operations (`fsync`, `fdatasync`) are currently no-ops because w
 
 Space allocation (`fallocate`, `posix_fallocate`) are not supported.
 
+#### Deletes
+
+File deletion (`unlink`) is planned but not yet supported (see [#78](https://github.com/awslabs/mountpoint-s3/issues/78)).
+When `unlink` is implemented, the following semantics are proposed.
+
+For files not yet committed to S3, the client will not permit `unlink` operations.
+The file should be closed and thus committed to S3, at which point an `unlink` can be performed on the remote file.
+
+For files already committed to S3, the client will _immediately_ delete the corresponding object from S3,
+and remove the file from its directory.
+If there are still open file handles to the file, future reads to them will fail.
+Because the object is immediately deleted from S3, future reads from other hosts will also fail.
+
 ### Directory operations
 
 Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported.
@@ -86,7 +99,7 @@ Creating directories (`mkdir`) is not currently supported, but will be [in the f
 
 Renaming files and directories (`rename`, `renameat`) is not currently supported.
 
-File deletion (`unlink`) is not currently supported, but will be [in the future](https://github.com/awslabs/mountpoint-s3/issues/78).
+File deletion (`unlink`) semantics are described in the [Deletes](#Deletes) section.
 
 Empty directory removal (`rmdir`) is not supported.
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -635,7 +635,7 @@ impl From<InodeError> for i32 {
             InodeError::ShadowedByDirectory(_, _) => libc::ENOENT,
             InodeError::FileAlreadyExists(_) => libc::EEXIST,
             // Not obvious what InodeNotWritable, InodeNotReadableWhileWriting should be.
-            // EINVAL or EROFS would also be reasonable -- but we'll treat them like a sealed file for now.
+            // EINVAL or EROFS would also be reasonable -- but we'll treat them like sealed files for now.
             InodeError::InodeNotWritable(_) => libc::EPERM,
             InodeError::InodeNotReadableWhileWriting(_) => libc::EPERM,
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1,5 +1,4 @@
 use futures::task::Spawn;
-use futures::TryFutureExt;
 use nix::unistd::{getgid, getuid};
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -619,10 +618,8 @@ where
     }
 
     pub async fn unlink(&self, parent_ino: InodeNo, name: &OsStr) -> Result<(), libc::c_int> {
-        self.superblock
-            .unlink(&self.client, parent_ino, name)
-            .map_err(Into::into)
-            .await
+        self.superblock.unlink(&self.client, parent_ino, name).await?;
+        Ok(())
     }
 }
 

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -264,4 +264,12 @@ where
             Err(e) => reply.error(e),
         }
     }
+
+    #[instrument(level="debug", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
+    fn unlink(&self, _req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
+        match block_on(self.fs.unlink(parent, name).in_current_span()) {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(e),
+        }
+    }
 }

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1566,7 +1566,7 @@ mod tests {
             part_size: 1024 * 1024,
         };
         let client = Arc::new(MockClient::new(client_config));
-        let prefix = Prefix::new(prefix).unwrap();
+        let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new("test_bucket", &prefix, Default::default());
 
         let file_name = OsString::from("file.txt");
@@ -1579,19 +1579,19 @@ mod tests {
         superblock
             .lookup(&client, parent_ino, &file_name)
             .await
-            .expect("should be able to lookup file");
+            .expect("file should exist");
 
         superblock
             .unlink(&client, parent_ino, &file_name)
             .await
-            .expect("should be able to delete file");
+            .expect("file delete should succeed as it exists");
 
         let err: i32 = superblock
             .lookup(&client, parent_ino, &file_name)
             .await
-            .expect_err("should not return an entry from lookup")
+            .expect_err("lookup should no longer find deleted file")
             .into();
-        assert_eq!(libc::ENOENT, err, "lookup should return no entry error");
+        assert_eq!(libc::ENOENT, err, "lookup should return no existing entry error");
     }
 
     #[tokio::test]

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -518,6 +518,8 @@ impl Superblock {
             }
         };
 
+        // TODO: When inode lookup/ref counting is implemented, decrement here to eventually remove from superblock.
+
         Ok(())
     }
 }

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -358,10 +358,6 @@ impl Superblock {
     /// Unlink the entry described by `parent_ino` and `name`.
     ///
     /// If the entry exists, delete it from S3 and the superblock.
-    /// 
-    /// We know that the Linux Kernel's VFS will lock both the parent and child,
-    /// so we can safely ignore concurrent operations within the same Mountpoint process to the file and its parent.
-    /// See: https://www.kernel.org/doc/html/next/filesystems/directory-locking.html
     pub async fn unlink<OC: ObjectClient>(
         &self,
         client: &OC,
@@ -375,13 +371,12 @@ impl Superblock {
             return Err(InodeError::IsDirectory(inode.ino()));
         }
 
-        // Take exclusive write locks early.
-        // We know that the VFS will already have locked its equivalent representations.
-        let mut parent_state = parent.inner.sync.write().unwrap();
-        // Take a write lock even if we don't mutate, since we would not want to permit any concurrent operations.
-        let inode_state = inode.inner.sync.write().unwrap();
+        let write_status = {
+            let inode_state = inode.inner.sync.read().unwrap();
+            inode_state.write_status
+        };
 
-        match inode_state.write_status {
+        match write_status {
             WriteStatus::LocalUnopened | WriteStatus::LocalOpen => {
                 // In the future, we may permit `unlink` and cancel any in-flight uploads.
                 error!(
@@ -412,13 +407,20 @@ impl Superblock {
             }
         }
 
+        let mut parent_state = parent.inner.sync.write().unwrap();
         match &mut parent_state.kind_data {
             InodeKindData::File { .. } => {
                 debug_assert!(false, "inodes never change kind");
                 return Err(InodeError::NotADirectory(parent.ino()));
             }
-            InodeKindData::Directory { children, .. } => {
-                children.remove(inode.name());
+            InodeKindData::Directory {
+                children,
+                writing_children,
+            } => {
+                writing_children.remove(&inode.ino());
+                if children.remove(inode.name()).is_none() {
+                    debug!("child was not present, another operation may have occurred in parallel");
+                }
             }
         };
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1569,25 +1569,23 @@ mod tests {
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new("test_bucket", &prefix, Default::default());
 
-        let file_name = OsString::from("file.txt");
-        client.add_object(
-            file_name.to_str().unwrap(),
-            MockObject::constant(0xaa, 30, ETag::for_tests()),
-        );
+        let file_name = "file.txt";
+        let file_key = format!("{prefix}{file_name}");
+        client.add_object(file_key.as_ref(), MockObject::constant(0xaa, 30, ETag::for_tests()));
         let parent_ino = FUSE_ROOT_INODE;
 
         superblock
-            .lookup(&client, parent_ino, &file_name)
+            .lookup(&client, parent_ino, file_name.as_ref())
             .await
             .expect("file should exist");
 
         superblock
-            .unlink(&client, parent_ino, &file_name)
+            .unlink(&client, parent_ino, file_name.as_ref())
             .await
             .expect("file delete should succeed as it exists");
 
         let err: i32 = superblock
-            .lookup(&client, parent_ino, &file_name)
+            .lookup(&client, parent_ino, file_name.as_ref())
             .await
             .expect_err("lookup should no longer find deleted file")
             .into();

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -6,6 +6,7 @@ mod perm_test;
 mod prefetch_test;
 mod readdir_test;
 mod semantics_doc_test;
+mod unlink_test;
 mod write_test;
 
 use std::ffi::OsStr;

--- a/mountpoint-s3/tests/fuse_tests/unlink_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/unlink_test.rs
@@ -127,7 +127,7 @@ where
     let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
     assert_eq!(raw_os_err, libc::EPERM, "unlink should fail with OS err EPERM");
 
-    f.write_all(&mut [0u8; 1]).expect("write should succeed");
+    f.write_all(&[0u8; 1]).expect("write should succeed");
 
     let err =
         fs::remove_file(&path).expect_err("file remove/unlink of path partial written to should continue to fail");

--- a/mountpoint-s3/tests/fuse_tests/unlink_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/unlink_test.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{ErrorKind, Read, Seek, SeekFrom};
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 
 use fuser::BackgroundSession;
 use mountpoint_s3::S3FilesystemConfig;
@@ -55,7 +55,7 @@ fn simple_unlink_test_mock(prefix: &str) {
 }
 
 /// Testing behavior when a file is unlinked in the middle of reading
-fn unlink_filehandle_test<F>(creator_fn: F, prefix: &str)
+fn unlink_readhandle_test<F>(creator_fn: F, prefix: &str)
 where
     F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
@@ -73,8 +73,8 @@ where
         .read(true)
         .write(false)
         .open(&path)
-        .expect("open should work");
-    f.read_exact(&mut [0u8; 1]).expect("read should work");
+        .expect("open should succeed");
+    f.read_exact(&mut [0u8; 1]).expect("read should succeed");
 
     fs::remove_file(&path).expect("file remove/unlink of existing path should succeed");
 
@@ -88,17 +88,77 @@ where
         .read_exact(&mut [0u8; 1])
         .expect_err("fresh read using open file handle should fail as object no longer exists");
     let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
-    assert_eq!(raw_os_err, libc::EIO);
+    assert_eq!(raw_os_err, libc::EIO, "unlink should fail with OS err EIO");
 }
 
 #[cfg(feature = "s3_tests")]
 #[test]
-fn unlink_filehandle_test_s3() {
-    unlink_filehandle_test(crate::fuse_tests::s3_session::new, "unlink_filehandle_test");
+fn unlink_readhandle_test_s3() {
+    unlink_readhandle_test(crate::fuse_tests::s3_session::new, "unlink_readhandle_test");
 }
 
 #[test_case(""; "no prefix")]
-#[test_case("unlink_filehandle_test"; "prefix")]
-fn unlink_filehandle_test_mock(prefix: &str) {
-    unlink_filehandle_test(crate::fuse_tests::mock_session::new, prefix);
+#[test_case("unlink_readhandle_test"; "prefix")]
+fn unlink_readhandle_test_mock(prefix: &str) {
+    unlink_readhandle_test(crate::fuse_tests::mock_session::new, prefix);
+}
+
+/// Testing behavior when a file is unlinked during and after writing
+fn unlink_writehandle_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/other.txt", &[0u8; 1024]).unwrap(); // Persist implicit directory for test
+
+    let main_dir = mount_point.path().join("dir");
+    let path = main_dir.join("writing.txt");
+
+    let mut f = File::options()
+        .read(false)
+        .write(true)
+        .create(true)
+        .open(&path)
+        .expect("open for writing should succeed");
+
+    let err = fs::remove_file(&path).expect_err("file remove/unlink of path open for writing should fail");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EPERM, "unlink should fail with OS err EPERM");
+
+    f.write_all(&mut [0u8; 1]).expect("write should succeed");
+
+    let err =
+        fs::remove_file(&path).expect_err("file remove/unlink of path partial written to should continue to fail");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EPERM, "unlink should fail with OS err EPERM");
+
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(
+        dir_entry_names,
+        vec!["other.txt", "writing.txt"],
+        "file should be present in readdir"
+    );
+
+    drop(f); // close file
+
+    fs::remove_file(&path).expect("file can be deleted after being persisted remotely");
+
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["other.txt"], "deleted file should be absent");
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn unlink_writehandle_test_s3() {
+    unlink_writehandle_test(crate::fuse_tests::s3_session::new, "unlink_writehandle_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("unlink_writehandle_test"; "prefix")]
+fn unlink_writehandle_test_mock(prefix: &str) {
+    unlink_writehandle_test(crate::fuse_tests::mock_session::new, prefix);
 }

--- a/mountpoint-s3/tests/fuse_tests/unlink_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/unlink_test.rs
@@ -1,0 +1,104 @@
+use std::fs::{self, File};
+use std::io::{ErrorKind, Read, Seek, SeekFrom};
+
+use fuser::BackgroundSession;
+use mountpoint_s3::S3FilesystemConfig;
+use tempfile::TempDir;
+use test_case::test_case;
+
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
+
+/// Simple test cases, assuming a file isn't open for reading elsewhere.
+fn simple_unlink_tests<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/hello.txt", b"hello world").unwrap();
+    test_client.put_object("dir/foo.txt", b"bar").unwrap();
+
+    let main_dir = mount_point.path().join("dir");
+    let path = mount_point.path().join("dir/hello.txt");
+    let nonexistent_path = mount_point.path().join("dir/not-here.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["foo.txt", "hello.txt"]);
+
+    let err = fs::remove_file(nonexistent_path).expect_err("file remove/unlink on non-existing file should fail");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+
+    fs::remove_file(&path).expect("file remove/unlink of existing path should succeed");
+
+    let err = fs::remove_file(path).expect_err("file remove/unlink a second time on existing file should fail");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+
+    // readdir should now show the file as gone
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["foo.txt"]);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn simple_unlink_test_s3() {
+    simple_unlink_tests(crate::fuse_tests::s3_session::new, "simple_unlink_tests");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("simple_unlink_test"; "prefix")]
+fn simple_unlink_test_mock(prefix: &str) {
+    simple_unlink_tests(crate::fuse_tests::mock_session::new, prefix);
+}
+
+/// Testing behavior when a file is unlinked in the middle of reading
+fn unlink_filehandle_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Add a file directly to the bucket
+    const B_IN_MB: usize = 1024 * 1024;
+    test_client.put_object("dir/this.txt", &[0u8; B_IN_MB * 128]).unwrap();
+    test_client.put_object("dir/other.txt", &[0u8; 1024]).unwrap(); // Persist implicit directory for test
+
+    let main_dir = mount_point.path().join("dir");
+    let path = mount_point.path().join("dir/this.txt");
+
+    let mut f = File::options()
+        .read(true)
+        .write(false)
+        .open(&path)
+        .expect("open should work");
+    f.read_exact(&mut [0u8; 1]).expect("read should work");
+
+    fs::remove_file(&path).expect("file remove/unlink of existing path should succeed");
+
+    // readdir should now show the file as gone
+    let read_dir_iter = fs::read_dir(main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["other.txt"]);
+
+    let _new_pos = f.seek(SeekFrom::Start((B_IN_MB * 120) as u64)).unwrap(); // Seek far ahead in file, to exceed prefetcher's progress
+    let err = f
+        .read_exact(&mut [0u8; 1])
+        .expect_err("fresh read using open file handle should fail as object no longer exists");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EIO);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn unlink_filehandle_test_s3() {
+    unlink_filehandle_test(crate::fuse_tests::s3_session::new, "unlink_filehandle_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("unlink_filehandle_test"; "prefix")]
+fn unlink_filehandle_test_mock(prefix: &str) {
+    unlink_filehandle_test(crate::fuse_tests::mock_session::new, prefix);
+}


### PR DESCRIPTION
PR focusing on `unlink`, `unlinkat` only.

- This implementation does not attempt to tackle the unbounded growth of the superblock. This should be tackled at a later date.
- This implementation does not allow a file that is being written locally to be unlinked. The file must be closed (and written to S3) first.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
