### PR TITLE
Limit dependabot to focus on lockfile updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
     day: "wednesday"
     time: "08:00"
     timezone: "Europe/London"
+  versioning-strategy: lockfile-only


### PR DESCRIPTION
## Description of change

With the current configuration, Dependabot was trying to merge breaking changes. For now, let's focus only on lockfile updates.

## Does this change impact existing behavior?

GitHub repo only. No Mountpoint changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
