### PR TITLE
Remove AL2 + fuse3 pair from test matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,6 +34,7 @@ jobs:
     environment: ${{ inputs.environment }}
 
     strategy:
+      fail-fast: false
       matrix:
         fuseVersion: [2, 3]
         runner:
@@ -41,6 +42,12 @@ jobs:
           tags: [ubuntu-22.04] # GitHub-hosted
         - name: Amazon Linux arm
           tags: [self-hosted, linux, arm64]
+        exclude:
+          # fuse3 is not available on Amazon Linux 2
+          - runner:
+              name: Amazon Linux arm
+              tags: [self-hosted, linux, arm64]
+            fuseVersion: 3
 
     steps:
     - name: Configure AWS credentials


### PR DESCRIPTION
`fuse3` is not available on Amazon Linux 2. We should remove it from the test matrix.

I believe when we have Amazon Linux 2023 runners then we can run fine with fuse3. You can see this on the new package list: https://docs.aws.amazon.com/linux/al2023/release-notes/new-packages.html

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
