### PR TITLE
Move GitHub workflow dependency installation to its own action file

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,35 @@
+name: 'Install dependencies'
+description: 'Installs dependencies based on the operating system.'
+inputs:
+  fuseVersion:
+    required: true
+    type: number
+  llvm:
+    description: "Install LLVM headers"
+    required: false
+    type: boolean
+    default: false
+  libunwind:
+    description: "Install libunwind"
+    required: false
+    type: boolean
+    default: false
+  fio:
+    description: "Install FIO"
+    required: false
+    type: boolean
+    default: false
+runs:
+  using: "composite"
+  steps:
+  - name: Install packages
+    shell: bash
+    run: |
+      bash ${GITHUB_ACTION_PATH}/install.sh \
+        --fuse-version ${{ inputs.fuseVersion }} \
+        --with-llvm ${{ inputs.llvm }} \
+        --with-libunwind ${{ inputs.libunwind }} \
+        --with-fio ${{ inputs.fio }}
+  - name: Configure FUSE to allow other users to access FS
+    shell: bash
+    run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf

--- a/.github/actions/install-dependencies/install.sh
+++ b/.github/actions/install-dependencies/install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+getopt --test > /dev/null
+ENHANCED_GETOPT=$?
+
+if [[ $ENHANCED_GETOPT -ne 4 ]]; then
+    echo "no enhanced getopt installed" >&2
+    exit 1
+fi
+
+LONGOPTS="fuse-version:,with-fio,with-libunwind,with-llvm"
+getopt --long=$LONGOPTS --name "$0" -- "$@"
+if [[ $? -ne 0 ]]; then
+    echo "couldn't read arguments" >&2
+    exit 2
+fi
+
+install_llvm=false
+install_fio=false
+install_libunwind=false
+unset -v fuse_version
+
+while true; do
+    case "$1" in
+        --fuse-version)
+            fuse_version="$2"
+            shift 2
+            ;;
+        --with-fio)
+            install_fio=true
+            shift
+            ;;
+        --with-libunwind)
+            install_libunwind=true
+            shift
+            ;;
+        --with-llvm)
+            install_llvm=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*|--*)
+            echo "unknown option $1" >&2
+            exit 3
+            ;;
+        *)
+            shift
+            break
+            ;;
+    esac
+done
+
+if [ -z "$fuse_version" ]; then
+        echo "missing --fuse-version" >&2
+        exit 4
+fi
+
+if [[ ! -f "/etc/os-release" ]]; then
+    echo "/etc/os-release does not exist" >&2
+    exit 5
+fi
+
+
+os_release_id=$(cat /etc/os-release | grep "^ID=" | cut -d '=' -f2 | tr -d '"')
+
+package_list="jq"
+
+case "$os_release_id" in
+    amzn)
+        package_list="${package_list} clang-devel"
+        package_list="${package_list} pkgconfig"
+        package_list="${package_list} cmake3"
+        ;;
+    ubuntu)
+        package_list="${package_list} libclang-dev"
+        package_list="${package_list} pkg-config"
+        package_list="${package_list} cmake=3*"
+        ;;
+    *)
+        echo "no distro specific config for $OS_RELEASE_ID" >&2
+        exit 6
+        ;;
+esac
+
+case $fuse_version in
+    2)
+        fuse_package_name="fuse"
+        ;;
+    3)
+        fuse_package_name="fuse3"
+        ;;
+    *)
+        echo "unexpected fuse version $fuse_version" >&2
+        exit 7
+esac
+
+case "$os_release_id" in
+    amzn)
+        package_list="${package_list} ${fuse_package_name} ${fuse_package_name}-devel"
+        ;;
+    ubuntu)
+        package_list="${package_list} ${fuse_package_name} lib${fuse_package_name}-dev"
+        ;;
+    *)
+        echo "no distro specific config for $OS_RELEASE_ID" &>2
+        exit 6
+        ;;
+esac
+
+if [[ $install_llvm == true ]]; then
+    case "$os_release_id" in
+        amzn)
+            package_list="${package_list} llvm-devel"
+            ;;
+        ubuntu)
+            package_list="${package_list} llvm-dev"
+            ;;
+        *)
+            echo "no distro specific config for $OS_RELEASE_ID" &>2
+            exit 6
+            ;;
+    esac
+fi
+
+if [[ $install_fio == true ]]; then
+    package_list="${package_list} fio"
+fi
+
+if [[ $install_libunwind == true ]]; then
+    case "$os_release_id" in
+        amzn)
+            package_list="${package_list} libunwind-devel"
+            ;;
+        ubuntu)
+            package_list="${package_list} libunwind-dev"
+            ;;
+        *)
+            echo "no distro specific config for $OS_RELEASE_ID" &>2
+            exit 6
+            ;;
+    esac
+fi
+
+case $os_release_id in
+    amzn)
+        sudo yum install -y $package_list
+        ;;
+    ubuntu)
+        sudo apt-get -q update
+        sudo apt-get install -y $package_list
+        ;;
+    *)
+        echo "no distro specific config for $OS_RELEASE_ID" &>2
+        exit 6
+        ;;
+esac
+
+exit 0

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,6 +39,12 @@ jobs:
         ref: ${{ inputs.ref }}
         submodules: true
         persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
     - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -55,14 +61,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Update package list
-      run: sudo apt-get update
-    - name: Install dependencies
-      run: sudo apt-get -y install cmake libclang-dev libunwind-dev pkg-config jq fio
-    - name: Install fuse
-      run: sudo apt-get -y install fuse libfuse-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
@@ -110,6 +108,12 @@ jobs:
         ref: ${{ inputs.ref }}
         submodules: true
         persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
     - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -126,14 +130,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Update package list
-      run: sudo apt-get update
-    - name: Install dependencies
-      run: sudo apt-get -y install cmake libclang-dev libunwind-dev pkg-config jq fio
-    - name: Install fuse
-      run: sudo apt-get -y install fuse libfuse-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
     - name: Build
       run: cargo build --release
     - name: Run Benchmark

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,14 +28,19 @@ permissions:
 
 jobs:
   test:
-    name: Tests
-    runs-on: ubuntu-22.04
+    name: Tests (${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
+    runs-on: ${{ matrix.runner.tags }}
 
     environment: ${{ inputs.environment }}
 
     strategy:
       matrix:
-        fuse: [fuse, fuse3]
+        fuseVersion: [2, 3]
+        runner:
+        - name: Ubuntu x86
+          tags: [ubuntu-22.04] # GitHub-hosted
+        - name: Amazon Linux arm
+          tags: [self-hosted, linux, arm64]
 
     steps:
     - name: Configure AWS credentials
@@ -64,67 +69,13 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-${{ matrix.fuse }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install ${{ matrix.fuse }} lib${{ matrix.fuse }}-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
-    - name: Run tests
-      run: cargo test --features $RUST_FEATURES
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR integration tests'
+        key: ${{ runner.os }}-${{ github.job }}-integration-fuse${{ matrix.fuseVersion }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
       with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
-
-  arm64-test:
-    name: Tests (arm64)
-    runs-on: [self-hosted, linux, arm64]
-
-    environment: ${{ inputs.environment }}
-
-    steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.ref }}
-        submodules: true
-        persist-credentials: false
-    - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install dependencies
-      run: |
-        sudo yum update
-        sudo yum install -y cmake3 clang-devel pkgconfig
-    - name: Install fuse
-      run: sudo yum install -y fuse fuse-devel
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+        fuseVersion: ${{ matrix.fuseVersion }}
+    - name: Build tests
+      run: cargo test --features $RUST_FEATURES --no-run
     - name: Run tests
       run: cargo test --features $RUST_FEATURES
     - name: Save Cargo cache
@@ -174,12 +125,11 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-integration-asan-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install fuse3 libfuse3-dev
-    - name: Install llvm-dev
-      run: sudo apt-get install llvm-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 3
+        llvm: true
     - name: Validate ASan is working
       run: make test-asan-working
     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,22 @@ env:
 
 jobs:
   test:
-    name: Tests
+    name: Tests (FUSE ${{ matrix.fuseVersion }})
     runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        fuse: [fuse, fuse3]
+        fuseVersion: [2, 3]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: ${{ matrix.fuseVersion }}
     - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -40,11 +44,9 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-${{ github.job }}-${{ matrix.fuse }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install ${{ matrix.fuse }} lib${{ matrix.fuse }}-dev
-    - name: Configure fuse
-      run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+        key: ${{ runner.os }}-${{ github.job }}-fuse${{ matrix.fuseVersion }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build tests
+      run: cargo test --features $RUST_FEATURES --no-run
     - name: Run tests
       run: cargo test --features $RUST_FEATURES
 
@@ -78,6 +80,8 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build tests
+      run: cargo test --no-run
     - name: Run tests
       run: cargo test -- --skip=mnt::test::mount_unmount
 
@@ -90,6 +94,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
     - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -105,8 +113,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install fuse libfuse-dev
     - name: Check all targets
       run: cargo check --locked --all-targets --all-features
 
@@ -119,6 +125,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
     - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -134,8 +144,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install fuse libfuse-dev
     - name: Run benchmarks
       run: cargo bench
 
@@ -153,6 +161,10 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
     - name: Cargo cache
       uses: actions/cache@v3
       with:
@@ -163,8 +175,6 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fuse
-      run: sudo apt-get install fuse libfuse-dev
     - name: Run Shuttle tests
       run: cargo test -p mountpoint-s3 --features shuttle -- shuttle
 
@@ -193,6 +203,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install operating system dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          fuseVersion: 2
       - name: Set up stable Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -209,8 +223,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install fuse
-        run: sudo apt-get install fuse libfuse2 libfuse-dev
       - name: Run Clippy
         run: make clippy
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -22,12 +22,11 @@ We keep the records of benchmarking results in `gh-pages` branch and the perform
 While our benchmark script is written for CI testing only, it is possible to run manually.
 You can use the following steps.
 
-1. Install dependencies by running below commands for Ubuntu.
+1. Install dependencies and configure FUSE by running the following script in the repository:
 
-        sudo apt-get update
-        sudo apt-get -y install cmake libclang-dev libunwind-dev pkg-config jq fio
-        sudo apt-get -y install fuse libfuse-dev
-        echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+        bash .github/actions/install-dependencies/install.sh \
+                --fuse-version 2 \
+                --with-fio --with-libunwind
 
 2. Set environment variables related to the benchmark. There are four required environment variables you need to set in order to run the benchmark.
 


### PR DESCRIPTION
This change collects all the dependency installation into one script, such that it is consistent across operating systems.

This should allow us to start building a matrix up for different operating systems, architectures, AWS regions, etc..

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
