### PR TITLE
Add `mkdir` and `rmdir` to reftests

### DIFF
--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -181,7 +181,6 @@ impl Reference {
         self.materialized = self.rematerialize();
     }
 
-    #[allow(unused)] // TODO: use to test `mkdir`
     pub fn add_local_directory(&mut self, path: impl AsRef<Path>) {
         let path = path.as_ref().to_owned();
         assert!(!self.local_directories.contains(&path), "duplicate local directory");
@@ -199,7 +198,6 @@ impl Reference {
         self.materialized = self.rematerialize();
     }
 
-    #[allow(unused)] // TODO: use to test `rmdir`
     pub fn remove_local_directory(&mut self, path: impl AsRef<Path>) {
         let idx = self
             .local_directories
@@ -208,6 +206,17 @@ impl Reference {
             .expect("local file must exist");
         self.local_directories.remove(idx);
         self.materialized = self.rematerialize();
+    }
+
+    /// When a file is made remote, all its parent directories implicitly become remote too. This
+    /// method removes those parents from the local directories list if they exist.
+    pub fn remove_local_parents(&mut self, path: impl AsRef<Path>) {
+        let parent = path
+            .as_ref()
+            .parent()
+            .expect("cannot remove local parents without a root");
+        // Path::starts_with only considers whole path components
+        self.local_directories.retain(|dir| !parent.starts_with(dir));
     }
 
     pub fn add_remote_key(&mut self, key: String, object: MockObject) {

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -215,7 +215,8 @@ impl Reference {
             .as_ref()
             .parent()
             .expect("cannot remove local parents without a root");
-        // Path::starts_with only considers whole path components
+        // [Path::starts_with] only considers whole path components, so this won't remove a local
+        // directory `a` if a sibling `ab` became remote, even though "ab" starts with "a".
         self.local_directories.retain(|dir| !parent.starts_with(dir));
     }
 


### PR DESCRIPTION
Nothing too surprising here -- we test that we can create directories as
long as a conflicting name doesn't already exist, and then we can remove
directories if and only if they're local and empty.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
