### PR TITLE
Fix shadowing semantics doc and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -3214,12 +3215,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -38,12 +38,12 @@ S3 places fewer restrictions on [valid object keys](https://docs.aws.amazon.com/
   * `red/`
   
   then mounting your bucket would give a file system with a `blue` directory containing an `image.jpg` file, and an empty `red` directory. The `blue/` and `red/` objects will not be accessible. Note that the S3 Console creates zero-byte objects like `blue/` and `red/` when creating directories in a bucket, and so these directories will work as expected.
-* Directories will be shadowed by files with the same name. For example, if your bucket has the following object keys:
+* Files will be shadowed by directories with the same name. For example, if your bucket has the following object keys:
 
   * `blue`
   * `blue/image.jpg`
   
-  then mounting your bucket would give a file system with a `blue` file, rather than a `blue` directory, and therefore `image.jpg` will not be accessible. Note that this means deleting the file `blue` will cause a directory `blue/` to become visible, and make `blue/image.jpg` accessible.
+  then mounting your bucket would give a file system with a `blue` directory, containing the file `image.jpg`. The `blue` object will not be accessible. Deleting the key `blue/image.jpg` will remove the `blue` directory, and cause the `blue` file to become visible.
 
 We test Mountpoint for Amazon S3 against these restrictions using a [reference model](https://github.com/awslabs/mountpoint-s3/blob/0ca2c771237032040bd1ec9405f5ed0ffa5d2eb9/s3-file-connector/tests/reftests/reference.rs#L121) that programmatically encodes the expected mapping between S3 objects and file system structure.
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -49,6 +49,7 @@ shuttle = { version = "0.5.0" }
 tempfile = "3.4.0"
 test-case = "2.2.2"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
+walkdir = "2.3.3"
 
 [features]
 fuse_tests = []

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -5,6 +5,7 @@ mod mount_test;
 mod perm_test;
 mod prefetch_test;
 mod readdir_test;
+mod semantics_doc_test;
 mod write_test;
 
 use std::ffi::OsStr;

--- a/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
@@ -1,0 +1,158 @@
+use std::path::Path;
+
+use fuser::BackgroundSession;
+use mountpoint_s3::S3FilesystemConfig;
+use tempfile::TempDir;
+use walkdir::WalkDir;
+
+use crate::fuse_tests::TestClientBox;
+
+/// Recursively list the contents of a directory and return the paths of all entries, with the
+/// initial `path` stripped. If `files` is true, the list contains only files; if false, it contains
+/// only directories.
+fn list_dir_recursive(path: impl AsRef<Path>, files: bool) -> Result<Vec<String>, walkdir::Error> {
+    let path_prefix = format!("{}/", path.as_ref().to_string_lossy());
+    let contents_iter = WalkDir::new(path)
+        .sort_by_file_name()
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    let contents_filtered = contents_iter.iter().filter(|d| {
+        if files {
+            d.file_type().is_file()
+        } else {
+            d.file_type().is_dir()
+        }
+    });
+    // flat_map to drop the root directory itself, which won't have the / at the end that
+    // path_prefix contains
+    let entries = contents_filtered
+        .flat_map(|d| {
+            d.path()
+                .to_string_lossy()
+                .strip_prefix(&path_prefix)
+                .map(|p| p.to_owned())
+        })
+        .collect::<Vec<_>>();
+    Ok(entries)
+}
+
+/// Mountpoint for Amazon S3 interprets keys in your S3 bucket as file system paths by splitting
+/// them on the `/` character. For example, if your bucket contains the following object keys:
+///
+/// * `colors/blue/image.jpg`
+/// * `colors/red/image.jpg`
+/// * `colors/list.txt`
+///
+/// then mounting your bucket would give the following file system structure:
+///
+/// * `colors` (directory)
+///     * `blue` (directory)
+///         * `image.jpg` (file)
+///     * `red` (directory)
+///         * `image.jpg` (file)
+///     * `list.txt` (file)
+fn basic_directory_structure<F>(creator_fn: F)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn("basic_directory_structure", Default::default());
+
+    test_client.put_object("colors/blue/image.jpg", b"hello world").unwrap();
+    test_client.put_object("colors/red/image.jpg", b"hello world").unwrap();
+    test_client.put_object("colors/list.txt", b"hello world").unwrap();
+
+    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    assert_eq!(
+        &files[..],
+        &["colors/blue/image.jpg", "colors/list.txt", "colors/red/image.jpg"]
+    );
+
+    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    assert_eq!(&dirs[..], &["colors", "colors/blue", "colors/red"]);
+}
+
+#[test]
+fn basic_directory_structure_mock() {
+    basic_directory_structure(crate::fuse_tests::mock_session::new);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn basic_directory_structure_s3() {
+    basic_directory_structure(crate::fuse_tests::s3_session::new);
+}
+
+/// Object keys that end in the path delimiter (`/`) will not be accessible. Instead, a directory of
+/// the same name will be visible. For example, if your bucket has the following object keys:
+///
+/// * `blue/`
+/// * `blue/image.jpg`
+/// * `red/`
+///   
+/// then mounting your bucket would give a file system with a `blue` directory containing an
+/// `image.jpg` file, and an empty `red` directory. The `blue/` and `red/` objects will not be
+/// accessible. Note that the S3 Console creates zero-byte objects like `blue/` and `red/` when
+/// creating directories in a bucket, and so these directories will work as expected.
+fn keys_ending_in_delimiter<F>(creator_fn: F)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn("keys_ending_in_delimiter", Default::default());
+
+    test_client.put_object("blue/", b"hello world").unwrap();
+    test_client.put_object("blue/image.jpg", b"hello world").unwrap();
+    test_client.put_object("red/", b"hello world").unwrap();
+
+    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    assert_eq!(&files[..], &["blue/image.jpg"]);
+
+    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    assert_eq!(&dirs[..], &["blue", "red"]);
+}
+
+#[test]
+fn keys_ending_in_delimiter_mock() {
+    keys_ending_in_delimiter(crate::fuse_tests::mock_session::new);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn keys_ending_in_delimiter_s3() {
+    keys_ending_in_delimiter(crate::fuse_tests::s3_session::new);
+}
+
+/// Files will be shadowed by directories with the same name. For example, if your bucket has the
+/// following object keys:
+///
+/// * `blue`
+/// * `blue/image.jpg`
+///   
+/// then mounting your bucket would give a file system with a `blue` directory, containing the file
+/// `image.jpg`. The `blue` object will not be accessible. Deleting the key `blue/image.jpg` will
+/// remove the `blue` directory, and cause the `blue` file to become visible.
+fn files_shadowed_by_directories<F>(creator_fn: F)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn("files_shadowed_by_directories", Default::default());
+
+    test_client.put_object("blue", b"hello world").unwrap();
+    test_client.put_object("blue/image.jpg", b"hello world").unwrap();
+
+    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    assert_eq!(&files[..], &["blue/image.jpg"]);
+
+    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    assert_eq!(&dirs[..], &["blue"]);
+}
+
+#[test]
+fn files_shadowed_by_directories_mock() {
+    files_shadowed_by_directories(crate::fuse_tests::mock_session::new);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn files_shadowed_by_directories_s3() {
+    files_shadowed_by_directories(crate::fuse_tests::s3_session::new);
+}


### PR DESCRIPTION
The doc was backwards from what we actually do and what we intended.
Directories will shadow files of the same name, in the interest of
making as many objects visible as possible.

I also added a new integration test that just quotes the documentation
and implements it directly.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
