### PR TITLE
Endpoint testing for transfer acceleration, single region access point, object lambda access point

### DIFF
--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -91,3 +91,14 @@ async fn test_addressing_style_uri_fips_dualstack(addressing_style: AddressingSt
     })
     .await;
 }
+
+// Transfer acceleration can only be supported with virtual-hosted-style addressing
+#[test_case(AddressingStyle::Virtual)]
+#[tokio::test]
+async fn test_addressing_style_uri_transfer_acceleration(addressing_style: AddressingStyle) {
+    run_test(|_region| {
+        let uri = format!("https://s3-accelerate.amazonaws.com");
+        Endpoint::from_uri(&uri, addressing_style).unwrap()
+    })
+    .await;
+}

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -102,3 +102,68 @@ async fn test_addressing_style_uri_transfer_acceleration(addressing_style: Addre
     })
     .await;
 }
+
+async fn run_access_points<F: FnOnce(&str) -> Endpoint>(f: F) {
+    let sdk_client = get_test_sdk_client().await;
+    let (access_point, prefix) =
+        get_test_access_point_alias_and_prefix("test_access_point", AccessPointType::SingleRegion);
+
+    // Create one object named "hello"
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&access_point)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let region = get_test_region();
+    let endpoint = f(&region);
+    let config = S3ClientConfig {
+        endpoint: Some(endpoint),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&region, config).expect("could not create test client");
+
+    let result = client
+        .get_object(&access_point, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+}
+
+#[test_case(AddressingStyle::Automatic)]
+#[test_case(AddressingStyle::Virtual)]
+#[test_case(AddressingStyle::Path)]
+#[tokio::test]
+async fn test_single_region_access_point_alias(addressing_style: AddressingStyle) {
+    run_access_points(|region| Endpoint::from_region(region, addressing_style).unwrap()).await;
+}
+
+async fn run_object_lambda_access_points<F: FnOnce(&str) -> Endpoint>(f: F) {
+    let (access_point, prefix) =
+        get_test_access_point_alias_and_prefix("test_access_point", AccessPointType::ObjectLambda);
+
+    let region = get_test_region();
+    let endpoint = f(&region);
+    let config = S3ClientConfig {
+        endpoint: Some(endpoint),
+        ..Default::default()
+    };
+    let client = S3CrtClient::new(&region, config).expect("could not create test client");
+    client
+        .list_objects(&access_point, None, "/", 10, &prefix)
+        .await
+        .expect("list_object should succeed");
+}
+
+#[test_case(AddressingStyle::Automatic)]
+#[test_case(AddressingStyle::Virtual)]
+#[test_case(AddressingStyle::Path)]
+#[tokio::test]
+async fn test_object_lambda_access_point_alias(addressing_style: AddressingStyle) {
+    run_object_lambda_access_points(|region| Endpoint::from_region(region, addressing_style).unwrap()).await;
+}


### PR DESCRIPTION
We need to add the accesspoints and enable transfer acceleration for our test bucket. For Object Lambda Access Point Path based addressing style is failing. Others are passing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
