### PR TITLE
Remove checksum feature from the workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ env:
   # A bucket our IAM role has no access to, but is in the right region, for permissions tests
   S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   S3_REGION: ${{ vars.S3_REGION }}
-  RUST_FEATURES: fuse_tests,s3_tests,checksum,delete
+  RUST_FEATURES: fuse_tests,s3_tests,delete
 
 permissions:
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_FEATURES: fuse_tests,checksum,delete
+  RUST_FEATURES: fuse_tests,delete
 
 jobs:
   test:


### PR DESCRIPTION
## Description of change

We are going to remove `checksum` feature from Mountpoint in https://github.com/awslabs/mountpoint-s3/pull/378 but the integration tests are blocking us because the workflows come from the main branch. To make the integration tests pass we have to remove this feature flag from the CI first.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
