### PR TITLE
Avoid CRT auto-ranged-get for small requests

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -100,6 +100,7 @@ pub struct S3CrtClient {
     /// Here it will add the user agent prefix and s3 client information.
     user_agent_header: String,
     request_payer: Option<String>,
+    part_size: Option<usize>,
 }
 
 impl S3CrtClient {
@@ -195,6 +196,7 @@ impl S3CrtClient {
             next_request_counter: AtomicU64::new(0),
             user_agent_header,
             request_payer: config.request_payer,
+            part_size: config.part_size,
         })
     }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -3,7 +3,7 @@
 use aws_sdk_s3 as s3;
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
-use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::{S3ClientConfig, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -18,7 +18,13 @@ fn init_tracing_subscriber() {
 }
 
 pub fn get_test_client() -> S3CrtClient {
-    S3CrtClient::new(&get_test_region(), Default::default()).expect("could not create test client")
+    // Try to match what mountpoint-s3's defaults are
+    let client_config = S3ClientConfig {
+        throughput_target_gbps: Some(10.0),
+        part_size: Some(8 * 1024 * 1024),
+        ..Default::default()
+    };
+    S3CrtClient::new(&get_test_region(), client_config).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -20,7 +20,8 @@ use test_case::test_case;
 #[test_case(30000000, None; "large object")]
 #[test_case(1, Some(0..1); "1-byte object with range")]
 #[test_case(10, Some(0..4); "small object with range")]
-#[test_case(30000000, Some(10000000..30000000); "large object with range")]
+#[test_case(30000000, Some(10000000..10000100); "large object with small range")]
+#[test_case(30000000, Some(10000000..30000000); "large object with large range")]
 #[tokio::test]
 async fn test_get_object(size: usize, range: Option<Range<u64>>) {
     let sdk_client = get_test_sdk_client().await;


### PR DESCRIPTION
The CRT's auto-ranged-get will always do a HeadObject request when a
range is specified. For small requests, that's a fairly large latency
hit. Let's avoid using the auto-ranged-get for requests small enough
that they would be sent as a single part anyway.

It would probably be nicer to have a way to turn off this behavior in
the CRT, but this is a reasonable change for now. We'll have to be
careful if we ever start relying on any extra behavior of the
auto-ranged-get machinery, like checksum validation, but we're not
currently planning anything like that.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
