### PR TITLE
Turn write support on

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ env:
   # A bucket our IAM role has no access to, but is in the right region, for permissions tests
   S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   S3_REGION: ${{ vars.S3_REGION }}
-  RUST_FEATURES: fuse_tests,s3_tests,checksum
+  RUST_FEATURES: fuse_tests,s3_tests,checksum,delete
 
 permissions:
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_FEATURES: fuse_tests,checksum
+  RUST_FEATURES: fuse_tests,checksum,delete
 
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -55,7 +55,7 @@ walkdir = "2.3.3"
 fuse_tests = []
 s3_tests = []
 shuttle = []
-put = []
+delete = []
 # A temporary feature flag to enable read-path checksums while we are working to improve its performance
 checksum = []
 

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -283,6 +283,7 @@ where
         }
     }
 
+    #[cfg(feature = "delete")]
     #[instrument(level="debug", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
     fn unlink(&self, _req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
         match block_on(self.fs.unlink(parent, name).in_current_span()) {

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -436,8 +436,6 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 
     let fs_name = String::from("mountpoint-s3");
     let mut options = vec![
-        #[cfg(not(feature = "put"))]
-        MountOption::RO,
         MountOption::DefaultPermissions,
         MountOption::FSName(fs_name),
         MountOption::NoAtime,

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -7,6 +7,7 @@ mod prefetch_test;
 mod readdir_test;
 mod rmdir_test;
 mod semantics_doc_test;
+#[cfg(feature = "delete")]
 mod unlink_test;
 mod write_test;
 


### PR DESCRIPTION
## Description of change

Enable write support by removing the `put` feature. Delete (`unlink`) is still not officially supported and only enabled under the `delete` feature.

Update SEMANTICS.md docs to reflect the change.

## Does this change impact existing behavior?

Write operations (not including delete) are now supported. Release version increased to `0.3.0`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
