### PR TITLE
reftests: always materialize reference model from bucket contents

### DIFF
--- a/mountpoint-s3/tests/reftests/generators.rs
+++ b/mountpoint-s3/tests/reftests/generators.rs
@@ -21,6 +21,21 @@ pub fn name_strategy() -> impl Strategy<Value = String> {
 #[derive(Clone, Debug, Arbitrary, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Name(#[proptest(strategy = "name_strategy()")] pub String);
 
+impl From<&str> for Name {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+#[derive(Clone, Debug, Arbitrary, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ValidName(#[proptest(strategy = "valid_name_strategy()")] pub String);
+
+impl From<&str> for ValidName {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Arbitrary)]
 pub enum FileSize {
     Small(u8),
@@ -67,11 +82,11 @@ pub fn gen_tree(depth: u32, max_size: u32, max_items: u32, max_width: usize) -> 
 }
 
 /// Take a generated tree and create the corresponding S3 namespace (list of keys)
-pub fn flatten_tree(node: TreeNode) -> Vec<(String, FileContent)> {
-    fn aux(node: TreeNode, path: String, acc: &mut Vec<(String, FileContent)>) {
+pub fn flatten_tree(node: TreeNode) -> Vec<(String, MockObject)> {
+    fn aux(node: TreeNode, path: String, acc: &mut Vec<(String, MockObject)>) {
         match node {
             TreeNode::File(content) => {
-                acc.push((path, content));
+                acc.push((path, content.to_mock_object()));
             }
             TreeNode::Directory(contents) => {
                 for (name, child) in contents {

--- a/mountpoint-s3/tests/reftests/generators.rs
+++ b/mountpoint-s3/tests/reftests/generators.rs
@@ -4,6 +4,9 @@ use proptest::prelude::*;
 use proptest::string::string_regex;
 use proptest_derive::Arbitrary;
 use std::collections::BTreeMap;
+use std::ops::Deref;
+
+use crate::reftests::reference::valid_inode_name;
 
 pub fn valid_name_strategy() -> impl Strategy<Value = String> {
     string_regex("[a-]{1,3}").unwrap()
@@ -21,6 +24,14 @@ pub fn name_strategy() -> impl Strategy<Value = String> {
 #[derive(Clone, Debug, Arbitrary, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Name(#[proptest(strategy = "name_strategy()")] pub String);
 
+impl Deref for Name {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl From<&str> for Name {
     fn from(value: &str) -> Self {
         Self(value.to_owned())
@@ -30,8 +41,17 @@ impl From<&str> for Name {
 #[derive(Clone, Debug, Arbitrary, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValidName(#[proptest(strategy = "valid_name_strategy()")] pub String);
 
+impl Deref for ValidName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl From<&str> for ValidName {
     fn from(value: &str) -> Self {
+        assert!(valid_inode_name(value), "invalid name for ValidName");
         Self(value.to_owned())
     }
 }

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -150,7 +150,7 @@ impl Harness {
             debug!(?op, "executing operation");
             match &op {
                 Op::WriteFile(name, directory_index, contents) => {
-                    let Some(index) = self.perform_create_file(&name.0, *directory_index, contents).await else {
+                    let Some(index) = self.perform_create_file(name, *directory_index, contents).await else {
                         continue;
                     };
                     self.perform_start_writing(index).await;
@@ -158,7 +158,7 @@ impl Harness {
                 }
 
                 Op::CreateFile(name, directory_index, contents) => {
-                    self.perform_create_file(&name.0, *directory_index, contents).await;
+                    self.perform_create_file(name, *directory_index, contents).await;
                 }
                 Op::StartWriting(index) => {
                     self.perform_start_writing(*index).await;
@@ -448,7 +448,7 @@ impl Harness {
 
                     match children.get(name) {
                         Some(node) => {
-                            let ref_kind = node.file_type();
+                            let ref_kind = node.node_type().into();
                             assert_eq!(
                                 fs_kind, ref_kind,
                                 "for file {name:?} expecting {ref_kind:?} found {fs_kind:?}"

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -4,8 +4,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
-
-use crate::reftests::generators::{FileContent, FileSize};
+use tracing::trace;
 
 #[derive(Debug)]
 pub enum File {
@@ -15,62 +14,141 @@ pub enum File {
 
 #[derive(Debug)]
 pub enum Node {
-    // TODO Also support hybrid nodes?
-    Directory(BTreeMap<String, Node>),
+    Directory {
+        children: BTreeMap<String, Node>,
+        is_local: bool,
+    },
     File(File),
 }
 
 impl Node {
+    /// Returns the type of this node (file or directory)
     pub fn file_type(&self) -> FileType {
         match self {
-            Node::Directory(_) => FileType::Directory,
+            Node::Directory { .. } => FileType::Directory,
             Node::File(_) => FileType::RegularFile,
         }
     }
 
-    // Returns the children of a directory node (panics if node is a file)
+    /// Returns the children of a directory node (panics if node is a file)
     pub fn children(&self) -> &BTreeMap<String, Node> {
         match self {
-            Self::Directory(map) => map,
+            Self::Directory { children, .. } => children,
             Self::File(_) => panic!("unexpected file"),
         }
     }
+}
 
-    pub fn depth(&self) -> usize {
-        if let Node::Directory(map) = self {
-            let mut depth = 0usize;
-            for child in map.values() {
-                depth = depth.max(1 + child.depth());
-            }
-            depth
-        } else {
-            0
-        }
-    }
+/// The expected state of a file system. We track three pieces of state: the keys in an S3 bucket,
+/// plus lists of local files and local directories. Whenever we need the tree structure of the
+/// file system, we construct it from these inputs as a [MaterializedReference]. Building the
+/// reference in this indirect way allows us to have only one definition of correctness -- the
+/// implementation of [build_reference] -- and to test both mutations to the file system itself and
+/// "remote" mutations to the bucket (like adding or deleting a key using another client).
+#[derive(Debug)]
+pub struct Reference {
+    /// Contents of our S3 bucket
+    remote_keys: Vec<(String, MockObject)>,
+    /// Local files
+    local_files: Vec<PathBuf>,
+    /// Local directories
+    local_directories: Vec<PathBuf>,
+    /// Materialized state
+    materialized: MaterializedReference,
 }
 
 #[derive(Debug)]
-pub struct Reference {
+struct MaterializedReference {
     root: Node,
-    /// Full path of all directories
     directories: Vec<PathBuf>,
-    /// Full path of all inflight writes
-    #[allow(unused)] // TODO when we test partially written files
-    inflight_writes: Vec<PathBuf>,
+}
+
+impl MaterializedReference {
+    /// Add a new node to the tree. Any missing intermediate directories will be created as local
+    /// directories. If the path already exists it will be overwritten, unless both the existing
+    /// and new nodes are directories.
+    fn add_local_node(&mut self, path: impl AsRef<Path>, new_node: Node) {
+        let mut components = path.as_ref().components().peekable();
+        assert_eq!(components.next(), Some(Component::RootDir));
+
+        let mut parent_node = &mut self.root;
+        while let Some(dir) = components.next() {
+            let Node::Directory { children, .. } = parent_node else {
+                panic!("unexpected internal file node");
+            };
+            let dir = dir.as_os_str().to_str().unwrap();
+            if components.peek().is_none() {
+                // If both a local and a remote directory exist, don't overwrite the remote one's
+                // contents, as they will be visible even though the directory is local. But
+                // remember the directory is still local.
+                if let Node::Directory {
+                    children: new_children,
+                    is_local: new_is_local,
+                } = &new_node
+                {
+                    if let Some(Node::Directory {
+                        is_local: curr_is_local,
+                        ..
+                    }) = children.get_mut(dir)
+                    {
+                        assert!(new_children.is_empty(), "local directories are always empty");
+                        assert!(
+                            new_is_local,
+                            "add_local_node should only be called on local directories"
+                        );
+                        *curr_is_local = true;
+                        break;
+                    }
+                }
+                children.insert(dir.to_owned(), new_node);
+                break;
+            } else {
+                parent_node = children.entry(dir.to_owned()).or_insert_with(|| Node::Directory {
+                    children: BTreeMap::new(),
+                    is_local: true,
+                })
+            }
+        }
+    }
 }
 
 impl Reference {
-    pub fn new() -> Self {
-        let root = Node::Directory(BTreeMap::new());
+    pub fn new(remote_keys: Vec<(String, MockObject)>) -> Self {
+        let local_files = vec![];
+        let local_directories = vec![];
+        let materialized = build_reference(&remote_keys);
         Self {
-            root,
-            directories: vec!["/".into()],
-            inflight_writes: vec![],
+            remote_keys,
+            local_files,
+            local_directories,
+            materialized,
         }
     }
 
+    fn rematerialize(&self) -> MaterializedReference {
+        trace!(
+            remote_keys=?self.remote_keys, local_files=?self.local_files, local_directories=?self.local_directories,
+            "rematerialize",
+        );
+        let mut materialized = build_reference(&self.remote_keys);
+        for local_dir in self.local_directories.iter() {
+            materialized.add_local_node(
+                local_dir,
+                Node::Directory {
+                    children: BTreeMap::new(),
+                    is_local: true,
+                },
+            );
+            materialized.directories.push(local_dir.clone());
+        }
+        for local_file in self.local_files.iter() {
+            materialized.add_local_node(local_file, Node::File(File::Local));
+        }
+        materialized
+    }
+
     pub fn root(&self) -> &Node {
-        &self.root
+        &self.materialized.root
     }
 
     /// Return a list of all inodes in the entire tree. Each file is a Vec<String> of path
@@ -79,7 +157,7 @@ impl Reference {
         fn aux<'a>(node: &'a Node, path: Vec<&'a str>, ret: &mut Vec<(Vec<&'a str>, &'a Node)>) {
             match node {
                 Node::File(_) => ret.push((path, node)),
-                Node::Directory(children) => {
+                Node::Directory { children, .. } => {
                     for (name, child) in children.iter() {
                         let mut path = path.clone();
                         path.push(name);
@@ -90,37 +168,60 @@ impl Reference {
             }
         }
         let mut ret = vec![];
-        aux(&self.root, vec![], &mut ret);
+        aux(&self.materialized.root, vec![], &mut ret);
         ret
     }
 
-    pub fn depth(&self) -> usize {
-        self.root.depth()
+    pub fn add_local_file(&mut self, path: impl AsRef<Path>) {
+        let path = path.as_ref().to_owned();
+        assert!(!self.local_files.contains(&path), "duplicate local file");
+        self.local_files.push(path);
+        self.materialized = self.rematerialize();
     }
 
-    // Add file to the reference, creating internal nodes as necessary
-    pub fn add_file(&mut self, path: impl AsRef<Path>, file: File) {
-        let mut components = path.as_ref().components().peekable();
-        assert_eq!(components.next(), Some(Component::RootDir));
+    #[allow(unused)] // TODO: use to test `mkdir`
+    pub fn add_local_directory(&mut self, path: impl AsRef<Path>) {
+        let path = path.as_ref().to_owned();
+        assert!(!self.local_directories.contains(&path), "duplicate local directory");
+        self.local_directories.push(path);
+        self.materialized = self.rematerialize();
+    }
 
-        let mut node = &mut self.root;
-        while let Some(dir) = components.next() {
-            node = match node {
-                Node::Directory(children) => {
-                    let dir = dir.as_os_str().to_str().unwrap().to_string();
-                    if children.get(&dir).is_none() {
-                        if components.peek().is_none() {
-                            children.insert(dir.clone(), Node::File(file));
-                            break;
-                        } else {
-                            children.insert(dir.clone(), Node::Directory(BTreeMap::new()));
-                        }
-                    }
-                    children.get_mut(&dir).unwrap()
-                }
-                _ => panic!("unexpected internal file node"),
-            };
-        }
+    pub fn remove_local_file(&mut self, path: impl AsRef<Path>) {
+        let idx = self
+            .local_files
+            .iter()
+            .position(|p| p == path.as_ref())
+            .expect("local file must exist");
+        self.local_files.remove(idx);
+        self.materialized = self.rematerialize();
+    }
+
+    #[allow(unused)] // TODO: use to test `rmdir`
+    pub fn remove_local_directory(&mut self, path: impl AsRef<Path>) {
+        let idx = self
+            .local_directories
+            .iter()
+            .position(|p| p == path.as_ref())
+            .expect("local file must exist");
+        self.local_directories.remove(idx);
+        self.materialized = self.rematerialize();
+    }
+
+    pub fn add_remote_key(&mut self, key: String, object: MockObject) {
+        self.remote_keys.push((key, object));
+        self.materialized = self.rematerialize();
+    }
+
+    #[allow(unused)] // TODO: use to test remote keys disappearing
+    pub fn remove_remote_key(&mut self, key: &str) {
+        let idx = self
+            .remote_keys
+            .iter()
+            .position(|(k, _)| k == key)
+            .expect("remote key must exist");
+        self.remote_keys.remove(idx);
+        self.materialized = self.rematerialize();
     }
 
     /// Get a node from a full path, if it exists. If any path component does not exist in the
@@ -129,32 +230,12 @@ impl Reference {
         let mut components = path.as_ref().components();
         assert_eq!(components.next(), Some(Component::RootDir));
 
-        let mut node = &self.root;
+        let mut node = &self.materialized.root;
         for component in components {
             node = match node {
-                Node::Directory(children) => {
+                Node::Directory { children, .. } => {
                     let dir = component.as_os_str().to_str().unwrap().to_string();
                     children.get(&dir)?
-                }
-                _ => return None,
-            };
-        }
-
-        Some(node)
-    }
-
-    /// Get a mutable reference to a node from a full path, if it exists. If any path component does
-    /// not exist in the reference, returns None.
-    pub fn lookup_mut(&mut self, path: impl AsRef<Path>) -> Option<&mut Node> {
-        let mut components = path.as_ref().components();
-        assert_eq!(components.next(), Some(Component::RootDir));
-
-        let mut node = &mut self.root;
-        for dir in components {
-            node = match node {
-                Node::Directory(children) => {
-                    let dir = dir.as_os_str().to_str().unwrap().to_string();
-                    children.get_mut(&dir)?
                 }
                 _ => return None,
             };
@@ -166,7 +247,7 @@ impl Reference {
     /// A list of absolute paths for every directory in the reference. This is never empty as "/" is
     /// always a valid directory, even in an empty file system.
     pub fn directories(&self) -> &[impl AsRef<Path>] {
-        &self.directories
+        &self.materialized.directories
     }
 }
 
@@ -177,11 +258,11 @@ fn valid_inode_name(name: &str) -> bool {
 /// Take an S3 namespace (list of keys) and create the expected reference file system tree. This is
 /// where all our semantics decisions about how to present a flat keyspace as a file system are
 /// made; we'll be testing the connector against the decisions made here.
-pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
+fn build_reference(flat: &[(String, MockObject)]) -> MaterializedReference {
     #[derive(Debug)]
     enum RefNode {
         Directory(Rc<RefCell<BTreeMap<String, RefNode>>>),
-        File(FileContent),
+        File(MockObject),
     }
 
     impl RefNode {
@@ -229,7 +310,9 @@ pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
             .map(|node| matches!(node, RefNode::File(_)))
             .unwrap_or(true);
         if valid_inode_name(file_name) && should_create {
-            leaf_dir.borrow_mut().insert(file_name.to_string(), RefNode::File(file));
+            leaf_dir
+                .borrow_mut()
+                .insert(file_name.to_string(), RefNode::File(file.clone()));
         }
     }
 
@@ -245,9 +328,12 @@ pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
                     let path = path.as_ref().join(&key);
                     directories.push(path.clone());
                     let converted = convert(contents.take(), &path, directories);
-                    Node::Directory(converted)
+                    Node::Directory {
+                        children: converted,
+                        is_local: false,
+                    }
                 }
-                RefNode::File(contents) => Node::File(File::Remote(contents.to_mock_object())),
+                RefNode::File(contents) => Node::File(File::Remote(contents)),
             };
             out.insert(key, node);
         }
@@ -256,26 +342,11 @@ pub fn build_reference(flat: Vec<(String, FileContent)>) -> Reference {
 
     let mut directories = vec!["/".into()];
     let root = convert(tree.take(), "/", &mut directories);
-    Reference {
-        root: Node::Directory(root),
+    MaterializedReference {
+        root: Node::Directory {
+            children: root,
+            is_local: false,
+        },
         directories,
-        inflight_writes: vec![],
     }
-}
-
-#[test]
-fn depth_test() {
-    let mut r = Reference::new();
-
-    assert_eq!(r.depth(), 0);
-
-    r.add_file(
-        "/a/b/c1",
-        File::Remote(FileContent(0xaa, FileSize::Small(0)).to_mock_object()),
-    );
-    r.add_file(
-        "/a/b/c2",
-        File::Remote(FileContent(0xbb, FileSize::Small(0)).to_mock_object()),
-    );
-    assert_eq!(r.depth(), 3);
 }


### PR DESCRIPTION
Today, the reference model for the reftests is just a tree structure. When we make changes to the expected state of the file system, we update this tree structure in place.

This needs to change to prepare us to extend the reftests with mutations to the *bucket*, not just the file system (i.e., concurrent mutations). When one of these mutations happens, we need to be able to compute what we expect the state of the file system to be after the change. For example, if my bucket contains keys `a` and `a/b`, and then I delete `a/b` from the bucket, what's the expected state of the file system? The current implementation asks us to compute this state by making in-place modifications to the file system tree, which is error prone -- we'd essentially be re-implementing the same inode management logic we use in the actual file system.

To avoid this complexity, this change instead "materializes" the file system structure from a reference bucket at every step of the reftest. The reference model is now just a "reference bucket" plus lists of local files and directories. In the example above, we can simulate deleting an object by just removing it from both the mock bucket (the one Mountpoint is accessing through the mock client) and the reference bucket (the one introduced in this change). Then, when we rematerialize the reference file system, we'll have the new directory structure, without having to manually compute the changes to make to that tree.

This is nice because it means the only "trusted" code in the reference model is `build_reference`, which specifies how to convert *any* bucket into a filesystem. One potential downside is that rematerializing the filesystem after every operation might be expensive, but in my testing the overhead hasn't seemed problematic.

This commit is not expected to change any semantics of the reftests, and doesn't add any new operations. Those will come later, building on this refactoring.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
