### PR TITLE
Suppress LeakSanitizer in glibc DNS resolver

### DIFF
--- a/lsan-suppressions.txt
+++ b/lsan-suppressions.txt
@@ -6,3 +6,6 @@ leak:aws_tls_init_static_state
 
 # libfuse is outside our control
 leak:fuse_opt_add_arg
+
+# glibc's DNS resolver is outside our control
+leak:__res_context_send


### PR DESCRIPTION
The allocation in `__res_context_send` is owned by glibc, which is
supposed to clean it up at shutdown, but that seems to break
occasionally. It's outside our control and a bounded allocation (once
per process), so let's just ignore it.

Fixes failures like this one: https://github.com/awslabs/mountpoint-s3/actions/runs/5314589837/jobs/9621971341

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
