### PR TITLE
Allow omitting commit hash from version when specified in env

### DIFF
--- a/mountpoint-s3/src/build_info.rs
+++ b/mountpoint-s3/src/build_info.rs
@@ -7,10 +7,10 @@ mod built {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-/// Valid SemVer version constructed using declared Cargo version and short commit hash.
+/// Valid SemVer version constructed using declared Cargo version and short commit hash if needed.
 pub const FULL_VERSION: &str = {
     // A little hacky so we can pull out the hash as a const
-    if built::GIT_COMMIT_HASH_SHORT.is_some() {
+    if built::GIT_COMMIT_HASH_SHORT.is_some() && !is_official_aws_release() {
         const COMMIT_HASH_STR: &str = match built::GIT_COMMIT_HASH_SHORT {
             Some(hash) => hash,
             // Evaluated at compile time, but never used
@@ -21,3 +21,8 @@ pub const FULL_VERSION: &str = {
         built::PKG_VERSION
     }
 };
+
+/// Checks environment to see if this build is for an official Mountpoint for Amazon S3 release.
+const fn is_official_aws_release() -> bool {
+    option_env!("MOUNTPOINT_S3_AWS_RELEASE").is_some()
+}


### PR DESCRIPTION
## Description of change

Official binary release of Mountpoint should drop the commit hash, so its clear its a canonical release.

Note, if the environment variable is set to any value (even `false`), this will still be treated as an official release. This code runs in a `const` context, so most string comparison appears to be unavailable.

Example of how it works:

```
~/devel/mountpoint-s3 allow-omitti…-commit-hash
❯ cargo run --quiet -- --version                    
mountpoint-s3 0.3.0-2e05fdf

~/devel/mountpoint-s3 allow-omitti…-commit-hash
❯ MOUNTPOINT_S3_AWS_RELEASE=true cargo run --quiet -- --version
mountpoint-s3 0.3.0

~/devel/mountpoint-s3 allow-omitti…-commit-hash
❯ MOUNTPOINT_S3_AWS_RELEASE=0 cargo run --quiet -- --version
mountpoint-s3 0.3.0
```

Relevant issues: N/A

## Does this change impact existing behavior?

Nothing material. Just drops commit hash from version identifier for `--version` and user agent, only for when we build canonical/official releases.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
