### PR TITLE
Disable new `items_after_test_module` Clippy lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ fmt-check:
 .PHONY: clippy
 clippy:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
-	cargo clippy $$packages --no-deps --all-targets --all-features -- -D clippy::all
+	cargo clippy $$packages --no-deps --all-targets --all-features -- -D clippy::all -A clippy::items-after-test-module


### PR DESCRIPTION
This is new in 1.71, but seems to get confused by the test_case macro.
It was supposedly fixed in
https://github.com/rust-lang/rust-clippy/pull/10992 but that seems to
not have entirely worked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
