### PR TITLE
Calculate crc32c checksums on write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "bytes",
  "clap 4.3.9",
  "const_format",
+ "crc32c",
  "ctor",
  "ctrlc",
  "fuser",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -31,6 +31,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
 home = "0.5.4"
 serde_json = "1.0.95"
+crc32c = "0.6.3"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/mountpoint-s3/src/checksums.rs
+++ b/mountpoint-s3/src/checksums.rs
@@ -1,0 +1,57 @@
+use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};
+
+/// A [ChecksummedSlice] is a slice that carries its [Crc32c] checksum.
+#[derive(Debug, Clone, Copy)]
+pub struct ChecksummedSlice<'a> {
+    slice: &'a [u8],
+    checksum: Crc32c,
+}
+
+impl<'a> ChecksummedSlice<'a> {
+    /// Create a [ChecksummedSlice] from a slice.
+    pub fn new(slice: &'a [u8]) -> Self {
+        let checksum = crc32c::checksum(slice);
+        Self { slice, checksum }
+    }
+
+    /// The slice in this [ChecksummedSlice].
+    pub fn slice(&self) -> &[u8] {
+        self.slice
+    }
+
+    /// Returns the number of elements in the slice.
+    pub fn len(&self) -> usize {
+        self.slice.len()
+    }
+
+    /// Returns `true` if the slice has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        self.slice.is_empty()
+    }
+
+    /// Calculates the combined checksum for `AB` where `A` has checksum
+    /// `prefix_checksum` and `B` is this slice.
+    pub fn combined_with_prefix(&self, prefix_checksum: &Crc32c) -> Crc32c {
+        Crc32c::new(::crc32c::crc32c_combine(
+            prefix_checksum.value(),
+            self.checksum.value(),
+            self.slice.len(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combine() {
+        const FULL_DATA: &[u8] = b"foobar";
+        let prefix_checksum = crc32c::checksum(&FULL_DATA[..3]);
+        let data = &FULL_DATA[3..];
+        let slice = ChecksummedSlice::new(data);
+        let combined_checksum = slice.combined_with_prefix(&prefix_checksum);
+        let full_checksum = crc32c::checksum(FULL_DATA);
+        assert_eq!(full_checksum, combined_checksum);
+    }
+}

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -11,6 +11,7 @@ use tracing::{debug, error, trace, warn};
 use fuser::{FileAttr, KernelConfig};
 use mountpoint_s3_client::{ETag, ObjectClient};
 
+use crate::checksums::ChecksummedSlice;
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, WriteHandle};
 use crate::prefetch::checksummed_bytes::IntegrityError;
 use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
@@ -69,7 +70,7 @@ enum UploadState<Client: ObjectClient> {
 }
 
 impl<Client: ObjectClient> UploadState<Client> {
-    async fn write(&mut self, offset: i64, data: &[u8], key: &str) -> Result<u32, libc::c_int> {
+    async fn write(&mut self, offset: i64, data: ChecksummedSlice<'_>, key: &str) -> Result<u32, libc::c_int> {
         let upload = self.get_upload_in_progress(key)?;
         match upload.write(offset, data).await {
             Ok(len) => Ok(len as u32),
@@ -537,17 +538,18 @@ where
         ino: InodeNo,
         fh: u64,
         offset: i64,
-        data: &[u8],
+        data: ChecksummedSlice<'_>,
         _write_flags: u32,
         _flags: i32,
         _lock_owner: Option<u64>,
     ) -> Result<u32, libc::c_int> {
+        let len = data.len();
         trace!(
             "fs:write with ino {:?} fh {:?} offset {:?} size {:?}",
             ino,
             fh,
             offset,
-            data.len()
+            len
         );
 
         let handle = {

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -6,6 +6,7 @@ use std::ffi::OsStr;
 use std::time::Duration;
 use tracing::{instrument, Instrument};
 
+use crate::checksums::ChecksummedSlice;
 use crate::fs::{DirectoryReplier, InodeNo, ReadReplier, S3Filesystem, S3FilesystemConfig};
 use crate::prefix::Prefix;
 use fuser::{
@@ -267,7 +268,15 @@ where
     ) {
         match block_on(
             self.fs
-                .write(ino, fh, offset, data, write_flags, flags, lock_owner)
+                .write(
+                    ino,
+                    fh,
+                    offset,
+                    ChecksummedSlice::new(data),
+                    write_flags,
+                    flags,
+                    lock_owner,
+                )
                 .in_current_span(),
         ) {
             Ok(bytes_written) => reply.written(bytes_written),

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod checksums;
 pub mod fs;
 pub mod fuse;
 mod inode;

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -1,6 +1,7 @@
 //! Manually implemented tests executing the FUSE protocol against [S3Filesystem]
 
 use fuser::FileType;
+use mountpoint_s3::checksums::ChecksummedSlice;
 use mountpoint_s3::fs::FUSE_ROOT_INODE;
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::failure_client::countdown_failure_client;
@@ -288,7 +289,10 @@ async fn test_sequential_write(write_size: usize) {
 
     let mut offset = 0;
     for data in body.chunks(write_size) {
-        let written = fs.write(file_ino, fh, offset, data, 0, 0, None).await.unwrap();
+        let written = fs
+            .write(file_ino, fh, offset, ChecksummedSlice::new(data), 0, 0, None)
+            .await
+            .unwrap();
         assert_eq!(written as usize, data.len());
         offset += written as i64;
     }
@@ -370,17 +374,20 @@ async fn test_unordered_write_fails() {
         .unwrap()
         .fh;
 
-    let written = fs.write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None).await.unwrap();
+    let written = fs
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
+        .await
+        .unwrap();
     assert_eq!(written, 27);
 
     let err = fs
-        .write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect_err("writes to earlier offsets should fail");
     assert_eq!(err, libc::EINVAL);
 
     let err = fs
-        .write(file_ino, fh, 55, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 55, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect_err("writes to later offsets should fail");
     assert_eq!(err, libc::EINVAL);
@@ -445,20 +452,28 @@ async fn test_upload_aborted_on_write_failure() {
         .fh;
 
     let written = fs
-        .write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect("first write should succeed");
 
     assert!(client.is_upload_in_progress(FILE_NAME));
 
     let write_error = fs
-        .write(file_ino, fh, written as i64, &[0xaa; 27], 0, 0, None)
+        .write(
+            file_ino,
+            fh,
+            written as i64,
+            ChecksummedSlice::new(&[0xaa; 27]),
+            0,
+            0,
+            None,
+        )
         .await
         .expect_err("second write should fail");
     assert_eq!(write_error, libc::EIO);
 
     let err = fs
-        .write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect_err("subsequent writes should fail");
     assert_eq!(err, libc::EIO);
@@ -512,7 +527,7 @@ async fn test_upload_aborted_on_fsync_failure() {
         .fh;
 
     _ = fs
-        .write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect("first write should succeed");
 
@@ -567,7 +582,7 @@ async fn test_upload_aborted_on_release_failure() {
         .fh;
 
     _ = fs
-        .write(file_ino, fh, 0, &[0xaa; 27], 0, 0, None)
+        .write(file_ino, fh, 0, ChecksummedSlice::new(&[0xaa; 27]), 0, 0, None)
         .await
         .expect("first write should succeed");
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use fuser::FileType;
 use futures::executor::ThreadPool;
 use futures::future::{BoxFuture, FutureExt};
+use mountpoint_s3::checksums::ChecksummedSlice;
 use mountpoint_s3::fs::{InodeNo, ReadReplier, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
@@ -342,7 +343,7 @@ impl Harness {
                 inflight_write.inode,
                 file_handle,
                 inflight_write.written as i64,
-                &bytes_to_write,
+                ChecksummedSlice::new(&bytes_to_write),
                 0,
                 0,
                 None,


### PR DESCRIPTION
## Description of change

Maintain a running crc32c checksum on the data received in write calls, before streaming it to the put request.

## Does this change impact existing behavior?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
