### PR TITLE
Compiling software binary in AL2 container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,14 @@ jobs:
     - uses: actions/checkout@v3
     - uses: taiki-e/create-gh-release-action@v1
       with:
-        prefix: mountpoint-s3(-[a-z]+)?
+        prefix: mountpoint-s3
         draft: true
         # TODO: set it true after we have changlog template reviewed.
         changelog: false
         # TODO: set it false after we have changlog template reviewed.
-        allow-missing-changelog: true
+        # Our chang log format may or may not align with workflows requirement,
+        # set allow-missing-changlog to true.
+        allow-missing-changelog: true 
         branch: main
         title: "Mountpoint for Amazon S3 v$version"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,17 +31,27 @@ jobs:
   upload-assets:
     name: Build and release on target ${{ matrix.runner.target}}
     runs-on: ${{ matrix.runner.tags }}
+    container: public.ecr.aws/amazonlinux/amazonlinux:2 
 
     strategy:
       fail-fast: false
       matrix:
         runner:
-        - tags: [ubuntu-20.04] # GitHub-hosted
-          target: x86_64-unknown-linux-gnu
+        - tags: ubuntu-latest
+          target: x86_64 
         - tags: [self-hosted, linux, arm64] 
-          target: aarch64-unknown-linux-gnu
+          target: aarch64 
 
     steps:
+    - name: Install dependencies 
+      run: |
+        yum update
+        yum -y install yum-utils tar git jq make cmake3 clang-devel pkg-config fuse fuse-devel llvm-devel libunwind-devel 
+        type -p yum-config-manager >/dev/null
+        yum-config-manager -y --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+        yum -y install gh
+        yum -t update gh
+        git config --system --add safe.directory '*'
     - name: Checkout source code
       uses: actions/checkout@v3
       with:
@@ -49,16 +61,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Install operating system dependencies
-      uses: ./.github/actions/install-dependencies
-      with:
-        fuseVersion: 2 
-    - name: Release mount-s3 binary
+    - name: Release mount-s3 binaries
       uses: taiki-e/upload-rust-binary-action@v1
       with:
         bin: mount-s3
         token: ${{ secrets.GITHUB_TOKEN }}
         checksum: sha512
         asset: LICENSE
-
-


### PR DESCRIPTION
Instead of using Github hosted Ubuntu runner, adopt self-hosted Amazon Linux2 x86_64.

## Description of change

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
