### PR TITLE
Add RustDoc for `fs`,`fuse`,`sync` modules, and on `InodeInner`'s `sync` field

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1,3 +1,5 @@
+//! FUSE file system types and operations, not tied to the _fuser_ library bindings.
+
 use futures::task::Spawn;
 use nix::unistd::{getgid, getuid};
 use std::collections::HashMap;

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -1,3 +1,5 @@
+//! Links _fuser_ method calls into Mountpoint's filesystem code in [crate::fs].
+
 use futures::executor::block_on;
 use futures::task::Spawn;
 use std::ffi::OsStr;

--- a/mountpoint-s3/src/sync.rs
+++ b/mountpoint-s3/src/sync.rs
@@ -1,3 +1,10 @@
+//! Module providing synchronization primitives for use in Mountpoint.
+//!
+//! Using this module allows replacement of [std::sync] by [shuttle::sync],
+//! which can help us find concurrency bugs during testing.
+//!
+//! Anywhere you want to use the [std::sync] types and implementations, you **should** use this module.
+
 #[cfg(not(all(feature = "shuttle", test)))]
 mod std {
     pub use std::sync::*;


### PR DESCRIPTION
Adding a few module comments and field comments to add some context.

We may need to update the comment on `InodeInner.sync` based on changes in #247 .

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
