### PR TITLE
Adds region in tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ env:
   # A bucket our IAM role has no access to, but is in the right region, for permissions tests
   S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   S3_REGION: ${{ vars.S3_REGION }}
-  RUST_FEATURES: fuse_tests,s3_tests,delete
+  RUST_FEATURES: fuse_tests,s3_tests,delete,fips_tests
 
 permissions:
   id-token: write

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -44,6 +44,10 @@ pub fn get_test_bucket_without_permissions() -> String {
     std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
 }
 
+pub fn get_secondary_test_region() -> String {
+    std::env::var("S3_SECONDARY_REGION").unwrap_or(String::from("ap-southeast-2"))
+ }
+ 
 pub async fn get_test_sdk_client() -> s3::Client {
     let config = aws_config::from_env()
         .region(Region::new(get_test_region()))

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -48,6 +48,10 @@ pub fn get_secondary_test_region() -> String {
     std::env::var("S3_SECONDARY_REGION").unwrap_or(String::from("ap-southeast-2"))
  }
  
+pub fn get_test_domain() -> String {
+    std::env::var("S3_DOMAIN").unwrap_or(String::from("com"))
+ }
+
 pub async fn get_test_sdk_client() -> s3::Client {
     let config = aws_config::from_env()
         .region(Region::new(get_test_region()))

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -49,7 +49,7 @@ pub fn get_secondary_test_region() -> String {
  }
  
 pub fn get_test_domain() -> String {
-    std::env::var("S3_DOMAIN").unwrap_or(String::from("com"))
+    std::env::var("S3_DOMAIN").unwrap_or(String::from("amazonaws.com"))
  }
 
 pub async fn get_test_sdk_client() -> s3::Client {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -46,11 +46,11 @@ pub fn get_test_bucket_without_permissions() -> String {
 
 pub fn get_secondary_test_region() -> String {
     std::env::var("S3_SECONDARY_REGION").unwrap_or(String::from("ap-southeast-2"))
- }
- 
+}
+
 pub fn get_test_domain() -> String {
     std::env::var("S3_DOMAIN").unwrap_or(String::from("amazonaws.com"))
- }
+}
 
 pub async fn get_test_sdk_client() -> s3::Client {
     let config = aws_config::from_env()

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -50,7 +50,7 @@ async fn test_addressing_style_region(addressing_style: AddressingStyle) {
 #[tokio::test]
 async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let domain = get_test_domain(region);
+        let domain = get_test_domain();
         let uri = format!("https://s3.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
@@ -63,7 +63,7 @@ async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
 #[tokio::test]
 async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let domain = get_test_domain(region);
+        let domain = get_test_domain();
         let uri = format!("https://s3.dualstack.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
@@ -76,7 +76,7 @@ async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) 
 #[tokio::test]
 async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let domain = get_test_domain(region);
+        let domain = get_test_domain();
         let uri = format!("https://s3-fips.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
@@ -88,16 +88,9 @@ async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
 #[tokio::test]
 async fn test_addressing_style_uri_fips_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let domain = get_test_domain(region);
+        let domain = get_test_domain();
         let uri = format!("https://s3-fips.dualstack.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
-}
-
-fn get_test_domain(region: &str) -> String {
-    match region {
-        "cn-north-1" | "cn-northwest-1" => "com.cn".to_string(),
-        _ => "com".to_string(),
-    }
 }

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -50,7 +50,8 @@ async fn test_addressing_style_region(addressing_style: AddressingStyle) {
 #[tokio::test]
 async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let uri = format!("https://s3.{region}.amazonaws.com");
+        let domain = get_test_domain(region);
+        let uri = format!("https://s3.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
@@ -62,29 +63,41 @@ async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
 #[tokio::test]
 async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let uri = format!("https://s3.dualstack.{region}.amazonaws.com");
+        let domain = get_test_domain(region);
+        let uri = format!("https://s3.dualstack.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
 }
 
 // FIPS endpoints can only be used with virtual-hosted-style addressing
+#[cfg(feature = "fips_tests")]
 #[test_case(AddressingStyle::Virtual)]
 #[tokio::test]
 async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let uri = format!("https://s3-fips.{region}.amazonaws.com");
+        let domain = get_test_domain(region);
+        let uri = format!("https://s3-fips.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
 }
 // FIPS endpoints can only be used with virtual-hosted-style addressing
+#[cfg(feature = "fips_tests")]
 #[test_case(AddressingStyle::Virtual)]
 #[tokio::test]
 async fn test_addressing_style_uri_fips_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
-        let uri = format!("https://s3-fips.dualstack.{region}.amazonaws.com");
+        let domain = get_test_domain(region);
+        let uri = format!("https://s3-fips.dualstack.{region}.amazonaws.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
+}
+
+fn get_test_domain(region: &str) -> String {
+    match region {
+        "cn-north-1" | "cn-northwest-1" => "com.cn".to_string(),
+        _ => "com".to_string(),
+    }
 }

--- a/mountpoint-s3-client/tests/endpoint.rs
+++ b/mountpoint-s3-client/tests/endpoint.rs
@@ -51,7 +51,7 @@ async fn test_addressing_style_region(addressing_style: AddressingStyle) {
 async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
     run_test(|region| {
         let domain = get_test_domain();
-        let uri = format!("https://s3.{region}.amazonaws.{domain}");
+        let uri = format!("https://s3.{region}.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
@@ -64,7 +64,7 @@ async fn test_addressing_style_uri(addressing_style: AddressingStyle) {
 async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
         let domain = get_test_domain();
-        let uri = format!("https://s3.dualstack.{region}.amazonaws.{domain}");
+        let uri = format!("https://s3.dualstack.{region}.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
@@ -77,7 +77,7 @@ async fn test_addressing_style_uri_dualstack(addressing_style: AddressingStyle) 
 async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
     run_test(|region| {
         let domain = get_test_domain();
-        let uri = format!("https://s3-fips.{region}.amazonaws.{domain}");
+        let uri = format!("https://s3-fips.{region}.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;
@@ -89,7 +89,7 @@ async fn test_addressing_style_uri_fips(addressing_style: AddressingStyle) {
 async fn test_addressing_style_uri_fips_dualstack(addressing_style: AddressingStyle) {
     run_test(|region| {
         let domain = get_test_domain();
-        let uri = format!("https://s3-fips.dualstack.{region}.amazonaws.{domain}");
+        let uri = format!("https://s3-fips.dualstack.{region}.{domain}");
         Endpoint::from_uri(&uri, addressing_style).unwrap()
     })
     .await;

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -15,7 +15,10 @@ async fn test_head_bucket_correct_region() {
 
 #[tokio::test]
 async fn test_head_bucket_wrong_region() {
-    let client = S3CrtClient::new("ap-southeast-2", Default::default()).expect("could not create test client");
+
+    let secondary_region = get_secondary_test_region();
+
+    let client = S3CrtClient::new(&secondary_region, Default::default()).expect("could not create test client");
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let expected_region = get_test_region();
 

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -15,9 +15,7 @@ async fn test_head_bucket_correct_region() {
 
 #[tokio::test]
 async fn test_head_bucket_wrong_region() {
-
     let secondary_region = get_secondary_test_region();
-
     let client = S3CrtClient::new(&secondary_region, Default::default()).expect("could not create test client");
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let expected_region = get_test_region();

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -24,7 +24,6 @@ fn run_in_background() -> Result<(), Box<dyn std::error::Error>> {
         .arg(mount_point.path())
         .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
-        .arg(format!("--region={region}"))
         .spawn()
         .expect("unable to spawn child");
 

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -24,6 +24,7 @@ fn run_in_background() -> Result<(), Box<dyn std::error::Error>> {
         .arg(mount_point.path())
         .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
+        .arg(format!("--region={region}"))
         .spawn()
         .expect("unable to spawn child");
 
@@ -61,6 +62,7 @@ fn run_in_foreground() -> Result<(), Box<dyn std::error::Error>> {
         .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
         .arg("--foreground")
+        .arg(format!("--region={region}"))
         .spawn()
         .expect("unable to spawn child");
 
@@ -158,6 +160,7 @@ fn run_in_foreground_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
 fn run_fail_on_duplicate_mount() -> Result<(), Box<dyn std::error::Error>> {
     let (bucket, prefix) = get_test_bucket_and_prefix("run_fail_on_duplicate_mount");
     let mount_point = assert_fs::TempDir::new()?;
+    let region = get_test_region();
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let mut first_mount = cmd
@@ -165,6 +168,7 @@ fn run_fail_on_duplicate_mount() -> Result<(), Box<dyn std::error::Error>> {
         .arg(mount_point.path())
         .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
+        .arg(format!("--region={region}"))
         .spawn()
         .expect("unable to spawn child");
 
@@ -215,6 +219,7 @@ fn run_fail_on_duplicate_mount() -> Result<(), Box<dyn std::error::Error>> {
 fn mount_readonly() -> Result<(), Box<dyn std::error::Error>> {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_mount_readonly");
     let mount_point = assert_fs::TempDir::new()?;
+    let region = get_test_region();
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let mut child = cmd
@@ -224,6 +229,7 @@ fn mount_readonly() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--auto-unmount")
         .arg("--foreground")
         .arg("--read-only")
+        .arg(format!("--region={region}"))
         .spawn()
         .expect("unable to spawn child");
 


### PR DESCRIPTION
## Description of change

To gets tests to pass in the gov cloud and china partitions, the region needs to be specified in some cases. Without this, the head bucket probe to us-east-1 one fails as us-east-1 is in a different partition and so credentials will not work there.

Tested by running in cn-north-1, all tests pass. 

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
