### PR TITLE
Adjust prefetcher to spawn requests earlier

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -219,7 +219,6 @@ where
     Runtime: Spawn + Send + Sync,
 {
     pub async fn init(&self, config: &mut KernelConfig) -> Result<(), libc::c_int> {
-        let _ = config.set_max_readahead(0);
         let _ = config.add_capabilities(fuser::consts::FUSE_DO_READDIRPLUS);
         Ok(())
     }


### PR DESCRIPTION
This change makes three adjustments to our prefetcher:
1. Currently we only try spawning requests once per read, at the start.
   This means we miss the opportunity to spawn requests after the read,
   so if the read caused us to cross the prefetch boundary, we don't
   trigger the request until the next read starts. This gives up a
   little bit of latency. Tweaking this also makes the code a little
   simpler/less branchy.
2. The prefetch threshold is a strict inequality, which is a bad fit for
   our power-of-two-oriented configs -- FUSE will read in 128k pieces,
   so if the data remaining is exactly half the size (which it often
   will be because of powers of two), we again have to wait an extra
   request.
3. Our default prefetcher config is mostly made up, and in benchmarking
   we've seen it's a little too pessimistic about random reads. I picked
   a new, still mostly-made-up first request size that allows us to
   service up to 1MiB reads in one request. I also adjusted it a little
   to account for Linux readahead (see the comment about that).

Also one thing I noticed along the way: `max_readhead` can't be set to
zero (fuser returns an error that we're ignoring), so I dropped that.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
