### PR TITLE
Enforce maximum upload size

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -63,11 +63,13 @@ fn main() {
         .map(|s| s.parse::<usize>().expect("iterations must be a number"));
     let region = matches.get_one::<String>("region").unwrap();
 
-    let config = S3ClientConfig {
-        throughput_target_gbps,
-        part_size,
-        ..Default::default()
-    };
+    let mut config = S3ClientConfig::new();
+    if let Some(throughput_target_gbps) = throughput_target_gbps {
+        config = config.throughput_target_gbps(throughput_target_gbps);
+    }
+    if let Some(part_size) = part_size {
+        config = config.part_size(part_size);
+    }
     let client = S3CrtClient::new(region, config).expect("couldn't create client");
 
     for i in 0..iterations.unwrap_or(1) {

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -68,6 +68,10 @@ where
     type PutObjectRequest = FailurePutObjectRequest<Client, GetWrapperState>;
     type ClientError = Client::ClientError;
 
+    fn part_size(&self) -> Option<usize> {
+        self.client.part_size()
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -249,6 +249,10 @@ impl ObjectClient for MockClient {
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
+    fn part_size(&self) -> Option<usize> {
+        Some(self.config.part_size)
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -61,6 +61,10 @@ pub trait ObjectClient {
     type PutObjectRequest: PutObjectRequest<ClientError = Self::ClientError>;
     type ClientError: std::error::Error + Send + Sync + 'static;
 
+    /// Query the part size this client uses for PUT and GET operations to the object store. This
+    /// can be `None` if the client does not do multi-part operations.
+    fn part_size(&self) -> Option<usize>;
+
     /// Delete a single object from the object store.
     ///
     /// DeleteObject will succeed even if the object within the bucket does not exist.

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -63,8 +63,7 @@ impl S3CrtClient {
                 .map_err(S3RequestError::construction_failure)?;
 
             let length = range.end.saturating_sub(range.start);
-            let part_size = self.inner.part_size.unwrap_or(0) as u64;
-            if length >= part_size {
+            if length >= self.inner.part_size as u64 {
                 (MetaRequestType::GetObject, 0)
             } else {
                 (MetaRequestType::Default, range.start)

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -53,10 +53,7 @@ async fn test_static_provider() {
         session_token: credentials.session_token(),
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
-    let config = S3ClientConfig {
-        auth_config: S3ClientAuthConfig::Provider(provider),
-        ..Default::default()
-    };
+    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Provider(provider));
     let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let result = client
@@ -75,10 +72,7 @@ async fn test_static_provider() {
         session_token: credentials.session_token(),
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
-    let config = S3ClientConfig {
-        auth_config: S3ClientAuthConfig::Provider(provider),
-        ..Default::default()
-    };
+    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Provider(provider));
     let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let mut request = client
@@ -146,10 +140,7 @@ aws_secret_access_key = {}",
     std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
 
     // Build a S3CrtClient that uses the config file
-    let config = S3ClientConfig {
-        auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
-        ..Default::default()
-    };
+    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()));
     let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let result = client
@@ -164,10 +155,7 @@ aws_secret_access_key = {}",
     let length = config_file.as_file().metadata().unwrap().len();
     config_file.as_file_mut().set_len(length - 5).unwrap();
 
-    let config = S3ClientConfig {
-        auth_config: S3ClientAuthConfig::Profile(profile_name.to_owned()),
-        ..Default::default()
-    };
+    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()));
     let client = S3CrtClient::new(&get_test_region(), config).unwrap();
 
     let mut request = client
@@ -184,10 +172,8 @@ aws_secret_access_key = {}",
     // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
     // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
     // be constructed.
-    let config = S3ClientConfig {
-        auth_config: S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()),
-        ..Default::default()
-    };
+    let config =
+        S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()));
     let _result = S3CrtClient::new(&get_test_region(), config).expect_err("profile doesn't exist");
 }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -18,13 +18,7 @@ fn init_tracing_subscriber() {
 }
 
 pub fn get_test_client() -> S3CrtClient {
-    // Try to match what mountpoint-s3's defaults are
-    let client_config = S3ClientConfig {
-        throughput_target_gbps: Some(10.0),
-        part_size: Some(8 * 1024 * 1024),
-        ..Default::default()
-    };
-    S3CrtClient::new(&get_test_region(), client_config).expect("could not create test client")
+    S3CrtClient::new(&get_test_region(), S3ClientConfig::new()).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -26,10 +26,7 @@ async fn run_test<F: FnOnce(&str) -> Endpoint>(f: F) {
 
     let region = get_test_region();
     let endpoint = f(&region);
-    let config = S3ClientConfig {
-        endpoint: Some(endpoint),
-        ..Default::default()
-    };
+    let config = S3ClientConfig::new().endpoint(endpoint);
     let client = S3CrtClient::new(&region, config).expect("could not create test client");
 
     let result = client

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -195,11 +195,7 @@ async fn test_put_object_abort() {
 async fn test_put_checksums() {
     const PART_SIZE: usize = 5 * 1024 * 1024;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
-    let client_config = S3ClientConfig {
-        throughput_target_gbps: Some(10.0),
-        part_size: Some(PART_SIZE),
-        ..Default::default()
-    };
+    let client_config = S3ClientConfig::new().part_size(PART_SIZE);
     let client = S3CrtClient::new(&get_test_region(), client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 

--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -146,10 +146,10 @@ fn mount_file_system(bucket_name: &str, region: &str, throughput_target_gbps: Op
     let temp_dir = tempdir().expect("Should be able to create temp directory");
     let mountpoint = temp_dir.path();
 
-    let config = S3ClientConfig {
-        throughput_target_gbps,
-        ..Default::default()
-    };
+    let mut config = S3ClientConfig::new();
+    if let Some(throughput_target_gbps) = throughput_target_gbps {
+        config = config.throughput_target_gbps(throughput_target_gbps);
+    }
     let client = S3CrtClient::new(region, config).expect("Failed to create S3 client");
     let runtime = client.event_loop_group();
 

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -67,11 +67,13 @@ fn main() {
         .map(|s| s.parse::<usize>().expect("iterations must be a number"));
     let region = matches.get_one::<String>("region").unwrap();
 
-    let config = S3ClientConfig {
-        throughput_target_gbps,
-        part_size,
-        ..Default::default()
-    };
+    let mut config = S3ClientConfig::new();
+    if let Some(throughput_target_gbps) = throughput_target_gbps {
+        config = config.throughput_target_gbps(throughput_target_gbps);
+    }
+    if let Some(part_size) = part_size {
+        config = config.part_size(part_size);
+    }
     let client = Arc::new(S3CrtClient::new(region, config).expect("couldn't create client"));
 
     for i in 0..iterations.unwrap_or(1) {

--- a/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
@@ -4,15 +4,14 @@ use std::{
 };
 
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 
 fn mkdir_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 

--- a/mountpoint-s3/tests/fuse_tests/mount_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/mount_test.rs
@@ -2,17 +2,16 @@ use std::fs::{read_dir, File};
 use std::io::{Read as _, Seek, SeekFrom};
 
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use rand::RngCore;
 use rand::SeedableRng as _;
 use rand_chacha::ChaChaRng;
 use tempfile::TempDir;
 
-use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 
 fn basic_read_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let mut rng = ChaChaRng::seed_from_u64(0x87654321);
 

--- a/mountpoint-s3/tests/fuse_tests/perm_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/perm_test.rs
@@ -10,11 +10,11 @@ use nix::unistd::{getgid, getuid};
 use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 
 fn perm_test<F>(creator_fn: F, uid: Option<u32>, gid: Option<u32>, dir_mode: Option<u16>, file_mode: Option<u16>)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let mut config = S3FilesystemConfig::default();
     if let Some(id) = uid {
@@ -30,7 +30,13 @@ where
         config.file_mode = mode;
     }
 
-    let (mount_point, _session, mut test_client) = creator_fn("", config);
+    let (mount_point, _session, mut test_client) = creator_fn(
+        "",
+        TestSessionConfig {
+            filesystem_config: config,
+            ..Default::default()
+        },
+    );
 
     // expected values
     let uid = uid.unwrap_or_else(|| getuid().into());
@@ -85,7 +91,7 @@ fn perm_test_negative<F>(
     dir_mode: Option<u16>,
     file_mode: Option<u16>,
 ) where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let mut config = S3FilesystemConfig::default();
     if let Some(id) = uid {
@@ -101,7 +107,13 @@ fn perm_test_negative<F>(
         config.file_mode = mode;
     }
 
-    let (mount_point, _session, mut test_client) = creator_fn("", config);
+    let (mount_point, _session, mut test_client) = creator_fn(
+        "",
+        TestSessionConfig {
+            filesystem_config: config,
+            ..Default::default()
+        },
+    );
 
     // expected values
     let uid = uid.unwrap_or_else(|| getuid().into());

--- a/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
@@ -1,6 +1,5 @@
-use crate::fuse_tests::{read_dir_to_entry_names, wait_for_success};
+use crate::fuse_tests::{read_dir_to_entry_names, wait_for_success, TestSessionConfig};
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use std::fs::{self, DirBuilder, File};
 use std::io::Write;
 use tempfile::TempDir;
@@ -10,7 +9,7 @@ use crate::fuse_tests::TestClientBox;
 
 fn rmdir_local_dir_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, test_client) = creator_fn(prefix, Default::default());
 
@@ -89,7 +88,7 @@ fn rmdir_local_dir_test_s3(prefix: &str) {
 
 fn rmdir_remote_dir_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 
@@ -150,7 +149,7 @@ fn rmdir_remote_dir_test_s3(prefix: &str) {
 
 fn create_after_rmdir_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, _test_client) = creator_fn(prefix, Default::default());
     // Create local directory

--- a/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
@@ -1,11 +1,10 @@
 use std::path::Path;
 
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use tempfile::TempDir;
 use walkdir::WalkDir;
 
-use crate::fuse_tests::TestClientBox;
+use crate::fuse_tests::{TestClientBox, TestSessionConfig};
 
 /// Recursively list the contents of a directory and return the paths of all entries, with the
 /// initial `path` stripped. If `files` is true, the list contains only files; if false, it contains
@@ -53,7 +52,7 @@ fn list_dir_recursive(path: impl AsRef<Path>, files: bool) -> Result<Vec<String>
 ///     * `list.txt` (file)
 fn basic_directory_structure<F>(creator_fn: F)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn("basic_directory_structure", Default::default());
 
@@ -95,7 +94,7 @@ fn basic_directory_structure_s3() {
 /// creating directories in a bucket, and so these directories will work as expected.
 fn keys_ending_in_delimiter<F>(creator_fn: F)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn("keys_ending_in_delimiter", Default::default());
 
@@ -132,7 +131,7 @@ fn keys_ending_in_delimiter_s3() {
 /// remove the `blue` directory, and cause the `blue` file to become visible.
 fn files_shadowed_by_directories<F>(creator_fn: F)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn("files_shadowed_by_directories", Default::default());
 

--- a/mountpoint-s3/tests/fuse_tests/unlink_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/unlink_test.rs
@@ -2,16 +2,15 @@ use std::fs::{self, File};
 use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::fuse_tests::{read_dir_to_entry_names, wait_for_success, TestClientBox};
+use crate::fuse_tests::{read_dir_to_entry_names, wait_for_success, TestClientBox, TestSessionConfig};
 
 /// Simple test cases, assuming a file isn't open for reading elsewhere.
 fn simple_unlink_tests<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 
@@ -57,7 +56,7 @@ fn simple_unlink_test_mock(prefix: &str) {
 /// Testing behavior when a file is unlinked in the middle of reading
 fn unlink_readhandle_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 
@@ -106,7 +105,7 @@ fn unlink_readhandle_test_mock(prefix: &str) {
 /// Testing behavior when a file is unlinked during and after writing
 fn unlink_writehandle_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -278,3 +278,53 @@ fn fsync_test_s3() {
 fn fsync_test_mock() {
     fsync_test(crate::fuse_tests::mock_session::new);
 }
+
+fn write_too_big_test<F>(creator_fn: F, write_size: usize)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const KEY: &str = "new.txt";
+    const PART_SIZE: usize = 64;
+    const MAX_S3_MULTIPART_UPLOAD_PARTS: usize = 10000;
+
+    let config = TestSessionConfig {
+        part_size: PART_SIZE,
+        ..Default::default()
+    };
+    let (mount_point, _session, _test_client) = creator_fn("write_too_big_test", config);
+
+    let path = mount_point.path().join(KEY);
+
+    let mut f = open_for_write(&path, false).unwrap();
+
+    let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;
+    let data = vec![0xaa; write_size];
+    for _ in 0..successful_writes {
+        f.write_all(&data).expect("object should fit");
+    }
+
+    let err = f.write_all(&data).expect_err("object should be too big");
+    assert_eq!(err.raw_os_error(), Some(libc::EFBIG));
+
+    let err = f
+        .sync_all()
+        .expect_err("upload should not succeed after growing too big");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOSPC));
+
+    drop(f);
+
+    // Wait a bit for `release` to be sure
+    std::thread::sleep(Duration::from_secs(5));
+
+    let err = metadata(&path).expect_err("upload shouldn't have succeeded");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+}
+
+// We intentionally don't run this test against S3 because the part size minimum is 5MiB there, and
+// so we'd have to upload 5MiB * 10000 = 50GiB to test the failure case.
+#[test_case(8000; "divisible by max size")]
+#[test_case(7000; "not divisible by max size")]
+#[test_case(640001; "single write too big")]
+fn write_too_big_test_mock(write_size: usize) {
+    write_too_big_test(crate::fuse_tests::mock_session::new, write_size);
+}

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -5,13 +5,12 @@ use std::path::Path;
 use std::time::Duration;
 
 use fuser::BackgroundSession;
-use mountpoint_s3::S3FilesystemConfig;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox};
+use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 
 fn open_for_write(path: impl AsRef<Path>, append: bool) -> std::io::Result<File> {
     let mut options = File::options();
@@ -25,7 +24,7 @@ fn open_for_write(path: impl AsRef<Path>, append: bool) -> std::io::Result<File>
 
 fn sequential_write_test<F>(creator_fn: F, prefix: &str, append: bool)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     const OBJECT_SIZE: usize = 50 * 1024;
     const WRITE_SIZE: usize = 1024;
@@ -104,7 +103,7 @@ fn sequential_write_test_mock(prefix: &str, append: bool) {
 
 fn write_errors_test<F>(creator_fn: F, prefix: &str)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
 
@@ -158,7 +157,7 @@ fn write_errors_test_mock(prefix: &str) {
 
 fn sequential_write_streaming_test<F>(creator_fn: F, object_size: usize, write_chunk_size: usize)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     const KEY: &str = "dir/new.txt";
 
@@ -228,7 +227,7 @@ fn sequential_write_streaming_test_mock(object_size: usize, write_chunk_size: us
 
 fn fsync_test<F>(creator_fn: F)
 where
-    F: FnOnce(&str, S3FilesystemConfig) -> (TempDir, BackgroundSession, TestClientBox),
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
 {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";


### PR DESCRIPTION
This turned out to be a lot of refactoring to expose the client's part size and allow our FUSE tests to choose a part size. So it might be easier to read the three commits individually.

## Description of change

Uploads can fail if they require more than 10,000 parts. Right now we
only find out about that failure asynchronously when the CRT actually
constructs the 10,0001th part. This is bad because unlike other upload
errors, this one is a deterministic failure that we should be able to
report up front.

One trick here is that the kernel appears to retry failed writes from
page cache when returning EFBIG, so we need to remember the reason the
write failed.

Relevant issues: Fixes #299

## Does this change impact existing behavior?

Yes, uploads will fail earlier than they did before, and with a different error code.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
