### PR TITLE
Remove unset of `AWS_PROFILE` in profile tests

### DIFF
--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -143,9 +143,6 @@ aws_secret_access_key = {}",
 
     // Set up the environment variables to use this new config file. This is only OK to do because
     // this test is run in a forked process, so won't affect any other concurrently running tests.
-    // We need to unset AWS_PROFILE if set, because the CRT's profile provider prefers it over the
-    // overriden profile name.
-    std::env::remove_var("AWS_PROFILE");
     std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
 
     // Build a S3CrtClient that uses the config file


### PR DESCRIPTION
This change was needed due to a bug in how profile can be overridden in CRT. The fix was merged in #271, so we can now drop this.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
