### PR TITLE
Extract `fn read_dir_to_string_vec` for FUSE tests

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
@@ -8,7 +8,7 @@ use mountpoint_s3::S3FilesystemConfig;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::fuse_tests::TestClientBox;
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
 
 fn mkdir_test<F>(creator_fn: F, prefix: &str)
 where
@@ -41,14 +41,9 @@ where
     test_client.remove_object(&format!("{dirname}/{filename}")).unwrap();
 
     // Verify that the directory disappeared
-    let dir = read_dir(mount_point.path()).unwrap();
-    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
-    assert_eq!(
-        dirs.iter()
-            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
-            .collect::<Vec<_>>(),
-        Vec::<String>::new()
-    );
+    let read_dir_iter = fs::read_dir(mount_point.path()).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, Vec::<String>::new());
 }
 
 #[cfg(feature = "s3_tests")]

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -7,6 +7,9 @@ mod prefetch_test;
 mod readdir_test;
 mod write_test;
 
+use std::ffi::OsStr;
+use std::fs::ReadDir;
+
 use fuser::{BackgroundSession, MountOption, Session};
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::prefix::Prefix;
@@ -221,4 +224,19 @@ mod s3_session {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
         }
     }
+}
+
+/// Take a `read_dir` iterator and return the entry names
+pub fn read_dir_to_entry_names(read_dir_iter: ReadDir) -> Vec<String> {
+    read_dir_iter
+        .map(|entry| {
+            let entry = entry.expect("no io err during readdir");
+            let entry_path = entry.path();
+            let name = entry_path
+                .file_name()
+                .and_then(OsStr::to_str)
+                .expect("path should end with valid unicode file or dir name");
+            name.to_owned()
+        })
+        .collect::<Vec<_>>()
 }

--- a/mountpoint-s3/tests/fuse_tests/readdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/readdir_test.rs
@@ -1,4 +1,4 @@
-use crate::fuse_tests::TestClientBox;
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
 use fuser::BackgroundSession;
 use mountpoint_s3::S3FilesystemConfig;
 use rand::distributions::{Alphanumeric, DistString};
@@ -59,13 +59,10 @@ where
 
     prepare_fs(test_client, &map);
 
-    let dir = fs::read_dir(mount_point.path()).unwrap();
-    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    let read_dir_iter = fs::read_dir(mount_point.path()).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
     assert_eq!(
-        dirs.iter()
-            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
-            .collect::<Vec<_>>(),
-        expected_list,
+        dir_entry_names, expected_list,
         "readdir test failed with random seed: {rng_seed}"
     );
 }
@@ -116,13 +113,10 @@ where
     }
     expected_list.sort();
 
-    let dir = fs::read_dir(mount_point.path()).unwrap();
-    let dirs: Vec<_> = dir.map(|f| f.unwrap()).collect();
+    let read_dir_iter = fs::read_dir(mount_point.path()).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
     assert_eq!(
-        dirs.iter()
-            .map(|f| f.path().file_name().unwrap().to_str().unwrap().to_owned())
-            .collect::<Vec<_>>(),
-        expected_list,
+        dir_entry_names, expected_list,
         "readdir test failed with random seed: {rng_seed}"
     );
 }


### PR DESCRIPTION
Extracting some common logic repeated all over the FUSE tests. Feedback from #232.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
