### PR TITLE
Add automation to warn on comment visibility for closed issues

### DIFF
--- a/.github/workflows/closed_issue.yml
+++ b/.github/workflows/closed_issue.yml
@@ -1,0 +1,20 @@
+name: Closed Issue Message
+on:
+  issues:
+    types: [closed]
+jobs:
+  auto_comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: aws-actions/closed-issue-message@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        message: |
+          ### ⚠️ COMMENT VISIBILITY WARNING ⚠️ 
+          
+          Comments on closed issues are hard for our team to see. 
+          If you need more assistance, please either tag a team member or open a new issue that references this one. 
+
+          If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
## Description of change

This change adds an automated message to encourage users to open new issues.

This is important because we would prefer users cut new issues so that we can focus on these features or bug reports in isolation, and provide clear answers and/or actions.

## Does this change impact existing behavior?

Repo change only, no impact to Mountpoint.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
