### PR TITLE
Use more specific labels for self-hosted runners

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   bench:
     name: Benchmark (Throughput)
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x64, high-performance]
 
     environment: ${{ inputs.environment }}
 
@@ -94,7 +94,7 @@ jobs:
   
   latency-bench:
     name: Benchmark (Latency)
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x64, high-performance]
 
     environment: ${{ inputs.environment }}
 


### PR DESCRIPTION
Just a small change to add specific labels when requesting self-hosted runners for workflows, we want to support more than one type of self-hosted runners in the future.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
