### PR TITLE
Move some inode-related error logging

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -468,7 +468,7 @@ impl Superblock {
         match write_status {
             WriteStatus::LocalUnopened | WriteStatus::LocalOpen => {
                 // In the future, we may permit `unlink` and cancel any in-flight uploads.
-                error!(
+                warn!(
                     parent = parent_ino,
                     ?name,
                     "unlink called on local file, unlink not supported until write is complete",
@@ -779,11 +779,11 @@ impl WriteHandle {
                 Ok(())
             }
             WriteStatus::LocalOpen => {
-                error!(inode=?self.ino, "inode is already being written");
+                warn!(inode=?self.ino, "inode is already being written");
                 Err(InodeError::InodeNotWritable(self.ino))
             }
             WriteStatus::Remote => {
-                error!(inode=?self.ino, "inode already exists");
+                warn!(inode=?self.ino, "inode already exists");
                 Err(InodeError::InodeNotWritable(self.ino))
             }
         }


### PR DESCRIPTION
These failures in `inode.rs` aren't really errors -- in general, if the
user asked us to do something, it's not an internal error if that's not
possible. These are really "expected failures" from Mountpoint's
perspective. So this change shifts the actual `error!` log message into
the filesystem, and changes the `inode.rs` messages to warnings. This
makes our CI and test output less spammy, especially the reftests that
expect to test these cases repeatedly.

Signed-off-by: James Bornholt <bornholt@amazon.com>



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
