### PR TITLE
Prepare to publish client and CRT crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "ctor",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.2.1 (May 26, 2023)
+
+Initial release.

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "mountpoint-s3-client"
-version = "0.2.0"
+# Steps to publish a new release:
+# - First publish a new release of `mountpoint-s3-crt` if needed
+# - Pull request to bump version number and update CHANGELOG.md
+#   - Make sure to also bump the `mountpoint-s3-crt` dependency if needed
+# - Create a new Git tag `mountpoint-s3-client-0.x.y`
+# - Run `cargo publish`
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
-publish = false
+repository = "https://github.com/awslabs/mountpoint-s3"
+description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.1" }
 
 async-trait = "0.1.57"
 auto_impl = "1.0.1"
@@ -14,6 +21,7 @@ futures = { version = "0.3.24", features = ["thread-pool"] }
 lazy_static = "1.4.0"
 libc = "0.2.126"
 libc-stdhandle = "0.1.0"
+md-5 = "0.10.5"
 metrics = "0.20.1"
 percent-encoding = "2.2.0"
 pin-project = "1.0.12"
@@ -23,7 +31,6 @@ thiserror = "1.0.34"
 time = { version = "0.3.17", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 xmltree = "0.10.3"
-md-5 = "0.10.5"
 
 [dev-dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/mountpoint-s3-client/README.md
+++ b/mountpoint-s3-client/README.md
@@ -1,0 +1,9 @@
+# mountpoint-s3-client
+
+This crate provides a high-performance Amazon S3 client for use by
+[Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3).
+The client binds to the [AWS Common Runtime](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html),
+which provides features such as AWS authentication, a HTTP client, and low-level IO primitives.
+
+**This crate is not intended for general-purpose use and we consider its interface to be unstable.**
+Customers looking for a general-purpose Amazon S3 client in Rust should use the official [AWS SDK for Rust](https://aws.amazon.com/sdk-for-rust/).

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.2.1 (May 26, 2023)
+
+Initial release.

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "mountpoint-s3-crt-sys"
-version = "0.2.0"
+# Steps to publish a new release:
+# - Pull request to bump version number and update CHANGELOG.md
+# - Create a new Git tag `mountpoint-s3-crt-sys-0.x.y`
+# - Run `cargo publish`
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
-publish = false
+repository = "https://github.com/awslabs/mountpoint-s3"
+description = "Rust FFI bindings to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }

--- a/mountpoint-s3-crt-sys/README.md
+++ b/mountpoint-s3-crt-sys/README.md
@@ -1,0 +1,7 @@
+# mountpoint-s3-crt-sys
+
+This crate provides automatically generated Rust FFI bindings to the [AWS Common Runtime](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html)
+for use by [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3).
+
+**This crate is not intended for general-purpose use and we consider its interface to be unstable.**
+Customers looking for general-purpose AWS client functionality in Rust should use the official [AWS SDK for Rust](https://aws.amazon.com/sdk-for-rust/).

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.2.1 (May 26, 2023)
+
+Initial release.

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "mountpoint-s3-crt"
-version = "0.2.0"
+# Steps to publish a new release:
+# - First publish a new release of `mountpoint-s3-crt-sys` if needed
+# - Pull request to bump version number and update CHANGELOG.md
+#   - Make sure to also bump the `mountpoint-s3-crt-sys` dependency if needed
+# - Create a new Git tag `mountpoint-s3-crt-0.x.y`
+# - Run `cargo publish`
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
-publish = false
+repository = "https://github.com/awslabs/mountpoint-s3"
+description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.2.1" }
 futures = "0.3.24"
 libc = "0.2.132"
 log = "0.4.17"

--- a/mountpoint-s3-crt/README.md
+++ b/mountpoint-s3-crt/README.md
@@ -1,0 +1,9 @@
+# mountpoint-s3-crt
+
+This crate provides a Rust interface to the [AWS Common Runtime](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html)
+for use by [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3).
+The interface includes only the AWS Common Runtime features needed by Mountpoint for Amazon S3,
+rather than the entire runtime.
+
+**This crate is not intended for general-purpose use and we consider its interface to be unstable.**
+Customers looking for general-purpose AWS client functionality in Rust should use the official [AWS SDK for Rust](https://aws.amazon.com/sdk-for-rust/).

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 fuser = { path = "../vendor/fuser", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client" }
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.2.1" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.1" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "1.8.0"


### PR DESCRIPTION
This change adds READMEs and CHANGELOGs for the client, crt, and crt-sys
crates, and bumps their version numbers just for clarity. It changes the
path dependencies to also include version numbers, so that local builds
of Mountpoint will use the path dependency but published releases will
use the published dependencies.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
