### PR TITLE
Correctly handle missing TTFB telemetry

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -281,7 +281,9 @@ impl S3CrtClient {
                 event!(log_level, %request_type, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
 
                 let op = span_telemetry.metadata().map(|m| m.name()).unwrap_or("unknown");
-                metrics::histogram!("s3.requests.first_byte_latency_us", ttfb.as_micros() as f64, "op" => op, "type" => request_type);
+                if let Some(ttfb) = ttfb {
+                    metrics::histogram!("s3.requests.first_byte_latency_us", ttfb.as_micros() as f64, "op" => op, "type" => request_type);
+                }
                 metrics::histogram!("s3.requests.total_latency_us", duration.as_micros() as f64, "op" => op, "type" => request_type);
                 metrics::counter!("s3.requests", 1, "op" => op, "type" => request_type);
                 if request_failure {


### PR DESCRIPTION
The send_end and receive_start times can be missing, which we weren't
handling.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
