### PR TITLE
Fix default config for logging

### DIFF
--- a/mountpoint-s3/src/fuse/session.rs
+++ b/mountpoint-s3/src/fuse/session.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use fuser::{Filesystem, Session, SessionUnmounter};
-use tracing::{error, info, trace};
+use tracing::{debug, error, trace};
 
 use crate::sync::mpsc;
 use crate::sync::thread;
@@ -37,7 +37,7 @@ impl FuseSession {
                         // SAFETY: this syscall is available since Linux 2.4.11 but glibc didn't
                         // wrap it until very recently.
                         let tid = unsafe { libc::syscall(libc::SYS_gettid) };
-                        info!("fuse worker {i} is thread ID {tid}");
+                        debug!("fuse worker {i} is thread ID {tid}");
                     }
                     session.run()
                 })


### PR DESCRIPTION
We'd like to capture info-level logs by default -- they report useful information including metrics and failed requests. I was also wrong about the "brutal hack" for providing a default value for RUST_LOG -- `EnvFilter::new` has always existed to parse a string, so let's use that instead.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
