### PR TITLE
Force compiler optimizations for aws-checksums

### DIFF
--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -221,6 +221,11 @@ fn compile_crt(output_dir: &Path) -> PathBuf {
             builder.define("DISABLE_GO", "ON");
         }
 
+        // Force compiler optimizations for aws-checksums even in debug builds to improve throughput
+        if lib.package_name == "aws-checksums" {
+            builder.profile("RelWithDebInfo");
+        }
+
         // Configure ASan in a way that will be compatible with Rust's clang-based version
         if rustflags::from_env().any(|f| f == Flag::Z("sanitizer=address".to_string())) {
             let mut clang = cc::Build::new();


### PR DESCRIPTION
The ARM implementations in aws-checksums are written in C, and so
compiler optimizations are essential to give them reasonable
performance. We've recently started validating a lot of checksums in our
tests (#263), and that's made the ARM CI much slower (> an hour). This
should get that back under control. x86 isn't affected because the
aws-checksums implementations are mostly hand-written assembly.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
