### PR TITLE
Implement forget

### DIFF
--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -152,7 +152,7 @@ where
 
         let replier = ReplyDirectory { inner: &mut reply };
 
-        match block_on(self.fs.readdir(parent, fh, offset, false, replier).in_current_span()) {
+        match block_on(self.fs.readdir(parent, fh, offset, replier).in_current_span()) {
             Ok(_) => reply.ok(),
             Err(e) => reply.error(e),
         }
@@ -187,7 +187,7 @@ where
 
         let replier = ReplyDirectoryPlus { inner: &mut reply };
 
-        match block_on(self.fs.readdir(parent, fh, offset, true, replier).in_current_span()) {
+        match block_on(self.fs.readdirplus(parent, fh, offset, replier).in_current_span()) {
             Ok(_) => reply.ok(),
             Err(e) => reply.error(e),
         }

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -126,8 +126,8 @@ impl Superblock {
                 error!("forget called on inode {ino} already removed from the superblock");
             }
             Some(inode) => {
-                let lookup_count = inode.dec_lookup_count(n);
-                if lookup_count < 1 {
+                let new_lookup_count = inode.dec_lookup_count(n);
+                if new_lookup_count == 0 {
                     // Safe to remove, kernel no longer has a reference to it.
                     trace!(ino, "removing inode from superblock");
                     inodes.remove(&ino);

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -400,8 +400,6 @@ impl Superblock {
             }
         };
 
-        // TODO: When inode lookup/ref counting is implemented, decrement here to eventually remove from superblock.
-
         Ok(())
     }
 }

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -94,6 +94,7 @@ impl Superblock {
                 stat: InodeStat::for_directory(mount_time, NEVER_EXPIRE_TTL),
                 write_status: WriteStatus::Remote,
                 kind_data: InodeKindData::default_for(InodeKind::Directory),
+                lookup_count: 1,
             }),
         };
         let root = Inode { inner: Arc::new(root) };
@@ -111,7 +112,32 @@ impl Superblock {
         Self { inner: Arc::new(inner) }
     }
 
-    /// Lookup an inode in the parent directory with the given name
+    /// The kernel tells us when it removes a reference to an [InodeNo] from its internal caches via a forget call.
+    /// The kernel may forget a number of references (`n`) in one forget message to our FUSE implementation.
+    /// If the lookup count reaches zero, it is safe for the [Superblock] to delete the [Inode].
+    pub fn forget(&self, ino: InodeNo, n: u64) {
+        let mut inodes = self.inner.inodes.write().unwrap();
+        match inodes.get(&ino) {
+            None => {
+                debug_assert!(
+                    false,
+                    "forget should not be called on inode already removed from superblock"
+                );
+                error!("forget called on inode {ino} already removed from the superblock");
+            }
+            Some(inode) => {
+                let lookup_count = inode.dec_lookup_count(n);
+                if lookup_count < 1 {
+                    // Safe to remove, kernel no longer has a reference to it.
+                    trace!(ino, "removing inode from superblock");
+                    inodes.remove(&ino);
+                }
+            }
+        }
+    }
+
+    /// Lookup an inode in the parent directory with the given name and
+    /// increments its lookup count.
     pub async fn lookup<OC: ObjectClient>(
         &self,
         client: &OC,
@@ -119,149 +145,9 @@ impl Superblock {
         name: &OsStr,
     ) -> Result<LookedUp, InodeError> {
         trace!(parent=?parent_ino, ?name, "lookup");
-
-        let name = name
-            .to_str()
-            .ok_or_else(|| InodeError::InvalidFileName(name.to_owned()))?;
-
-        // This should be impossible, but just to be safe, explicitly reject lookups to files that
-        // end with '/', since they could be shadowed by directories.
-        if name.ends_with('/') {
-            return Err(InodeError::InvalidFileName(name.into()));
-        }
-
-        // TODO use caches. if we already know about this name, we just need to revalidate the stat
-        // cache and then read it.
-        let remote = self.remote_lookup(client, parent_ino, name).await?;
-        self.inner.update_from_remote(parent_ino, name, remote)
-    }
-
-    /// Lookup an inode in the parent directory with the given name
-    /// on the remote client.
-    async fn remote_lookup<OC: ObjectClient>(
-        &self,
-        client: &OC,
-        parent_ino: InodeNo,
-        name: &str,
-    ) -> Result<Option<RemoteLookup>, InodeError> {
-        let parent = self.inner.get(parent_ino)?;
-        if parent.kind() != InodeKind::Directory {
-            return Err(InodeError::NotADirectory(parent_ino));
-        }
-        let mut full_path = parent.full_key().to_owned();
-        assert!(full_path.is_empty() || full_path.ends_with('/'));
-        full_path.push_str(name);
-
-        let mut full_path_suffixed = full_path.clone();
-        full_path_suffixed.push('/');
-
-        // We need to try two requests here, one to find an object with the given name, and one to
-        // discover a possible shadowing (implicit) directory with the same name. There's a few
-        // different cases we need to consider here:
-        //   (1) Consider this namespace with two keys:
-        //           a
-        //           a/b
-        //       Here we need to make a choice about whether to make `a` visible as a file or as a
-        //       directory. We choose to make it a directory. If we lookup("a") and only do a
-        //       HeadObject for `a`, we'd see the object `a`, but we need to shadow that object with
-        //       a directory. Doing the concurrent ListObjects lets us find out that `a` needs to be
-        //       a directory and so we should suppress the file lookup. Note that this means we
-        //       can't respond to the `lookup` call until both the Head and List calls complete.
-        //   (2) Consider this namespace with two keys, similar to (1):
-        //           a
-        //           a/
-        //       This has the same problem as (1), except that we also need to warn the user that
-        //       the key `a/` will be inaccessible.
-        //   (3) Consider this namespace with two keys:
-        //           dir-1/foo
-        //           dir/ bar
-        //       Here we need to be careful how we issue the ListObjects call. If we don't append a
-        //       "/" to the prefix in the request, the first common prefix we'll get back will be
-        //       "dir-1/", because that precedes "dir/" in lexicographic order. Doing the
-        //       ListObjects with "/" appended makes sure we always observe the correct prefix.
-        let mut file_lookup = client.head_object(&self.inner.bucket, &full_path).fuse();
-        let mut dir_lookup = client
-            .list_objects(&self.inner.bucket, None, "/", 1, &full_path_suffixed)
-            .fuse();
-
-        let mut file_state = None;
-
-        for _ in 0..2 {
-            select_biased! {
-                result = file_lookup => {
-                    match result {
-                        Ok(HeadObjectResult { object, .. }) => {
-                            let stat = InodeStat::for_file(object.size as usize, object.last_modified, Some(object.etag.clone()), self.inner.cache_config.file_ttl);
-                            file_state = Some(stat);
-                        }
-                        // If the object is not found, might be a directory, so keep going
-                        Err(ObjectClientError::ServiceError(HeadObjectError::NotFound)) => {},
-                        Err(e) => return Err(InodeError::ClientError(e.into())),
-                    }
-                }
-
-                result = dir_lookup => {
-                    let result = result.map_err(|e| InodeError::ClientError(e.into()))?;
-
-                    let found_directory = if result
-                        .common_prefixes
-                        .get(0)
-                        .map(|prefix| prefix.starts_with(&full_path_suffixed))
-                        .unwrap_or(false)
-                    {
-                        true
-                    } else if result
-                        .objects
-                        .get(0)
-                        .map(|object| object.key.starts_with(&full_path_suffixed))
-                        .unwrap_or(false)
-                    {
-                        if result.objects[0].key == full_path_suffixed {
-                            trace!(
-                                parent = ?parent_ino,
-                                ?name,
-                                size = result.objects[0].size,
-                                "found a directory that shadows this name"
-                            );
-                            // The S3 Console creates zero-sized keys for explicit directories, so
-                            // let's not warn about those cases.
-                            if result.objects[0].size > 0 {
-                                warn!(
-                                    "key {:?} is not a valid filename (ends in `/`); will be hidden and unavailable",
-                                    full_path_suffixed
-                                );
-                            }
-                        }
-                        true
-                    } else {
-                        false
-                    };
-
-                    // We don't have to wait for the HeadObject to complete because in our
-                    // semantics, directories always shadow files.
-                    if found_directory {
-                        trace!(parent = ?parent_ino, ?name, "lookup ListObjects found a directory");
-                        let stat = InodeStat::for_directory(self.inner.mount_time, self.inner.cache_config.dir_ttl);
-                        return Ok(Some(RemoteLookup { kind: InodeKind::Directory, stat }));
-                    }
-                }
-            }
-        }
-
-        // If we reach here, the ListObjects didn't find a shadowing directory, so we know we either
-        // have a valid file, or both requests failed to find the object so the file must not exist remotely
-        if let Some(mut stat) = file_state {
-            trace!(parent = ?parent_ino, ?name, "found a regular file");
-            // Update the validity of the stat in case the racing ListObjects took a long time
-            stat.update_validity(self.inner.cache_config.file_ttl);
-            Ok(Some(RemoteLookup {
-                kind: InodeKind::File,
-                stat,
-            }))
-        } else {
-            trace!(parent = ?parent_ino, ?name, "not found");
-            Ok(None)
-        }
+        let lookup = self.inner.lookup(client, parent_ino, name).await?;
+        self.inner.remember(&lookup.inode);
+        Ok(lookup)
     }
 
     /// Retrieve the attributes for an inode
@@ -282,7 +168,7 @@ impl Superblock {
             }
         }
 
-        self.lookup(client, inode.parent(), inode.name().as_ref()).await
+        self.inner.lookup(client, inode.parent(), inode.name().as_ref()).await
     }
 
     /// Create a new write handle to be used for state transition
@@ -330,7 +216,7 @@ impl Superblock {
     ) -> Result<LookedUp, InodeError> {
         trace!(parent=?dir, ?name, "create");
 
-        let existing = self.lookup(client, dir, name).await;
+        let existing = self.inner.lookup(client, dir, name).await;
         match existing {
             Ok(lookup) => return Err(InodeError::FileAlreadyExists(lookup.inode.ino())),
             Err(InodeError::FileDoesNotExist) => (),
@@ -366,11 +252,13 @@ impl Superblock {
             stat: stat.clone(),
             kind_data: InodeKindData::default_for(kind),
             write_status: WriteStatus::LocalUnopened,
+            lookup_count: 0,
         };
         let inode = self
             .inner
             .create_inode_locked(&parent_inode, &mut parent_state, name, kind, state, true)?;
 
+        self.inner.remember(&inode);
         Ok(LookedUp { inode, stat })
     }
 
@@ -382,7 +270,7 @@ impl Superblock {
         parent_ino: InodeNo,
         name: &OsStr,
     ) -> Result<(), InodeError> {
-        let LookedUp { inode, .. } = self.lookup(client, parent_ino, name).await?;
+        let LookedUp { inode, .. } = self.inner.lookup(client, parent_ino, name).await?;
 
         if inode.kind() == InodeKind::File {
             return Err(InodeError::NotADirectory(inode.ino()));
@@ -448,7 +336,7 @@ impl Superblock {
         name: &OsStr,
     ) -> Result<(), InodeError> {
         let parent = self.inner.get(parent_ino)?;
-        let LookedUp { inode, .. } = self.lookup(client, parent_ino, name).await?;
+        let LookedUp { inode, .. } = self.inner.lookup(client, parent_ino, name).await?;
 
         if inode.kind() == InodeKind::Directory {
             return Err(InodeError::IsDirectory(inode.ino()));
@@ -529,6 +417,168 @@ impl SuperblockInner {
             .ok_or(InodeError::InodeDoesNotExist(ino))
     }
 
+    /// Increase the lookup count of the given inode and
+    /// ensure it is registered with this superblock.
+    pub fn remember(&self, inode: &Inode) -> u64 {
+        let lookup_count = inode.inc_lookup_count();
+        if lookup_count == 1 {
+            let previous = self.inodes.write().unwrap().insert(inode.ino(), inode.clone());
+            assert!(previous.is_none(), "inode numbers are never reused");
+        }
+        lookup_count
+    }
+
+    /// Lookup an inode in the parent directory with the given name.
+    pub async fn lookup<OC: ObjectClient>(
+        &self,
+        client: &OC,
+        parent_ino: InodeNo,
+        name: &OsStr,
+    ) -> Result<LookedUp, InodeError> {
+        let name = name
+            .to_str()
+            .ok_or_else(|| InodeError::InvalidFileName(name.to_owned()))?;
+
+        // This should be impossible, but just to be safe, explicitly reject lookups to files that
+        // end with '/', since they could be shadowed by directories.
+        if name.ends_with('/') {
+            return Err(InodeError::InvalidFileName(name.into()));
+        }
+
+        // TODO use caches. if we already know about this name, we just need to revalidate the stat
+        // cache and then read it.
+        let remote = self.remote_lookup(client, parent_ino, name).await?;
+        self.update_from_remote(parent_ino, name, remote)
+    }
+
+    /// Lookup an inode in the parent directory with the given name
+    /// on the remote client.
+    async fn remote_lookup<OC: ObjectClient>(
+        &self,
+        client: &OC,
+        parent_ino: InodeNo,
+        name: &str,
+    ) -> Result<Option<RemoteLookup>, InodeError> {
+        let parent = self.get(parent_ino)?;
+        if parent.kind() != InodeKind::Directory {
+            return Err(InodeError::NotADirectory(parent_ino));
+        }
+        let mut full_path = parent.full_key().to_owned();
+        assert!(full_path.is_empty() || full_path.ends_with('/'));
+        full_path.push_str(name);
+
+        let mut full_path_suffixed = full_path.clone();
+        full_path_suffixed.push('/');
+
+        // We need to try two requests here, one to find an object with the given name, and one to
+        // discover a possible shadowing (implicit) directory with the same name. There's a few
+        // different cases we need to consider here:
+        //   (1) Consider this namespace with two keys:
+        //           a
+        //           a/b
+        //       Here we need to make a choice about whether to make `a` visible as a file or as a
+        //       directory. We choose to make it a directory. If we lookup("a") and only do a
+        //       HeadObject for `a`, we'd see the object `a`, but we need to shadow that object with
+        //       a directory. Doing the concurrent ListObjects lets us find out that `a` needs to be
+        //       a directory and so we should suppress the file lookup. Note that this means we
+        //       can't respond to the `lookup` call until both the Head and List calls complete.
+        //   (2) Consider this namespace with two keys, similar to (1):
+        //           a
+        //           a/
+        //       This has the same problem as (1), except that we also need to warn the user that
+        //       the key `a/` will be inaccessible.
+        //   (3) Consider this namespace with two keys:
+        //           dir-1/foo
+        //           dir/ bar
+        //       Here we need to be careful how we issue the ListObjects call. If we don't append a
+        //       "/" to the prefix in the request, the first common prefix we'll get back will be
+        //       "dir-1/", because that precedes "dir/" in lexicographic order. Doing the
+        //       ListObjects with "/" appended makes sure we always observe the correct prefix.
+        let mut file_lookup = client.head_object(&self.bucket, &full_path).fuse();
+        let mut dir_lookup = client
+            .list_objects(&self.bucket, None, "/", 1, &full_path_suffixed)
+            .fuse();
+
+        let mut file_state = None;
+
+        for _ in 0..2 {
+            select_biased! {
+                result = file_lookup => {
+                    match result {
+                        Ok(HeadObjectResult { object, .. }) => {
+                            let stat = InodeStat::for_file(object.size as usize, object.last_modified, Some(object.etag.clone()), self.cache_config.file_ttl);
+                            file_state = Some(stat);
+                        }
+                        // If the object is not found, might be a directory, so keep going
+                        Err(ObjectClientError::ServiceError(HeadObjectError::NotFound)) => {},
+                        Err(e) => return Err(InodeError::ClientError(e.into())),
+                    }
+                }
+
+                result = dir_lookup => {
+                    let result = result.map_err(|e| InodeError::ClientError(e.into()))?;
+
+                    let found_directory = if result
+                        .common_prefixes
+                        .get(0)
+                        .map(|prefix| prefix.starts_with(&full_path_suffixed))
+                        .unwrap_or(false)
+                    {
+                        true
+                    } else if result
+                        .objects
+                        .get(0)
+                        .map(|object| object.key.starts_with(&full_path_suffixed))
+                        .unwrap_or(false)
+                    {
+                        if result.objects[0].key == full_path_suffixed {
+                            trace!(
+                                parent = ?parent_ino,
+                                ?name,
+                                size = result.objects[0].size,
+                                "found a directory that shadows this name"
+                            );
+                            // The S3 Console creates zero-sized keys for explicit directories, so
+                            // let's not warn about those cases.
+                            if result.objects[0].size > 0 {
+                                warn!(
+                                    "key {:?} is not a valid filename (ends in `/`); will be hidden and unavailable",
+                                    full_path_suffixed
+                                );
+                            }
+                        }
+                        true
+                    } else {
+                        false
+                    };
+
+                    // We don't have to wait for the HeadObject to complete because in our
+                    // semantics, directories always shadow files.
+                    if found_directory {
+                        trace!(parent = ?parent_ino, ?name, "lookup ListObjects found a directory");
+                        let stat = InodeStat::for_directory(self.mount_time, self.cache_config.dir_ttl);
+                        return Ok(Some(RemoteLookup { kind: InodeKind::Directory, stat }));
+                    }
+                }
+            }
+        }
+
+        // If we reach here, the ListObjects didn't find a shadowing directory, so we know we either
+        // have a valid file, or both requests failed to find the object so the file must not exist remotely
+        if let Some(mut stat) = file_state {
+            trace!(parent = ?parent_ino, ?name, "found a regular file");
+            // Update the validity of the stat in case the racing ListObjects took a long time
+            stat.update_validity(self.cache_config.file_ttl);
+            Ok(Some(RemoteLookup {
+                kind: InodeKind::File,
+                stat,
+            }))
+        } else {
+            trace!(parent = ?parent_ino, ?name, "not found");
+            Ok(None)
+        }
+    }
+
     /// Update the inode with the given name in a parent directory with the remote data.
     /// It may update or delete an existing inode, or insert a new one.
     pub fn update_from_remote(
@@ -574,7 +624,6 @@ impl SuperblockInner {
                             Ok(LookedUp { inode, stat })
                         } else {
                             // Remove from children.
-                            // TODO: also handle inode in [Self::inodes].
                             children.remove(name);
                             Err(InodeError::FileDoesNotExist)
                         }
@@ -586,6 +635,7 @@ impl SuperblockInner {
                     stat: stat.clone(),
                     kind_data: InodeKindData::default_for(kind),
                     write_status: WriteStatus::Remote,
+                    lookup_count: 0,
                 };
                 self.create_inode_locked(&parent, &mut parent_state, name, kind, state, false)
                     .map(|inode| LookedUp { inode, stat })
@@ -706,9 +756,6 @@ impl SuperblockInner {
                 }
             }
         }
-
-        let previous = self.inodes.write().unwrap().insert(next_ino, inode.clone());
-        assert!(previous.is_none(), "inode numbers are never reused");
 
         Ok(inode)
     }
@@ -889,6 +936,29 @@ impl Inode {
         &self.inner.full_key
     }
 
+    /// Increment lookup count for [Inode] by 1, returning the new value.
+    /// This should be called whenever we pass a `fuse_reply_entry` or `fuse_reply_create` struct to the FUSE driver.
+    ///
+    /// Locks [InodeState] for writing.
+    pub fn inc_lookup_count(&self) -> u64 {
+        let mut state = self.inner.sync.write().unwrap();
+        let lookup_count = &mut state.lookup_count;
+        *lookup_count += 1;
+        trace!(new_lookup_count = lookup_count, "incremented lookup count");
+        *lookup_count
+    }
+
+    /// Decrement lookup count by `n` for [Inode], returning the new value.
+    ///
+    /// Locks [InodeState] for writing.
+    pub fn dec_lookup_count(&self, n: u64) -> u64 {
+        let mut state = self.inner.sync.write().unwrap();
+        let lookup_count = &mut state.lookup_count;
+        *lookup_count -= n;
+        trace!(new_lookup_count = lookup_count, "decremented lookup count");
+        *lookup_count
+    }
+
     pub fn start_reading(&self) -> Result<(), InodeError> {
         let state = self.get_inode_state()?;
         match state.write_status {
@@ -926,6 +996,9 @@ struct InodeState {
     stat: InodeStat,
     write_status: WriteStatus,
     kind_data: InodeKindData,
+    /// Number of references the kernel is holding to the [Inode].
+    /// A number of FS operations increment this, while the kernel calls [`Inode::forget(ino, n)`] to decrement.
+    lookup_count: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1209,6 +1282,84 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_forget() {
+        let superblock = Superblock::new("test_bucket", &Default::default(), Default::default());
+        let ino = 42;
+        let inode_name = "made-up-inode";
+        let inode = Inode {
+            inner: Arc::new(InodeInner {
+                ino,
+                parent: ROOT_INODE_NO,
+                name: inode_name.to_owned(),
+                full_key: inode_name.to_owned(),
+                kind: InodeKind::File,
+                sync: RwLock::new(InodeState {
+                    write_status: WriteStatus::Remote,
+                    stat: InodeStat::for_file(0, OffsetDateTime::now_utc(), None, Default::default()),
+                    kind_data: InodeKindData::File {},
+                    lookup_count: 5,
+                }),
+            }),
+        };
+        superblock.inner.inodes.write().unwrap().insert(ino, inode.clone());
+
+        superblock.forget(ino, 3);
+        let lookup_count = {
+            let inode_state = inode.inner.sync.read().unwrap();
+            inode_state.lookup_count
+        };
+        assert_eq!(lookup_count, 2, "lookup should have been reduced");
+        assert!(
+            superblock.inner.get(ino).is_ok(),
+            "inode should be present in superblock"
+        );
+
+        superblock.forget(ino, 2);
+        let lookup_count = {
+            let inode_state = inode.inner.sync.read().unwrap();
+            inode_state.lookup_count
+        };
+        assert_eq!(lookup_count, 0, "lookup should have been reduced");
+        assert!(
+            superblock.inner.inodes.read().unwrap().get(&ino).is_none(),
+            "inode should not be present in superblock"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forget_can_remove_inodes() {
+        let client_config = MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024 * 1024,
+        };
+        let client = Arc::new(MockClient::new(client_config));
+
+        let name = "foo";
+        client.add_object(name, b"foo".into());
+
+        let superblock = Superblock::new("test_bucket", &Default::default(), Default::default());
+
+        let lookup = superblock.lookup(&client, ROOT_INODE_NO, name.as_ref()).await.unwrap();
+        let lookup_count = lookup.inode.inner.sync.read().unwrap().lookup_count;
+        assert_eq!(lookup_count, 1);
+        let ino = lookup.inode.ino();
+        superblock.forget(ino, 1);
+
+        let lookup_count = lookup.inode.inner.sync.read().unwrap().lookup_count;
+        assert_eq!(lookup_count, 0);
+
+        let err = superblock
+            .getattr(&client, ino, false)
+            .await
+            .expect_err("Inode should not be valid");
+        assert!(matches!(err, InodeError::InodeDoesNotExist(_)));
+
+        let lookup = superblock.lookup(&client, ROOT_INODE_NO, name.as_ref()).await.unwrap();
+        let lookup_count = lookup.inode.inner.sync.read().unwrap().lookup_count;
+        assert_eq!(lookup_count, 1);
     }
 
     #[test_case(""; "unprefixed")]

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -104,7 +104,11 @@ impl ReaddirHandle {
 
     /// Return the next inode for the directory stream. If the stream is finished, returns
     /// `Ok(None)`.
-    pub async fn next<OC: ObjectClient>(&self, client: &OC, inc_lookup_count: bool) -> Result<Option<LookedUp>, InodeError> {
+    pub async fn next<OC: ObjectClient>(
+        &self,
+        client: &OC,
+        inc_lookup_count: bool,
+    ) -> Result<Option<LookedUp>, InodeError> {
         if let Some(readded) = self.readded.lock().unwrap().take() {
             return Ok(Some(readded));
         }

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -104,7 +104,7 @@ impl ReaddirHandle {
 
     /// Return the next inode for the directory stream. If the stream is finished, returns
     /// `Ok(None)`.
-    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
+    pub async fn next<OC: ObjectClient>(&self, client: &OC, inc_lookup_count: bool) -> Result<Option<LookedUp>, InodeError> {
         if let Some(readded) = self.readded.lock().unwrap().take() {
             return Ok(Some(readded));
         }
@@ -123,6 +123,9 @@ impl ReaddirHandle {
                     warn!("{} has an invalid name and will be unavailable", next.description());
                 } else {
                     let lookup = self.instantiate_remote_inode(next)?;
+                    if inc_lookup_count {
+                        self.inner.remember(&lookup.inode);
+                    }
                     return Ok(Some(lookup));
                 }
             } else {
@@ -168,7 +171,7 @@ impl ReaddirHandle {
     #[cfg(test)]
     pub(super) async fn collect<OC: ObjectClient>(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
         let mut result = vec![];
-        while let Some(entry) = self.next(client).await? {
+        while let Some(entry) = self.next(client, true).await? {
             result.push(entry);
         }
         Ok(result)

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -47,7 +47,7 @@ async fn test_read_dir_root(prefix: &str) {
     // Listing the root directory doesn't require resolving it first, can just opendir the root inode
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
+    let _reply = fs.readdirplus(1, dir_handle, 0, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 3);
 
@@ -83,7 +83,7 @@ async fn test_read_dir_root(prefix: &str) {
 
     let mut reply = Default::default();
     let _reply = fs
-        .readdir(FUSE_ROOT_INODE, dir_handle, offset, false, &mut reply)
+        .readdir(FUSE_ROOT_INODE, dir_handle, offset, &mut reply)
         .await
         .unwrap();
     assert_eq!(reply.entries.len(), 0);
@@ -122,7 +122,7 @@ async fn test_read_dir_nested(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
+    let _reply = fs.readdirplus(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 2);
 
@@ -156,10 +156,7 @@ async fn test_read_dir_nested(prefix: &str) {
     assert!(offset > 0);
 
     let mut reply = Default::default();
-    let _reply = fs
-        .readdir(dir_ino, dir_handle, offset, false, &mut reply)
-        .await
-        .unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, offset, &mut reply).await.unwrap();
     assert_eq!(reply.entries.len(), 0);
 
     fs.releasedir(dir_ino, dir_handle, 0).await.unwrap();
@@ -179,7 +176,7 @@ async fn test_random_read(object_size: usize) {
     // Find the object
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
+    let _reply = fs.readdirplus(1, dir_handle, 0, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 
@@ -229,7 +226,7 @@ async fn test_implicit_directory_shadow(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
+    let _reply = fs.readdirplus(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 
@@ -750,10 +747,7 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs
-            .readdir(foo_dir.attr.ino, dir_handle, 0, false, &mut reply)
-            .await
-            .unwrap();
+        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
         fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry
@@ -774,10 +768,7 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry_new = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs
-            .readdir(bar_file.attr.ino, dir_handle, 0, false, &mut reply)
-            .await
-            .unwrap();
+        let _reply = fs.readdir(bar_file.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
         fs.releasedir(bar_file.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry
@@ -800,10 +791,7 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs
-            .readdir(foo_dir.attr.ino, dir_handle, 0, false, &mut reply)
-            .await
-            .unwrap();
+        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
         fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry
@@ -820,4 +808,61 @@ async fn test_directory_shadowing_readdir() {
     let bar_file = fs.lookup(foo_dir.attr.ino, "bar".as_ref()).await.unwrap();
     assert_eq!(bar_file.attr.kind, FileType::RegularFile);
     assert_eq!(bar_file.attr.ino, bar_dentry.attr.ino);
+}
+
+#[tokio::test]
+async fn test_readdir_vs_readdirplus() {
+    let (client, fs) = make_test_filesystem("test_readdir_vs_readdirplus", &Default::default(), Default::default());
+
+    client.add_object("bar", b"bar".into());
+    client.add_object("baz/foo", b"foo".into());
+
+    let readdir_entries = {
+        let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
+        let mut reply = Default::default();
+        let _reply = fs.readdir(FUSE_ROOT_INODE, dir_handle, 0, &mut reply).await.unwrap();
+        fs.releasedir(FUSE_ROOT_INODE, dir_handle, 0).await.unwrap();
+
+        // Skip . and ..
+        reply.entries.into_iter().skip(2).collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        readdir_entries.iter().map(|e| &e.name).collect::<Vec<_>>(),
+        &["bar", "baz"]
+    );
+
+    for entry in readdir_entries {
+        let err = fs
+            .getattr(entry.ino)
+            .await
+            .expect_err("readdir should not add inodes to the superblock");
+        assert!(matches!(err, libc::ENOENT));
+    }
+
+    let readdirplus_entries = {
+        let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
+        let mut reply = Default::default();
+        let _reply = fs
+            .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut reply)
+            .await
+            .unwrap();
+        fs.releasedir(FUSE_ROOT_INODE, dir_handle, 0).await.unwrap();
+
+        // Skip . and ..
+        reply.entries.into_iter().skip(2).collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        readdirplus_entries.iter().map(|e| &e.name).collect::<Vec<_>>(),
+        &["bar", "baz"]
+    );
+
+    for entry in readdirplus_entries {
+        let attr = fs
+            .getattr(entry.ino)
+            .await
+            .expect("readdirplus should add inodes to the superblock");
+        assert_eq!(entry.ino, attr.attr.ino);
+    }
 }

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -47,7 +47,7 @@ async fn test_read_dir_root(prefix: &str) {
     // Listing the root directory doesn't require resolving it first, can just opendir the root inode
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 3);
 
@@ -83,7 +83,7 @@ async fn test_read_dir_root(prefix: &str) {
 
     let mut reply = Default::default();
     let _reply = fs
-        .readdir(FUSE_ROOT_INODE, dir_handle, offset, &mut reply)
+        .readdir(FUSE_ROOT_INODE, dir_handle, offset, false, &mut reply)
         .await
         .unwrap();
     assert_eq!(reply.entries.len(), 0);
@@ -122,7 +122,7 @@ async fn test_read_dir_nested(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 2);
 
@@ -156,7 +156,10 @@ async fn test_read_dir_nested(prefix: &str) {
     assert!(offset > 0);
 
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, offset, &mut reply).await.unwrap();
+    let _reply = fs
+        .readdir(dir_ino, dir_handle, offset, false, &mut reply)
+        .await
+        .unwrap();
     assert_eq!(reply.entries.len(), 0);
 
     fs.releasedir(dir_ino, dir_handle, 0).await.unwrap();
@@ -176,7 +179,7 @@ async fn test_random_read(object_size: usize) {
     // Find the object
     let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(1, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(1, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 
@@ -226,7 +229,7 @@ async fn test_implicit_directory_shadow(prefix: &str) {
 
     let dir_handle = fs.opendir(dir_ino, 0).await.unwrap().fh;
     let mut reply = Default::default();
-    let _reply = fs.readdir(dir_ino, dir_handle, 0, &mut reply).await.unwrap();
+    let _reply = fs.readdir(dir_ino, dir_handle, 0, true, &mut reply).await.unwrap();
 
     assert_eq!(reply.entries.len(), 2 + 1);
 
@@ -747,7 +750,10 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        let _reply = fs
+            .readdir(foo_dir.attr.ino, dir_handle, 0, false, &mut reply)
+            .await
+            .unwrap();
         fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry
@@ -768,7 +774,10 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry_new = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs.readdir(bar_file.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        let _reply = fs
+            .readdir(bar_file.attr.ino, dir_handle, 0, false, &mut reply)
+            .await
+            .unwrap();
         fs.releasedir(bar_file.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry
@@ -791,7 +800,10 @@ async fn test_directory_shadowing_readdir() {
     let bar_dentry = {
         let dir_handle = fs.opendir(foo_dir.attr.ino, 0).await.unwrap().fh;
         let mut reply = Default::default();
-        let _reply = fs.readdir(foo_dir.attr.ino, dir_handle, 0, &mut reply).await.unwrap();
+        let _reply = fs
+            .readdir(foo_dir.attr.ino, dir_handle, 0, false, &mut reply)
+            .await
+            .unwrap();
         fs.releasedir(foo_dir.attr.ino, dir_handle, 0).await.unwrap();
 
         // Skip . and .. to get to the `bar` dentry

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -481,7 +481,7 @@ impl Harness {
             let mut keys = children.keys().cloned().collect::<HashSet<_>>();
 
             let mut reply = DirectoryReply::new(self.readdir_limit);
-            self.fs.readdir(fs_dir, dir_handle, 0, &mut reply).await.unwrap();
+            self.fs.readdir(fs_dir, dir_handle, 0, false, &mut reply).await.unwrap();
 
             // TODO `stat` on these needs to work
             let e0 = reply.entries.pop_front().unwrap();
@@ -491,7 +491,10 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
+                self.fs
+                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
+                    .await
+                    .unwrap();
             }
 
             let e1 = reply.entries.pop_front().unwrap();
@@ -501,7 +504,10 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
+                self.fs
+                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
+                    .await
+                    .unwrap();
             }
 
             while !reply.entries.is_empty() {
@@ -543,7 +549,11 @@ impl Harness {
                     }
                 }
                 reply.clear();
-                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
+                let _reply = self
+                    .fs
+                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
+                    .await
+                    .unwrap();
             }
 
             assert!(

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -481,7 +481,7 @@ impl Harness {
             let mut keys = children.keys().cloned().collect::<HashSet<_>>();
 
             let mut reply = DirectoryReply::new(self.readdir_limit);
-            self.fs.readdir(fs_dir, dir_handle, 0, false, &mut reply).await.unwrap();
+            self.fs.readdir(fs_dir, dir_handle, 0, &mut reply).await.unwrap();
 
             // TODO `stat` on these needs to work
             let e0 = reply.entries.pop_front().unwrap();
@@ -491,10 +491,7 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                self.fs
-                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
-                    .await
-                    .unwrap();
+                self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
             }
 
             let e1 = reply.entries.pop_front().unwrap();
@@ -504,10 +501,7 @@ impl Harness {
 
             if reply.entries.is_empty() {
                 reply.clear();
-                self.fs
-                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
-                    .await
-                    .unwrap();
+                self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
             }
 
             while !reply.entries.is_empty() {
@@ -549,11 +543,7 @@ impl Harness {
                     }
                 }
                 reply.clear();
-                let _reply = self
-                    .fs
-                    .readdir(fs_dir, dir_handle, offset, false, &mut reply)
-                    .await
-                    .unwrap();
+                let _reply = self.fs.readdir(fs_dir, dir_handle, offset, &mut reply).await.unwrap();
             }
 
             assert!(


### PR DESCRIPTION
## Description of change

Implement forget and maintain a lookup count on inodes. Ensure that only inodes with non-zero lookup count are registered with the superblock, and thus can be looked up by inode number.

Relevant issues: #277

## Does this change impact existing behavior?

Internal change to prevent memory leaking.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
