### PR TITLE
Run benchmark with auto network throughput

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -26,7 +26,6 @@ cd ${project_dir}
 
 results_dir=results
 jobs_dir=mountpoint-s3/scripts/fio/read
-target_gbps=100
 thread_count=4
 
 rm -rf ${results_dir}
@@ -43,7 +42,6 @@ for job_file in "${jobs_dir}"/*.fio; do
   cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
     --foreground \
     --prefix=${S3_BUCKET_TEST_PREFIX} \
-    --throughput-target-gbps=${target_gbps} \
     --thread-count=${thread_count} > bench.out 2>&1 &
   # get file system PID
   fs_pid=$!

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -25,7 +25,6 @@ project_dir="${base_dir}/../.."
 cd ${project_dir}
 
 results_dir=results
-target_gbps=100
 thread_count=4
 
 rm -rf ${results_dir}
@@ -46,7 +45,6 @@ do
     # mount file system
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
         --prefix=${S3_BUCKET_TEST_PREFIX} \
-        --throughput-target-gbps=${target_gbps} \
         --thread-count=${thread_count}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
@@ -108,7 +106,6 @@ for job_file in "${jobs_dir}"/*.fio; do
   # mount file system
   cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
     --prefix=${S3_BUCKET_TEST_PREFIX} \
-    --throughput-target-gbps=${target_gbps} \
     --thread-count=${thread_count}
   mount_status=$?
   if [ $mount_status -ne 0 ]; then


### PR DESCRIPTION
Now that we have auto network throughput configuration for Mountpoint we can use default configuration in the benchmark. It also makes the benchmark script more flexible when running on other types of instance.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
