### PR TITLE
Explicitly prevent mounting over an existing mount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -1779,6 +1779,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1911,6 +1917,7 @@ dependencies = [
  "nix",
  "once_cell",
  "predicates 2.1.5",
+ "procfs",
  "proptest",
  "proptest-derive",
  "rand",
@@ -2342,6 +2349,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "rustix 0.36.14",
+]
+
+[[package]]
 name = "proptest"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2586,20 @@ checksum = "a45e222b29b1c72df440525c4158fa44fda5347a95f14dc47bb37fd7c1969b43"
 
 [[package]]
 name = "rustix"
+version = "0.36.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
@@ -2574,7 +2608,7 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
 
@@ -2919,7 +2953,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -3507,7 +3541,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3527,11 +3561,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -32,6 +32,9 @@ const_format = "0.2.30"
 home = "0.5.4"
 serde_json = "1.0.95"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { version = "0.15.1", default-features = false }
+
 [dev-dependencies]
 assert_cmd = "2.0.6"
 assert_fs = "1.0.9"

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -251,14 +251,6 @@ impl CliArgs {
 fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
-    // validate mount point
-    if !args.mount_point.exists() || !args.mount_point.is_dir() {
-        return Err(anyhow!(
-            "Mount point {} does not exist or it is not a directory",
-            args.mount_point.display()
-        ));
-    }
-
     if args.foreground {
         init_tracing_subscriber(args.foreground, args.log_directory.as_deref())
             .context("failed to initialize logging")?;
@@ -369,6 +361,8 @@ fn main() -> anyhow::Result<()> {
 
 fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     const DEFAULT_TARGET_THROUGHPUT: f64 = 10.0;
+
+    validate_mount_point(&args.mount_point)?;
 
     let addressing_style = args.addressing_style();
     let endpoint = args
@@ -569,6 +563,39 @@ fn get_maximum_network_throughput(ec2_instance_type: &str) -> anyhow::Result<f64
         .get(ec2_instance_type)
         .and_then(|t| t.as_f64())
         .ok_or_else(|| anyhow!("no throughput configuration for EC2 instance type {ec2_instance_type}"))
+}
+
+fn validate_mount_point(path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let mount_point = path.as_ref();
+
+    if !mount_point.exists() {
+        return Err(anyhow!("mount point {} does not exist", mount_point.display()));
+    }
+
+    if !mount_point.is_dir() {
+        return Err(anyhow!("mount point {} is not a directory", mount_point.display()));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use procfs::process::Process;
+
+        // This is a best-effort validation, so don't fail if we can't read /proc/self/mountinfo for
+        // some reason.
+        let mounts = match Process::myself().and_then(|me| me.mountinfo()) {
+            Ok(mounts) => mounts,
+            Err(e) => {
+                tracing::debug!("failed to read mountinfo, not checking for existing mounts: {e:?}");
+                return Ok(());
+            }
+        };
+
+        if mounts.iter().any(|mount| mount.mount_point == path.as_ref()) {
+            return Err(anyhow!("mount point {} is already mounted", path.as_ref().display()));
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -12,7 +12,7 @@ fn mount_point_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("mount-s3")?;
 
     cmd.arg("test-bucket").arg("test/dir");
-    let error_message = "Mount point test/dir does not exist or it is not a directory";
+    let error_message = "mount point test/dir does not exist";
     cmd.assert().failure().stderr(predicate::str::contains(error_message));
 
     Ok(())
@@ -20,14 +20,12 @@ fn mount_point_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn mount_point_isnt_dir() -> Result<(), Box<dyn std::error::Error>> {
-    let file = assert_fs::NamedTempFile::new("test/file.txt")?;
+    let file = assert_fs::NamedTempFile::new("file.txt")?;
+    fs::write(file.path(), b"hello")?;
     let mut cmd = Command::cargo_bin("mount-s3")?;
 
     cmd.arg("test-bucket").arg(file.path());
-    let error_message = format!(
-        "Mount point {} does not exist or it is not a directory",
-        file.path().display()
-    );
+    let error_message = format!("mount point {} is not a directory", file.path().display());
     cmd.assert().failure().stderr(predicate::str::contains(error_message));
 
     Ok(())


### PR DESCRIPTION
## Description of change

It's valid to mount multiple file systems to the same directory, but
doing so requires the first one to be mounted read-write, which is why
this wasn't a problem for us until #327. It seems libfuse2's version of
fusermount explicitly checked this(?), but libfuse3 no longer rejects
it.

In principle this might be something we'd want to allow, but I think the
less surprising/error-prone customer experience is to refuse to do it,
so let's explicitly forbid it.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
