### PR TITLE
Disable logging to file by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,15 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,7 +1900,6 @@ dependencies = [
  "fuser",
  "futures",
  "hdrhistogram",
- "home",
  "libc",
  "metrics",
  "mountpoint-s3-client",

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -13,7 +13,7 @@ A new log file will be created for each execution of `mount-s3`.
 Both the directory and log files are created with permissions such that the process owner has read/write access and the group has read access.
 Log files are not rotated or cleaned up.
 
-When running in foreground mode (`-f, --foreground`), `mount-s3` will emit logs to stdout irrespective of the `--log-directory` configuration.
+When running in foreground mode (`-f, --foreground`), `mount-s3` will emit logs to stdout in addition to any configured log directory.
 
 ## Log details
 

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -1,18 +1,23 @@
 # Logging
 
-Mountpoint for Amazon S3 uses the [tracing](https://docs.rs/tracing/latest/tracing/) ecosystem for logging. This makes it easy to configure the verbosity and target of log output. By default we output minimal log information, but for reporting issues or debugging application problems, you may want to customize this logging behavior.
+Mountpoint for Amazon S3 uses the [tracing](https://docs.rs/tracing/latest/tracing/) ecosystem for logging. This makes it easy to configure the verbosity and target of log output.
+The logging level is minimal by default, but for reporting issues or debugging application problems, you may want to customize this logging behavior.
 
 ## Log outputs
 
-By default, Mountpoint for Amazon S3 outputs logs to the `~/.mountpoint-s3/` directory, creating it if it doesn't exist. This destination can be changed using the `-l, --log-directory` command-line argument.
+By default, Mountpoint for Amazon S3 will not emit any logs to disk.
 
-A new log file is created for each execution of `mount-s3`. Log files are never automatically rotated or cleaned up.
+You can enable logging to disk by providing a destination directory using the `-l, --log-directory` command-line argument.
+The directory will be created if it doesn't exist.
+A new log file will be created for each execution of `mount-s3`.
+Both the directory and log files are created with permissions such that the process owner has read/write access and the group has read access.
+Log files are not rotated or cleaned up.
 
-When running in foreground mode (`-f, --foreground`), `mount-s3` also emits the same log information to stdout.
+When running in foreground mode (`-f, --foreground`), `mount-s3` will emit logs to stdout irrespective of the `--log-directory` configuration.
 
 ## Log details
 
-By default, we output minimal (error-level) information to the log file. For reporting issues or debugging application problems, it can be helpful to increase this verbosity. We use the common `RUST_LOG` environment variable for controlling log verbosity and subjects.
+By default, the logging level is minimal. For reporting issues or debugging application problems, it can be helpful to increase this verbosity. We use the common `RUST_LOG` environment variable for controlling log verbosity and subjects.
 
 To control the log verbosity, set the `RUST_LOG` environment variable. If unset, it defaults to `error` to enable only error-level log messages. Verbosity can be increased by instead setting `RUST_LOG` to `warn`, `info`, `debug`, or `trace`.
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Unreleased
+
+Breaking changes:
+
+* Logging to disk is now disabled by default.
+  Logs will not longer be written to `$HOME/.mountpoint-s3/` and should be configured using `--log-directory <DIRECTORY>`.
+
+# v0.3.0 (June 30, 2023)
+
+Initial change log entry.

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -29,7 +29,6 @@ tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 nix = "0.26.2"
 time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
-home = "0.5.4"
 serde_json = "1.0.95"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -164,7 +164,8 @@ struct CliArgs {
     #[clap(
         short,
         long,
-        help = "Configure a directory for logs to be written to a file. [default: no logs written to a file]"
+        help = "Configure a directory for logs to be written to. [default: no logs written to a file]",
+        value_name = "DIRECTORY"
     )]
     pub log_directory: Option<PathBuf>,
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -101,7 +101,7 @@ mod logging {
 
         let file_layer = if let Some(path) = log_directory {
             const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
-                macros::format_description!("mountpoint_s3_[year][month][day][hour][minute][second].log");
+                macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
             let filename = OffsetDateTime::now_utc()
                 .format(LOG_FILE_NAME_FORMAT)
                 .context("couldn't format log file name")?;


### PR DESCRIPTION
## Description of change

Logging by default to a location on disk is unexpected. It risks accumulating logs over time since the user may not be aware that they are written there, and there is no log rotation or truncation in place.

This change disables logging to a file by default. Logging can still be configured as usual using `--log-directory <DIRECTORY>`, `-l <LOG_DIRECTORY>`.

This ensures users are making a conscious decision to enable logging and handle log rotation.

Relevant issues: #303

## Does this change impact existing behavior?

Yes. When updating to a version of Mountpoint containing this change, logs will no longer be emitted to `$HOME/.mountpoint-s3` if no configuration was provided by `-l` or `--log-directory`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
