### PR TITLE
Allow custom credentials providers for S3CrtClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1599,7 @@ checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.8",
  "windows-sys 0.45.0",
 ]
 
@@ -1704,6 +1715,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "log"
@@ -1861,6 +1878,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "bytes",
  "clap 3.2.23",
@@ -1878,7 +1896,9 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
+ "rusty-fork",
  "static_assertions",
+ "tempfile",
  "test-case",
  "thiserror",
  "time",
@@ -2380,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
@@ -2471,10 +2491,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.7",
  "windows-sys 0.45.0",
 ]
 
@@ -2791,15 +2825,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "rustix 0.37.3",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3362,7 +3396,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
 ]
 
 [[package]]
@@ -3371,13 +3405,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -3386,7 +3420,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3395,13 +3438,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -3411,10 +3469,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3423,10 +3493,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3435,16 +3517,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "wyz"

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -28,6 +28,7 @@ md-5 = "0.10.5"
 [dev-dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 aws-config = "0.54.1"
+aws-credential-types = "0.54.1"
 aws-sdk-s3 = "0.24.0"
 bytes = "1.2.1"
 clap = "3.2.12"
@@ -35,6 +36,8 @@ ctor = "0.1.23"
 proptest = "1.0.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+rusty-fork = "0.3.0"
+tempfile = "3.5.0"
 test-case = "2.2.2"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -10,7 +10,7 @@ pub use endpoint::{AddressingStyle, Endpoint};
 pub use imds_crt_client::ImdsCrtClient;
 pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
-pub use s3_crt_client::{S3ClientConfig, S3CrtClient, S3RequestError};
+pub use s3_crt_client::{S3ClientAuthConfig, S3ClientConfig, S3CrtClient, S3RequestError};
 
 #[cfg(test)]
 mod tests {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -66,7 +66,7 @@ pub enum S3ClientAuthConfig {
     #[default]
     Default,
     /// Do not sign requests at all
-    None,
+    NoSigning,
     /// Explicitly load the given profile name from the AWS CLI configuration file
     Profile(String),
     /// Use a custom credentials provider
@@ -126,7 +126,7 @@ impl S3CrtClient {
                         .map_err(NewClientError::ProviderFailure)?,
                 )
             }
-            S3ClientAuthConfig::None => None,
+            S3ClientAuthConfig::NoSigning => None,
             S3ClientAuthConfig::Profile(profile_name) => {
                 let credentials_profile_options = CredentialsProviderProfileOptions {
                     bootstrap: &mut client_bootstrap,

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -25,7 +25,6 @@ async fn test_static_provider() {
     let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_static_provider");
 
-    // Create one object named "hello"
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
     sdk_client
@@ -45,7 +44,7 @@ async fn test_static_provider() {
     let credentials = sdk_provider
         .provide_credentials()
         .await
-        .expect("can't get static credentials");
+        .expect("static credentials should be available");
 
     // Build a S3CrtClient that uses a static credentials provider with the creds we just got
     let config = CredentialsProviderStaticOptions {
@@ -53,12 +52,12 @@ async fn test_static_provider() {
         secret_access_key: credentials.secret_access_key(),
         session_token: credentials.session_token(),
     };
-    let provider = CredentialsProvider::new_static(&Allocator::default(), config).expect("couldn't create provider");
+    let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
     let config = S3ClientConfig {
         auth_config: S3ClientAuthConfig::Provider(provider),
         ..Default::default()
     };
-    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let result = client
         .get_object(&bucket, &key, None, None)
@@ -75,12 +74,12 @@ async fn test_static_provider() {
         secret_access_key: bogus_secret_access_key,
         session_token: credentials.session_token(),
     };
-    let provider = CredentialsProvider::new_static(&Allocator::default(), config).expect("couldn't create provider");
+    let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
     let config = S3ClientConfig {
         auth_config: S3ClientAuthConfig::Provider(provider),
         ..Default::default()
     };
-    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let mut request = client
         .get_object(&bucket, &key, None, None)
@@ -104,7 +103,6 @@ async fn test_profile_provider_async() {
     let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider");
 
-    // Create one object named "hello"
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
     sdk_client
@@ -124,7 +122,7 @@ async fn test_profile_provider_async() {
     let credentials = sdk_provider
         .provide_credentials()
         .await
-        .expect("can't get static credentials");
+        .expect("static credentials should be available");
 
     // Write the credentials in CLI config format into a temp file
     let profile_name = "mountpoint-profile";
@@ -155,7 +153,7 @@ aws_secret_access_key = {}",
         auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
         ..Default::default()
     };
-    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let result = client
         .get_object(&bucket, &key, None, None)
@@ -173,7 +171,7 @@ aws_secret_access_key = {}",
         auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
         ..Default::default()
     };
-    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let mut request = client
         .get_object(&bucket, &key, None, None)

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -1,0 +1,206 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use std::io::Write;
+use std::option::Option::None;
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sdk_s3::types::ByteStream;
+use aws_sdk_s3::Region;
+use bytes::Bytes;
+use common::*;
+use futures::StreamExt;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+use mountpoint_s3_client::{S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
+use mountpoint_s3_crt::common::allocator::Allocator;
+use rusty_fork::rusty_fork_test;
+use tempfile::NamedTempFile;
+
+/// Test creating a client with the static credentials provider
+#[tokio::test]
+async fn test_static_provider() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_static_provider");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    // Get some static credentials by just using the SDK's default provider, which we know works
+    let sdk_provider = DefaultCredentialsChain::builder()
+        .region(Region::new(get_test_region()))
+        .build()
+        .await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("can't get static credentials");
+
+    // Build a S3CrtClient that uses a static credentials provider with the creds we just got
+    let config = CredentialsProviderStaticOptions {
+        access_key_id: credentials.access_key_id(),
+        secret_access_key: credentials.secret_access_key(),
+        session_token: credentials.session_token(),
+    };
+    let provider = CredentialsProvider::new_static(&Allocator::default(), config).expect("couldn't create provider");
+    let config = S3ClientConfig {
+        auth_config: S3ClientAuthConfig::Provider(provider),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+
+    // Try it again but corrupt the credentials so that we know they're actually being used. The
+    // client can't tell that the corrupted secret access key is invalid, so the request gets sent,
+    // but fails.
+    let bogus_secret_access_key = credentials.secret_access_key().split_at(5).0;
+    let config = CredentialsProviderStaticOptions {
+        access_key_id: credentials.access_key_id(),
+        secret_access_key: bogus_secret_access_key,
+        session_token: credentials.session_token(),
+    };
+    let provider = CredentialsProvider::new_static(&Allocator::default(), config).expect("couldn't create provider");
+    let config = S3ClientConfig {
+        auth_config: S3ClientAuthConfig::Provider(provider),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+
+    let mut request = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object request should be sent");
+
+    let _error = request
+        .next()
+        .await
+        .unwrap()
+        .expect_err("bogus credentials should not work");
+}
+
+/// Test creating a client with the profile credentials provider
+///
+/// This is complicated because CLI profiles are inherently global state, but we want to isolate the
+/// test. So the [test_profile_provider] test below is forked into its own process, where it can set
+/// the environment variables it needs to point to an isolated CLI configuration file without
+/// affecting the rest of the real test runner.
+async fn test_profile_provider_async() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider");
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    // Get some static credentials by just using the SDK's default provider chain
+    let sdk_provider = DefaultCredentialsChain::builder()
+        .region(Region::new(get_test_region()))
+        .build()
+        .await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("can't get static credentials");
+
+    // Write the credentials in CLI config format into a temp file
+    let profile_name = "mountpoint-profile";
+    let mut config_file = NamedTempFile::new().unwrap();
+    writeln!(
+        config_file,
+        "[profile {}]
+aws_access_key_id = {}
+aws_secret_access_key = {}",
+        profile_name,
+        credentials.access_key_id(),
+        credentials.secret_access_key()
+    )
+    .unwrap();
+    if let Some(session_token) = credentials.session_token() {
+        writeln!(config_file, "aws_session_token = {}", session_token).unwrap()
+    }
+
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    // We need to unset AWS_PROFILE if set, because the CRT's profile provider prefers it over the
+    // overriden profile name.
+    std::env::remove_var("AWS_PROFILE");
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    // Build a S3CrtClient that uses the config file
+    let config = S3ClientConfig {
+        auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+
+    // Try it again, but scribble over the credentials, so we know it's not succeeding by accident.
+    // The client can't tell that the corrupted session token is invalid, so the request gets sent,
+    // but fails.
+    let length = config_file.as_file().metadata().unwrap().len();
+    config_file.as_file_mut().set_len(length - 5).unwrap();
+
+    let config = S3ClientConfig {
+        auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&get_test_region(), config).expect("couldn't create client");
+
+    let mut request = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should be sent");
+
+    let _error = request
+        .next()
+        .await
+        .unwrap()
+        .expect_err("bogus credentials should not work");
+
+    // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
+    // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
+    // be constructed.
+    let config = S3ClientConfig {
+        auth_config: S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()),
+        ..Default::default()
+    };
+    let _result = S3CrtClient::new(&get_test_region(), config).expect_err("profile doesn't exist");
+}
+
+rusty_fork_test! {
+    #[test]
+    fn test_profile_provider() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_profile_provider_async());
+    }
+}

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -47,7 +47,7 @@ impl Debug for CredentialsProviderStaticOptions<'_> {
         f.debug_struct("CredentialsProviderStaticOptions")
             .field("access_key_id", &"** redacted **")
             .field("secret_access_key", &"** redacted **")
-            .field("sesssion_token", &self.session_token.map(|_| "** redacted **"))
+            .field("session_token", &self.session_token.map(|_| "** redacted **"))
             .finish()
     }
 }

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -1,17 +1,19 @@
 //! AWS credentials providers
 
+use std::ptr::NonNull;
+
 use mountpoint_s3_crt_sys::{
-    aws_credentials_provider, aws_credentials_provider_chain_default_options,
+    aws_credentials_provider, aws_credentials_provider_acquire, aws_credentials_provider_chain_default_options,
     aws_credentials_provider_new_chain_default, aws_credentials_provider_new_profile,
-    aws_credentials_provider_profile_options, aws_credentials_provider_release,
+    aws_credentials_provider_new_static, aws_credentials_provider_profile_options, aws_credentials_provider_release,
+    aws_credentials_provider_static_options,
 };
 
 use crate::auth::auth_library_init;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::io::channel_bootstrap::ClientBootstrap;
-use crate::{CrtError as _, StringExt};
-use std::ptr::NonNull;
+use crate::{CrtError as _, StringExt as _};
 
 /// Options for creating a default credentials provider
 #[derive(Debug)]
@@ -27,6 +29,17 @@ pub struct CredentialsProviderProfileOptions<'a> {
     pub bootstrap: &'a mut ClientBootstrap,
     /// The name of profile to use.
     pub profile_name_override: &'a str,
+}
+
+/// Options for creating a static credentials provider
+#[derive(Debug)]
+pub struct CredentialsProviderStaticOptions<'a> {
+    /// AWS access key ID
+    pub access_key_id: &'a str,
+    /// AWS secret access key
+    pub secret_access_key: &'a str,
+    /// AWS session token (only required for some credentials sources, e.g. STS)
+    pub session_token: Option<&'a str>,
 }
 
 /// A credentials provider is an object that has an asynchronous query function for retrieving AWS
@@ -74,6 +87,39 @@ impl CredentialsProvider {
         };
 
         Ok(Self { inner })
+    }
+
+    /// Creates a static credential provider that always returns the given credentials
+    pub fn new_static(allocator: &Allocator, options: CredentialsProviderStaticOptions) -> Result<Self, Error> {
+        auth_library_init(allocator);
+
+        // SAFETY: aws_credentials_provider_new_static makes a copy of the strings
+        let inner = unsafe {
+            let inner_options = aws_credentials_provider_static_options {
+                access_key_id: options.access_key_id.as_aws_byte_cursor(),
+                secret_access_key: options.secret_access_key.as_aws_byte_cursor(),
+                session_token: options
+                    .session_token
+                    .map(|t| t.as_aws_byte_cursor())
+                    .unwrap_or_default(),
+                ..Default::default()
+            };
+
+            aws_credentials_provider_new_static(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
+        };
+
+        Ok(Self { inner })
+    }
+}
+
+impl Clone for CredentialsProvider {
+    fn clone(&self) -> Self {
+        // SAFETY: `self.inner` is a valid `aws_credentials_provider` for as long as `self` exists
+        unsafe {
+            aws_credentials_provider_acquire(self.inner.as_ptr());
+        }
+
+        Self { inner: self.inner }
     }
 }
 

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -1,5 +1,6 @@
 //! AWS credentials providers
 
+use std::fmt::Debug;
 use std::ptr::NonNull;
 
 use mountpoint_s3_crt_sys::{
@@ -32,7 +33,6 @@ pub struct CredentialsProviderProfileOptions<'a> {
 }
 
 /// Options for creating a static credentials provider
-#[derive(Debug)]
 pub struct CredentialsProviderStaticOptions<'a> {
     /// AWS access key ID
     pub access_key_id: &'a str,
@@ -40,6 +40,16 @@ pub struct CredentialsProviderStaticOptions<'a> {
     pub secret_access_key: &'a str,
     /// AWS session token (only required for some credentials sources, e.g. STS)
     pub session_token: Option<&'a str>,
+}
+
+impl Debug for CredentialsProviderStaticOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialsProviderStaticOptions")
+            .field("access_key_id", &"** redacted **")
+            .field("secret_access_key", &"** redacted **")
+            .field("sesssion_token", &self.session_token.map(|_| "** redacted **"))
+            .finish()
+    }
 }
 
 /// A credentials provider is an object that has an asynchronous query function for retrieving AWS

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -375,7 +375,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     tracing::info!("target network throughput {throughput_target_gbps} Gbps");
 
     let auth_config = if args.no_sign_request {
-        S3ClientAuthConfig::None
+        S3ClientAuthConfig::NoSigning
     } else if let Some(profile_name) = args.profile {
         // The CRT profile provider will prefer the AWS_PROFILE environment variable over this
         // override if set, which is the opposite of the AWS CLI's documented behavior. Let's match


### PR DESCRIPTION
This slightly generalizes the work we've done to expose profiles and no-sign-request by allowing a custom credentials provider. Right now, only the CRT providers that we've explicitly bound can be used here, but eventually we'll bind the `aws_credentials_provider_delegate` version that can invoke an arbitrary callback to fetch credentials. For now, added a static provider that can be manually configured with credentials for customers using the client as a library with credentials vended from elsewhere.

I also took this chance to write a test for the profile credentials provider. It's a little annoying to do because CLI profiles are global state, so we do it by forking the test into a new process where it's safe to futz with the environment variables we need. Along the way, I realized that the CRT auth provider prefers the AWS_PROFILE environment variable over `--profile`, which is the wrong behavior, so I fixed that by unsetting the variable in main.rs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
