### PR TITLE
Allow static linking of BYO CRT libs

### DIFF
--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -282,7 +282,9 @@ fn compile_logging_shim(crt_include_dir: impl AsRef<Path>) {
 /// libraries expected to be in `MOUNTPOINT_CRT_LIB_DIR`. In this case, the
 /// `MOUNTPOINT_CRT_INCLUDE_DIR` variable must point to the directory the CRT headers were installed
 /// to. The build still needs access to the Git submodules for any private CRT headers we use, but
-/// the code from the submodules won't be compiled.
+/// the code from the submodules won't be compiled. When `MOUNTPOINT_CRT_LIB_DIR` is set,
+/// by default the CRT libraries will be dynmically linked. Static linking occurs when the
+/// `MOUNTPOINT_CRT_LIB_LINK_STATIC` is set.
 ///
 /// Note that `MOUNTPOINT_CRT_LIB_DIR` requires a compatible version of the CRT libraries. The CRT
 /// has no versioning mechanism for shared libraries right now, so customers configuring this
@@ -295,9 +297,14 @@ fn main() {
     let include_dir = if let Some(path) = get_env("MOUNTPOINT_CRT_LIB_DIR") {
         println!("cargo:rustc-link-search=native={path}");
 
+        let link_type = match get_env("MOUNTPOINT_CRT_LIB_LINK_STATIC") {
+            Some(_) => "static",
+            None => "dylib",
+        };
+
         let libraries = get_required_libraries(&get_target_os());
         for lib in libraries {
-            println!("cargo:rustc-link-lib=dylib={}", lib.library_name);
+            println!("cargo:rustc-link-lib={}={}", link_type, lib.library_name);
         }
 
         PathBuf::from(


### PR DESCRIPTION
Testing:

```
% export MOUNTPOINT_CRT_INCLUDE_DIR
% export MOUNTPOINT_CRT_LIB_DIR

% export MOUNTPOINT_CRT_LIB_LINK_STATIC=1

% cargo build
    ...
    Finished dev [unoptimized + debuginfo] target(s) in 9.22s

% ldd target/debug/mount-s3
	linux-vdso.so.1 (0x00007fff2b73b000)
	libfuse.so.2 => /lib64/libfuse.so.2 (0x00007f4f5d91f000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f4f5d709000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f4f5d501000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f4f5d2e3000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f4f5cfa3000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f4f5cd9f000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f4f5c9f2000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4f5f030000)

% unset MOUNTPOINT_CRT_LIB_LINK_STATIC

% cargo build
   ...
    Finished dev [unoptimized + debuginfo] target(s) in 8.69s

% ldd target/debug/mount-s3
	linux-vdso.so.1 (0x00007ffd599c8000)
	libaws-c-common.so.1 => not found
	libaws-c-io.so.1.0.0 => not found
	libaws-c-http.so.1.0.0 => not found
	libaws-c-auth.so.1.0.0 => not found
	libaws-checksums.so.1.0.0 => not found
	libaws-c-s3.so.0unstable => not found
	libfuse.so.2 => /lib64/libfuse.so.2 (0x00007f2ecc6eb000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f2ecc4d5000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f2ecc2cd000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f2ecc0af000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f2ecbd6f000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f2ecbb6b000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f2ecb7be000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2ecd6a8000)
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
