### PR TITLE
Adds in support to configure storage class

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -99,6 +99,10 @@ impl MockClient {
     pub fn is_upload_in_progress(&self, key: &str) -> bool {
         self.in_progress_uploads.read().unwrap().contains(key)
     }
+
+    pub fn get_object_storage_class(&self, key: &str) -> String {
+        self.objects.read().unwrap().get(key).unwrap().storage_class.to_owned()
+    }
 }
 
 #[derive(Clone)]

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -99,10 +99,6 @@ impl MockClient {
     pub fn is_upload_in_progress(&self, key: &str) -> bool {
         self.in_progress_uploads.read().unwrap().contains(key)
     }
-
-    pub fn get_object_storage_class(&self, key: &str) -> String {
-        self.objects.read().unwrap().get(key).unwrap().storage_class.to_owned()
-    }
 }
 
 #[derive(Clone)]

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -255,7 +255,7 @@ pub struct PutObjectParams {
     /// Enable Crc32c trailing checksums.
     pub trailing_checksums: bool,
     /// Storage class to be used when creating new S3 object
-    pub storage_class: String,
+    pub storage_class: Option<String>,
 }
 
 impl PutObjectParams {
@@ -271,7 +271,7 @@ impl PutObjectParams {
     }
 
     /// Set the storage class.
-    pub fn storage_class(mut self, value: &str) -> Self {
+    pub fn storage_class(mut self, value: Option<String>) -> Self {
         self.storage_class = value.to_owned();
         self
     }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -254,6 +254,8 @@ pub enum GetObjectAttributesError {
 pub struct PutObjectParams {
     /// Enable Crc32c trailing checksums.
     pub trailing_checksums: bool,
+    /// Storage class to be used when creating new S3 object
+    pub storage_class: String,
 }
 
 impl PutObjectParams {
@@ -265,6 +267,12 @@ impl PutObjectParams {
     /// Set Crc32c trailing checksums.
     pub fn trailing_checksums(mut self, value: bool) -> Self {
         self.trailing_checksums = value;
+        self
+    }
+
+    /// Set the storage class.
+    pub fn storage_class(mut self, value: &str) -> Self {
+        self.storage_class = value.to_owned();
         self
     }
 }

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -49,6 +49,13 @@ impl S3CrtClient {
                 ObjectClientError::ClientError(S3RequestError::ResponseError(result))
             })?;
 
+        message
+            .add_header(&Header::new(
+                "x-amz-storage-class",
+                self.params.storage_class.to_owned(),
+            ))
+            .map_err(S3RequestError::construction_failure)?;
+
         Ok(S3PutObjectRequest {
             body,
             writer,

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -49,12 +49,11 @@ impl S3CrtClient {
                 ObjectClientError::ClientError(S3RequestError::ResponseError(result))
             })?;
 
-        message
-            .add_header(&Header::new(
-                "x-amz-storage-class",
-                self.params.storage_class.to_owned(),
-            ))
-            .map_err(S3RequestError::construction_failure)?;
+        if let Some(storage_class) = self.params.storage_class.to_owned() {
+            message
+                .add_header(&Header::new("x-amz-storage-class", storage_class))
+                .map_err(S3RequestError::construction_failure)?;
+        }
 
         Ok(S3PutObjectRequest {
             body,

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -18,6 +18,8 @@ use mountpoint_s3_crt::checksums::crc32c;
 use rand::Rng;
 use test_case::test_case;
 
+use test_case::test_case;
+
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
 // contents are correct with a GET.
 async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str) {
@@ -277,6 +279,69 @@ async fn test_put_review(pass_review: bool) {
     }
 }
 
+fn write_with_storage_class_test<F>(creator_fn: F, storage_class: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const KEY: &str = "new.txt";
+
+    let filesystem_config: S3FilesystemConfig = S3FilesystemConfig {
+        storage_class: Some(storage_class.to_owned()),
+        ..Default::default()
+    };
+
+    let config = TestSessionConfig {
+        filesystem_config,
+        ..Default::default()
+    };
+    let (mount_point, _session, test_client) = creator_fn("write_with_storage_class_test", config);
+
+    let path = mount_point.path().join(KEY);
+
+    let mut f = open_for_write(&path, false).unwrap();
+
+    let data = [0xaa; 16];
+    f.write_all(&data).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+
+    let s3_storage_class = test_client.get_storage_class(KEY).unwrap();
+    
+    assert_eq!(s3_storage_class, storage_class);
+
+}
+
+fn write_with_invalid_storage_class_test<F>(creator_fn: F, storage_class: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const KEY: &str = "new.txt";
+
+    let filesystem_config: S3FilesystemConfig = S3FilesystemConfig {
+        storage_class: Some(storage_class.to_owned()),
+        ..Default::default()
+    };
+
+    let config = TestSessionConfig {
+        filesystem_config,
+        ..Default::default()
+    };
+    let (mount_point, _session, _test_client) = creator_fn("write_with_storage_class_test", config);
+
+    let path = mount_point.path().join(KEY);
+    write_file(path).expect_err("write with invalid storage class should fail");
+  
+}
+
+fn write_file(path: PathBuf) -> std::io::Result<()> {
+    let mut f = open_for_write(&path, false)?;
+    let data = [0xaa; 16];
+    f.write_all(&data)?;
+    Ok(())
+}
+
+
 async fn check_get_object<Client: ObjectClient>(
     client: &Client,
     bucket: &str,
@@ -286,4 +351,17 @@ async fn check_get_object<Client: ObjectClient>(
     pin_mut!(result);
     result.next().await.unwrap()?;
     Ok(())
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case("INTELLIGENT_TIERING")]
+#[test_case("GLACIER")]
+fn write_with_storage_class_test_s3(storage_class: &str) {
+    write_with_storage_class_test(crate::fuse_tests::s3_session::new, storage_class);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case("INVALID_CLASS")]
+fn write_with_invalid_storage_class_test_s3(storage_class: &str) {
+    write_with_invalid_storage_class_test(crate::fuse_tests::s3_session::new, storage_class);
 }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -305,11 +305,9 @@ where
     f.sync_all().unwrap();
     drop(f);
 
-
     let s3_storage_class = test_client.get_storage_class(KEY).unwrap();
-    
-    assert_eq!(s3_storage_class, storage_class);
 
+    assert_eq!(s3_storage_class, storage_class);
 }
 
 fn write_with_invalid_storage_class_test<F>(creator_fn: F, storage_class: &str)
@@ -331,7 +329,6 @@ where
 
     let path = mount_point.path().join(KEY);
     write_file(path).expect_err("write with invalid storage class should fail");
-  
 }
 
 fn write_file(path: PathBuf) -> std::io::Result<()> {
@@ -340,7 +337,6 @@ fn write_file(path: PathBuf) -> std::io::Result<()> {
     f.write_all(&data)?;
     Ok(())
 }
-
 
 async fn check_get_object<Client: ObjectClient>(
     client: &Client,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -223,6 +223,8 @@ pub struct S3FilesystemConfig {
     pub file_mode: u16,
     /// Prefetcher configuration
     pub prefetcher_config: PrefetcherConfig,
+    /// Storage class to be used
+    pub storage_class: String,
 }
 
 impl Default for S3FilesystemConfig {
@@ -238,6 +240,7 @@ impl Default for S3FilesystemConfig {
             dir_mode: 0o755,
             file_mode: 0o644,
             prefetcher_config: PrefetcherConfig::default(),
+            storage_class: "INTELLIGENT_TIERING".to_string(),
         }
     }
 }
@@ -268,7 +271,7 @@ where
         let client = Arc::new(client);
 
         let prefetcher = Prefetcher::new(client.clone(), runtime, config.prefetcher_config);
-        let uploader = Uploader::new(client.clone());
+        let uploader = Uploader::new(client.clone(), &config.storage_class);
 
         Self {
             config,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -224,7 +224,7 @@ pub struct S3FilesystemConfig {
     /// Prefetcher configuration
     pub prefetcher_config: PrefetcherConfig,
     /// Storage class to be used
-    pub storage_class: String,
+    pub storage_class: Option<String>,
 }
 
 impl Default for S3FilesystemConfig {
@@ -240,7 +240,7 @@ impl Default for S3FilesystemConfig {
             dir_mode: 0o755,
             file_mode: 0o644,
             prefetcher_config: PrefetcherConfig::default(),
-            storage_class: "INTELLIGENT_TIERING".to_string(),
+            storage_class: None,
         }
     }
 }
@@ -271,7 +271,7 @@ where
         let client = Arc::new(client);
 
         let prefetcher = Prefetcher::new(client.clone(), runtime, config.prefetcher_config);
-        let uploader = Uploader::new(client.clone(), &config.storage_class);
+        let uploader = Uploader::new(client.clone(), config.storage_class.to_owned());
 
         Self {
             config,

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -215,7 +215,7 @@ struct CliArgs {
         help_heading = MOUNT_OPTIONS_HEADER
     )]
     pub read_only: bool,
-    
+
     #[clap(long, help = "Set the storage class for new objects", help_heading = BUCKET_OPTIONS_HEADER)]
     pub storage_class: Option<String>,
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -216,7 +216,7 @@ struct CliArgs {
     )]
     pub read_only: bool,
     
-    #[clap(long, help = "Set the storage class", help_heading = BUCKET_OPTIONS_HEADER)]
+    #[clap(long, help = "Set the storage class for new objects", help_heading = BUCKET_OPTIONS_HEADER)]
     pub storage_class: Option<String>,
 
     #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
@@ -496,9 +496,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     if let Some(file_mode) = args.file_mode {
         filesystem_config.file_mode = file_mode;
     }
-    if let Some(storage_class) = args.storage_class {
-        filesystem_config.storage_class = storage_class;
-    }    
+    filesystem_config.storage_class = args.storage_class;
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
 
     let prefix = args.prefix.unwrap_or_default();

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -215,6 +215,9 @@ struct CliArgs {
         help_heading = MOUNT_OPTIONS_HEADER
     )]
     pub read_only: bool,
+    
+    #[clap(long, help = "Set the storage class", help_heading = BUCKET_OPTIONS_HEADER)]
+    pub storage_class: Option<String>,
 
     #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
     pub auto_unmount: bool,
@@ -493,6 +496,9 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     if let Some(file_mode) = args.file_mode {
         filesystem_config.file_mode = file_mode;
     }
+    if let Some(storage_class) = args.storage_class {
+        filesystem_config.storage_class = storage_class;
+    }    
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
 
     let prefix = args.prefix.unwrap_or_default();

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -30,7 +30,7 @@ impl<Client: ObjectClient> Uploader<Client> {
     pub fn new(client: Arc<Client>, storage_class: Option<String>) -> Self {
         let inner = UploaderInner {
             client,
-            storage_class: storage_class,
+            storage_class,
         };
         Self { inner: Arc::new(inner) }
     }

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -22,15 +22,15 @@ pub struct Uploader<Client> {
 #[derive(Debug)]
 struct UploaderInner<Client> {
     client: Arc<Client>,
-    storage_class: String,
+    storage_class: Option<String>,
 }
 
 impl<Client: ObjectClient> Uploader<Client> {
     /// Create a new [Uploader] that will make requests to the given client.
-    pub fn new(client: Arc<Client>, storage_class: &str) -> Self {
+    pub fn new(client: Arc<Client>, storage_class: Option<String>) -> Self {
         let inner = UploaderInner {
             client,
-            storage_class: storage_class.to_owned(),
+            storage_class: storage_class,
         };
         Self { inner: Arc::new(inner) }
     }
@@ -77,7 +77,7 @@ impl<Client: ObjectClient> UploadRequest<Client> {
     ) -> ObjectClientResult<Self, PutObjectError, Client::ClientError> {
         let params = PutObjectParams::new()
             .trailing_checksums(true)
-            .storage_class(&inner.storage_class);
+            .storage_class(inner.storage_class.to_owned());
         let request = inner.client.put_object(bucket, key, &params).await?;
         let maximum_upload_size = inner.client.part_size().map(|ps| ps * MAX_S3_MULTIPART_UPLOAD_PARTS);
 

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -204,13 +204,12 @@ mod tests {
         let bucket = "bucket";
         let name = "hello";
         let key = name;
-        let storage_class = "INTELLIGENT_TIERING";
 
         let client = Arc::new(MockClient::new(MockClientConfig {
             bucket: bucket.to_owned(),
             part_size: 32,
         }));
-        let uploader = Uploader::new(client.clone(), storage_class);
+        let uploader = Uploader::new(client.clone(), None);
         let request = uploader.put(bucket, key).await.unwrap();
 
         assert!(!client.contains_key(key));
@@ -233,7 +232,7 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 32,
         }));
-        let uploader = Uploader::new(client.clone(), storage_class);
+        let uploader = Uploader::new(client.clone(), Some(storage_class.to_owned()));
 
         let mut request = uploader.put(bucket, key).await.unwrap();
 
@@ -263,7 +262,6 @@ mod tests {
         let bucket = "bucket";
         let name = "hello";
         let key = name;
-        let storage_class = "INTELLIGENT_TIERING";
 
         let client = Arc::new(MockClient::new(MockClientConfig {
             bucket: bucket.to_owned(),
@@ -282,7 +280,7 @@ mod tests {
             put_failures,
         ));
 
-        let uploader = Uploader::new(failure_client.clone(), storage_class);
+        let uploader = Uploader::new(failure_client.clone(), None);
 
         // First request fails on first write.
         {
@@ -317,13 +315,12 @@ mod tests {
         let bucket = "bucket";
         let name = "hello";
         let key = name;
-        let storage_class = "INTELLIGENT_TIERING";
 
         let client = Arc::new(MockClient::new(MockClientConfig {
             bucket: bucket.to_owned(),
             part_size: PART_SIZE,
         }));
-        let uploader = Uploader::new(client.clone(), storage_class);
+        let uploader = Uploader::new(client.clone(), None);
         let mut request = uploader.put(bucket, key).await.unwrap();
 
         let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -146,7 +146,7 @@ mod mock_session {
 
         fn get_storage_class(&self, key: &str) -> Result<String, Box<dyn std::error::Error>> {
             let full_key = format!("{}{}", self.prefix, key);
-           Ok(self.client.get_object_storage_class(&full_key))
+            Ok(self.client.get_object_storage_class(&full_key))
         }
     }
 }
@@ -304,15 +304,13 @@ mod s3_session {
             let full_key = format!("{}{}", self.prefix, key);
             tokio_block_on(
                 self.sdk_client
-                        .get_object_attributes()
-                .bucket(&self.bucket)
-                .key(full_key)
-                .object_attributes(aws_sdk_s3::model::ObjectAttributes::StorageClass)
-                .send()
+                    .get_object_attributes()
+                    .bucket(&self.bucket)
+                    .key(full_key)
+                    .object_attributes(aws_sdk_s3::model::ObjectAttributes::StorageClass)
+                    .send(),
             )
-            .map(|output| {
-                output.storage_class.unwrap().as_str().to_owned()
-            })
+            .map(|output| output.storage_class.unwrap().as_str().to_owned())
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
         }
     }

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -32,6 +32,8 @@ pub trait TestClient {
     fn contains_key(&self, key: &str) -> Result<bool, Box<dyn std::error::Error>>;
 
     fn is_upload_in_progress(&self, key: &str) -> Result<bool, Box<dyn std::error::Error>>;
+
+    fn get_storage_class(&self, key: &str) -> Result<String, Box<dyn std::error::Error>>;
 }
 
 pub type TestClientBox = Box<dyn TestClient>;
@@ -140,6 +142,11 @@ mod mock_session {
         fn is_upload_in_progress(&self, key: &str) -> Result<bool, Box<dyn std::error::Error>> {
             let full_key = format!("{}{}", self.prefix, key);
             Ok(self.client.is_upload_in_progress(&full_key))
+        }
+
+        fn get_storage_class(&self, key: &str) -> Result<String, Box<dyn std::error::Error>> {
+            let full_key = format!("{}{}", self.prefix, key);
+           Ok(self.client.get_object_storage_class(&full_key))
         }
     }
 }
@@ -290,6 +297,22 @@ mod s3_session {
                     .send(),
             )
             .map(|output| output.uploads().map_or(0, |u| u.len()) > 0)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        }
+
+        fn get_storage_class(&self, key: &str) -> Result<String, Box<dyn std::error::Error>> {
+            let full_key = format!("{}{}", self.prefix, key);
+            tokio_block_on(
+                self.sdk_client
+                        .get_object_attributes()
+                .bucket(&self.bucket)
+                .key(full_key)
+                .object_attributes(aws_sdk_s3::model::ObjectAttributes::StorageClass)
+                .send()
+            )
+            .map(|output| {
+                output.storage_class.unwrap().as_str().to_owned()
+            })
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
         }
     }

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -437,7 +437,6 @@ where
     assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 }
 
-
 fn write_with_storage_class_test<F>(creator_fn: F, storage_class: &str)
 where
     F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
@@ -464,13 +463,10 @@ where
     f.sync_all().unwrap();
     drop(f);
 
-
     let s3_storage_class = test_client.get_storage_class(KEY).unwrap();
-    
+
     assert_eq!(s3_storage_class, storage_class);
-
 }
-
 
 fn write_with_invalid_storage_class_test<F>(creator_fn: F, storage_class: &str)
 where
@@ -491,7 +487,6 @@ where
 
     let path = mount_point.path().join(KEY);
     write_file(path).expect_err("write with invalid storage class should fail");
-  
 }
 
 fn write_file(path: PathBuf) -> std::io::Result<()> {
@@ -525,4 +520,3 @@ fn write_with_storage_class_test_s3(storage_class: &str) {
 fn write_with_invalid_storage_class_test_s3(storage_class: &str) {
     write_with_invalid_storage_class_test(crate::fuse_tests::s3_session::new, storage_class);
 }
-


### PR DESCRIPTION
## Description of change

Adds in new CLI option to configure storage class at mount time. Users can now do `mount --storage-class = "STANDARD"`, default storage class is set to intelligent tiering. 

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
