### PR TITLE
Implement checksum validation for prefetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,7 @@ dependencies = [
  "bytes",
  "clap 4.1.9",
  "const_format",
+ "crc32c",
  "ctor",
  "ctrlc",
  "fuser",

--- a/mountpoint-s3-crt/src/checksums.rs
+++ b/mountpoint-s3-crt/src/checksums.rs
@@ -1,0 +1,4 @@
+//! Implementation of CRT checksums.
+
+/// CRC checksums
+pub mod crc;

--- a/mountpoint-s3-crt/src/checksums/crc.rs
+++ b/mountpoint-s3-crt/src/checksums/crc.rs
@@ -1,0 +1,34 @@
+use mountpoint_s3_crt_sys::*;
+
+/// Calculate CRC32 checksum of the data in the given buffer, append to the previous checksum if provided.
+pub fn checksums_crc32(buf: &[u8], previous_checksum: Option<u32>) -> u32 {
+    // SAFETY: we pass a valid buffer to the CRT, and trust
+    // the CRT function to only read from the buffer's boundary.
+    unsafe { aws_checksums_crc32(buf.as_ptr(), buf.len() as i32, previous_checksum.unwrap_or(0)) }
+}
+
+/// Calculate CRC32C checksum of the data in the given buffer, append to the previous checksum if provided.
+pub fn checksums_crc32c(buf: &[u8], previous_checksum: Option<u32>) -> u32 {
+    // SAFETY: we pass a valid buffer to the CRT, and trust
+    // the CRT function to only read from the buffer's boundary.
+    unsafe { aws_checksums_crc32c(buf.as_ptr(), buf.len() as i32, previous_checksum.unwrap_or(0)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc32_works() {
+        let buf: &[u8] = b"123456789";
+        let crc = checksums_crc32(buf, None);
+        assert_eq!(crc, 0xcbf43926);
+    }
+
+    #[test]
+    fn crc32c_works() {
+        let buf: &[u8] = b"123456789";
+        let crc = checksums_crc32c(buf, None);
+        assert_eq!(crc, 0xe3069283);
+    }
+}

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -5,6 +5,7 @@
 use mountpoint_s3_crt_sys::*;
 
 pub mod auth;
+pub mod checksums;
 pub mod common;
 pub mod http;
 pub mod io;

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -31,6 +31,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
 home = "0.5.4"
 serde_json = "1.0.95"
+crc32c = "0.6.3"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/mountpoint-s3/proptest-regressions/prefetch.txt
+++ b/mountpoint-s3/proptest-regressions/prefetch.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1cefc6aa7160d95c9497b4f4407115c749a2f97e74c5dd3a5e0f68f33edc5a41 # shrinks to size = 3, read_factor = 2, config = TestConfig { first_request_size: 16, max_request_size: 16, sequential_prefetch_multiplier: 1, client_part_size: 16 }
+cc 5766b08dab3255bc3f26382330b9cb738e51542bf25f0e86bf2c8cfaa8ff1f88 # shrinks to size = 241849, read_size = 1, config = TestConfig { first_request_size: 16, max_request_size: 16, sequential_prefetch_multiplier: 1, client_part_size: 16 }
+cc 3e1688fb734cb931736cf60002a8bd2ec417e67676d2b08fd7bc9ace755e6a38 # shrinks to size = 275240, read_size = 2, config = TestConfig { first_request_size: 16, max_request_size: 16, sequential_prefetch_multiplier: 1, client_part_size: 57639 }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -10,7 +10,7 @@ use fuser::{FileAttr, KernelConfig};
 use mountpoint_s3_client::{ETag, ObjectClient, PutObjectParams};
 
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, WriteHandle};
-use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
+use crate::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use crate::sync::{Arc, AsyncMutex, AsyncRwLock};
@@ -351,7 +351,7 @@ where
 
         match request.as_mut().unwrap().read(offset as u64, size as usize).await {
             Ok(body) => reply.data(&body),
-            Err(PrefetchReadError::GetRequestFailed(_)) => reply.error(libc::EIO),
+            Err(_) => reply.error(libc::EIO),
         }
     }
 

--- a/mountpoint-s3/src/prefetch/part.rs
+++ b/mountpoint-s3/src/prefetch/part.rs
@@ -1,5 +1,9 @@
 use bytes::Bytes;
+use mountpoint_s3_crt::checksums::crc::checksums_crc32c;
 use thiserror::Error;
+use tracing::trace;
+
+use super::ChecksumCrc;
 
 /// A self-identifying part of an S3 object. Users can only retrieve the bytes from this part if
 /// they can prove they have the correct offset and key.
@@ -11,15 +15,26 @@ pub struct Part {
     key: String,
     offset: u64,
     bytes: Bytes,
+    checksum: ChecksumCrc,
 }
 
 impl Part {
     pub fn new(key: &str, offset: u64, bytes: Bytes) -> Self {
+        let checksum = checksums_crc32c(&bytes, None);
         Self {
             key: key.to_owned(),
             offset,
             bytes,
+            checksum,
         }
+    }
+
+    pub fn checksum(&self) -> ChecksumCrc {
+        self.checksum
+    }
+
+    pub fn bytes_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 
     pub fn into_bytes(self, key: &str, offset: u64) -> Result<Bytes, PartMismatchError> {
@@ -30,13 +45,22 @@ impl Part {
     ///
     /// Returns a newly allocated part containing the range [at, len). After the call, the original
     /// part will be left containing the elements [0, at).
-    pub fn split_off(&mut self, at: usize) -> Part {
+    pub fn split_off(&mut self, at: usize) -> Result<Part, PartMismatchError> {
+        trace!(size = self.bytes.len(), at, "split_off");
+        let before_checksum = self.checksum;
+
         let new_bytes = self.bytes.split_off(at);
-        Part {
-            key: self.key.clone(),
-            offset: self.offset + at as u64,
-            bytes: new_bytes,
+        // update self checksum
+        self.checksum = checksums_crc32c(&self.bytes, None);
+
+        let new_part = Self::new(&self.key, self.offset + at as u64, new_bytes);
+
+        // validate the checksum after the split
+        let after_checksum = checksums_crc32c(new_part.bytes.as_ref(), Some(self.checksum));
+        if before_checksum != after_checksum {
+            return Err(PartMismatchError::Checksum);
         }
+        Ok(new_part)
     }
 
     pub(super) fn len(&self) -> usize {
@@ -71,4 +95,52 @@ pub enum PartMismatchError {
 
     #[error("wrong part offset: actual={actual}, requested={requested}")]
     Offset { actual: u64, requested: u64 },
+
+    #[error("checksum mismatch at part split off")]
+    Checksum,
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn split_off() {
+        let key = "test_key";
+        let offset = 0;
+        let data = b"split_off_checksum_valid";
+        let expected_checksum = checksums_crc32c(data, None);
+        let mut part = Part::new(key, offset, Bytes::copy_from_slice(data));
+
+        let part_checksum = part.checksum;
+        assert_eq!(expected_checksum, part_checksum);
+
+        let new_part = part.split_off(10).expect("should be able to split off the part");
+
+        let expected_first_checksum = checksums_crc32c(b"split_off_", None);
+        let expected_second_checksum = checksums_crc32c(b"checksum_valid", None);
+
+        assert_eq!(expected_first_checksum, part.checksum);
+        assert_eq!(expected_second_checksum, new_part.checksum);
+    }
+
+    #[test]
+    fn split_off_checksum_mismatch() {
+        let key = "test_key";
+        let offset = 0;
+        let data = b"split_off_checksum_mismatch";
+        let expected_checksum = checksums_crc32c(data, None);
+        let mut part = Part::new(key, offset, Bytes::copy_from_slice(data));
+
+        let part_checksum = part.checksum;
+        assert_eq!(expected_checksum, part_checksum);
+
+        // mutate the bytes before split off
+        part.bytes = Bytes::copy_from_slice(b"split_off-checksum_mismatch");
+
+        let new_part = part.split_off(10);
+        assert!(matches!(new_part, Err(PartMismatchError::Checksum)));
+    }
 }


### PR DESCRIPTION
We want to ensure data integrity while object data is within Mountpoint's custody. So, we will calculate CRC checksum for the data as soon as we receive it from S3 and validate them every time we move it around our part queue, and before returning them to FUSE.

The validation would definitely impact Mountpoint's performance. But we can improve it a bit if we assume that most of the sequential read would have the same read size. In that case, we can pre-split the parts in part queues to a preferred size and avoid splitting them during read.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
