### PR TITLE
Add HeadBucket NoSuchBucket error to S3CrtClient

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
@@ -11,7 +11,7 @@ pub enum HeadBucketError {
     IncorrectRegion(String),
 
     #[error("The bucket did not exist")]
-    NoSuchBucket(),
+    NoSuchBucket,
 
     #[error("Permission denied")]
     PermissionDenied(MetaRequestResult),
@@ -40,7 +40,7 @@ impl S3CrtClient {
                         ))),
                     // S3 returns 400 for invalid or expired STS tokens
                     400 | 403 => ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(request_result)),
-                    404 => ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket()),
+                    404 => ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket),
                     _ => ObjectClientError::ClientError(S3RequestError::ResponseError(request_result)),
                 }
             })?

--- a/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
@@ -10,6 +10,9 @@ pub enum HeadBucketError {
     #[error("Wrong region: should be {0}")]
     IncorrectRegion(String),
 
+    #[error("The bucket did not exist")]
+    NoSuchBucket(),
+
     #[error("Permission denied")]
     PermissionDenied(MetaRequestResult),
 }
@@ -37,6 +40,7 @@ impl S3CrtClient {
                         ))),
                     // S3 returns 400 for invalid or expired STS tokens
                     400 | 403 => ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(request_result)),
+                    404 => ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket()),
                     _ => ObjectClientError::ClientError(S3RequestError::ResponseError(request_result)),
                 }
             })?

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -45,7 +45,8 @@ async fn test_head_bucket_forbidden() {
 #[tokio::test]
 async fn test_head_bucket_not_found() {
     let client = get_test_client();
-    let bucket = "nosuch..bucket"; // Invalid bucket name, so cannot be created by anyone.
+    // Buckets are case sensitive. This bucket will use path-style access and 404.
+    let bucket = "DOC-EXAMPLE-BUCKET";
 
     let result = client.head_bucket(bucket).await;
 

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -51,6 +51,6 @@ async fn test_head_bucket_not_found() {
 
     assert!(matches!(
         result,
-        Err(ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket()))
+        Err(ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket))
     ));
 }

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -41,3 +41,16 @@ async fn test_head_bucket_forbidden() {
         Err(ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(_)))
     ));
 }
+
+#[tokio::test]
+async fn test_head_bucket_not_found() {
+    let client = get_test_client();
+    let bucket = "test-nosuchbucket-s3alias";
+
+    let result = client.head_bucket(bucket).await;
+
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket()))
+    ));
+}

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -45,7 +45,7 @@ async fn test_head_bucket_forbidden() {
 #[tokio::test]
 async fn test_head_bucket_not_found() {
     let client = get_test_client();
-    let bucket = "test-nosuchbucket-s3alias";
+    let bucket = "nosuch..bucket"; // Invalid bucket name, so cannot be created by anyone.
 
     let result = client.head_bucket(bucket).await;
 


### PR DESCRIPTION
This change recognizes 404 as a real service error rather than falling back on our client error code.

This changes the following failure mode when trying to connect to a bucket that doesn't exist.

### Before

```
Error: Failed to create S3 client

Caused by:
    0: HeadBucket failed for bucket dannycjones-use1 in region us-east-1
    1: Client error
    2: Unknown response error: MetaRequestResult { response_status: 404, crt_error: Error(14343, "aws-c-s3: AWS_ERROR_S3_INVALID_RESPONSE_STATUS, Invalid response status from request"), error_response_headers: Some(Headers { inner: 0x7f7d49f0afa0 }), error_response_body: None }
```

### After

```
Error: Failed to create S3 client

Caused by:
    0: HeadBucket failed for bucket dannycjones-use1 in region us-east-1
    1: Service error
    2: The bucket does not exist
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
