### PR TITLE
Support open with O_RDWR flag

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -58,7 +58,7 @@ Mountpoint for Amazon S3 intentionally does not support all POSIX file system op
 #### Reads
 
 Basic read-only operations are fully supported, including both sequential and random reads:
-* `open`, `openat`, in read-only mode (`O_RDONLY`)
+* `open`, `openat`
 * `read`, `readv`, `pread`, `preadv`
 * `lseek`
 * `close`

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -58,7 +58,7 @@ Mountpoint for Amazon S3 intentionally does not support all POSIX file system op
 #### Reads
 
 Basic read-only operations are fully supported, including both sequential and random reads:
-* `open`, `openat`
+* `open`, `openat`, a file can be opened in read-write mode (`O_RDWR`) but you can't both read and write to the same file descriptor
 * `read`, `readv`, `pread`, `preadv`
 * `lseek`
 * `close`

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -425,8 +425,10 @@ where
         let handle_type = if flags & libc::O_RDWR != 0 {
             let remote_file = lookup.inode.is_remote()?;
             if remote_file {
+                trace!("fs:open choosing read handle for O_RDWR");
                 FileHandleType::new_read_handle(&lookup).await?
             } else {
+                trace!("fs:open choosing write handle for O_RDWR");
                 FileHandleType::new_write_handle(&lookup, ino, flags, self).await?
             }
         } else if flags & libc::O_WRONLY != 0 {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -960,6 +960,11 @@ impl Inode {
         *lookup_count
     }
 
+    pub fn is_remote(&self) -> Result<bool, InodeError> {
+        let state = self.get_inode_state()?;
+        Ok(state.write_status == WriteStatus::Remote)
+    }
+
     pub fn start_reading(&self) -> Result<(), InodeError> {
         let state = self.get_inode_state()?;
         match state.write_status {

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -184,7 +184,7 @@ where
         .expect_err("writing to O_RDONLY file should fail");
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
 
-    // We can't write to an existing file even it's opened in O_RDWR
+    // Existing files can be opened O_RDWR but only reading should work on them
     let mut file = File::options().read(true).write(true).create(true).open(&path).unwrap();
     let err = file
         .write(b"hello world")


### PR DESCRIPTION
## Description of change

Currently, Mountpoint supports either open with `O_WRONLY` or `O_RDONLY` because we don't allow applications to do both read and write at the same time. However, it's possible support `O_RDWR` flag too since we can decide at open time whether to give a read handle or a write handle back, and for any inode it's never possible for both start_reading and start_writing to work.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
