### PR TITLE
Configure Dependabot to update Cargo and GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "cargo"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "wednesday"
+    time: "08:00"
+    timezone: "Europe/London"


### PR DESCRIPTION
## Description of change

This change means we'll pick up new dependency updates on a regular basis for both crate dependencies in Mountpoint as well as our CI.

Relevant issues:
- Closes #268 

Tested in fork: https://github.com/dannycjones/mountpoint-s3/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot

## Does this change impact existing behavior?

No change to Mountpoint itself.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
