### PR TITLE
Refactor ReaddirHandle to lazily create inodes 

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -300,13 +300,7 @@ impl Superblock {
         let dir_key = dir.full_key();
         assert!(dir_key.is_empty() || dir_key.ends_with('/'));
 
-        Ok(ReaddirHandle::new(
-            self.inner.clone(),
-            dir_ino,
-            parent_ino,
-            dir_key.to_string(),
-            page_size,
-        ))
+        ReaddirHandle::new(self.inner.clone(), dir_ino, parent_ino, dir_key.to_string(), page_size)
     }
 
     /// Create a new regular file or directory inode ready to be opened in write-only mode

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -20,7 +20,7 @@
 //! Some cached state is dependent on the inode kind; that state is hidden behind a [InodeStatKind]
 //! enum.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::os::unix::prelude::OsStrExt;
 use std::time::Instant;
@@ -34,7 +34,10 @@ use tracing::{error, trace, warn};
 
 use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicU64, Ordering};
-use crate::sync::{Arc, Mutex, RwLock};
+use crate::sync::{Arc, RwLock};
+
+mod readdir;
+pub use readdir::ReaddirHandle;
 
 pub type InodeNo = u64;
 
@@ -297,16 +300,13 @@ impl Superblock {
         let dir_key = dir.full_key();
         assert!(dir_key.is_empty() || dir_key.ends_with('/'));
 
-        Ok(ReaddirHandle {
-            inner: self.inner.clone(),
+        Ok(ReaddirHandle::new(
+            self.inner.clone(),
             dir_ino,
             parent_ino,
-            full_path: dir_key.to_string(),
+            dir_key.to_string(),
             page_size,
-            remote_results: Default::default(),
-            local_results: Default::default(),
-            next_continuation_token: Mutex::new(ReaddirStreamState::NotStarted),
-        })
+        ))
     }
 
     /// Create a new regular file or directory inode ready to be opened in write-only mode
@@ -666,209 +666,6 @@ impl WriteHandle {
             }
             _ => Err(InodeError::InodeNotWritable(inode.ino())),
         }
-    }
-}
-
-/// Handle for an inflight directory listing
-#[derive(Debug)]
-pub struct ReaddirHandle {
-    inner: Arc<SuperblockInner>,
-    dir_ino: InodeNo,
-    parent_ino: InodeNo,
-    full_path: String,
-    page_size: usize,
-    remote_results: RwLock<VecDeque<LookedUp>>,
-    local_results: RwLock<VecDeque<LookedUp>>,
-    next_continuation_token: Mutex<ReaddirStreamState>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum ReaddirStreamState {
-    NotStarted,
-    /// Continuation token for the next call
-    Continued(String),
-    Finished,
-}
-
-impl ReaddirStreamState {
-    fn take(&mut self) -> Option<String> {
-        let old_state = std::mem::replace(self, ReaddirStreamState::Finished);
-        if let ReaddirStreamState::Continued(s) = old_state {
-            Some(s)
-        } else {
-            None
-        }
-    }
-}
-
-impl ReaddirHandle {
-    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
-        // We will start fetching new results when number of items in the remote results queue is empty
-        while self.remote_results.read().unwrap().is_empty() {
-            let continuation_token = {
-                let mut next_token = self.next_continuation_token.lock().unwrap();
-
-                // populate local results before the first stream
-                if *next_token == ReaddirStreamState::NotStarted {
-                    let inode = self.inner.get(self.dir_ino)?;
-                    let kind_data = &inode.inner.sync.read().unwrap().kind_data;
-                    let local_files = match kind_data {
-                        InodeKindData::File { .. } => unreachable!("we know this is a directory"),
-                        InodeKindData::Directory {
-                            children: _,
-                            writing_children,
-                        } => writing_children.iter().map(|ino| {
-                            let inode = self.inner.get(*ino)?;
-                            let stat = inode.inner.sync.read().unwrap().stat.clone();
-                            Ok(LookedUp { inode, stat })
-                        }),
-                    };
-
-                    match local_files.collect::<Result<Vec<_>, _>>() {
-                        Ok(mut new_results) => {
-                            new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
-                            self.local_results.write().unwrap().extend(new_results);
-                        }
-                        Err(e) => {
-                            error!(error=?e, "readdir failed");
-                            return Err(e);
-                        }
-                    }
-                }
-
-                if *next_token == ReaddirStreamState::Finished {
-                    trace!(self=?self as *const _, "readdir finished");
-                    return Ok(self.compare_and_get_next());
-                }
-                next_token.take()
-            };
-
-            trace!(self=?self as *const _, ?continuation_token, "continuing readdir");
-
-            let result = client
-                .list_objects(
-                    self.inner.bucket.as_str(),
-                    continuation_token.as_deref(),
-                    "/",
-                    self.page_size,
-                    self.full_path.as_str(),
-                )
-                .await
-                .map_err(|e| InodeError::ClientError(anyhow::Error::new(e)))?;
-
-            *self.next_continuation_token.lock().unwrap() = match result.next_continuation_token {
-                Some(token) => ReaddirStreamState::Continued(token),
-                None => ReaddirStreamState::Finished,
-            };
-
-            let prefixes = result
-                .common_prefixes
-                .iter()
-                .map(|prefix| &prefix[self.full_path.len()..prefix.len() - 1])
-                .filter(|name| valid_inode_name(name))
-                .map(|name| {
-                    let stat = InodeStat::for_directory(self.inner.mount_time, Instant::now());
-                    self.inner.update_from_remote(
-                        self.dir_ino,
-                        name,
-                        Some(RemoteLookup {
-                            kind: InodeKind::Directory,
-                            stat,
-                        }),
-                    )
-                });
-            let objects = result
-                .objects
-                .iter()
-                .map(|object| (&object.key[self.full_path.len()..], object))
-                // Hide keys that end with '/', since they can be confused with directories
-                .filter(|(name, _object)| valid_inode_name(name))
-                .flat_map(|(name, object)| {
-                    let last_modified = object.last_modified;
-                    let stat = InodeStat::for_file(
-                        object.size as usize,
-                        last_modified,
-                        Instant::now(),
-                        Some(object.etag.clone()),
-                    );
-                    let result = self.inner.update_from_remote(
-                        self.dir_ino,
-                        name,
-                        Some(RemoteLookup {
-                            kind: InodeKind::File,
-                            stat,
-                        }),
-                    );
-                    // Skip over keys that are shadowed by a directory. We can do this here because
-                    // common prefixes are iterated first, and the `sort_by` below is stable.
-                    match result {
-                        Err(InodeError::ShadowedByDirectory(_, _)) => {
-                            warn!(
-                                "key {:?} is shadowed by a directory with the same name and will be unavailable",
-                                object.key
-                            );
-                            None
-                        }
-                        _ => Some(result),
-                    }
-                });
-
-            // TODO would be nice to do this as a merge sort but the Result makes it messy
-            match prefixes.chain(objects).collect::<Result<Vec<_>, _>>() {
-                Ok(mut new_results) => {
-                    new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
-                    self.remote_results.write().unwrap().extend(new_results);
-                }
-                Err(e) => {
-                    error!(error=?e, "readdir failed");
-                    return Err(e);
-                }
-            }
-        }
-
-        Ok(self.compare_and_get_next())
-    }
-
-    /// Re-add an entry to the front of the queue if the consumer wasn't able to use it
-    pub fn readd(&self, entry: LookedUp) {
-        self.remote_results.write().unwrap().push_front(entry);
-    }
-
-    pub fn parent(&self) -> InodeNo {
-        self.parent_ino
-    }
-
-    fn compare_and_get_next(&self) -> Option<LookedUp> {
-        let mut local_locked = self.local_results.write().unwrap();
-        let mut remote_locked = self.remote_results.write().unwrap();
-        match (local_locked.front(), remote_locked.front()) {
-            (None, None) => None,
-            (None, Some(_)) => remote_locked.pop_front(),
-            (Some(_), None) => local_locked.pop_front(),
-            (Some(local_lookup), Some(remote_lookup)) => {
-                let ordering = local_lookup.inode.name().cmp(remote_lookup.inode.name());
-                // compare the inodes at the front of both queues by their names and return the one that has less ordering.
-                // in case both inodes have the same name we will prioritise the one from the remote queue,
-                // return it as a result and remove the one in the local queue.
-                match ordering {
-                    std::cmp::Ordering::Less => local_locked.pop_front(),
-                    std::cmp::Ordering::Equal => {
-                        let _ = local_locked.pop_front();
-                        remote_locked.pop_front()
-                    }
-                    std::cmp::Ordering::Greater => remote_locked.pop_front(),
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    async fn collect<OC: ObjectClient>(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
-        let mut result = vec![];
-        while let Some(entry) = self.next(client).await? {
-            result.push(entry);
-        }
-        Ok(result)
     }
 }
 

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -1,0 +1,233 @@
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use mountpoint_s3_client::ObjectClient;
+use tracing::{error, trace, warn};
+
+use crate::sync::{Arc, Mutex, RwLock};
+
+use super::{
+    valid_inode_name, InodeError, InodeKind, InodeKindData, InodeNo, InodeStat, LookedUp, RemoteLookup, SuperblockInner,
+};
+
+/// Handle for an inflight directory listing
+#[derive(Debug)]
+pub struct ReaddirHandle {
+    inner: Arc<SuperblockInner>,
+    dir_ino: InodeNo,
+    parent_ino: InodeNo,
+    full_path: String,
+    page_size: usize,
+    remote_results: RwLock<VecDeque<LookedUp>>,
+    local_results: RwLock<VecDeque<LookedUp>>,
+    next_continuation_token: Mutex<ReaddirStreamState>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ReaddirStreamState {
+    NotStarted,
+    /// Continuation token for the next call
+    Continued(String),
+    Finished,
+}
+
+impl ReaddirStreamState {
+    fn take(&mut self) -> Option<String> {
+        let old_state = std::mem::replace(self, ReaddirStreamState::Finished);
+        if let ReaddirStreamState::Continued(s) = old_state {
+            Some(s)
+        } else {
+            None
+        }
+    }
+}
+
+impl ReaddirHandle {
+    pub(super) fn new(
+        inner: Arc<SuperblockInner>,
+        dir_ino: InodeNo,
+        parent_ino: InodeNo,
+        full_path: String,
+        page_size: usize,
+    ) -> Self {
+        Self {
+            inner,
+            dir_ino,
+            parent_ino,
+            full_path,
+            page_size,
+            remote_results: Default::default(),
+            local_results: Default::default(),
+            next_continuation_token: Mutex::new(ReaddirStreamState::NotStarted),
+        }
+    }
+
+    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
+        // We will start fetching new results when number of items in the remote results queue is empty
+        while self.remote_results.read().unwrap().is_empty() {
+            let continuation_token = {
+                let mut next_token = self.next_continuation_token.lock().unwrap();
+
+                // populate local results before the first stream
+                if *next_token == ReaddirStreamState::NotStarted {
+                    let inode = self.inner.get(self.dir_ino)?;
+                    let kind_data = &inode.inner.sync.read().unwrap().kind_data;
+                    let local_files = match kind_data {
+                        InodeKindData::File { .. } => unreachable!("we know this is a directory"),
+                        InodeKindData::Directory {
+                            children: _,
+                            writing_children,
+                        } => writing_children.iter().map(|ino| {
+                            let inode = self.inner.get(*ino)?;
+                            let stat = inode.inner.sync.read().unwrap().stat.clone();
+                            Ok(LookedUp { inode, stat })
+                        }),
+                    };
+
+                    match local_files.collect::<Result<Vec<_>, _>>() {
+                        Ok(mut new_results) => {
+                            new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
+                            self.local_results.write().unwrap().extend(new_results);
+                        }
+                        Err(e) => {
+                            error!(error=?e, "readdir failed");
+                            return Err(e);
+                        }
+                    }
+                }
+
+                if *next_token == ReaddirStreamState::Finished {
+                    trace!(self=?self as *const _, "readdir finished");
+                    return Ok(self.compare_and_get_next());
+                }
+                next_token.take()
+            };
+
+            trace!(self=?self as *const _, ?continuation_token, "continuing readdir");
+
+            let result = client
+                .list_objects(
+                    self.inner.bucket.as_str(),
+                    continuation_token.as_deref(),
+                    "/",
+                    self.page_size,
+                    self.full_path.as_str(),
+                )
+                .await
+                .map_err(|e| InodeError::ClientError(anyhow::Error::new(e)))?;
+
+            *self.next_continuation_token.lock().unwrap() = match result.next_continuation_token {
+                Some(token) => ReaddirStreamState::Continued(token),
+                None => ReaddirStreamState::Finished,
+            };
+
+            let prefixes = result
+                .common_prefixes
+                .iter()
+                .map(|prefix| &prefix[self.full_path.len()..prefix.len() - 1])
+                .filter(|name| valid_inode_name(name))
+                .map(|name| {
+                    let stat = InodeStat::for_directory(self.inner.mount_time, Instant::now());
+                    self.inner.update_from_remote(
+                        self.dir_ino,
+                        name,
+                        Some(RemoteLookup {
+                            kind: InodeKind::Directory,
+                            stat,
+                        }),
+                    )
+                });
+            let objects = result
+                .objects
+                .iter()
+                .map(|object| (&object.key[self.full_path.len()..], object))
+                // Hide keys that end with '/', since they can be confused with directories
+                .filter(|(name, _object)| valid_inode_name(name))
+                .flat_map(|(name, object)| {
+                    let last_modified = object.last_modified;
+                    let stat = InodeStat::for_file(
+                        object.size as usize,
+                        last_modified,
+                        Instant::now(),
+                        Some(object.etag.clone()),
+                    );
+                    let result = self.inner.update_from_remote(
+                        self.dir_ino,
+                        name,
+                        Some(RemoteLookup {
+                            kind: InodeKind::File,
+                            stat,
+                        }),
+                    );
+                    // Skip over keys that are shadowed by a directory. We can do this here because
+                    // common prefixes are iterated first, and the `sort_by` below is stable.
+                    match result {
+                        Err(InodeError::ShadowedByDirectory(_, _)) => {
+                            warn!(
+                                "key {:?} is shadowed by a directory with the same name and will be unavailable",
+                                object.key
+                            );
+                            None
+                        }
+                        _ => Some(result),
+                    }
+                });
+
+            // TODO would be nice to do this as a merge sort but the Result makes it messy
+            match prefixes.chain(objects).collect::<Result<Vec<_>, _>>() {
+                Ok(mut new_results) => {
+                    new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
+                    self.remote_results.write().unwrap().extend(new_results);
+                }
+                Err(e) => {
+                    error!(error=?e, "readdir failed");
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(self.compare_and_get_next())
+    }
+
+    /// Re-add an entry to the front of the queue if the consumer wasn't able to use it
+    pub fn readd(&self, entry: LookedUp) {
+        self.remote_results.write().unwrap().push_front(entry);
+    }
+
+    pub fn parent(&self) -> InodeNo {
+        self.parent_ino
+    }
+
+    fn compare_and_get_next(&self) -> Option<LookedUp> {
+        let mut local_locked = self.local_results.write().unwrap();
+        let mut remote_locked = self.remote_results.write().unwrap();
+        match (local_locked.front(), remote_locked.front()) {
+            (None, None) => None,
+            (None, Some(_)) => remote_locked.pop_front(),
+            (Some(_), None) => local_locked.pop_front(),
+            (Some(local_lookup), Some(remote_lookup)) => {
+                let ordering = local_lookup.inode.name().cmp(remote_lookup.inode.name());
+                // compare the inodes at the front of both queues by their names and return the one that has less ordering.
+                // in case both inodes have the same name we will prioritise the one from the remote queue,
+                // return it as a result and remove the one in the local queue.
+                match ordering {
+                    std::cmp::Ordering::Less => local_locked.pop_front(),
+                    std::cmp::Ordering::Equal => {
+                        let _ = local_locked.pop_front();
+                        remote_locked.pop_front()
+                    }
+                    std::cmp::Ordering::Greater => remote_locked.pop_front(),
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) async fn collect<OC: ObjectClient>(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
+        let mut result = vec![];
+        while let Some(entry) = self.next(client).await? {
+            result.push(entry);
+        }
+        Ok(result)
+    }
+}

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -1,10 +1,48 @@
+//! Utilities for implementing the `readdir` operation on a directory inode.
+//!
+//! `readdir` is conceptually simple ("just call ListObjectsV2") but has some subtleties that make
+//! it complicated:
+//!
+//! 1. It's possible for a directory to contain both a subdirectory and a file of the same name, in
+//!    which case we need to implement shadowing in the right way.
+//! 2. A directory can also contain local files/subdirectories, which we want to have appear in the
+//!    readdir stream, but be shadowed by remote files/subdirectories.
+//! 3. ListObjectsV2 returns common prefixes including the trailing '/', which messes up ordering
+//!    of entries in the readdir stream. For example, `a-/` < `a/`, but `a-` > `a` in lexicographic
+//!    order, so we need to re-sort the common prefixes rather than just streaming them directly.
+//! 4. We want to do large ListObjectsV2 calls (i.e. with a large page size), but `readdir` calls
+//!    typically are much smaller, so we need to hold onto ListObjectsV2 results for a while. But we
+//!    don't want them to expire while we're holding onto them.
+//! 5. FUSE's `readdir` design makes it hard to know in advance exactly how many entries we'll be
+//!    able to return in a single request (fixed-size buffer but names are variable size), so we
+//!    need to be able to "peek" the next entry in the stream in case it won't fit.
+//!
+//! This module tries to decouple each of these requirements by building a hierarchy of iterators
+//! to implement the `readdir` stream:
+//!
+//! * [ReaddirHandle] is the top-level iterator, and the only public struct in this module. Its
+//!   results can be directly returned to `readdir`. It takes results from [ReaddirIter] and creates
+//!   inodes for them, achieving point 4. It also has a [ReaddirHandle::readd] method to handle
+//!   point 5.
+//! * [ReaddirIter] is an iterator over [ReaddirEntry]s, which are entries that may not yet have
+//!   inodes created for them. [ReaddirIter] merges together two streams, [RemoteIter] and
+//!   [LocalIter], to handle point 2. While merging, [ReaddirIter] also deduplicates the entries it
+//!   returns to handle point 1.
+//! * [RemoteIter] is an iterator over [ReaddirEntry]s returned by paginated calls to ListObjectsV2.
+//!   Rather than directly streaming the entries out of the list call, it collects them in memory
+//!   and re-sorts them to handle point 3.
+//! * [LocalIter] is an iterator over [ReaddirEntry]s that are local children of the directory.
+//!   These children are listed only once, at the start of the readdir operation, and so are a
+//!   snapshot in time of the directory.
+
+use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use mountpoint_s3_client::ObjectClient;
+use mountpoint_s3_client::{ObjectClient, ObjectInfo};
 use tracing::{error, trace, warn};
 
-use crate::sync::{Arc, Mutex, RwLock};
+use crate::sync::{Arc, AsyncMutex, Mutex};
 
 use super::{
     valid_inode_name, InodeError, InodeKind, InodeKindData, InodeNo, InodeStat, LookedUp, RemoteLookup, SuperblockInner,
@@ -16,30 +54,8 @@ pub struct ReaddirHandle {
     inner: Arc<SuperblockInner>,
     dir_ino: InodeNo,
     parent_ino: InodeNo,
-    full_path: String,
-    page_size: usize,
-    remote_results: RwLock<VecDeque<LookedUp>>,
-    local_results: RwLock<VecDeque<LookedUp>>,
-    next_continuation_token: Mutex<ReaddirStreamState>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum ReaddirStreamState {
-    NotStarted,
-    /// Continuation token for the next call
-    Continued(String),
-    Finished,
-}
-
-impl ReaddirStreamState {
-    fn take(&mut self) -> Option<String> {
-        let old_state = std::mem::replace(self, ReaddirStreamState::Finished);
-        if let ReaddirStreamState::Continued(s) = old_state {
-            Some(s)
-        } else {
-            None
-        }
-    }
+    iter: AsyncMutex<ReaddirIter>,
+    readded: Mutex<Option<LookedUp>>,
 }
 
 impl ReaddirHandle {
@@ -49,176 +65,127 @@ impl ReaddirHandle {
         parent_ino: InodeNo,
         full_path: String,
         page_size: usize,
-    ) -> Self {
-        Self {
-            inner,
-            dir_ino,
-            parent_ino,
-            full_path,
-            page_size,
-            remote_results: Default::default(),
-            local_results: Default::default(),
-            next_continuation_token: Mutex::new(ReaddirStreamState::NotStarted),
-        }
-    }
-
-    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
-        // We will start fetching new results when number of items in the remote results queue is empty
-        while self.remote_results.read().unwrap().is_empty() {
-            let continuation_token = {
-                let mut next_token = self.next_continuation_token.lock().unwrap();
-
-                // populate local results before the first stream
-                if *next_token == ReaddirStreamState::NotStarted {
-                    let inode = self.inner.get(self.dir_ino)?;
-                    let kind_data = &inode.inner.sync.read().unwrap().kind_data;
-                    let local_files = match kind_data {
-                        InodeKindData::File { .. } => unreachable!("we know this is a directory"),
-                        InodeKindData::Directory {
-                            children: _,
-                            writing_children,
-                        } => writing_children.iter().map(|ino| {
-                            let inode = self.inner.get(*ino)?;
-                            let stat = inode.inner.sync.read().unwrap().stat.clone();
-                            Ok(LookedUp { inode, stat })
-                        }),
-                    };
-
-                    match local_files.collect::<Result<Vec<_>, _>>() {
-                        Ok(mut new_results) => {
-                            new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
-                            self.local_results.write().unwrap().extend(new_results);
-                        }
-                        Err(e) => {
-                            error!(error=?e, "readdir failed");
-                            return Err(e);
-                        }
-                    }
-                }
-
-                if *next_token == ReaddirStreamState::Finished {
-                    trace!(self=?self as *const _, "readdir finished");
-                    return Ok(self.compare_and_get_next());
-                }
-                next_token.take()
+    ) -> Result<Self, InodeError> {
+        let local_entries = {
+            let inode = inner.get(dir_ino)?;
+            let kind_data = &inode.inner.sync.read().unwrap().kind_data;
+            let local_files = match kind_data {
+                InodeKindData::File { .. } => return Err(InodeError::NotADirectory(dir_ino)),
+                InodeKindData::Directory {
+                    children: _,
+                    writing_children,
+                } => writing_children.iter().map(|ino| {
+                    let inode = inner.get(*ino)?;
+                    let stat = inode.inner.sync.read().unwrap().stat.clone();
+                    Ok(ReaddirEntry::LocalInode {
+                        lookup: LookedUp { inode, stat },
+                    })
+                }),
             };
 
-            trace!(self=?self as *const _, ?continuation_token, "continuing readdir");
-
-            let result = client
-                .list_objects(
-                    self.inner.bucket.as_str(),
-                    continuation_token.as_deref(),
-                    "/",
-                    self.page_size,
-                    self.full_path.as_str(),
-                )
-                .await
-                .map_err(|e| InodeError::ClientError(anyhow::Error::new(e)))?;
-
-            *self.next_continuation_token.lock().unwrap() = match result.next_continuation_token {
-                Some(token) => ReaddirStreamState::Continued(token),
-                None => ReaddirStreamState::Finished,
-            };
-
-            let prefixes = result
-                .common_prefixes
-                .iter()
-                .map(|prefix| &prefix[self.full_path.len()..prefix.len() - 1])
-                .filter(|name| valid_inode_name(name))
-                .map(|name| {
-                    let stat = InodeStat::for_directory(self.inner.mount_time, Instant::now());
-                    self.inner.update_from_remote(
-                        self.dir_ino,
-                        name,
-                        Some(RemoteLookup {
-                            kind: InodeKind::Directory,
-                            stat,
-                        }),
-                    )
-                });
-            let objects = result
-                .objects
-                .iter()
-                .map(|object| (&object.key[self.full_path.len()..], object))
-                // Hide keys that end with '/', since they can be confused with directories
-                .filter(|(name, _object)| valid_inode_name(name))
-                .flat_map(|(name, object)| {
-                    let last_modified = object.last_modified;
-                    let stat = InodeStat::for_file(
-                        object.size as usize,
-                        last_modified,
-                        Instant::now(),
-                        Some(object.etag.clone()),
-                    );
-                    let result = self.inner.update_from_remote(
-                        self.dir_ino,
-                        name,
-                        Some(RemoteLookup {
-                            kind: InodeKind::File,
-                            stat,
-                        }),
-                    );
-                    // Skip over keys that are shadowed by a directory. We can do this here because
-                    // common prefixes are iterated first, and the `sort_by` below is stable.
-                    match result {
-                        Err(InodeError::ShadowedByDirectory(_, _)) => {
-                            warn!(
-                                "key {:?} is shadowed by a directory with the same name and will be unavailable",
-                                object.key
-                            );
-                            None
-                        }
-                        _ => Some(result),
-                    }
-                });
-
-            // TODO would be nice to do this as a merge sort but the Result makes it messy
-            match prefixes.chain(objects).collect::<Result<Vec<_>, _>>() {
+            match local_files.collect::<Result<Vec<_>, _>>() {
                 Ok(mut new_results) => {
-                    new_results.sort_by(|left, right| left.inode.name().cmp(right.inode.name()));
-                    self.remote_results.write().unwrap().extend(new_results);
+                    new_results.sort();
+                    new_results
                 }
                 Err(e) => {
-                    error!(error=?e, "readdir failed");
+                    error!(error=?e, "readdir failed listing local files");
                     return Err(e);
                 }
             }
+        };
+
+        let iter = ReaddirIter::new(&inner.bucket, &full_path, page_size, local_entries.into());
+
+        Ok(Self {
+            inner,
+            dir_ino,
+            parent_ino,
+            iter: AsyncMutex::new(iter),
+            readded: Default::default(),
+        })
+    }
+
+    /// Return the next inode for the directory stream. If the stream is finished, returns
+    /// `Ok(None)`.
+    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
+        if let Some(readded) = self.readded.lock().unwrap().take() {
+            return Ok(Some(readded));
         }
 
-        Ok(self.compare_and_get_next())
+        // Loop because the next entry from the [ReaddirIter] may be hidden from the file system,
+        // either because it has an invalid name or because it's shadowed by another entry.
+        loop {
+            let next = {
+                let mut iter = self.iter.lock().await;
+                iter.next(client).await?
+            };
+
+            if let Some(next) = next {
+                if let Some(lookup) = self.instantiate_remote_inode(next)? {
+                    return Ok(Some(lookup));
+                }
+            } else {
+                return Ok(None);
+            }
+        }
     }
 
     /// Re-add an entry to the front of the queue if the consumer wasn't able to use it
     pub fn readd(&self, entry: LookedUp) {
-        self.remote_results.write().unwrap().push_front(entry);
+        let old = self.readded.lock().unwrap().replace(entry);
+        assert!(old.is_none(), "cannot readd more than one entry");
     }
 
+    /// Return the inode number of the parent directory of this directory handle
     pub fn parent(&self) -> InodeNo {
         self.parent_ino
     }
 
-    fn compare_and_get_next(&self) -> Option<LookedUp> {
-        let mut local_locked = self.local_results.write().unwrap();
-        let mut remote_locked = self.remote_results.write().unwrap();
-        match (local_locked.front(), remote_locked.front()) {
-            (None, None) => None,
-            (None, Some(_)) => remote_locked.pop_front(),
-            (Some(_), None) => local_locked.pop_front(),
-            (Some(local_lookup), Some(remote_lookup)) => {
-                let ordering = local_lookup.inode.name().cmp(remote_lookup.inode.name());
-                // compare the inodes at the front of both queues by their names and return the one that has less ordering.
-                // in case both inodes have the same name we will prioritise the one from the remote queue,
-                // return it as a result and remove the one in the local queue.
-                match ordering {
-                    std::cmp::Ordering::Less => local_locked.pop_front(),
-                    std::cmp::Ordering::Equal => {
-                        let _ = local_locked.pop_front();
-                        remote_locked.pop_front()
-                    }
-                    std::cmp::Ordering::Greater => remote_locked.pop_front(),
-                }
+    /// Create or update an inode for the given ReaddirEntry.
+    ///
+    /// This returns `Ok(None)` if inode creation fails because the ReaddirEntry should not be
+    /// visible in the file system (e.g. due to shadowing or an invalid inode name).
+    fn instantiate_remote_inode(&self, entry: ReaddirEntry) -> Result<Option<LookedUp>, InodeError> {
+        let (stat, kind) = match &entry {
+            ReaddirEntry::LocalInode { lookup } => return Ok(Some(lookup.clone())),
+            ReaddirEntry::RemotePrefix { .. } => {
+                let stat = InodeStat::for_directory(self.inner.mount_time, Instant::now());
+                (stat, InodeKind::Directory)
             }
+            ReaddirEntry::RemoteObject { object_info, .. } => {
+                let stat = InodeStat::for_file(
+                    object_info.size as usize,
+                    object_info.last_modified,
+                    Instant::now(),
+                    Some(object_info.etag.clone()),
+                );
+                (stat, InodeKind::File)
+            }
+        };
+        let remote_lookup = RemoteLookup { stat, kind };
+
+        // Short-circuit the update if we know it'll fail because the name is invalid
+        if !valid_inode_name(entry.name()) {
+            warn!(
+                "{} has an invalid name and will be unavailable",
+                entry.shadowed_description()
+            );
+            return Ok(None);
+        }
+
+        let result = self
+            .inner
+            .update_from_remote(self.dir_ino, entry.name(), Some(remote_lookup));
+        match result {
+            Err(InodeError::ShadowedByDirectory(_, _)) => {
+                warn!(
+                    "{} is shadowed by another directory entry with the same name and will be unavailable",
+                    entry.shadowed_description(),
+                );
+                Ok(None)
+            }
+            _ => Ok(Some(result?)),
         }
     }
 
@@ -229,5 +196,259 @@ impl ReaddirHandle {
             result.push(entry);
         }
         Ok(result)
+    }
+}
+
+/// A single entry in a readdir stream. Remote entries have not yet been converted to inodes -- that
+/// should be done lazily by the consumer of the entry.
+#[derive(Debug)]
+enum ReaddirEntry {
+    RemotePrefix { name: String },
+    RemoteObject { name: String, object_info: ObjectInfo },
+    LocalInode { lookup: LookedUp },
+}
+
+// This looks a little silly but makes the [Ord] implementation for [ReaddirEntry] a bunch clearer
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+enum ReaddirEntryKind {
+    RemotePrefix,
+    RemoteObject,
+    LocalInode,
+}
+
+impl ReaddirEntry {
+    fn name(&self) -> &str {
+        match self {
+            Self::RemotePrefix { name } => name,
+            Self::RemoteObject { name, .. } => name,
+            Self::LocalInode { lookup } => lookup.inode.name(),
+        }
+    }
+
+    fn kind(&self) -> ReaddirEntryKind {
+        match self {
+            Self::RemotePrefix { .. } => ReaddirEntryKind::RemotePrefix,
+            Self::RemoteObject { .. } => ReaddirEntryKind::RemoteObject,
+            Self::LocalInode { .. } => ReaddirEntryKind::LocalInode,
+        }
+    }
+
+    /// How to describe this entry in an error message about shadowing
+    fn shadowed_description(&self) -> String {
+        match self {
+            Self::RemotePrefix { name } => {
+                debug_assert!(false, "should be impossible to shadow a remote prefix");
+                format!("directory '{name}'")
+            }
+            Self::RemoteObject { name, object_info } => {
+                format!("file '{}' (full key '{}')", name, object_info.key)
+            }
+            Self::LocalInode { lookup } => {
+                let kind = match lookup.inode.kind() {
+                    InodeKind::Directory => "directory",
+                    InodeKind::File => "file",
+                };
+                format!("local {} '{}'", kind, lookup.inode.name())
+            }
+        }
+    }
+}
+
+impl PartialEq for ReaddirEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name() && self.kind() == other.kind()
+    }
+}
+
+impl Eq for ReaddirEntry {}
+
+impl PartialOrd for ReaddirEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// We sort readdir entries by name, and then by kind. So if two entries have the same name, a remote
+// directory sorts before a remote object, which sorts before a local entry.
+impl Ord for ReaddirEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name()
+            .cmp(other.name())
+            .then_with(|| self.kind().cmp(&other.kind()))
+    }
+}
+
+/// An iterator over [ReaddirEntry]s for a directory. This merges iterators of remote and local
+/// [ReaddirEntry]s, returning them in name order, and filtering out entries that are shadowed by
+/// other entries of the same name.
+#[derive(Debug)]
+struct ReaddirIter {
+    remote: RemoteIter,
+    local: LocalIter,
+    next_remote: Option<ReaddirEntry>,
+    next_local: Option<ReaddirEntry>,
+    last_name: Option<String>,
+}
+
+impl ReaddirIter {
+    fn new(bucket: &str, full_path: &str, page_size: usize, local_entries: VecDeque<ReaddirEntry>) -> Self {
+        Self {
+            remote: RemoteIter::new(bucket, full_path, page_size),
+            local: LocalIter::new(local_entries),
+            next_remote: None,
+            next_local: None,
+            last_name: None,
+        }
+    }
+
+    /// Return the next [ReaddirEntry] for the directory stream. If the stream is finished, returns
+    /// `Ok(None)`.
+    async fn next(&mut self, client: &impl ObjectClient) -> Result<Option<ReaddirEntry>, InodeError> {
+        // The only reason to go around this loop more than once is if the next entry to return is
+        // a duplicate, in which case it's skipped.
+        loop {
+            // First refill the peeks at the next entries on each iterator
+            if self.next_remote.is_none() {
+                self.next_remote = self.remote.next(client).await?;
+            }
+            if self.next_local.is_none() {
+                self.next_local = self.local.next();
+            }
+
+            // Merge-sort the two iterators, preferring the remote iterator if the two entries are
+            // equal (i.e. have the same name)
+            let next = match (&self.next_remote, &self.next_local) {
+                (Some(remote), Some(local)) => {
+                    if remote <= local {
+                        self.next_remote.take()
+                    } else {
+                        self.next_local.take()
+                    }
+                }
+                (Some(_), None) => self.next_remote.take(),
+                (None, _) => self.next_local.take(),
+            };
+
+            // Deduplicate the entry we want to return
+            match next {
+                Some(entry) => {
+                    if self.last_name.as_deref() == Some(entry.name()) {
+                        warn!(
+                            "{} is shadowed by another directory entry with the same name and will be unavailable",
+                            entry.shadowed_description(),
+                        );
+                    } else {
+                        self.last_name = Some(entry.name().to_owned());
+                        return Ok(Some(entry));
+                    }
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteIterState {
+    /// Next ListObjects call should use this continuation token
+    InProgress(Option<String>),
+    /// No more ListObjects calls to make
+    Finished,
+}
+
+/// An iterator over [ReaddirEntry]s returned by paginated ListObjects calls to S3. This iterator
+/// handles combining directories (common prefixes) and files (objects) into a single stream,
+/// and re-sorting that stream to account for common prefixes not being in lexicographic order (see
+/// the module comment).
+#[derive(Debug)]
+struct RemoteIter {
+    entries: VecDeque<ReaddirEntry>,
+    bucket: String,
+    full_path: String,
+    page_size: usize,
+    state: RemoteIterState,
+}
+
+impl RemoteIter {
+    fn new(bucket: &str, full_path: &str, page_size: usize) -> Self {
+        Self {
+            entries: VecDeque::new(),
+            bucket: bucket.to_owned(),
+            full_path: full_path.to_owned(),
+            page_size,
+            state: RemoteIterState::InProgress(None),
+        }
+    }
+
+    async fn next(&mut self, client: &impl ObjectClient) -> Result<Option<ReaddirEntry>, InodeError> {
+        if self.entries.is_empty() {
+            let continuation_token = match &mut self.state {
+                RemoteIterState::Finished => {
+                    trace!(self=?self as *const _, "remote iter finished");
+                    return Ok(None);
+                }
+                RemoteIterState::InProgress(token) => token.take(),
+            };
+
+            trace!(self=?self as *const _, ?continuation_token, "continuing remote iter");
+
+            let result = client
+                .list_objects(
+                    &self.bucket,
+                    continuation_token.as_deref(),
+                    "/",
+                    self.page_size,
+                    self.full_path.as_str(),
+                )
+                .await
+                .map_err(|e| InodeError::ClientError(anyhow::Error::new(e)))?;
+
+            self.state = match result.next_continuation_token {
+                Some(token) => RemoteIterState::InProgress(Some(token)),
+                None => RemoteIterState::Finished,
+            };
+
+            let prefixes = result
+                .common_prefixes
+                .into_iter()
+                .map(|prefix| ReaddirEntry::RemotePrefix {
+                    name: prefix[self.full_path.len()..prefix.len() - 1].to_owned(),
+                });
+
+            let objects = result
+                .objects
+                .into_iter()
+                .map(|object_info| ReaddirEntry::RemoteObject {
+                    name: object_info.key[self.full_path.len()..].to_owned(),
+                    object_info,
+                });
+
+            // ListObjectsV2 results are sorted, so ideally we'd just merge-sort the two streams.
+            // But `prefixes` isn't quite in sorted order any more because we trimmed off the
+            // trailing `/` from the names. There's still probably a less naive way to do this sort,
+            // but this should be good enough.
+            let mut new_entries = prefixes.chain(objects).collect::<Vec<_>>();
+            new_entries.sort();
+
+            self.entries.extend(new_entries);
+        }
+
+        Ok(self.entries.pop_front())
+    }
+}
+
+/// An iterator over local [ReaddirEntry]s listed from a directory at the start of a [ReaddirHandle]
+#[derive(Debug)]
+struct LocalIter {
+    entries: VecDeque<ReaddirEntry>,
+}
+
+impl LocalIter {
+    fn new(entries: VecDeque<ReaddirEntry>) -> Self {
+        Self { entries }
+    }
+
+    fn next(&mut self) -> Option<ReaddirEntry> {
+        self.entries.pop_front()
     }
 }


### PR DESCRIPTION
The motivation here is that `readdir` calls from FUSE generally only
retrieve a small number of entries, but ListObjectsV2 calls to S3
retrieve many entries. In the current code, we instantiate inodes for
those entries as soon as the ListObjectsV2 call completes, but because
of the small batch size of `readdir`, most of these inodes will not be
returned to FUSE until some time later. Because the TTL of an inode's
attributes is chosen at inode creation time, it will have expired by
this point, and so the kernel will immediately re-`lookup` these entries
when they're returned to `readdir`. That makes `readdir` do O(n)
`lookup` calls back to S3, defeating the purpose of ListObjectsV2.

To solve this problem, this change refactors the `ReaddirHandle`
implementation to defer creating inodes until an entry is actually
returned to `readdir`. The big idea is that we now just create a new
[ReaddirEntry] struct for each entry returned by ListObjectsV2, and all
the `readdir` logic works in terms of those things rather than directly
on inodes. The conversion from [ReaddirEntry] to an actual inode then
happens right before returning the entry to `readdir`.

I took this opportunity to refactor this code (hopefully for the
better!) since this change was adding yet another layer of complexity
into the logic for iterating directory entries. I also tried to capture
my understanding of this code in a new module comment. There is still a
bug here around page sizes (#190) that I think this comment and refactor
will make it easier to fix, but let's do that separately to avoid making
this change bigger.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
