### PR TITLE
Endpoint Resolver for each request

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use clap::{Arg, Command};
 use futures::StreamExt;
-use mountpoint_s3_client::{ObjectClient, S3ClientConfig, S3CrtClient};
+use mountpoint_s3_client::{EndpointConfig, ObjectClient, S3ClientConfig, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -63,14 +63,15 @@ fn main() {
         .map(|s| s.parse::<usize>().expect("iterations must be a number"));
     let region = matches.get_one::<String>("region").unwrap();
 
-    let mut config = S3ClientConfig::new();
+    let endpoint_config = EndpointConfig::new().bucket(bucket).region(region);
+    let mut config = S3ClientConfig::new().endpoint_config(endpoint_config).clone();
     if let Some(throughput_target_gbps) = throughput_target_gbps {
         config = config.throughput_target_gbps(throughput_target_gbps);
     }
     if let Some(part_size) = part_size {
         config = config.part_size(part_size);
     }
-    let client = S3CrtClient::new(region, config).expect("couldn't create client");
+    let client = S3CrtClient::new(config).expect("couldn't create client");
 
     for i in 0..iterations.unwrap_or(1) {
         let received_size = Arc::new(AtomicU64::new(0));
@@ -79,7 +80,13 @@ fn main() {
         let received_size_clone = Arc::clone(&received_size);
         futures::executor::block_on(async move {
             let mut request = client
-                .get_object(bucket, key, None, None)
+                .get_object(
+                    bucket,
+                    key,
+                    None,
+                    None,
+                    EndpointConfig::new().bucket(bucket).region(region),
+                )
                 .await
                 .expect("couldn't create get request");
             loop {

--- a/mountpoint-s3-client/examples/download.rs
+++ b/mountpoint-s3-client/examples/download.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use clap::{Arg, Command};
 use futures::StreamExt;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+use mountpoint_s3_client::{EndpointConfig, ObjectClient, S3ClientConfig, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use regex::Regex;
 use tracing_subscriber::fmt::Subscriber;
@@ -51,13 +51,15 @@ fn main() {
         start..(end + 1)
     });
 
-    let client = S3CrtClient::new(region, Default::default()).expect("couldn't create client");
+    let endpoint_config = EndpointConfig::new().bucket(bucket).region(region);
+    let client = S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config.clone()))
+        .expect("couldn't create client");
 
     let last_offset = Arc::new(Mutex::new(None));
     let last_offset_clone = Arc::clone(&last_offset);
     futures::executor::block_on(async move {
         let mut request = client
-            .get_object(bucket, key, range, None)
+            .get_object(bucket, key, range, None, endpoint_config)
             .await
             .expect("couldn't create get request");
         loop {

--- a/mountpoint-s3-client/examples/list.rs
+++ b/mountpoint-s3-client/examples/list.rs
@@ -1,4 +1,4 @@
-use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::{EndpointConfig, S3ClientConfig, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 
 use clap::{Arg, Command};
@@ -33,10 +33,14 @@ fn main() {
     let delimiter = matches.get_one::<String>("delimiter").unwrap();
     let prefix = matches.get_one::<String>("prefix").unwrap();
     let region = matches.get_one::<String>("region").unwrap();
+    let endpoint_config = EndpointConfig::new().bucket(bucket).region(region);
 
-    let client = S3CrtClient::new(region, Default::default()).expect("couldn't create client");
+    let client = S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config.clone()))
+        .expect("couldn't create client");
 
-    let result = futures::executor::block_on(client.list_objects(bucket, None, delimiter, 500, prefix)).unwrap();
+    let result =
+        futures::executor::block_on(client.list_objects(bucket, None, delimiter, 500, prefix, endpoint_config))
+            .unwrap();
 
     for object in result.objects {
         println!("{object:?}");

--- a/mountpoint-s3-client/src/endpoint.rs
+++ b/mountpoint-s3-client/src/endpoint.rs
@@ -1,109 +1,80 @@
-use lazy_static::lazy_static;
 use mountpoint_s3_crt::common::allocator::Allocator;
 use mountpoint_s3_crt::common::uri::Uri;
 use mountpoint_s3_crt::s3::endpoint_resolver::{RequestContext, ResolverError, RuleEngine};
-use regex::Regex;
 use std::ffi::OsStr;
 use std::os::unix::prelude::OsStrExt;
 use thiserror::Error;
 
-lazy_static! {
-    /// Bucket names that are acceptable as virtual host names for DNS
-    static ref VALID_DNS_REGEX: Regex = Regex::new(r"[a-z0-9][a-z0-9\-]*[a-z0-9]").unwrap();
-}
+use crate::EndpointConfig;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Endpoint {
     uri: Uri,
-    addressing_style: AddressingStyle,
 }
 
 impl Endpoint {
-    /// Create a new endpoint for the given S3 region. This method automatically resolves the right
+    /// get uri from Endpoint
+    fn get_uri(&self) -> Uri {
+        self.uri.clone()
+    }
+
+    /// Create a new endpoint URI for the given Endpoint Configuration. This method automatically resolves the right
     /// endpoint URI to target.
-    pub fn from_region(region: &str, addressing_style: AddressingStyle) -> Result<Self, EndpointError> {
+    pub fn set_endpoint(endpoint_config: EndpointConfig) -> Result<Uri, EndpointError> {
         let allocator = Allocator::default();
-        let endpoint_rule_engine = RuleEngine::new(&allocator).unwrap();
         let mut endpoint_request_context = RequestContext::new(&allocator).unwrap();
+        let endpoint_rule_engine = RuleEngine::new(&allocator).unwrap();
         endpoint_request_context
-            .add_string(&allocator, "Region", region)
+            .add_string(&allocator, "Region", endpoint_config.get_region())
             .unwrap();
+        if let Some(endpoint_uri) = endpoint_config.get_endpoint() {
+            endpoint_request_context
+                .add_string(&allocator, "Endpoint", endpoint_uri.get_uri().as_os_str())
+                .unwrap()
+        };
+        if let Some(bucket) = endpoint_config.get_bucket() {
+            // TODO: Handle the case of Invalid bucket name/ Alias/ ARN
+            endpoint_request_context
+                .add_string(&allocator, "Bucket", bucket)
+                .unwrap()
+        };
+        if endpoint_config.is_accelerate() {
+            endpoint_request_context
+                .add_boolean(&allocator, "UseFIPS", true)
+                .unwrap()
+        };
+        if endpoint_config.is_dual_stack() {
+            endpoint_request_context
+                .add_boolean(&allocator, "UseDualStack", true)
+                .unwrap()
+        };
+        if endpoint_config.is_accelerate() {
+            endpoint_request_context
+                .add_boolean(&allocator, "Accelerate", true)
+                .unwrap()
+        };
+        if endpoint_config.get_addresssing_style() == AddressingStyle::Path {
+            endpoint_request_context
+                .add_boolean(&allocator, "ForcePathStyle", true)
+                .unwrap()
+        };
+
         let resolved_endpoint = endpoint_rule_engine
             .resolve(endpoint_request_context)
             .map_err(EndpointError::UnresolvedEndpoint)?;
-
         let endpoint_uri = resolved_endpoint.get_url();
-        let uri = Uri::new_from_str(&allocator, &endpoint_uri)
-            .map_err(|e| EndpointError::InvalidUri(InvalidUriError::CouldNotParse(e)))?;
-        Ok(Self { uri, addressing_style })
+        Uri::new_from_str(&allocator, &endpoint_uri)
+            .map_err(|e| EndpointError::InvalidUri(InvalidUriError::CouldNotParse(e)))
     }
 
     /// Create a new endpoint with a manually specified URI.
-    pub fn from_uri(uri: &str, addressing_style: AddressingStyle) -> Result<Self, EndpointError> {
-        // Force path-style addressing in automatic mode if a URI was specified manually
-        let addressing_style = if addressing_style == AddressingStyle::Automatic {
-            AddressingStyle::Path
-        } else {
-            addressing_style
-        };
-        Self::from_uri_inner(uri, addressing_style)
-    }
-
-    fn from_uri_inner(uri: &str, addressing_style: AddressingStyle) -> Result<Self, EndpointError> {
+    pub fn from_uri(uri: &str) -> Result<Self, EndpointError> {
         let parsed_uri = Uri::new_from_str(&Allocator::default(), OsStr::from_bytes(uri.as_bytes()))
             .map_err(InvalidUriError::CouldNotParse)?;
-        tracing::debug!(endpoint=?parsed_uri.as_os_str(), ?addressing_style, "selected endpoint");
-        Ok(Self {
-            uri: parsed_uri,
-            addressing_style,
-        })
+        tracing::debug!(endpoint=?parsed_uri.as_os_str());
+        Ok(Self { uri: parsed_uri })
     }
-
-    /// Given a bucket name, determine whether to do path-based or virtual-host-based addressing,
-    /// and return the host URI to access and the prefix to apply to paths
-    pub(crate) fn for_bucket(&self, bucket: &str) -> Result<(Uri, String), EndpointError> {
-        match self.addressing_style {
-            AddressingStyle::Automatic => {
-                if is_valid_dns_name(bucket) {
-                    let uri = insert_virtual_host(bucket, &self.uri)?;
-                    Ok((uri, String::new()))
-                } else {
-                    Ok((self.uri.clone(), format!("/{bucket}")))
-                }
-            }
-            AddressingStyle::Virtual => {
-                let uri = insert_virtual_host(bucket, &self.uri)?;
-                Ok((uri, String::new()))
-            }
-            AddressingStyle::Path => Ok((self.uri.clone(), format!("/{bucket}"))),
-        }
-    }
-}
-
-fn is_valid_dns_name(bucket: &str) -> bool {
-    // `.` is valid in DNS and in bucket names, but will break SSL certificates, so reject buckets
-    // that include it.
-    !bucket.contains('.')
-        && VALID_DNS_REGEX
-            .find(bucket)
-            .map(|m| m.end() == bucket.len())
-            .unwrap_or(false)
-}
-
-fn insert_virtual_host(bucket: &str, uri: &Uri) -> Result<Uri, InvalidUriError> {
-    let empty_path = uri.path().is_empty() || uri.path() == OsStr::from_bytes("/".as_bytes());
-    if !empty_path || !uri.query_string().is_empty() {
-        return Err(InvalidUriError::CannotContainPathOrQueryString);
-    }
-
-    let scheme = uri.scheme().to_str().ok_or(InvalidUriError::InvalidUtf8)?;
-    let authority = uri.authority().to_str().ok_or(InvalidUriError::InvalidUtf8)?;
-    let new_uri = format!("{scheme}://{bucket}.{authority}");
-    Ok(Uri::new_from_str(
-        &Allocator::default(),
-        OsStr::from_bytes(new_uri.as_bytes()),
-    )?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -135,18 +106,4 @@ pub enum InvalidUriError {
     CannotContainPathOrQueryString,
     #[error("URI is not valid UTF-8")]
     InvalidUtf8,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn valid_dns_names() {
-        assert!(is_valid_dns_name("test-bucket"));
-        assert!(!is_valid_dns_name("test.bucket"));
-        assert!(!is_valid_dns_name("test-bucket-"));
-        assert!(is_valid_dns_name("test-1bucket"));
-        assert!(is_valid_dns_name("1test-bucket"));
-    }
 }

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -11,7 +11,7 @@ pub use endpoint::{AddressingStyle, Endpoint};
 pub use imds_crt_client::ImdsCrtClient;
 pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
-pub use s3_crt_client::{S3ClientAuthConfig, S3ClientConfig, S3CrtClient, S3RequestError};
+pub use s3_crt_client::{EndpointConfig, S3ClientAuthConfig, S3ClientConfig, S3CrtClient, S3RequestError};
 
 #[cfg(test)]
 mod tests {
@@ -19,6 +19,6 @@ mod tests {
 
     #[test]
     fn smoke() {
-        let _client = S3CrtClient::new("us-east-1", Default::default()).unwrap();
+        let _client = S3CrtClient::new(Default::default()).unwrap();
     }
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -12,6 +12,8 @@ use time::OffsetDateTime;
 
 use md5::{Digest, Md5};
 
+use crate::EndpointConfig;
+
 /// A single element of the [ObjectClient::get_object] response is a pair of offset within the
 /// object and the bytes starting at that offset.
 pub type GetBodyPart = (u64, Box<[u8]>);
@@ -72,6 +74,7 @@ pub trait ObjectClient {
         &self,
         bucket: &str,
         key: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError>;
 
     /// Get an object from the object store. Returns a stream of body parts of the object. Parts are
@@ -82,6 +85,7 @@ pub trait ObjectClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError>;
 
     /// List the objects in a bucket under a given prefix
@@ -92,6 +96,7 @@ pub trait ObjectClient {
         delimiter: &str,
         max_keys: usize,
         prefix: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<ListObjectsResult, ListObjectsError, Self::ClientError>;
 
     /// Retrieve object metadata without retrieving the object contents
@@ -99,6 +104,7 @@ pub trait ObjectClient {
         &self,
         bucket: &str,
         key: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError>;
 
     /// Put an object into the object store. Returns a [PutObjectRequest] for callers
@@ -108,6 +114,7 @@ pub trait ObjectClient {
         bucket: &str,
         key: &str,
         params: &PutObjectParams,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<Self::PutObjectRequest, PutObjectError, Self::ClientError>;
 
     /// Retrieves all the metadata from an object without returning the object contents.
@@ -118,6 +125,7 @@ pub trait ObjectClient {
         max_parts: Option<usize>,
         part_number_marker: Option<usize>,
         object_attributes: &[ObjectAttribute],
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError>;
 }
 

--- a/mountpoint-s3-client/src/s3_crt_client/delete_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/delete_object.rs
@@ -5,7 +5,7 @@ use mountpoint_s3_crt::s3::client::{MetaRequestResult, MetaRequestType};
 use tracing::debug;
 
 use crate::object_client::{DeleteObjectError, DeleteObjectResult, ObjectClientError};
-use crate::{ObjectClientResult, S3CrtClient, S3RequestError};
+use crate::{EndpointConfig, ObjectClientResult, S3CrtClient, S3RequestError};
 
 impl S3CrtClient {
     /// Create and begin a new DeleteObject request.
@@ -13,15 +13,17 @@ impl S3CrtClient {
         &self,
         bucket: &str,
         key: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, S3RequestError> {
         let span = request_span!(self.inner, "delete_object");
         span.in_scope(|| debug!(?bucket, ?key, "new request"));
 
         // Scope the endpoint, message, etc. since otherwise rustc thinks we use Message across the await.
+        let endpoint_config = endpoint_config.bucket(bucket);
         let request = {
             let mut message = self
                 .inner
-                .new_request_template("DELETE", bucket)
+                .new_request_template("DELETE", endpoint_config)
                 .map_err(S3RequestError::construction_failure)?;
             message
                 .set_request_path(format!("/{key}"))

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -16,6 +16,7 @@ use tracing::debug;
 use crate::object_client::{GetBodyPart, GetObjectError, ObjectClientError};
 use crate::s3_crt_client::S3HttpRequest;
 use crate::ETag;
+use crate::EndpointConfig;
 use crate::{ObjectClientResult, S3CrtClient, S3RequestError};
 
 impl S3CrtClient {
@@ -27,15 +28,17 @@ impl S3CrtClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
+        endpoint_config: EndpointConfig,
     ) -> Result<S3GetObjectRequest, ObjectClientError<GetObjectError, S3RequestError>> {
         let span = request_span!(self.inner, "get_object");
         span.in_scope(
             || debug!(?bucket, ?key, ?range, ?if_match, size=?range.as_ref().map(|range| range.end - range.start), "new request"),
         );
 
+        let endpoint_config = endpoint_config.bucket(bucket);
         let mut message = self
             .inner
-            .new_request_template("GET", bucket)
+            .new_request_template("GET", endpoint_config)
             .map_err(S3RequestError::construction_failure)?;
 
         // Overwrite "accept" header since this returns raw object data.

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 use tracing::debug;
 
 use crate::{
-    Checksum, GetObjectAttributesError, GetObjectAttributesParts, GetObjectAttributesResult, ObjectAttribute,
-    ObjectClientError, ObjectClientResult, ObjectPart, S3CrtClient, S3RequestError,
+    Checksum, EndpointConfig, GetObjectAttributesError, GetObjectAttributesParts, GetObjectAttributesResult,
+    ObjectAttribute, ObjectClientError, ObjectClientResult, ObjectPart, S3CrtClient, S3RequestError,
 };
 
 #[derive(Error, Debug)]
@@ -107,11 +107,13 @@ impl S3CrtClient {
         max_parts: Option<usize>,
         part_number_marker: Option<usize>,
         object_attributes: &[ObjectAttribute],
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, S3RequestError> {
+        let endpoint_config = endpoint_config.bucket(bucket);
         let body = {
             let mut message = self
                 .inner
-                .new_request_template("GET", bucket)
+                .new_request_template("GET", endpoint_config)
                 .map_err(S3RequestError::construction_failure)?;
 
             let query = vec![("attributes", "")];

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error};
 
 use crate::object_client::{HeadObjectError, HeadObjectResult, ObjectClientError, ObjectClientResult, ObjectInfo};
 use crate::s3_crt_client::S3RequestError;
-use crate::S3CrtClient;
+use crate::{EndpointConfig, S3CrtClient};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -62,11 +62,13 @@ impl S3CrtClient {
         &self,
         bucket: &str,
         key: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, S3RequestError> {
+        let endpoint_config = endpoint_config.bucket(bucket);
         let request = {
             let mut message = self
                 .inner
-                .new_request_template("HEAD", bucket)
+                .new_request_template("HEAD", endpoint_config)
                 .map_err(S3RequestError::construction_failure)?;
 
             let key = key.to_string();

--- a/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error};
 
 use crate::object_client::{ListObjectsError, ListObjectsResult, ObjectClientError, ObjectClientResult, ObjectInfo};
 use crate::s3_crt_client::S3RequestError;
-use crate::S3CrtClient;
+use crate::{EndpointConfig, S3CrtClient};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -136,12 +136,14 @@ impl S3CrtClient {
         delimiter: &str,
         max_keys: usize,
         prefix: &str,
+        endpoint_config: EndpointConfig,
     ) -> ObjectClientResult<ListObjectsResult, ListObjectsError, S3RequestError> {
         // Scope the endpoint, message, etc. since otherwise rustc thinks we use Message across the await.
+        let endpoint_config = endpoint_config.bucket(bucket);
         let body = {
             let mut message = self
                 .inner
-                .new_request_template("GET", bucket)
+                .new_request_template("GET", endpoint_config)
                 .map_err(S3RequestError::construction_failure)?;
 
             let max_keys = format!("{max_keys}");

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -12,7 +12,7 @@ use aws_sdk_s3::Region;
 use bytes::Bytes;
 use common::*;
 use futures::StreamExt;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+use mountpoint_s3_client::{EndpointConfig, ObjectClient, S3CrtClient};
 use mountpoint_s3_client::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
@@ -53,11 +53,14 @@ async fn test_static_provider() {
         session_token: credentials.session_token(),
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
-    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Provider(provider));
-    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
+    let endpoint_config = EndpointConfig::new().region(&get_test_region());
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Provider(provider))
+        .endpoint_config(endpoint_config.clone());
+    let client = S3CrtClient::new(config).unwrap();
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, None, None, endpoint_config)
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -72,11 +75,14 @@ async fn test_static_provider() {
         session_token: credentials.session_token(),
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
-    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Provider(provider));
-    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
+    let endpoint_config = EndpointConfig::new().region(&get_test_region());
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Provider(provider))
+        .endpoint_config(endpoint_config.clone());
+    let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, None, None, endpoint_config)
         .await
         .expect("get_object request should be sent");
 
@@ -140,11 +146,14 @@ aws_secret_access_key = {}",
     std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
 
     // Build a S3CrtClient that uses the config file
-    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()));
-    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
+    let endpoint_config = EndpointConfig::new().region(&get_test_region());
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .endpoint_config(endpoint_config.clone());
+    let client = S3CrtClient::new(config).unwrap();
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, None, None, endpoint_config)
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -155,11 +164,14 @@ aws_secret_access_key = {}",
     let length = config_file.as_file().metadata().unwrap().len();
     config_file.as_file_mut().set_len(length - 5).unwrap();
 
-    let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()));
-    let client = S3CrtClient::new(&get_test_region(), config).unwrap();
+    let endpoint_config = EndpointConfig::new().region(&get_test_region());
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .endpoint_config(endpoint_config.clone());
+    let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, None, None, endpoint_config.clone())
         .await
         .expect("get_object should be sent");
 
@@ -172,9 +184,10 @@ aws_secret_access_key = {}",
     // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
     // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
     // be constructed.
-    let config =
-        S3ClientConfig::new().auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()));
-    let _result = S3CrtClient::new(&get_test_region(), config).expect_err("profile doesn't exist");
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
+        .endpoint_config(endpoint_config.clone());
+    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
 }
 
 rusty_fork_test! {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -135,7 +135,7 @@ macro_rules! object_client_test {
         mod $test_fn_identifier {
             use super::$test_fn_identifier;
             use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
-            use $crate::{get_test_bucket_and_prefix, get_test_client};
+            use $crate::{get_test_bucket_and_prefix, get_test_client, get_test_endpoint_config};
 
             #[tokio::test]
             async fn mock() {
@@ -152,8 +152,7 @@ macro_rules! object_client_test {
             #[tokio::test]
             async fn rust_crt() {
                 let (bucket, prefix) = get_test_bucket_and_prefix(stringify!($test_fn_identifier));
-                let endpoint_config = get_test_endpoint_config();
-                let client = get_test_client(endpoint_config);
+                let client = get_test_client(get_test_endpoint_config());
 
                 $test_fn_identifier(&client, &bucket, &prefix).await;
             }

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -3,7 +3,7 @@
 use aws_sdk_s3 as s3;
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
-use mountpoint_s3_client::{S3ClientConfig, S3CrtClient};
+use mountpoint_s3_client::{EndpointConfig, S3ClientConfig, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -17,8 +17,12 @@ fn init_tracing_subscriber() {
     let _ = tracing_subscriber::fmt::try_init();
 }
 
-pub fn get_test_client() -> S3CrtClient {
-    S3CrtClient::new(&get_test_region(), S3ClientConfig::new()).expect("could not create test client")
+pub fn get_test_endpoint_config() -> EndpointConfig {
+    EndpointConfig::new().region(&get_test_region())
+}
+
+pub fn get_test_client(endpoint_config: EndpointConfig) -> S3CrtClient {
+    S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
@@ -148,8 +152,8 @@ macro_rules! object_client_test {
             #[tokio::test]
             async fn rust_crt() {
                 let (bucket, prefix) = get_test_bucket_and_prefix(stringify!($test_fn_identifier));
-
-                let client = get_test_client();
+                let endpoint_config = get_test_endpoint_config();
+                let client = get_test_client(endpoint_config);
 
                 $test_fn_identifier(&client, &bucket, &prefix).await;
             }

--- a/mountpoint-s3-client/tests/delete_object.rs
+++ b/mountpoint-s3-client/tests/delete_object.rs
@@ -23,9 +23,10 @@ async fn test_delete_object() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let _result = client
-        .delete_object(&bucket, &key)
+        .delete_object(&bucket, &key, endpoint_config)
         .await
         .expect("delete_object should succeed");
 
@@ -56,9 +57,10 @@ async fn test_delete_object_no_obj() {
         .expect_err("object should not exist");
     assert!(head_obj_err.into_service_error().is_not_found());
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let _result = client
-        .delete_object(&bucket, &key)
+        .delete_object(&bucket, &key, endpoint_config)
         .await
         .expect("delete_object should not fail for non-existent object");
 }
@@ -69,9 +71,10 @@ async fn test_delete_object_404_bucket() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
-    let result = client.delete_object("DOC-EXAMPLE-BUCKET", &key).await;
+    let result = client.delete_object("DOC-EXAMPLE-BUCKET", &key, endpoint_config).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(DeleteObjectError::NoSuchBucket))
@@ -85,9 +88,10 @@ async fn test_delete_object_no_perm() {
 
     let key = format!("{prefix}/some_key");
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
-    let result = client.delete_object(&bucket, &key).await;
+    let result = client.delete_object(&bucket, &key, endpoint_config).await;
 
     if let Err(ObjectClientError::ClientError(S3RequestError::ResponseError(err))) = &result {
         assert!(err.response_status == 403);

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -26,8 +26,8 @@ async fn run_test<F: FnOnce(&str) -> Endpoint>(f: F) {
 
     let region = get_test_region();
     let endpoint = f(&region);
-    let config = S3ClientConfig::new().endpoint(endpoint);
-    let client = S3CrtClient::new(&region, config).expect("could not create test client");
+    let config = S3ClientConfig::new().endpoint_config(endpoint);
+    let client = S3CrtClient::new(config).expect("could not create test client");
 
     let result = client
         .get_object(&bucket, &key, None, None)

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -38,10 +38,11 @@ async fn test_get_object(size: usize, range: Option<Range<u64>>) {
         .await
         .unwrap();
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
     let result = client
-        .get_object(&bucket, &key, range.clone(), None)
+        .get_object(&bucket, &key, range.clone(), None, endpoint_config)
         .await
         .expect("get_object should succeed");
     let expected = match range {
@@ -57,10 +58,11 @@ async fn test_get_object_404_key() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
     let mut result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, None, None, endpoint_config)
         .await
         .expect("get_object should succeed");
     let next = StreamExt::next(&mut result).await.expect("stream needs to return Err");
@@ -78,10 +80,11 @@ async fn test_get_object_404_bucket() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
     let mut result = client
-        .get_object("DOC-EXAMPLE-BUCKET", &key, None, None)
+        .get_object("DOC-EXAMPLE-BUCKET", &key, None, None, endpoint_config)
         .await
         .expect("get_object failed");
     let next = StreamExt::next(&mut result).await.expect("stream needs to return Err");
@@ -108,11 +111,12 @@ async fn test_get_object_success_if_match() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let etag = Some(ETag::from_str(response.e_tag().expect("E-Tag should be set")).unwrap());
 
     let result = client
-        .get_object(&bucket, &key, None, etag)
+        .get_object(&bucket, &key, None, etag, endpoint_config)
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -135,11 +139,12 @@ async fn test_get_object_412_if_match() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let etag = Some(ETag::from_str("incorrect_etag").unwrap());
 
     let mut result = client
-        .get_object(&bucket, &key, None, etag)
+        .get_object(&bucket, &key, None, etag, endpoint_config)
         .await
         .expect("get_object should succeed");
 

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -3,23 +3,31 @@
 pub mod common;
 
 use common::*;
-use mountpoint_s3_client::{HeadBucketError, ObjectClientError, S3CrtClient};
+use mountpoint_s3_client::{EndpointConfig, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient};
 
 #[tokio::test]
 async fn test_head_bucket_correct_region() {
-    let client = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_correct_region");
 
-    client.head_bucket(&bucket).await.expect("HeadBucket failed");
+    client
+        .head_bucket(&bucket, endpoint_config)
+        .await
+        .expect("HeadBucket failed");
 }
 
 #[tokio::test]
 async fn test_head_bucket_wrong_region() {
-    let client = S3CrtClient::new("ap-southeast-2", Default::default()).expect("could not create test client");
+    let endpoint_config = EndpointConfig::new().region("ap-southeast-2");
+    let client =
+        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client");
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let expected_region = get_test_region();
 
-    let result = client.head_bucket(&bucket).await;
+    let result = client
+        .head_bucket(&bucket, EndpointConfig::new().region(&expected_region))
+        .await;
 
     match result {
         Err(ObjectClientError::ServiceError(HeadBucketError::IncorrectRegion(actual_region))) => {
@@ -31,10 +39,11 @@ async fn test_head_bucket_wrong_region() {
 
 #[tokio::test]
 async fn test_head_bucket_forbidden() {
-    let client = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     let bucket = get_test_bucket_without_permissions();
 
-    let result = client.head_bucket(&bucket).await;
+    let result = client.head_bucket(&bucket, endpoint_config).await;
 
     assert!(matches!(
         result,
@@ -44,11 +53,12 @@ async fn test_head_bucket_forbidden() {
 
 #[tokio::test]
 async fn test_head_bucket_not_found() {
-    let client = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
     // Buckets are case sensitive. This bucket will use path-style access and 404.
     let bucket = "DOC-EXAMPLE-BUCKET";
 
-    let result = client.head_bucket(bucket).await;
+    let result = client.head_bucket(bucket, endpoint_config).await;
 
     assert!(matches!(
         result,

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -23,8 +23,12 @@ async fn test_head_object() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = get_test_client();
-    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
+    let result = client
+        .head_object(&bucket, &key, endpoint_config)
+        .await
+        .expect("head_object failed");
 
     assert_eq!(result.bucket, bucket);
     assert_eq!(result.object.key, key);
@@ -37,9 +41,9 @@ async fn test_head_object_404_key() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3CrtClient = get_test_client();
-
-    let result = client.head_object(&bucket, &key).await;
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
+    let result = client.head_object(&bucket, &key, endpoint_config).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))
@@ -52,9 +56,10 @@ async fn test_head_object_404_bucket() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client: S3CrtClient = get_test_client();
+    let endpoint_config = get_test_endpoint_config();
+    let client: S3CrtClient = get_test_client(endpoint_config.clone());
 
-    let result = client.head_object("DOC-EXAMPLE-BUCKET", &key).await;
+    let result = client.head_object("DOC-EXAMPLE-BUCKET", &key, endpoint_config).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -74,7 +74,7 @@ fn main() {
     if let Some(part_size) = part_size {
         config = config.part_size(part_size);
     }
-    let client = Arc::new(S3CrtClient::new(region, config).expect("couldn't create client"));
+    let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
 
     for i in 0..iterations.unwrap_or(1) {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -491,7 +491,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     }
 
     let bucket_name = args.bucket_name;
-    let client = create_client_for_bucket(&bucket_name, &endpoint_config, client_config)
+    let client = create_client_for_bucket(&bucket_name, endpoint_config.clone(), client_config)
         .context("Failed to create S3 client")?;
     let runtime = client.event_loop_group();
 
@@ -511,7 +511,14 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
 
     let prefix = args.prefix.unwrap_or_default();
-    let fs = S3FuseFilesystem::new(client, runtime, &args.bucket_name, &prefix, filesystem_config);
+    let fs = S3FuseFilesystem::new(
+        client,
+        runtime,
+        &args.bucket_name,
+        &prefix,
+        filesystem_config,
+        endpoint_config.clone(),
+    );
 
     let fs_name = String::from("mountpoint-s3");
     let mut options = vec![

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -13,9 +13,10 @@ use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::metrics::MetricsSink;
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::{
-    AddressingStyle, Endpoint, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient,
+    AddressingStyle, Endpoint, EndpointConfig, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient,
 };
 use mountpoint_s3_client::{ImdsCrtClient, S3ClientAuthConfig};
+use mountpoint_s3_crt::common::allocator::Allocator;
 use nix::sys::signal::Signal;
 use nix::unistd::ForkResult;
 use regex::Regex;
@@ -197,6 +198,15 @@ struct CliArgs {
 
     #[clap(long, help = "Force path-style addressing", help_heading = BUCKET_OPTIONS_HEADER)]
     pub path_addressing: bool,
+
+    #[clap(long, help = "Use S3 Transfer Acceleration", help_heading = BUCKET_OPTIONS_HEADER)]
+    pub transfer_acceleration: bool,
+
+    #[clap(long, help = "Use dual stack endpoint", help_heading = BUCKET_OPTIONS_HEADER)]
+    pub dual_stack: bool,
+
+    #[clap(long, help = "Use FIPS endpoint", help_heading = BUCKET_OPTIONS_HEADER)]
+    pub fips: bool,
 
     #[clap(long, help = "Set the 'x-amz-request-payer' to 'requester' on S3 requests", help_heading = BUCKET_OPTIONS_HEADER)]
     pub requester_pays: bool,
@@ -435,7 +445,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     let addressing_style = args.addressing_style();
     let endpoint = args
         .endpoint_url
-        .map(|uri| Endpoint::from_uri(&uri, addressing_style))
+        .map(|uri| Endpoint::from_uri(&uri))
         .transpose()
         .context("Failed to parse endpoint URL")?;
 
@@ -459,6 +469,14 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
         S3ClientAuthConfig::Default
     };
 
+    let endpoint_config = EndpointConfig::new()
+        .region(args.region)
+        .addressing_style(addressing_style)
+        .endpoint(endpoint)
+        .use_fips(args.fips)
+        .use_accelerate(args.transfer_acceleration)
+        .use_dual_stack(args.dual_stack);
+
     let mut client_config = S3ClientConfig::new()
         .auth_config(auth_config)
         .throughput_target_gbps(throughput_target_gbps)
@@ -472,14 +490,9 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
         client_config = client_config.bucket_owner(&owner);
     }
 
-    let client = create_client_for_bucket(
-        &args.bucket_name,
-        args.region.as_deref(),
-        endpoint,
-        client_config,
-        addressing_style,
-    )
-    .context("Failed to create S3 client")?;
+    let bucket_name = args.bucket_name;
+    let client = create_client_for_bucket(&bucket_name, &endpoint_config, client_config)
+        .context("Failed to create S3 client")?;
     let runtime = client.event_loop_group();
 
     let mut filesystem_config = S3FilesystemConfig::default();
@@ -537,15 +550,13 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 /// responses, which means we don't have to wait for the first file read to start the rampup period.
 fn create_client_for_bucket(
     bucket: &str,
-    supposed_region: Option<&str>,
-    endpoint: Option<Endpoint>,
+    endpoint_config: EndpointConfig,
     client_config: S3ClientConfig,
-    addressing_style: AddressingStyle,
 ) -> Result<S3CrtClient, anyhow::Error> {
     const DEFAULT_REGION: &str = "us-east-1";
 
-    let region_to_try = supposed_region.unwrap_or_else(|| {
-        if endpoint.is_some() {
+    let region_to_try = endpoint_config.get_region().unwrap_or_else(|| {
+        if endpoint_config.get_endpoint().is_some() {
             tracing::warn!(
                 "endpoint specified but region unspecified. using {} as the signing region.",
                 DEFAULT_REGION
@@ -554,23 +565,18 @@ fn create_client_for_bucket(
         DEFAULT_REGION
     });
 
-    let endpoint = if let Some(endpoint) = endpoint.clone() {
-        endpoint
-    } else {
-        Endpoint::from_region(region_to_try, addressing_style)?
-    };
+    let endpoint_config = endpoint_config.region(region_to_try);
+    let client = S3CrtClient::new(client_config.clone().endpoint_config(&endpoint_config))?;
 
-    let client = S3CrtClient::new(region_to_try, client_config.clone().endpoint(endpoint))?;
-
-    let head_request = client.head_bucket(bucket);
+    let head_request = client.head_bucket(bucket, &endpoint_config);
     match futures::executor::block_on(head_request) {
         Ok(_) => Ok(client),
         // Don't try to automatically correct the region if it was manually specified incorrectly
         Err(ObjectClientError::ServiceError(HeadBucketError::IncorrectRegion(region))) if supposed_region.is_none() => {
             tracing::warn!("bucket {bucket} is in region {region}, not {region_to_try}. redirecting...");
-            let endpoint = Endpoint::from_region(&region, addressing_style)?;
-            let new_client = S3CrtClient::new(&region, client_config.endpoint(endpoint))?;
-            let head_request = new_client.head_bucket(bucket);
+            let endpoint_config = endpoint_config.region(&region);
+            let new_client = S3CrtClient::new(client_config.endpoint_config(&endpoint_config))?;
+            let head_request = new_client.head_bucket(bucket, &endpoint_config);
             futures::executor::block_on(head_request)
                 .map(|_| new_client)
                 .with_context(|| format!("HeadBucket failed for bucket {bucket} in region {region}"))

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -20,7 +20,7 @@ use futures::pin_mut;
 use futures::stream::StreamExt;
 use futures::task::{Spawn, SpawnExt};
 use metrics::counter;
-use mountpoint_s3_client::{ETag, GetObjectError, ObjectClient, ObjectClientError};
+use mountpoint_s3_client::{ETag, GetObjectError, ObjectClient, ObjectClientError, EndpointConfig};
 use mountpoint_s3_crt::checksums::crc32c;
 use thiserror::Error;
 use tracing::{debug_span, error, trace, Instrument};
@@ -97,8 +97,8 @@ where
     }
 
     /// Start a new get request to the specified object.
-    pub fn get(&self, bucket: &str, key: &str, size: u64, etag: ETag) -> PrefetchGetObject<Client, Runtime> {
-        PrefetchGetObject::new(Arc::clone(&self.inner), bucket, key, size, etag)
+    pub fn get(&self, bucket: &str, key: &str, size: u64, etag: ETag, endpoint_config: EndpointConfig) -> PrefetchGetObject<Client, Runtime> {
+        PrefetchGetObject::new(Arc::clone(&self.inner), bucket, key, size, etag, endpoint_config)
     }
 }
 
@@ -119,6 +119,7 @@ pub struct PrefetchGetObject<Client: ObjectClient, Runtime> {
     next_request_offset: u64,
     size: u64,
     etag: ETag,
+    endpoint_config: EndpointConfig,
 }
 
 impl<Client, Runtime> PrefetchGetObject<Client, Runtime>
@@ -127,7 +128,7 @@ where
     Runtime: Spawn,
 {
     /// Create and spawn a new prefetching request for an object
-    fn new(inner: Arc<PrefetcherInner<Client, Runtime>>, bucket: &str, key: &str, size: u64, etag: ETag) -> Self {
+    fn new(inner: Arc<PrefetcherInner<Client, Runtime>>, bucket: &str, key: &str, size: u64, etag: ETag, endpoint_config: EndpointConfig) -> Self {
         PrefetchGetObject {
             inner: inner.clone(),
             current_task: None,
@@ -140,6 +141,7 @@ where
             key: key.to_owned(),
             size,
             etag,
+            endpoint_config,
         }
     }
 
@@ -287,9 +289,10 @@ where
             let key = self.key.to_owned();
             let etag = self.etag.clone();
             let span = debug_span!("prefetch", range=?range);
+            let endpoint_config = self.endpoint_config.clone();
 
             async move {
-                match client.get_object(&bucket, &key, Some(range.clone()), Some(etag)).await {
+                match client.get_object(&bucket, &key, Some(range.clone()), Some(etag), endpoint_config.clone()).await {
                     Err(e) => {
                         error!(error=?e, "RequestTask get object failed");
                         part_queue_producer.push(Err(e));
@@ -455,7 +458,7 @@ mod tests {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
 
-        let mut request = prefetcher.get("test-bucket", "hello", size, etag);
+        let mut request = prefetcher.get("test-bucket", "hello", size, etag, Default::default());
 
         let mut next_offset = 0;
         loop {
@@ -531,7 +534,7 @@ mod tests {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
 
-        let mut request = prefetcher.get("test-bucket", "hello", size, etag);
+        let mut request = prefetcher.get("test-bucket", "hello", size, etag, Default::default());
 
         let mut next_offset = 0;
         loop {
@@ -607,7 +610,7 @@ mod tests {
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
         let etag = ETag::for_tests();
 
-        let mut request = prefetcher.get("test-bucket", "hello", object_size, etag);
+        let mut request = prefetcher.get("test-bucket", "hello", object_size, etag, Default::default());
 
         request.next_request_offset = next_request_offset as u64;
         request.next_request_size = current_request_size;
@@ -652,7 +655,7 @@ mod tests {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = Prefetcher::new(Arc::new(client), runtime, test_config);
 
-        let mut request = prefetcher.get("test-bucket", "hello", object_size, etag);
+        let mut request = prefetcher.get("test-bucket", "hello", object_size, etag, Default::default());
 
         for (offset, length) in reads {
             assert!(offset < object_size);


### PR DESCRIPTION
## Description of change
Using CRT endpoint resolver to resolve endpoint for each request. With this support for ARN, mount options for FIPS, transfer acceleration and dual stack will be enabled.

<!-- Please describe your contribution here. What and why? -->
Added the mount options. Created endpointConfig which contains all the configuration for endpoint resolution in mountpoint client. This configuration is used to resolve endpoint for each request in mountpoint. 
Still need to add some tests to see if it is right. So, adding it as a draft.

Relevant issues: <!-- Please add issue numbers. -->
#4 

## Does this change impact existing behavior?
Yes, new mount options will get added after this change. Also, ARN will get supported as bucket name.

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking change for mountpoint. Just we are not resolving endpoint in 2 step process like earlier (first, for region and then for bucket and addressing for each request)
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
