### PR TITLE
Release new crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-channel",
  "criterion",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bindgen",
  "cc",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v0.3.0 (June 20, 2023)
+
+Breaking changes:
+
+* Use CRT's new asynchronous streaming APIs for `put_object` requests ([#282](https://github.com/awslabs/mountpoint-s3/pull/298), [#295](https://github.com/awslabs/mountpoint-s3/pull/295)). This change modifies the `put_object` API.
+
+Other changes:
+
+* Avoid using CRT auto-ranged-get infrastructure for small requests ([#285](https://github.com/awslabs/mountpoint-s3/pull/285))
+* Add `NoSuchBucket` error for `head_object` requests ([#273](https://github.com/awslabs/mountpoint-s3/pull/273))
+* Fix a bug in computing time-to-first-byte for per-request telemetry ([#275](https://github.com/awslabs/mountpoint-s3/pull/275))
+
+# v0.2.2 (May 31, 2023)
+
+* Fix a build failure when consuming this crate from outside a Git repository ([(#269](https://github.com/awslabs/mountpoint-s3/pull/269))
+* Include `mountpoint-s3-client` version in `User-agent` strings ([#266](https://github.com/awslabs/mountpoint-s3/pull/266))
+* Integrate per-request telemetry for S3 requests ([#261](https://github.com/awslabs/mountpoint-s3/pull/261))
+
 # v0.2.1 (May 26, 2023)
 
 Initial release.

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -6,14 +6,14 @@ name = "mountpoint-s3-client"
 #   - Make sure to also bump the `mountpoint-s3-crt` dependency if needed
 # - Create a new Git tag `mountpoint-s3-client-0.x.y`
 # - Run `cargo publish`
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.1" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.2" }
 
 async-trait = "0.1.57"
 auto_impl = "1.0.1"

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.2 (June 20, 2023)
+
+* Update to latest CRT dependencies
+* Allow static linking of CRT libraries ([#298](https://github.com/awslabs/mountpoint-s3/pull/298))
+* Force `aws-checksums` to compile in release mode ([#284](https://github.com/awslabs/mountpoint-s3/pull/284))
+
 # v0.2.1 (May 26, 2023)
 
 Initial release.

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -4,7 +4,7 @@ name = "mountpoint-s3-crt-sys"
 # - Pull request to bump version number and update CHANGELOG.md
 # - Create a new Git tag `mountpoint-s3-crt-sys-0.x.y`
 # - Run `cargo publish`
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.2 (June 20, 2023)
+
+* Update to latest CRT dependencies
+* Implement `AsyncInputStream` bindings for S3 client ([#282](https://github.com/awslabs/mountpoint-s3/pull/282))
+* Expose `aws-c-s3` telemetry callbacks ([#261](https://github.com/awslabs/mountpoint-s3/pull/261), [#275](https://github.com/awslabs/mountpoint-s3/pull/275))
+
 # v0.2.1 (May 26, 2023)
 
 Initial release.

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -6,14 +6,14 @@ name = "mountpoint-s3-crt"
 #   - Make sure to also bump the `mountpoint-s3-crt-sys` dependency if needed
 # - Create a new Git tag `mountpoint-s3-crt-0.x.y`
 # - Run `cargo publish`
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.2.1" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.2.2" }
 
 async-channel = "1.8.0"
 futures = "0.3.24"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.12.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.2.2" }
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.3.0" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.2.2" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "1.8.0"


### PR DESCRIPTION
The main goal here is to get #298 out the door, but it's a good point to
get the last month of updates out too.

The async streaming work changed the `put_object` interface, so this
release is a breaking change for `mountpoint-s3-client`.

We also missed writing a changelog for v0.2.2 of `mountpoint-s3-client`,
so I'm writing it here.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
