### PR TITLE
Add incremental writes to reftests

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -168,7 +168,12 @@ impl<T: AsRef<[u8]>> From<T> for MockObject {
 
 impl std::fmt::Debug for MockObject {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("MockObject").finish()
+        f.debug_struct("MockObject")
+            .field("size", &self.size)
+            .field("storage_class", &self.storage_class)
+            .field("last_modified", &self.last_modified)
+            .field("etag", &self.etag)
+            .finish()
     }
 }
 

--- a/mountpoint-s3/tests/reftests/generators.rs
+++ b/mountpoint-s3/tests/reftests/generators.rs
@@ -43,12 +43,6 @@ impl FileContent {
     pub fn to_mock_object(&self) -> MockObject {
         MockObject::constant(self.0, self.1.into(), ETag::for_tests())
     }
-
-    pub fn to_boxed_slice(&self) -> Box<[u8]> {
-        let size: usize = self.1.into();
-        let obj = self.to_mock_object();
-        obj.read(0, size)
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
In #229 we added initial support for writes to the reference model tests. So far, those tests have only covered writing to a file as a single atomic operation (create, open, write, close), but we'd also like to test interleavings of those individual operations, so that we can see, for example, multiple writers try to touch the same file.

This change adds the create/open/write/close steps as separate operations that the reftest can choose to perform in any order. We retain the original atomic operation, but it's now just a "shortcut" that does all four steps together.

The important thing we do here is introduce a couple of "index" types that `proptest` can generate. These indexes allow the generated test to refer to inflight writes, existing directories, etc all without actually needing to understand paths. The indexes are strongly typed even though they're just wrappers around `usize` so that we don't mix them up.

This change is hopefully also a template for how to add additional operations in the future: we need to add new variants to `Op`, implement a `perform_` method for them, and think about how to track any inflight state so that future operations can refer to it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
