### PR TITLE
Fix dependency installation in GitHub workflows

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -27,9 +27,9 @@ runs:
     run: |
       bash ${GITHUB_ACTION_PATH}/install.sh \
         --fuse-version ${{ inputs.fuseVersion }} \
-        --with-llvm ${{ inputs.llvm }} \
-        --with-libunwind ${{ inputs.libunwind }} \
-        --with-fio ${{ inputs.fio }}
+        ${{ fromJSON(inputs.llvm) && '--with-llvm' || '' }} \
+        ${{ fromJSON(inputs.libunwind) && '--with-libunwind' || '' }} \
+        ${{ fromJSON(inputs.fio) && '--with-fio' || '' }}
   - name: Configure FUSE to allow other users to access FS
     shell: bash
     run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! command -v fio &> /dev/null; then
+  echo "fio must be installed to run this benchmark"
+  exit 1
+fi
+
 if [[ -z "${S3_BUCKET_NAME}" ]]; then
   echo "Set S3_BUCKET_NAME to run this benchmark"
   exit 1

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! command -v fio &> /dev/null; then
+  echo "fio must be installed to run this benchmark"
+  exit 1
+fi
+
 if [[ -z "${S3_BUCKET_NAME}" ]]; then
   echo "Set S3_BUCKET_NAME to run this benchmark"
   exit 1


### PR DESCRIPTION
The action wasn't quite hooked up properly to the script, and the script wasn't parsing arguments properly if there were unexpected positional args. That's now fixed in the script too.

(I have no idea why the inputs aren't working properly as booleans. I'd rather we didn't have the `fromJSON(...)` but here we are.)

I've verified that this is now working in my fork: https://github.com/dannycjones/mountpoint-s3/actions/runs/5360459957

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
