### PR TITLE
Fix cli help for prefix option

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -120,11 +120,10 @@ struct CliArgs {
 
     #[clap(
         long,
-        default_value = "",
         help = "Prefix inside the bucket to mount, ending in '/' [default: mount the entire bucket]",
         help_heading = BUCKET_OPTIONS_HEADER
     )]
-    pub prefix: Prefix,
+    pub prefix: Option<Prefix>,
 
     #[clap(
         long,
@@ -445,7 +444,8 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     }
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
 
-    let fs = S3FuseFilesystem::new(client, runtime, &args.bucket_name, &args.prefix, filesystem_config);
+    let prefix = args.prefix.unwrap_or_default();
+    let fs = S3FuseFilesystem::new(client, runtime, &args.bucket_name, &prefix, filesystem_config);
 
     let fs_name = String::from("mountpoint-s3");
     let mut options = vec![


### PR DESCRIPTION
## Description of change

Remove the extra `[default: ]` from the description of the prefix option in the cli help:
```
--prefix <PREFIX>
          Prefix inside the bucket to mount, ending in '/' [default: mount the entire bucket] [default: ]
```

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
