### PR TITLE
Implement fsync and handle write errors

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -252,7 +252,7 @@ pub struct PutObjectParams {}
 /// A streaming put request which allows callers to asynchronously write
 /// the body of the request.
 #[async_trait]
-pub trait PutObjectRequest {
+pub trait PutObjectRequest: Send {
     type ClientError: std::error::Error + Send + Sync + 'static;
 
     /// Write the given slice to the put request body.

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -188,6 +188,14 @@ where
         }
     }
 
+    #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync))]
+    fn fsync(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+        match block_on(self.fs.fsync(ino, fh, datasync).in_current_span()) {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(e),
+        }
+    }
+
     #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino, fh=fh))]
     fn release(
         &self,

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -385,7 +385,7 @@ mod tests {
 
     use super::*;
     use futures::executor::{block_on, ThreadPool};
-    use mountpoint_s3_client::failure_client::{countdown_failure_client, GetFailureMap};
+    use mountpoint_s3_client::failure_client::{countdown_failure_client, RequestFailureMap};
     use mountpoint_s3_client::mock_client::{ramp_bytes, MockClient, MockClientConfig, MockClientError, MockObject};
     use proptest::proptest;
     use proptest::strategy::{Just, Strategy};
@@ -482,7 +482,7 @@ mod tests {
         size: u64,
         read_size: usize,
         test_config: TestConfig,
-        get_failures: GetFailureMap<MockClient>,
+        get_failures: RequestFailureMap<MockClient, GetObjectError>,
     ) {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
@@ -494,7 +494,7 @@ mod tests {
 
         client.add_object("hello", object);
 
-        let client = countdown_failure_client(client, get_failures, HashMap::new(), HashMap::new());
+        let client = countdown_failure_client(client, get_failures, HashMap::new(), HashMap::new(), HashMap::new());
 
         let test_config = PrefetcherConfig {
             first_request_size: test_config.first_request_size,

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -20,10 +20,7 @@ struct UploaderInner<Client> {
     client: Arc<Client>,
 }
 
-impl<Client> Uploader<Client>
-where
-    Client: ObjectClient + Send + Sync + 'static,
-{
+impl<Client: ObjectClient> Uploader<Client> {
     /// Create a new [Uploader] that will make requests to the given client.
     pub fn new(client: Arc<Client>) -> Self {
         let inner = UploaderInner { client };
@@ -59,10 +56,7 @@ pub struct UploadRequest<Client: ObjectClient> {
     request: Client::PutObjectRequest,
 }
 
-impl<Client> UploadRequest<Client>
-where
-    Client: ObjectClient + Send + Sync + 'static,
-{
+impl<Client: ObjectClient> UploadRequest<Client> {
     async fn new(
         inner: Arc<UploaderInner<Client>>,
         bucket: &str,
@@ -85,7 +79,11 @@ where
         self.next_request_offset
     }
 
-    pub async fn write(&mut self, offset: i64, data: &[u8]) -> Result<(), UploadWriteError<PutRequestError<Client>>> {
+    pub async fn write(
+        &mut self,
+        offset: i64,
+        data: &[u8],
+    ) -> Result<usize, UploadWriteError<PutRequestError<Client>>> {
         let next_offset = self.next_request_offset;
         if offset != next_offset as i64 {
             return Err(UploadWriteError::OutOfOrderWrite {
@@ -96,7 +94,7 @@ where
 
         self.request.write(data).await?;
         self.next_request_offset += data.len() as u64;
-        Ok(())
+        Ok(data.len())
     }
 
     pub async fn complete(self) -> Result<PutObjectResult, PutRequestError<Client>> {
@@ -104,15 +102,131 @@ where
     }
 }
 
-impl<Client> Debug for UploadRequest<Client>
-where
-    Client: ObjectClient,
-{
+impl<Client: ObjectClient> Debug for UploadRequest<Client> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UploadRequest")
             .field("bucket", &self.bucket)
             .field("key", &self.key)
             .field("next_request_offset", &self.next_request_offset)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use mountpoint_s3_client::{
+        failure_client::countdown_failure_client,
+        mock_client::{MockClient, MockClientConfig, MockClientError},
+    };
+
+    #[tokio::test]
+    async fn complete_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+        }));
+        let uploader = Uploader::new(client.clone());
+        let request = uploader.put(bucket, key).await.unwrap();
+
+        assert!(!client.contains_key(key));
+        assert!(client.is_upload_in_progress(key));
+
+        request.complete().await.unwrap();
+
+        assert!(client.contains_key(key));
+        assert!(!client.is_upload_in_progress(key));
+    }
+
+    #[tokio::test]
+    async fn write_order_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+        }));
+        let uploader = Uploader::new(client.clone());
+
+        let mut request = uploader.put(bucket, key).await.unwrap();
+
+        let data = "foo";
+        let mut offset = 0;
+        offset += request.write(offset, data.as_bytes()).await.unwrap() as i64;
+
+        request
+            .write(0, data.as_bytes())
+            .await
+            .expect_err("out of order write should fail");
+
+        offset += request
+            .write(offset, data.as_bytes())
+            .await
+            .expect("subsequent in order write should succeed") as i64;
+
+        let size = request.size();
+        assert_eq!(offset, size as i64);
+
+        request.complete().await.unwrap();
+        assert!(client.contains_key(key));
+    }
+
+    #[tokio::test]
+    async fn failure_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+        }));
+
+        let mut put_failures = HashMap::new();
+        put_failures.insert(1, Ok((1, MockClientError("error".to_owned().into()))));
+        put_failures.insert(2, Ok((2, MockClientError("error".to_owned().into()))));
+
+        let failure_client = Arc::new(countdown_failure_client(
+            client.clone(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            put_failures,
+        ));
+
+        let uploader = Uploader::new(failure_client.clone());
+
+        // First request fails on first write.
+        {
+            let mut request = uploader.put(bucket, key).await.unwrap();
+
+            let data = "foo";
+            request
+                .write(0, data.as_bytes())
+                .await
+                .expect_err("first write should fail");
+        }
+        assert!(!client.is_upload_in_progress(key));
+        assert!(!client.contains_key(key));
+
+        // Second request fails on complete (after one write).
+        {
+            let mut request = uploader.put(bucket, key).await.unwrap();
+
+            let data = "foo";
+            _ = request.write(0, data.as_bytes()).await.unwrap();
+
+            request.complete().await.expect_err("complete should fail");
+        }
+        assert!(!client.is_upload_in_progress(key));
+        assert!(!client.contains_key(key));
     }
 }


### PR DESCRIPTION
Implement `fsync` to allow users to complete a put request and receive confirmation that it succeeded or failed. If a file handle is released without a call to `fsync`, `release` will still complete the upload as before. 

Wrap the `UploadRequest` in the file handle in a new `UploadState` enum, in order to detect:
* on `release`, whether the request had been already completed by an `fsync` call,
* `write` is invoked after an `fsync`,
* `write` (or `fsync`) is invoked after a previous call failed.

Also adds support for put failures to FailureClient.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
