### PR TITLE
Fix issue with file shadowed by a deleted directory

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -657,7 +657,6 @@ impl From<InodeError> for i32 {
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,
-            InodeError::ShadowedByDirectory(_, _) => libc::ENOENT,
             InodeError::FileAlreadyExists(_) => libc::EEXIST,
             // Not obvious what these two cases should be -- EINVAL would also be reasonable, or
             // EROFS for not-writable -- but we'll treat it like a sealed file

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -532,31 +532,35 @@ impl SuperblockInner {
             (None, None) => Ok(UpdateStatus::Neither),
             (None, Some(inode)) => Ok(UpdateStatus::LocalOnly(inode.clone())),
             (Some(remote), None) => Ok(UpdateStatus::RemoteKey(remote.clone())),
-            (Some(remote @ RemoteLookup { kind, stat }), Some(inode)) => {
-                let mut inode_state = inode.get_mut_inode_state()?;
-
-                // In our semantics, directories shadow files of the same name. So if the inode
-                // already exists but the kind has changed, we need to decide what to do.
-                match (inode.kind(), kind) {
-                    // If the inode is currently a directory but we're asking to create a file,
-                    // fail the update, as the directory shadows the file.
-                    // TODO what if the directory is gone on the remote?
-                    (InodeKind::Directory, InodeKind::File) => Err(InodeError::ShadowedByDirectory(
-                        inode.full_key().to_owned(),
-                        inode.ino(),
-                    )),
-                    // If the inode is currently a file but we're asking to update a directory,
-                    // overwrite it, since directories shadow files.
-                    (InodeKind::File, InodeKind::Directory) => {
-                        warn!(parent=?inode.parent(), name=?inode.name(), ino=?inode.ino(), "inode changed from file to directory, will recreate it");
+            (
+                Some(
+                    remote @ RemoteLookup {
+                        kind: remote_kind,
+                        stat,
+                    },
+                ),
+                Some(existing_inode),
+            ) => {
+                let mut inode_state = existing_inode.get_mut_inode_state()?;
+                match (existing_inode.kind(), remote_kind) {
+                    // If the kind has changed, we need a new inode.
+                    (InodeKind::File, InodeKind::Directory) | (InodeKind::Directory, InodeKind::File) => {
+                        warn!(
+                            parent=?existing_inode.parent(),
+                            name=?existing_inode.name(),
+                            ino=?existing_inode.ino(),
+                            "inode changed from {:?} to {:?}, will recreate it",
+                            existing_inode.kind(),
+                            remote_kind,
+                        );
                         Ok(UpdateStatus::RemoteKey(remote.clone()))
                     }
                     // Otherwise, we'll just update this inode in place.
                     (InodeKind::File, InodeKind::File) | (InodeKind::Directory, InodeKind::Directory) => {
-                        trace!(parent=?inode.parent(), name=?inode.name(), ino=?inode.ino(), "updating inode in place");
+                        trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "updating inode in place");
                         inode_state.stat = stat.clone();
                         Ok(UpdateStatus::Updated(LookedUp {
-                            inode: inode.clone(),
+                            inode: existing_inode.clone(),
                             stat: stat.clone(),
                         }))
                     }
@@ -975,8 +979,6 @@ pub enum InodeError {
     InodeDoesNotExist(InodeNo),
     #[error("invalid file name {0:?}")]
     InvalidFileName(OsString),
-    #[error("file {0:?} is shadowed by a directory with inode {1}")]
-    ShadowedByDirectory(String, InodeNo),
     #[error("inode {0} is not a directory")]
     NotADirectory(InodeNo),
     #[error("file already exists at inode {0}")]

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -85,7 +85,7 @@ pub fn assert_attr(attr: FileAttr, ftype: FileType, size: u64, uid: u32, gid: u3
     assert_eq!(attr.perm, perm);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DirectoryEntry {
     pub ino: u64,
     pub offset: i64,

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -523,8 +523,12 @@ async fn test_local_dir(prefix: &str) {
 }
 
 #[tokio::test]
-async fn test_directory_shadowing() {
-    let (client, fs) = make_test_filesystem("test_local_dir", &Default::default(), Default::default());
+async fn test_directory_shadowing_lookup() {
+    let (client, fs) = make_test_filesystem(
+        "test_directory_shadowing_lookup",
+        &Default::default(),
+        Default::default(),
+    );
 
     // Add an object
     let name = "foo";
@@ -545,4 +549,84 @@ async fn test_directory_shadowing() {
 
     let lookup_entry = fs.lookup(FUSE_ROOT_INODE, name.as_ref()).await.unwrap();
     assert_eq!(lookup_entry.attr.kind, FileType::RegularFile);
+}
+
+#[tokio::test]
+async fn test_directory_shadowing_readdir() {
+    let (client, fs) = make_test_filesystem(
+        "test_directory_shadowing_readdir",
+        &Default::default(),
+        Default::default(),
+    );
+
+    // Add `foo/bar` as a file
+    client.add_object("foo/bar", b"foo/bar".into());
+
+    let foo_dir = fs.lookup(FUSE_ROOT_INODE, "foo".as_ref()).await.unwrap();
+    assert_eq!(foo_dir.attr.kind, FileType::Directory);
+
+    let bar_dentry = {
+        let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
+        let mut reply = Default::default();
+        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
+
+        // Skip . and .. to get to the `bar` dentry
+        reply.entries.get(2).unwrap().clone()
+    };
+    // The `bar` dentry should be a file
+    assert_eq!(bar_dentry.attr.kind, FileType::RegularFile);
+    assert_eq!(bar_dentry.name, "bar");
+
+    // Lookup should be consistent with readdir
+    let bar_file = fs.lookup(foo_dir.attr.ino, "bar".as_ref()).await.unwrap();
+    assert_eq!(bar_file.attr.kind, FileType::RegularFile);
+    assert_eq!(bar_file.attr.ino, bar_dentry.attr.ino);
+
+    // Add another object that shadows the first `bar` file with a directory
+    client.add_object("foo/bar/baz", b"bar".into());
+
+    let bar_dentry_new = {
+        let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
+        let mut reply = Default::default();
+        let _reply = fs.readdir(bar_file.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        fs.releasedir(bar_file.attr.ino, dir_handle, 0).await.unwrap();
+
+        // Skip . and .. to get to the `bar` dentry
+        reply.entries.get(2).unwrap().clone()
+    };
+    // The `bar` dentry should now be a directory and a different
+    // inode to the original `bar`
+    assert_eq!(bar_dentry_new.attr.kind, FileType::Directory);
+    assert_eq!(bar_dentry.name, "bar");
+    assert_ne!(bar_dentry_new.attr.ino, bar_dentry.attr.ino);
+
+    // Lookup should again be consistent with readdir
+    let bar_dir = fs.lookup(foo_dir.attr.ino, "bar".as_ref()).await.unwrap();
+    assert_eq!(bar_dir.attr.kind, FileType::Directory);
+    assert_eq!(bar_dir.attr.ino, bar_dentry_new.attr.ino);
+
+    // Remove the second object, revealing the original `bar` file again
+    client.remove_object("foo/bar/baz");
+
+    let bar_dentry = {
+        let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
+        let mut reply = Default::default();
+        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
+
+        // Skip . and .. to get to the `bar` dentry
+        reply.entries.get(2).unwrap().clone()
+    };
+    // The `bar` dentry should be a file again and a different inode to
+    // the `bar` directory above that's now gone. We're ambivalent about
+    // whether it's the same inode as the original file we saw above.
+    assert_eq!(bar_dentry.attr.kind, FileType::RegularFile);
+    assert_eq!(bar_dentry.name, "bar");
+    assert_ne!(bar_dentry.attr.ino, bar_dentry_new.attr.ino);
+
+    // Lookup should be consistent with readdir
+    let bar_file = fs.lookup(foo_dir.attr.ino, "bar".as_ref()).await.unwrap();
+    assert_eq!(bar_file.attr.kind, FileType::RegularFile);
+    assert_eq!(bar_file.attr.ino, bar_dentry.attr.ino);
 }


### PR DESCRIPTION
This change fixes an issue where a file that had been shadowed by a directory would still not become visible after the directory was removed from S3. 

The problem was in the code in `update_from_remote` which would return `InodeError::ShadowedByDirectory` for a name for which `remote_lookup` returned a file while it had previously returned a directory (i.e. the directory was removed remotely). Note that the issue affected `lookup`, but not `readdir`, since the latter handles shadowing by controlling the order in which remote results are processed. In fact, `InodeError::ShadowedByDirectory` had previously been used in `readdir` to skip shadowed files, but has been redundant since the recent refactor.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
