### PR TITLE
Add unlink to reference model tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 .cargo/
+# We prefer to manually commit regression tests
+*.proptest-regressions

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -771,7 +771,7 @@ impl From<InodeError> for i32 {
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,
-            InodeError::IsDirectory(_) => libc::EPERM,
+            InodeError::IsDirectory(_) => libc::EISDIR,
             InodeError::FileAlreadyExists(_) => libc::EEXIST,
             // Not obvious what InodeNotWritable, InodeNotReadableWhileWriting should be.
             // EINVAL or EROFS would also be reasonable -- but we'll treat them like sealed files for now.


### PR DESCRIPTION
## Description of change

This is pretty annoying because of some weird edge cases around implicit
directories being removed while local children are present. I think in
the long term we want to fix this, but it's a similar problem to what we
saw in #359 -- we need `readdir` to clean up removed directories
properly. So for now, I've changed the reference model to match our
current semantics, which is that if an ancestor of a local
file/directory is removed, that file/directory will no longer be visible
through the filesystem. Of course, once that file/directory becomes
remote it will become visible, and the model still captures that.

Relevant issues: #78 

## Does this change impact existing behavior?

Yes, but indirectly. We've changed the reference model to allow a different set of behavior around implicit directories, so bugs that the tests might have caught before could now be missed, and vice versa.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
