### PR TITLE
Allow empty PutObject requests

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -68,12 +68,12 @@ fn main() {
         part_size,
         ..Default::default()
     };
-    let client = Arc::new(S3CrtClient::new(region, config).expect("couldn't create client"));
+    let client = S3CrtClient::new(region, config).expect("couldn't create client");
 
     for i in 0..iterations.unwrap_or(1) {
         let received_size = Arc::new(AtomicU64::new(0));
         let start = Instant::now();
-        let client = Arc::clone(&client);
+        let client = client.clone();
         let received_size_clone = Arc::clone(&received_size);
         futures::executor::block_on(async move {
             let mut request = client

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -245,7 +245,7 @@ pub enum GetObjectAttributesError {
 
 /// Parameters to a [ObjectClient::put_object] request
 /// TODO: Populate this struct with parameters from the S3 API, e.g., storage class, encryption.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct PutObjectParams {}
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -34,7 +34,7 @@ use tracing::{error, trace, Span};
 use crate::build_info;
 use crate::endpoint::{AddressingStyle, Endpoint, EndpointError};
 use crate::object_client::*;
-use crate::s3_crt_client::get_object::GetObjectRequest;
+use crate::s3_crt_client::get_object::S3GetObjectRequest;
 use crate::s3_crt_client::put_object::S3PutObjectRequest;
 
 macro_rules! request_span {
@@ -648,7 +648,7 @@ fn extract_range_header(headers: &Headers) -> Option<Range<u64>> {
 
 #[async_trait]
 impl ObjectClient for S3CrtClient {
-    type GetObjectResult = GetObjectRequest;
+    type GetObjectResult = S3GetObjectRequest;
     type PutObjectRequest = S3PutObjectRequest;
     type ClientError = S3RequestError;
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -35,8 +35,7 @@ use crate::build_info;
 use crate::endpoint::{AddressingStyle, Endpoint, EndpointError};
 use crate::object_client::*;
 use crate::s3_crt_client::get_object::GetObjectRequest;
-
-use self::put_object::S3PutObjectRequest;
+use crate::s3_crt_client::put_object::S3PutObjectRequest;
 
 macro_rules! request_span {
     ($self:expr, $method:expr) => {{
@@ -91,7 +90,7 @@ pub enum S3ClientAuthConfig {
     Provider(CredentialsProvider),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct S3CrtClient {
     inner: Arc<S3CrtClientInner>,
 }
@@ -109,7 +108,7 @@ impl S3CrtClient {
 }
 
 #[derive(Debug)]
-pub struct S3CrtClientInner {
+struct S3CrtClientInner {
     s3_client: Client,
     event_loop_group: EventLoopGroup,
     endpoint: Endpoint,
@@ -123,7 +122,7 @@ pub struct S3CrtClientInner {
 }
 
 impl S3CrtClientInner {
-    pub fn new(region: &str, config: S3ClientConfig) -> Result<Self, NewClientError> {
+    fn new(region: &str, config: S3ClientConfig) -> Result<Self, NewClientError> {
         let allocator = Allocator::default();
 
         let mut event_loop_group = EventLoopGroup::new_default(&allocator, None, || {}).unwrap();

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -27,7 +27,7 @@ impl S3CrtClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> Result<GetObjectRequest, ObjectClientError<GetObjectError, S3RequestError>> {
+    ) -> Result<S3GetObjectRequest, ObjectClientError<GetObjectError, S3RequestError>> {
         let span = request_span!(self.inner, "get_object");
         span.in_scope(
             || debug!(?bucket, ?key, ?range, ?if_match, size=?range.as_ref().map(|range| range.end - range.start), "new request"),
@@ -100,7 +100,7 @@ impl S3CrtClient {
             },
         )?;
 
-        Ok(GetObjectRequest {
+        Ok(S3GetObjectRequest {
             request,
             finish_receiver: receiver,
             finished: false,
@@ -110,7 +110,7 @@ impl S3CrtClient {
 
 #[derive(Debug)]
 #[pin_project]
-pub struct GetObjectRequest {
+pub struct S3GetObjectRequest {
     #[pin]
     request: S3HttpRequest<(), GetObjectError>,
     #[pin]
@@ -118,7 +118,7 @@ pub struct GetObjectRequest {
     finished: bool,
 }
 
-impl Stream for GetObjectRequest {
+impl Stream for S3GetObjectRequest {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, S3RequestError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -65,6 +65,7 @@ impl S3CrtClient {
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, S3RequestError> {
         let request = {
             let mut message = self
+                .inner
                 .new_request_template("HEAD", bucket)
                 .map_err(S3RequestError::construction_failure)?;
 
@@ -80,10 +81,10 @@ impl S3CrtClient {
             let header: Arc<Mutex<Option<Result<HeadObjectResult, ParseError>>>> = Default::default();
             let header1 = header.clone();
 
-            let span = request_span!(self, "head_object");
+            let span = request_span!(self.inner, "head_object");
             span.in_scope(|| debug!(?bucket, ?key, "new request"));
 
-            self.make_meta_request(
+            self.inner.make_meta_request(
                 message,
                 MetaRequestType::Default,
                 span,

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::io::async_stream::{self, AsyncStreamWriter};
 use mountpoint_s3_crt::s3::client::MetaRequestType;
-use tracing::debug;
+use tracing::{debug, Span};
 
 use super::{S3CrtClientInner, S3HttpRequest};
 
@@ -31,24 +31,32 @@ type S3PutRequest = (S3HttpRequest<Vec<u8>, PutObjectError>, AsyncStreamWriter);
 #[derive(Debug)]
 pub struct S3PutObjectRequest {
     client: Arc<S3CrtClientInner>,
+    span: Span,
     bucket: String,
     key: String,
     params: PutObjectParams,
+    /// Delay the request after the first write: empty requests need special handling.
     inner: Option<S3PutRequest>,
 }
 
 impl S3PutObjectRequest {
     fn new(client: Arc<S3CrtClientInner>, bucket: String, key: String, params: PutObjectParams) -> Self {
+        let span = request_span!(client, "put_object");
+        span.in_scope(|| debug!(?bucket, ?key, ?params, "create request"));
         Self {
             client,
+            span,
             bucket,
             key,
             params,
-            inner: Default::default(),
+            inner: None,
         }
     }
 
-    fn make_request(&self, content_length: Option<usize>) -> Result<S3PutRequest, S3RequestError> {
+    /// Make a PutObject meta-request.
+    /// To upload an empty object, set `is_empty` to `true` and drop the
+    /// returned [AsyncStreamWriter] without completing it.
+    fn make_request(&self, is_empty: bool) -> Result<S3PutRequest, S3RequestError> {
         let mut message = self
             .client
             .new_request_template("PUT", &self.bucket)
@@ -62,20 +70,19 @@ impl S3PutObjectRequest {
         let (body_async_stream, writer) = async_stream::new_stream(&self.client.allocator);
         message.set_body_stream(Some(body_async_stream));
 
-        if let Some(len) = content_length {
+        if is_empty {
             message
-                .add_header(&Header::new("Content-Length", len.to_string()))
+                .add_header(&Header::new("Content-Length", 0.to_string()))
                 .map_err(S3RequestError::construction_failure)?;
         }
 
-        let span = request_span!(self.client, "put_object");
-        span.in_scope(|| debug!(bucket=?self.bucket, ?key, params=?self.params, "new request"));
-
-        let body = self
-            .client
-            .make_simple_http_request(message, MetaRequestType::PutObject, span, |result| {
-                ObjectClientError::ClientError(S3RequestError::ResponseError(result))
-            })?;
+        self.span
+            .in_scope(|| debug!(bucket=?self.bucket, ?key, params=?self.params, "make request"));
+        let body =
+            self.client
+                .make_simple_http_request(message, MetaRequestType::PutObject, self.span.clone(), |result| {
+                    ObjectClientError::ClientError(S3RequestError::ResponseError(result))
+                })?;
         Ok((body, writer))
     }
 }
@@ -87,7 +94,7 @@ impl PutObjectRequest for S3PutObjectRequest {
     async fn write(&mut self, slice: &[u8]) -> ObjectClientResult<(), PutObjectError, Self::ClientError> {
         let (_, writer) = match &mut self.inner {
             Some(inner) => inner,
-            None => self.inner.insert(self.make_request(None)?),
+            None => self.inner.insert(self.make_request(false)?),
         };
 
         writer
@@ -107,14 +114,15 @@ impl PutObjectRequest for S3PutObjectRequest {
             }
             None => {
                 // If the request has not started yet, this is an empty object and we need to
-                // set Content-Length=0 on the meta request and immediately drop the writer.
-                let (body, writer) = self.make_request(Some(0))?;
+                // set Content-Length=0 on the meta request.
+                let (body, writer) = self.make_request(true)?;
+                // We drop the writer without calling `complete()` on it, since the CRT will not
+                // try to read from the stream when Content-Length==0.
                 drop(writer);
                 body
             }
         };
 
-        _ = body.await?;
-        Ok(PutObjectResult {})
+        body.await.map(|_| PutObjectResult {})
     }
 }

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -1,11 +1,14 @@
+use std::sync::Arc;
+
 use crate::object_client::{ObjectClientResult, PutObjectError, PutObjectParams};
 use crate::{ObjectClientError, PutObjectRequest, PutObjectResult, S3CrtClient, S3RequestError};
 use async_trait::async_trait;
+use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::io::async_stream::{self, AsyncStreamWriter};
 use mountpoint_s3_crt::s3::client::MetaRequestType;
 use tracing::debug;
 
-use super::S3HttpRequest;
+use super::{S3CrtClientInner, S3HttpRequest};
 
 impl S3CrtClient {
     pub(super) async fn put_object(
@@ -14,38 +17,66 @@ impl S3CrtClient {
         key: &str,
         params: &PutObjectParams,
     ) -> ObjectClientResult<S3PutObjectRequest, PutObjectError, S3RequestError> {
+        Ok(S3PutObjectRequest::new(
+            self.inner.clone(),
+            bucket.to_owned(),
+            key.to_owned(),
+            params.to_owned(),
+        ))
+    }
+}
+
+type S3PutRequest = (S3HttpRequest<Vec<u8>, PutObjectError>, AsyncStreamWriter);
+
+#[derive(Debug)]
+pub struct S3PutObjectRequest {
+    client: Arc<S3CrtClientInner>,
+    bucket: String,
+    key: String,
+    params: PutObjectParams,
+    inner: Option<S3PutRequest>,
+}
+
+impl S3PutObjectRequest {
+    fn new(client: Arc<S3CrtClientInner>, bucket: String, key: String, params: PutObjectParams) -> Self {
+        Self {
+            client,
+            bucket,
+            key,
+            params,
+            inner: Default::default(),
+        }
+    }
+
+    fn make_request(&self, content_length: Option<usize>) -> Result<S3PutRequest, S3RequestError> {
         let mut message = self
-            .new_request_template("PUT", bucket)
+            .client
+            .new_request_template("PUT", &self.bucket)
             .map_err(S3RequestError::construction_failure)?;
 
-        let key = format!("/{key}");
+        let key = format!("/{}", self.key);
         message
             .set_request_path(&key)
             .map_err(S3RequestError::construction_failure)?;
 
-        let (body_async_stream, writer) = async_stream::new_stream(&self.allocator);
+        let (body_async_stream, writer) = async_stream::new_stream(&self.client.allocator);
         message.set_body_stream(Some(body_async_stream));
 
-        let span = request_span!(self, "put_object");
-        span.in_scope(|| debug!(?bucket, ?key, ?params, "new request"));
+        if let Some(len) = content_length {
+            message
+                .add_header(&Header::new("Content-Length", len.to_string()))
+                .map_err(S3RequestError::construction_failure)?;
+        }
 
-        let body = self.make_simple_http_request(message, MetaRequestType::PutObject, span, |result| {
-            ObjectClientError::ClientError(S3RequestError::ResponseError(result))
-        })?;
+        let span = request_span!(self.client, "put_object");
+        span.in_scope(|| debug!(bucket=?self.bucket, ?key, params=?self.params, "new request"));
 
-        Ok(S3PutObjectRequest::new(body, writer))
-    }
-}
-
-#[derive(Debug)]
-pub struct S3PutObjectRequest {
-    body: S3HttpRequest<Vec<u8>, PutObjectError>,
-    writer: AsyncStreamWriter,
-}
-
-impl S3PutObjectRequest {
-    fn new(body: S3HttpRequest<Vec<u8>, PutObjectError>, writer: AsyncStreamWriter) -> Self {
-        Self { body, writer }
+        let body = self
+            .client
+            .make_simple_http_request(message, MetaRequestType::PutObject, span, |result| {
+                ObjectClientError::ClientError(S3RequestError::ResponseError(result))
+            })?;
+        Ok((body, writer))
     }
 }
 
@@ -54,21 +85,36 @@ impl PutObjectRequest for S3PutObjectRequest {
     type ClientError = S3RequestError;
 
     async fn write(&mut self, slice: &[u8]) -> ObjectClientResult<(), PutObjectError, Self::ClientError> {
-        self.writer
+        let (_, writer) = match &mut self.inner {
+            Some(inner) => inner,
+            None => self.inner.insert(self.make_request(None)?),
+        };
+
+        writer
             .write(slice)
             .await
             .map_err(|e| S3RequestError::InternalError(Box::new(e)).into())
     }
 
     async fn complete(mut self) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
-        let body = {
-            self.writer
-                .complete()
-                .await
-                .map_err(|e| S3RequestError::InternalError(Box::new(e)))?;
-            self.body
+        let body = match self.inner {
+            Some((body, writer)) => {
+                writer
+                    .complete()
+                    .await
+                    .map_err(|e| S3RequestError::InternalError(Box::new(e)))?;
+                body
+            }
+            None => {
+                // If the request has not started yet, this is an empty object and we need to
+                // set Content-Length=0 on the meta request and immediately drop the writer.
+                let (body, writer) = self.make_request(Some(0))?;
+                drop(writer);
+                body
+            }
         };
-        body.await?;
+
+        _ = body.await?;
         Ok(PutObjectResult {})
     }
 }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -37,7 +37,7 @@ async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str)
 
 object_client_test!(test_put_object);
 
-// Simple test for PUT object. Puts a single, empty object as a single part and checks that the
+// Simple test for PUT object. Puts a single, empty object and checks that the (empty)
 // contents are correct with a GET.
 async fn test_put_object_empty(client: &impl ObjectClient, bucket: &str, prefix: &str) {
     let key = format!("{prefix}hello");

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -37,6 +37,27 @@ async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str)
 
 object_client_test!(test_put_object);
 
+// Simple test for PUT object. Puts a single, empty object as a single part and checks that the
+// contents are correct with a GET.
+async fn test_put_object_empty(client: &impl ObjectClient, bucket: &str, prefix: &str) {
+    let key = format!("{prefix}hello");
+
+    let request = client
+        .put_object(bucket, &key, &Default::default())
+        .await
+        .expect("put_object should succeed");
+
+    request.complete().await.unwrap();
+
+    let result = client
+        .get_object(bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &[]).await;
+}
+
+object_client_test!(test_put_object_empty);
+
 // Test for multi-part PUT interface. Splits up a small object into a number of pieces, and streams
 // the pieces to the object client. Checks contents are correct using a GET.
 async fn test_put_object_multi_part(client: &impl ObjectClient, bucket: &str, prefix: &str) {


### PR DESCRIPTION
The new streaming PUT implementation in #282 broke empty PutObject requests (i.e. with a 0-byte body). This is because the CRT does not currently support 0-byte meta-requests without Content-Length. Here is the returned error:

```
0 byte meta requests without Content-Length header are currently not supported. Set Content-Length header to 0 to upload empty object 
```

While this limitation is likely to be lifted in the CRT in the future, this change addresses it in `mountpoint-s3-client` by delaying the request until the first write is requested or complete is called, so that the Content-Length=0 header can be set in the latter case.

A minor complication of this change is that `S3PutObjectRequest` now needs to hold on to the client to issue the request at a later time. To allow for it, `S3CrtClient` has been refactored to hold a pointer to a `S3CrtClientInner` which can be passed to the request.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
