### PR TITLE
Abort upload on out-of-order writes

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -76,15 +76,10 @@ impl<Client: ObjectClient> UploadState<Client> {
             Ok(len) => Ok(len as u32),
             Err(e) => {
                 error!("write failed: {e}");
-                match e {
-                    UploadWriteError::PutRequestFailed(_) | UploadWriteError::ObjectTooBig { .. } => {
-                        // Abort the request.
-                        let ret: libc::c_int = e.into();
-                        *self = Self::Failed(ret);
-                        Err(ret)
-                    }
-                    UploadWriteError::OutOfOrderWrite { .. } => Err(e.into()),
-                }
+                // Abort the request.
+                let ret: libc::c_int = e.into();
+                *self = Self::Failed(ret);
+                Err(ret)
             }
         }
     }


### PR DESCRIPTION
## Description of change

Out-of-order writes previously failed but would not abort the upload and would even allow to resume writing sequentially.   

This change aborts the upload and mark the file handle has failed, so that subsequent operations (e.g. write, fsync) will return an error.

## Does this change impact existing behavior?

Yes, the behavior of write when trying to write out-of-order has changed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
