### PR TITLE
Enable PUT checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +1940,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "base64ct",
  "built",
  "bytes",
  "clap 3.2.25",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 aws-config = "0.54.1"
 aws-credential-types = "0.54.1"
 aws-sdk-s3 = "0.24.0"
+base64ct = { version = "1.6.0", features = ["std"] }
 bytes = "1.2.1"
 clap = "3.2.12"
 ctor = "0.1.23"

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -247,7 +247,23 @@ pub enum GetObjectAttributesError {
 /// TODO: Populate this struct with parameters from the S3 API, e.g., storage class, encryption.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct PutObjectParams {}
+pub struct PutObjectParams {
+    /// Enable Crc32c trailing checksums.
+    pub trailing_checksums: bool,
+}
+
+impl PutObjectParams {
+    /// Create a default [PutObjectParams].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set Crc32c trailing checksums.
+    pub fn trailing_checksums(mut self, value: bool) -> Self {
+        self.trailing_checksums = value;
+        self
+    }
+}
 
 /// A streaming put request which allows callers to asynchronously write
 /// the body of the request.

--- a/mountpoint-s3-crt/src/checksums/crc32.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32.rs
@@ -9,6 +9,11 @@ impl Crc32 {
     pub fn new(value: u32) -> Crc32 {
         Crc32(value)
     }
+
+    /// The CRC32 checksum value.
+    pub fn value(&self) -> u32 {
+        self.0
+    }
 }
 
 /// Computes the CRC32 checksum of a byte slice.

--- a/mountpoint-s3-crt/src/checksums/crc32c.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32c.rs
@@ -9,6 +9,11 @@ impl Crc32c {
     pub fn new(value: u32) -> Crc32c {
         Crc32c(value)
     }
+
+    /// The CRC32C checksum value.
+    pub fn value(&self) -> u32 {
+        self.0
+    }
 }
 
 /// Computes the CRC32C checksum of a byte slice.

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -68,10 +68,8 @@ where
         bucket: &str,
         key: &str,
     ) -> ObjectClientResult<Self, PutObjectError, Client::ClientError> {
-        let request = inner
-            .client
-            .put_object(bucket, key, &PutObjectParams::default())
-            .await?;
+        let params = PutObjectParams::new().trailing_checksums(true);
+        let request = inner.client.put_object(bucket, key, &params).await?;
 
         Ok(Self {
             bucket: bucket.to_owned(),


### PR DESCRIPTION
## Description of change

Enable Crc32c checksums when uploading objects. PUT requests now have an option to enable trailing checksums. 

## Does this change impact existing behavior?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
