### PR TITLE
Introduce release workflow.

### DIFF
--- a/.github/actions/install-dependencies/install.sh
+++ b/.github/actions/install-dependencies/install.sh
@@ -159,6 +159,10 @@ if [[ $dry_run == false ]]; then
     case $os_release_id in
         amzn)
             sudo yum install -y $package_list
+            type -p yum-config-manager >/dev/null || sudo yum install yum-utils -y
+            sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo -y
+            sudo yum install gh -y
+            sudo yum update gh -y
             ;;
         ubuntu)
             sudo apt-get -q update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - mountpoint-s3-[0-9]+.*
+      - mountpoint-s3-[a-z]+-[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: taiki-e/create-gh-release-action@v1
+      with:
+        prefix: mountpoint-s3(-[a-z]+)?
+        draft: true
+        # TODO: set it true after we have changlog template reviewed.
+        changelog: false
+        # TODO: set it false after we have changlog template reviewed.
+        allow-missing-changelog: true
+        branch: main
+        title: "Mountpoint for Amazon S3 v$version"
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    name: Build and release on target ${{ matrix.runner.target}}
+    runs-on: ${{ matrix.runner.tags }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+        - tags: [ubuntu-20.04] # GitHub-hosted
+          target: x86_64-unknown-linux-gnu
+        - tags: [self-hosted, linux, arm64] 
+          target: aarch64-unknown-linux-gnu
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2 
+    - name: Release mount-s3 binary
+      uses: taiki-e/upload-rust-binary-action@v1
+      with:
+        bin: mount-s3
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checksum: sha512
+        asset: LICENSE
+
+


### PR DESCRIPTION
We adopt two Github Action to automate release for Mounpoint-S3
* Github Action ID: [taiki-e/create-gh-release-action](https://github.com/taiki-e/create-gh-release-action) for create Github Release. * During the release, operator must have consensus with team on version, draft, prefix and title as workflow inputs. * This workflow can also take changelog as inputs, we can opt in that once we have a change log format ready.
* Github Action ID: [taiki-e/upload-rust-binary-action](https://github.com/taiki-e/upload-rust-binary-action) for uploading Mountpoint-S3 binary and all other artifacts. * This workflow uploads compiled binary on target platforms. When we do the release, artifacts must includes: bin, LICENSE, archive and checksum.

TODO: create cross compilation for EC2 AARCH64
## Description of change

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
