### PR TITLE
Implement fsync and handle write errors

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -252,7 +252,7 @@ pub struct PutObjectParams {}
 /// A streaming put request which allows callers to asynchronously write
 /// the body of the request.
 #[async_trait]
-pub trait PutObjectRequest {
+pub trait PutObjectRequest: Send {
     type ClientError: std::error::Error + Send + Sync + 'static;
 
     /// Write the given slice to the put request body.

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -188,6 +188,14 @@ where
         }
     }
 
+    #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync))]
+    fn fsync(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+        match block_on(self.fs.fsync(ino, fh, datasync).in_current_span()) {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(e),
+        }
+    }
+
     #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino, fh=fh))]
     fn release(
         &self,

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -385,7 +385,7 @@ mod tests {
 
     use super::*;
     use futures::executor::{block_on, ThreadPool};
-    use mountpoint_s3_client::failure_client::{countdown_failure_client, GetFailureMap};
+    use mountpoint_s3_client::failure_client::{countdown_failure_client, RequestFailureMap};
     use mountpoint_s3_client::mock_client::{ramp_bytes, MockClient, MockClientConfig, MockClientError, MockObject};
     use proptest::proptest;
     use proptest::strategy::{Just, Strategy};
@@ -482,7 +482,7 @@ mod tests {
         size: u64,
         read_size: usize,
         test_config: TestConfig,
-        get_failures: GetFailureMap<MockClient>,
+        get_failures: RequestFailureMap<MockClient, GetObjectError>,
     ) {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
@@ -494,7 +494,7 @@ mod tests {
 
         client.add_object("hello", object);
 
-        let client = countdown_failure_client(client, get_failures, HashMap::new(), HashMap::new());
+        let client = countdown_failure_client(client, get_failures, HashMap::new(), HashMap::new(), HashMap::new());
 
         let test_config = PrefetcherConfig {
             first_request_size: test_config.first_request_size,

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -6,6 +6,7 @@ use mountpoint_s3_client::{
 };
 
 use thiserror::Error;
+use tracing::{debug, error};
 
 type PutRequestError<Client> = ObjectClientError<PutObjectError, <Client as ObjectClient>::ClientError>;
 
@@ -31,35 +32,52 @@ where
     }
 
     /// Start a new put request to the specified object.
-    pub async fn put(
+    pub async fn put<Handle>(
         &self,
         bucket: &str,
         key: &str,
-    ) -> ObjectClientResult<UploadRequest<Client>, PutObjectError, Client::ClientError> {
-        UploadRequest::new(Arc::clone(&self.inner), bucket, key).await
+        handle: Handle,
+    ) -> ObjectClientResult<UploadRequest<Client, Handle>, PutObjectError, Client::ClientError> {
+        UploadRequest::new(Arc::clone(&self.inner), bucket, key, handle).await
     }
 }
 
 #[derive(Debug, Error)]
-pub enum UploadWriteError<E: std::error::Error> {
+pub enum UploadError<E: std::error::Error> {
     #[error("put request failed")]
     PutRequestFailed(#[from] E),
 
     #[error("out of order write; expected offset {expected_offset:?} but got {write_offset:?}")]
     OutOfOrderWrite { write_offset: u64, expected_offset: u64 },
+
+    #[error("put request had already completed")]
+    PutRequestAlreadyCompleted,
+
+    #[error("put request had previously failed")]
+    PutRequestPreviouslyFailed,
 }
 
 /// Manages the upload of an object to S3.
 ///
-/// Wraps a PutObject request and enforces sequential writes.
-pub struct UploadRequest<Client: ObjectClient> {
-    bucket: String,
+/// Handles the lifecycle of a PutObject request,
+/// invalidates it on errors, and enforces sequential writes.
+#[derive(Debug)]
+pub struct UploadRequest<Client: ObjectClient, Handle> {
     key: String,
     next_request_offset: u64,
-    request: Client::PutObjectRequest,
+    state: UploadRequestState<Client, Handle>,
 }
 
-impl<Client> UploadRequest<Client>
+enum UploadRequestState<Client: ObjectClient, Handle> {
+    InProgress {
+        request: Client::PutObjectRequest,
+        handle: Handle,
+    },
+    Completed,
+    Failed,
+}
+
+impl<Client, Handle> UploadRequest<Client, Handle>
 where
     Client: ObjectClient + Send + Sync + 'static,
 {
@@ -67,6 +85,7 @@ where
         inner: Arc<UploaderInner<Client>>,
         bucket: &str,
         key: &str,
+        handle: Handle,
     ) -> ObjectClientResult<Self, PutObjectError, Client::ClientError> {
         let request = inner
             .client
@@ -74,10 +93,9 @@ where
             .await?;
 
         Ok(Self {
-            bucket: bucket.to_owned(),
             key: key.to_owned(),
             next_request_offset: 0,
-            request,
+            state: UploadRequestState::InProgress { request, handle },
         })
     }
 
@@ -85,34 +103,163 @@ where
         self.next_request_offset
     }
 
-    pub async fn write(&mut self, offset: i64, data: &[u8]) -> Result<(), UploadWriteError<PutRequestError<Client>>> {
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self.state, UploadRequestState::InProgress { .. })
+    }
+
+    pub async fn write(&mut self, offset: i64, data: &[u8]) -> Result<usize, UploadError<PutRequestError<Client>>> {
         let next_offset = self.next_request_offset;
         if offset != next_offset as i64 {
-            return Err(UploadWriteError::OutOfOrderWrite {
+            return Err(UploadError::OutOfOrderWrite {
                 write_offset: offset as u64,
                 expected_offset: next_offset,
             });
         }
 
-        self.request.write(data).await?;
-        self.next_request_offset += data.len() as u64;
-        Ok(())
+        let request = match &mut self.state {
+            UploadRequestState::InProgress { request, .. } => request,
+            UploadRequestState::Completed => {
+                error!(key = self.key, "object already uploaded");
+                return Err(UploadError::PutRequestAlreadyCompleted);
+            }
+            UploadRequestState::Failed => {
+                error!(key = self.key, "error on previous write");
+                return Err(UploadError::PutRequestPreviouslyFailed);
+            }
+        };
+
+        match request.write(data).await {
+            Ok(()) => {
+                self.next_request_offset += data.len() as u64;
+                Ok(data.len())
+            }
+            Err(e) => {
+                error!("write failed: {:?}", e);
+                self.state = UploadRequestState::Failed;
+                Err(e.into())
+            }
+        }
     }
 
-    pub async fn complete(self) -> Result<PutObjectResult, PutRequestError<Client>> {
-        self.request.complete().await
+    pub async fn complete(&mut self) -> Result<PutObjectResult, UploadError<PutRequestError<Client>>> {
+        let (request, handle) = match std::mem::replace(&mut self.state, UploadRequestState::Completed) {
+            UploadRequestState::InProgress { request, handle } => (request, handle),
+            UploadRequestState::Completed => {
+                error!(key = self.key, "object already uploaded");
+                return Err(UploadError::PutRequestAlreadyCompleted);
+            }
+            UploadRequestState::Failed => {
+                self.state = UploadRequestState::Failed;
+                error!(key = self.key, "error on previous write");
+                return Err(UploadError::PutRequestPreviouslyFailed);
+            }
+        };
+
+        let key = &self.key;
+        let size = self.size() as usize;
+        let put = request.complete().await;
+        drop(handle);
+        match put {
+            Ok(result) => {
+                debug!(key, size, "put succeeded");
+                Ok(result)
+            }
+            Err(e) => {
+                self.state = UploadRequestState::Failed;
+                error!(key, size, "put failed, object was not uploaded: {e:?}");
+                Err(e.into())
+            }
+        }
     }
 }
 
-impl<Client> Debug for UploadRequest<Client>
-where
-    Client: ObjectClient,
-{
+impl<Client: ObjectClient, Handle> Debug for UploadRequestState<Client, Handle> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UploadRequest")
-            .field("bucket", &self.bucket)
-            .field("key", &self.key)
-            .field("next_request_offset", &self.next_request_offset)
-            .finish()
+        let case = match self {
+            UploadRequestState::InProgress { .. } => "InProgress",
+            UploadRequestState::Completed => "Completed",
+            UploadRequestState::Failed => "Failed",
+        };
+        f.write_str(case)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+
+    struct Handle(Arc<Mutex<bool>>);
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            *self.0.lock().unwrap() = true;
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_handle_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+        }));
+        let uploader = Uploader::new(client.clone());
+
+        let dropped = Arc::new(Mutex::new(false));
+        let handle = Handle(dropped.clone());
+        let mut request = uploader.put(bucket, key, handle).await.unwrap();
+
+        assert!(!client.contains_key(key));
+        assert!(client.is_upload_in_progress(key));
+        assert!(!*dropped.lock().unwrap());
+        assert!(request.is_in_progress());
+
+        request.complete().await.unwrap();
+
+        assert!(client.contains_key(key));
+        assert!(!client.is_upload_in_progress(key));
+        assert!(*dropped.lock().unwrap());
+        assert!(!request.is_in_progress());
+    }
+
+    #[tokio::test]
+    async fn write_order_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+        }));
+        let uploader = Uploader::new(client.clone());
+
+        let mut request = uploader.put(bucket, key, true).await.unwrap();
+
+        let data = "foo";
+        let mut offset = 0;
+        offset += request.write(offset, data.as_bytes()).await.unwrap() as i64;
+
+        request
+            .write(0, data.as_bytes())
+            .await
+            .expect_err("out of order write should fail");
+
+        offset += request
+            .write(offset, data.as_bytes())
+            .await
+            .expect("subsequent in order write should succeed") as i64;
+
+        request.complete().await.unwrap();
+
+        assert!(client.contains_key(key));
+        assert!(!request.is_in_progress());
+
+        assert_eq!(offset, request.size() as i64);
     }
 }

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -225,3 +225,57 @@ fn sequential_write_streaming_test_s3(object_size: usize, write_chunk_size: usiz
 fn sequential_write_streaming_test_mock(object_size: usize, write_chunk_size: usize) {
     sequential_write_streaming_test(crate::fuse_tests::mock_session::new, object_size, write_chunk_size);
 }
+
+fn fsync_test<F>(creator_fn: F)
+where
+    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const OBJECT_SIZE: usize = 32;
+    const KEY: &str = "new.txt";
+
+    let (mount_point, _session, test_client) = creator_fn("fsync_test", Default::default());
+
+    let path = mount_point.path().join(KEY);
+
+    let mut f = open_for_write(&path, false).unwrap();
+
+    // The file is visible with size 0 as soon as we open it for write
+    let m = metadata(&path).unwrap();
+    assert_eq!(m.len(), 0);
+
+    let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
+    let mut body = vec![0u8; OBJECT_SIZE];
+    rng.fill(&mut body[..]);
+
+    f.write_all(&body).unwrap();
+
+    assert!(test_client.is_upload_in_progress(KEY).unwrap());
+
+    f.sync_all().unwrap();
+
+    assert!(!test_client.is_upload_in_progress(KEY).unwrap());
+
+    let m = metadata(&path).unwrap();
+    assert_eq!(m.len(), body.len() as u64);
+
+    f.write_all(&body).expect_err("write after sync should fail");
+
+    drop(f);
+
+    let m = metadata(&path).unwrap();
+    assert_eq!(m.len(), body.len() as u64);
+
+    let buf = read(&path).unwrap();
+    assert_eq!(&buf[..], &body[..]);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn fsync_test_s3() {
+    fsync_test(crate::fuse_tests::s3_session::new);
+}
+
+#[test]
+fn fsync_test_mock() {
+    fsync_test(crate::fuse_tests::mock_session::new);
+}


### PR DESCRIPTION
Implement `fsync` to allow users to complete a put request and receive confirmation that it succeeded or failed. If a file handle is released without a call to `fsync`, `release` will still complete the upload as before. 

This change modifies `UploadRequest` to keep track of the state of a `PutObjectRequest`, so that
* `release` can detect whether the request had been already completed by an `fsync` call,
* `write` is invoked after an `fsync`,
* `write` (or `fsync`) is invoked after a previous call failed.


**Note**: Creating as draft:
* missing additional tests, especially around failures,
* should we add a flag to enable the new `fsync` behavior?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
