### PR TITLE
Exclude some test files from crt-sys crate

### DIFF
--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -9,6 +9,34 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust FFI bindings to the AWS Common Runtime for Mountpoint for Amazon S3."
+exclude = [
+    # Exclude large files/directories not required to build the CRT (e.g. tests, docs)
+    "crt/*/tests",
+    "!crt/aws-lc/tests/compiler_features_tests",
+    "!crt/s2n-tls/tests/features",
+    "crt/*/docs",
+    "crt/aws-c-cal/ecdsa-fuzz-corpus/*",
+    "crt/aws-c-common/verification/*",
+    "crt/aws-lc/crypto/*/*_tests.txt",
+    "crt/aws-lc/crypto/cipher_extra/test/*",
+    "crt/aws-lc/crypto/fipsmodule/bn/test/*",
+    "crt/aws-lc/crypto/fipsmodule/ecdsa/*_tests.txt",
+    "crt/aws-lc/crypto/fipsmodule/policydocs/*",
+    "crt/aws-lc/crypto/fipsmodule/sha/testvectors/*",
+    "crt/aws-lc/crypto/hpke/test-vectors.json",
+    "crt/aws-lc/crypto/kyber/kat/*",
+    "crt/aws-lc/crypto/x509/*_test.cc",
+    "crt/aws-lc/crypto/x509/test/*",
+    "crt/aws-lc/fuzz/*",
+    "crt/aws-lc/generated-src/crypto_test_data.cc",
+    "crt/aws-lc/ssl/ssl_test.cc",
+    "crt/aws-lc/ssl/test/*",
+    "crt/aws-lc/third_party/googletest/test/*",
+    "crt/aws-lc/third_party/wycheproof_testvectors/*",
+    "crt/aws-lc/util/fipstools/acvp/acvptool/test/*",
+    "crt/s2n-tls/compliance/*",
+    "crt/s2n-tls/scram/SCRAM_paper.pdf",
+]
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }


### PR DESCRIPTION
`cargo publish --package mountpoint-s3-crt-sys --dry-run` generates a crate > 10MB (default limit for crates.io).
With this change, the crate size decreases from:
`Packaged 19006 files, 226.0MiB (64.1MiB compressed)`
to:
`Packaged 2801 files, 44.3MiB (8.1MiB compressed)`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
