### PR TITLE
Implement checksum validation for the prefetcher

### DIFF
--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -15,15 +15,17 @@ use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::time::Duration;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::pin_mut;
 use futures::stream::StreamExt;
 use futures::task::{Spawn, SpawnExt};
 use metrics::counter;
 use mountpoint_s3_client::{ETag, GetObjectError, ObjectClient, ObjectClientError};
+use mountpoint_s3_crt::checksums::crc32c;
 use thiserror::Error;
 use tracing::{debug_span, error, trace, Instrument};
 
+use crate::prefetch::checksummed_bytes::ChecksummedBytes;
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueue};
 use crate::sync::{Arc, RwLock};
@@ -132,7 +134,11 @@ where
     /// Read some bytes from the object. This function will always return exactly `size` bytes,
     /// except at the end of the object where it will return however many bytes are left (including
     /// possibly 0 bytes).
-    pub async fn read(&mut self, offset: u64, length: usize) -> Result<Bytes, PrefetchReadError<TaskError<Client>>> {
+    pub async fn read(
+        &mut self,
+        offset: u64,
+        length: usize,
+    ) -> Result<ChecksummedBytes, PrefetchReadError<TaskError<Client>>> {
         trace!(
             offset,
             length,
@@ -142,7 +148,7 @@ where
 
         let remaining = self.size.saturating_sub(offset);
         if remaining == 0 {
-            return Ok(Bytes::new());
+            return Ok(ChecksummedBytes::default());
         }
         let mut to_read = (length as u64).min(remaining);
 
@@ -170,10 +176,10 @@ where
         // object.
         if self.current_task.is_none() {
             trace!(offset, length, "read beyond object size");
-            return Ok(Bytes::new());
+            return Ok(ChecksummedBytes::default());
         }
 
-        let mut response = BytesMut::new();
+        let mut response = ChecksummedBytes::default();
         while to_read > 0 {
             let current_task = self.current_task.as_mut().unwrap();
             debug_assert!(current_task.remaining > 0);
@@ -198,8 +204,11 @@ where
                 return Ok(part_bytes);
             }
 
-            response.extend_from_slice(&part_bytes[..]);
-            to_read -= part_bytes.len() as u64;
+            let part_len = part_bytes.len() as u64;
+            if response.extend(part_bytes).is_err() {
+                return Err(PrefetchReadError::Integrity);
+            }
+            to_read -= part_len;
             if current_task.remaining == 0 {
                 self.prepare_requests();
                 if self.current_task.is_none() {
@@ -208,7 +217,7 @@ where
             }
         }
 
-        Ok(response.freeze())
+        Ok(response)
     }
 
     /// Runs on every read to prepare and spawn any requests our prefetching logic requires
@@ -268,7 +277,10 @@ where
                         loop {
                             match request.next().await {
                                 Some(Ok((offset, body))) => {
-                                    let part = Part::new(&key, offset, body.into());
+                                    let bytes: Bytes = body.into();
+                                    let checksum = crc32c::checksum(&bytes);
+                                    let checksum_bytes = ChecksummedBytes::new(bytes, checksum);
+                                    let part = Part::new(&key, offset, checksum_bytes);
                                     part_queue_producer.push(Ok(part));
                                 }
                                 Some(Err(e)) => {
@@ -351,6 +363,9 @@ pub enum PrefetchReadError<E: std::error::Error> {
 
     #[error("get request terminated unexpectedly")]
     GetRequestTerminatedUnexpectedly,
+
+    #[error("integrity check failed")]
+    Integrity,
 }
 
 #[cfg(test)]
@@ -412,6 +427,7 @@ mod tests {
             if buf.is_empty() {
                 break;
             }
+            let buf = buf.into_bytes().unwrap();
             let expected = ramp_bytes((0xaa + next_offset) as usize, buf.len());
             assert_eq!(&buf[..], &expected[..buf.len()]);
             next_offset += buf.len() as u64;
@@ -487,6 +503,7 @@ mod tests {
                 Ok(buf) => buf,
                 Err(_) => break,
             };
+            let buf = buf.into_bytes().unwrap();
 
             if buf.is_empty() {
                 break;
@@ -606,6 +623,7 @@ mod tests {
             assert!(offset + length as u64 <= object_size);
             let expected = ramp_bytes((0xaa + offset) as usize, length);
             let buf = block_on(request.read(offset, length)).unwrap();
+            let buf = buf.into_bytes().unwrap();
             assert_eq!(buf.len(), expected.len());
             // Don't spew the giant buffer if this test fails
             if buf[..] != expected[..] {
@@ -711,6 +729,7 @@ mod tests {
                 if buf.is_empty() {
                     break;
                 }
+                let buf = buf.into_bytes().unwrap();
                 let expected = ramp_bytes((0xaa + next_offset) as usize, buf.len());
                 assert_eq!(&buf[..], &expected[..buf.len()]);
                 next_offset += buf.len() as u64;
@@ -762,6 +781,7 @@ mod tests {
                 let length = rng.gen_range(1usize..(object_size - offset + 1) as usize);
                 let expected = ramp_bytes((0xaa + offset) as usize, length);
                 let buf = block_on(request.read(offset, length)).unwrap();
+                let buf = buf.into_bytes().unwrap();
                 assert_eq!(buf.len(), expected.len());
                 // Don't spew the giant buffer if this test fails
                 if buf[..] != expected[..] {


### PR DESCRIPTION
We want to ensure data integrity while it is within Mountpoint's custody but S3 API doesn't support ranged-get checksum at the moment.

As a temporary measure, we will calculate CRC checksum for the data as soon as we receive it from S3 and do the validation every time we pass it around our part queue, and right before returning them to FUSE. To do this, we will use ChecksummedBytes from previous change instead of Bytes in the prefetcher.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
