### PR TITLE
Remove another profile override

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -377,11 +377,6 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     let auth_config = if args.no_sign_request {
         S3ClientAuthConfig::NoSigning
     } else if let Some(profile_name) = args.profile {
-        // The CRT profile provider will prefer the AWS_PROFILE environment variable over this
-        // override if set, which is the opposite of the AWS CLI's documented behavior. Let's match
-        // the CLI by explicitly unsetting AWS_PROFILE for this process if a profile was specified.
-        std::env::remove_var("AWS_PROFILE");
-
         S3ClientAuthConfig::Profile(profile_name)
     } else {
         S3ClientAuthConfig::Default


### PR DESCRIPTION
We fixed one of these obsolete overrides in #272 but missed this one.

Tested manually to verify that `--profile` still overrides `AWS_PROFILE`, as we expect.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
