### PR TITLE
Remove the temporary checksum feature

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -59,8 +59,6 @@ fuse_tests = []
 s3_tests = []
 shuttle = []
 delete = []
-# A temporary feature flag to enable read-path checksums while we are working to improve its performance
-checksum = []
 
 [build-dependencies]
 built = { version = "0.6.0", features = ["git2"] }

--- a/mountpoint-s3/src/prefetch/checksummed_bytes.rs
+++ b/mountpoint-s3/src/prefetch/checksummed_bytes.rs
@@ -25,7 +25,6 @@ impl ChecksummedBytes {
     ///
     /// Return `IntegrityError` on data corruption.
     pub fn into_bytes(self) -> Result<Bytes, IntegrityError> {
-        #[cfg(feature = "checksum")]
         self.validate()?;
 
         Ok(self.curr_slice)
@@ -72,7 +71,6 @@ impl ChecksummedBytes {
         let new_checksummed_bytes = ChecksummedBytes::new(new_bytes, new_checksum);
 
         // Validate data integrity with checksum bracketing.
-        #[cfg(feature = "checksum")]
         {
             // 1. repeat the operation, which means copying into a new buffer in this case.
             let mut bytes_mut_dup = BytesMut::with_capacity(total_len);
@@ -145,7 +143,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(feature = "checksum")]
     #[test]
     fn test_into_bytes_integrity_error() {
         let bytes = Bytes::from_static(b"some bytes");
@@ -210,7 +207,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(feature = "checksum")]
     #[test]
     fn test_extend_self_corrupted() {
         let bytes = Bytes::from_static(b"some bytes");
@@ -228,7 +224,6 @@ mod tests {
         assert!(matches!(result, Err(IntegrityError::ChecksumMismatch(_, _))));
     }
 
-    #[cfg(feature = "checksum")]
     #[test]
     fn test_extend_other_corrupted() {
         let bytes = Bytes::from_static(b"some bytes");


### PR DESCRIPTION
## Description of change

We have made some improvements on the prefetcher's checksum in https://github.com/awslabs/mountpoint-s3/pull/315 and https://github.com/awslabs/mountpoint-s3/pull/328. Now the performance should be good enough to enable this feature by default.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
