### PR TITLE
Disable dependabot cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-- package-ecosystem: "cargo"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "wednesday"
-    time: "08:00"
-    timezone: "Europe/London"
-  versioning-strategy: lockfile-only


### PR DESCRIPTION
## Description of change

Dependabot is not behaving as we expected. We do not want to make major version changes without reason, but even lockfile updates appear to include these.

Let's disable automated cargo dependabot changes for now.

## Does this change impact existing behavior?

Does not impact Mountpoint.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
