### PR TITLE
Checkout PR branch when running ASAN workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -114,6 +114,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
+        ref: ${{ inputs.ref }}
         submodules: true
     - name: Install nightly Rust
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Description of change

Fix the Address Sanitizer workflow to checkout the PR branch (rather than `main`).

## Does this change impact existing behavior?

N/A
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
