### PR TITLE
Add benchmarks for CRT checksum bindings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,35 @@ jobs:
     - name: Check all targets
       run: cargo check --locked --all-targets --all-features
 
+  bench:
+    name: Cargo benchmarks
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Cargo cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install fuse
+      run: sudo apt-get install fuse libfuse-dev
+    - name: Run benchmarks
+      run: cargo bench
+
   shuttle:
     name: Shuttle tests
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "libc",
  "log",
  "mountpoint-s3-crt-sys",
+ "rand",
  "smallstr",
  "static_assertions",
  "tempfile",

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -17,9 +17,14 @@ thiserror = "1.0.35"
 [dev-dependencies]
 criterion = "0.4.0"
 ctor = "0.1.23"
+rand = { version = "0.8.5", features = ["small_rng"] }
 tempfile = "3.4.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 
 [[bench]]
 name = "event_loop_future"
+harness = false
+
+[[bench]]
+name = "checksums"
 harness = false

--- a/mountpoint-s3-crt/benches/checksums.rs
+++ b/mountpoint-s3-crt/benches/checksums.rs
@@ -1,0 +1,39 @@
+//! Benchmarks for the CRT checksums library
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use mountpoint_s3_crt::checksums::{crc32, crc32c};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+fn benchmark_hasher<F, R>(c: &mut Criterion, hash_fn: F, name: &str)
+where
+    F: Fn(&[u8]) -> R,
+{
+    let mut group = c.benchmark_group(name);
+    let mut rng = SmallRng::seed_from_u64(0x12345678);
+    for expt in [4, 8, 12, 16, 20] {
+        let size = 1usize << expt;
+        group.throughput(Throughput::Bytes(size as u64));
+
+        let mut data = vec![0u8; size];
+        rng.fill(&mut data[..]);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data[..], |b, data| {
+            b.iter(|| {
+                let _ = black_box(hash_fn(data));
+            })
+        });
+    }
+    group.finish();
+}
+
+fn crc32(c: &mut Criterion) {
+    benchmark_hasher(c, crc32::checksum, "crc32");
+}
+
+fn crc32c(c: &mut Criterion) {
+    benchmark_hasher(c, crc32c::checksum, "crc32c");
+}
+
+criterion_group!(checksum_benches, crc32, crc32c);
+criterion_main!(checksum_benches);


### PR DESCRIPTION
Just a few simple benchmarks to make sure our bindings aren't affecting performance. This should also make it easy to play with performance on Graviton.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
