### PR TITLE
Implement CRT bindings for CRC checksum functions

### DIFF
--- a/mountpoint-s3-crt/src/checksums.rs
+++ b/mountpoint-s3-crt/src/checksums.rs
@@ -1,0 +1,7 @@
+//! Implementation of CRT checksums.
+
+/// CRC32 checksums
+pub mod crc32;
+
+/// CRC32C checksums
+pub mod crc32c;

--- a/mountpoint-s3-crt/src/checksums/crc32.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32.rs
@@ -1,0 +1,76 @@
+use mountpoint_s3_crt_sys::*;
+
+/// CRC32 checksum
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Crc32(u32);
+
+/// Computes the CRC32 checksum of a byte slice.
+///
+/// Use [`Hasher`] for more advanced use-cases.
+pub fn hash(buf: &[u8]) -> Crc32 {
+    let mut hasher = Hasher::new();
+    hasher.update(buf);
+    hasher.finalize()
+}
+
+/// CRC32 Hasher
+#[derive(Debug, Clone)]
+pub struct Hasher {
+    state: Crc32,
+}
+
+impl Hasher {
+    /// Create a new CRC32 [`Hasher`].
+    pub fn new() -> Self {
+        Self { state: Crc32(0) }
+    }
+
+    /// Update the hash state with the given bytes slice.
+    pub fn update(&mut self, buf: &[u8]) {
+        self.state = Hasher::crc32(buf, &self.state);
+    }
+
+    /// Finalize the hash state and return the computed CRC32 checksum value.
+    pub fn finalize(self) -> Crc32 {
+        self.state
+    }
+
+    /// Compute CRC32 checksum of the data in the given bytes slice, append to the previous checksum.
+    fn crc32(buf: &[u8], previous_checksum: &Crc32) -> Crc32 {
+        // SAFETY: we pass a valid buffer to the CRT, and trust
+        // the CRT function to only read from the buffer's boundary.
+        let checksum = unsafe { aws_checksums_crc32(buf.as_ptr(), buf.len() as i32, previous_checksum.0) };
+        Crc32(checksum)
+    }
+}
+
+impl std::hash::Hasher for Hasher {
+    fn finish(&self) -> u64 {
+        self.clone().finalize().0.into()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.update(bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checksums::crc32::{self, Crc32};
+
+    #[test]
+    fn crc32_simple() {
+        let buf: &[u8] = b"123456789";
+        let crc = crc32::hash(buf);
+        assert_eq!(crc, Crc32(0xcbf43926));
+    }
+
+    #[test]
+    fn crc32_append() {
+        let mut hasher = crc32::Hasher::new();
+        hasher.update(b"1234");
+        hasher.update(b"56789");
+        let crc = hasher.finalize();
+        assert_eq!(crc, Crc32(0xcbf43926));
+    }
+}

--- a/mountpoint-s3-crt/src/checksums/crc32.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32.rs
@@ -1,13 +1,13 @@
-use mountpoint_s3_crt_sys::*;
+use mountpoint_s3_crt_sys::aws_checksums_crc32;
 
 /// CRC32 checksum
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Crc32(u32);
 
 /// Computes the CRC32 checksum of a byte slice.
 ///
 /// Use [`Hasher`] for more advanced use-cases.
-pub fn hash(buf: &[u8]) -> Crc32 {
+pub fn checksum(buf: &[u8]) -> Crc32 {
     let mut hasher = Hasher::new();
     hasher.update(buf);
     hasher.finalize()
@@ -27,7 +27,7 @@ impl Hasher {
 
     /// Update the hash state with the given bytes slice.
     pub fn update(&mut self, buf: &[u8]) {
-        self.state = Hasher::crc32(buf, &self.state);
+        self.state = Hasher::crc32(buf, self.state);
     }
 
     /// Finalize the hash state and return the computed CRC32 checksum value.
@@ -36,11 +36,22 @@ impl Hasher {
     }
 
     /// Compute CRC32 checksum of the data in the given bytes slice, append to the previous checksum.
-    fn crc32(buf: &[u8], previous_checksum: &Crc32) -> Crc32 {
+    ///
+    /// The underlying CRT funtion requires the buffer's length to be type `i32`, so this function cannot take
+    /// any buffer that is bigger than `i32::MAX` as an input.
+    fn crc32(buf: &[u8], previous_checksum: Crc32) -> Crc32 {
+        assert!(buf.len() <= i32::MAX as usize);
+
         // SAFETY: we pass a valid buffer to the CRT, and trust
         // the CRT function to only read from the buffer's boundary.
         let checksum = unsafe { aws_checksums_crc32(buf.as_ptr(), buf.len() as i32, previous_checksum.0) };
         Crc32(checksum)
+    }
+}
+
+impl Default for Hasher {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -61,7 +72,7 @@ mod tests {
     #[test]
     fn crc32_simple() {
         let buf: &[u8] = b"123456789";
-        let crc = crc32::hash(buf);
+        let crc = crc32::checksum(buf);
         assert_eq!(crc, Crc32(0xcbf43926));
     }
 

--- a/mountpoint-s3-crt/src/checksums/crc32c.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32c.rs
@@ -1,0 +1,76 @@
+use mountpoint_s3_crt_sys::*;
+
+/// CRC32C checksum
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Crc32c(u32);
+
+/// Computes the CRC32C checksum of a byte slice.
+///
+/// Use [`Hasher`] for more advanced use-cases.
+pub fn hash(buf: &[u8]) -> Crc32c {
+    let mut hasher = Hasher::new();
+    hasher.update(buf);
+    hasher.finalize()
+}
+
+/// CRC32C Hasher
+#[derive(Debug, Clone)]
+pub struct Hasher {
+    state: Crc32c,
+}
+
+impl Hasher {
+    /// Create a new CRC32C [`Hasher`].
+    pub fn new() -> Self {
+        Self { state: Crc32c(0) }
+    }
+
+    /// Update the hash state with the given bytes slice.
+    pub fn update(&mut self, buf: &[u8]) {
+        self.state = Hasher::crc32c(buf, &self.state);
+    }
+
+    /// Finalize the hash state and return the computed CRC32C checksum value.
+    pub fn finalize(self) -> Crc32c {
+        self.state
+    }
+
+    /// Compute CRC32C checksum of the data in the given bytes slice, append to the previous checksum.
+    fn crc32c(buf: &[u8], previous_checksum: &Crc32c) -> Crc32c {
+        // SAFETY: we pass a valid buffer to the CRT, and trust
+        // the CRT function to only read from the buffer's boundary.
+        let checksum = unsafe { aws_checksums_crc32c(buf.as_ptr(), buf.len() as i32, previous_checksum.0) };
+        Crc32c(checksum)
+    }
+}
+
+impl std::hash::Hasher for Hasher {
+    fn finish(&self) -> u64 {
+        self.clone().finalize().0.into()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.update(bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checksums::crc32c::{self, Crc32c};
+
+    #[test]
+    fn crc32c_simple() {
+        let buf: &[u8] = b"123456789";
+        let crc = crc32c::hash(buf);
+        assert_eq!(crc, Crc32c(0xe3069283));
+    }
+
+    #[test]
+    fn crc32c_append() {
+        let mut hasher = crc32c::Hasher::new();
+        hasher.update(b"1234");
+        hasher.update(b"56789");
+        let crc = hasher.finalize();
+        assert_eq!(crc, Crc32c(0xe3069283));
+    }
+}

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -5,6 +5,7 @@
 use mountpoint_s3_crt_sys::*;
 
 pub mod auth;
+pub mod checksums;
 pub mod common;
 pub mod http;
 pub mod io;


### PR DESCRIPTION
Add rust interfaces for CRC32 and CRC32C functions. We will be using these functions to do data integrity check in the future.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
