### PR TITLE
Add `fuser` version to `mountpoint-s3` dependency

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-fuser = { path = "../vendor/fuser", features = ["abi-7-28"] }
+fuser = { path = "../vendor/fuser", version = "0.12.0", features = ["abi-7-28"] }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.2.2" }
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.1" }
 


### PR DESCRIPTION
We did not specify the version of our vendored fuser crate.

Adding this will ensure we're aware of the major or minor version changes when pulling in new fuser versions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
