### PR TITLE
Add a CI job to validate Graviton instance support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,6 +83,62 @@ jobs:
           target/
         key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
 
+  arm64-test:
+    name: Tests (arm64)
+    runs-on: [self-hosted, linux, arm64]
+
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-integration-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install dependencies
+      run: |
+        sudo yum update
+        sudo yum install -y cmake3 clang-devel pkgconfig
+    - name: Install fuse
+      run: sudo yum install -y fuse fuse-devel
+    - name: Configure fuse
+      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+    - name: Run tests
+      run: cargo test --features $RUST_FEATURES
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR integration tests'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
+
   asan:
     name: Address sanitizer
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We want to make sure that Mountpoint can be built and run on aarch64 and Graviton instances, but GitHub currently doesn't support this type of runner. What we can do for now is using self-hosted runners, which we maintain internally, until GitHub provides official ARM-based images.

The current configuration for our runners is [m7g.medium](https://aws.amazon.com/ec2/instance-types/m7g/) instance type with Amazon Linux 2 operating system.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
