### PR TITLE
Add clang and pkg-config dependencies to getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The alpha release of Mountpoint for Amazon S3 is only available by building from
 
 First, install the necessary dependencies. For RPM-based distributions (Amazon Linux 2 and 2023, Fedora, CentOS, etc):
 
-    sudo yum install fuse fuse-devel cmake3 clang-devel git
+    sudo yum install fuse fuse-devel cmake3 clang git pkg-config
 
 or for apt-based distributions (Debian, Ubuntu, etc):
 
-    sudo apt install fuse libfuse-dev cmake libclang-dev git
+    sudo apt install fuse libfuse-dev cmake clang git pkg-config
 
 Secondly, install the Rust compiler via [rustup](https://rustup.rs/):
 


### PR DESCRIPTION
We were missing these two packages when using a fresh OS installation and following the getting started instructions.

`pkg-config` is already included on AL, but name it as a dependency anyway to be consistent with the Ubuntu instructions.

Tested by creating new EC2 Instances for:
- Ubuntu
- AL2
- AL2023

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
