### PR TITLE
Reconcile remote and existing inodes at `update` time

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -608,7 +608,7 @@ impl SuperblockInner {
     ) -> Result<LookedUp, InodeError> {
         let parent = self.get(parent_ino)?;
 
-        // TODO what if a file was overwritten by a directory on the server side?
+        // Should be impossible since all callers check this already, but let's be safe
         if parent.kind() != InodeKind::Directory {
             return Err(InodeError::NotADirectory(parent_ino));
         }
@@ -616,101 +616,152 @@ impl SuperblockInner {
         // Fast path: try with only a read lock on the directory first.
         {
             let parent_state = parent.get_inode_state()?;
-            match Self::try_update_child(&parent_state, name, &remote)? {
-                UpdateStatus::Neither => return Err(InodeError::FileDoesNotExist),
-                UpdateStatus::Updated(lookedup) => return Ok(lookedup),
-                _ => {} // Fallback, we need a write lock to update the parent.
+            if let Some(looked_up) = Self::try_update_fast_path(&parent_state, name, &remote)? {
+                return Ok(looked_up);
             }
         }
 
-        // If the fast path failed, take the write lock. We first have to try the update again, as
-        // a racing writer might have beat us to the lock after our fast path attempt.
-        let mut parent_state = parent.get_mut_inode_state()?;
-        match Self::try_update_child(&parent_state, name, &remote)? {
-            UpdateStatus::Neither => Err(InodeError::FileDoesNotExist),
-            UpdateStatus::Updated(lookedup) => Ok(lookedup),
-            UpdateStatus::LocalOnly(inode) => {
-                match &mut parent_state.kind_data {
-                    InodeKindData::File {} => unreachable!("we know parent is a directory"),
-                    InodeKindData::Directory {
-                        children,
-                        writing_children,
-                        ..
-                    } => {
-                        if writing_children.contains(&inode.ino()) {
-                            // Return the local inode.
-                            let stat = inode.get_inode_state()?.stat.clone();
-                            Ok(LookedUp { inode, stat })
-                        } else {
-                            // Remove from children.
-                            children.remove(name);
-                            Err(InodeError::FileDoesNotExist)
-                        }
-                    }
-                }
-            }
-            UpdateStatus::RemoteKey(RemoteLookup { stat, kind }) => {
-                let state = InodeState {
-                    stat: stat.clone(),
-                    kind_data: InodeKindData::default_for(kind),
-                    write_status: WriteStatus::Remote,
-                    lookup_count: 0,
-                };
-                self.create_inode_locked(&parent, &mut parent_state, name, kind, state, false)
-                    .map(|inode| LookedUp { inode, stat })
-            }
-        }
+        self.update_slow_path(parent, name, remote)
     }
 
-    /// Try to update the inode for the given name in the parent directory and
-    /// return an [UpdateStatus].
-    /// Don't use this directly -- use [SuperblockInner::update_from_remote] instead.
-    fn try_update_child(
+    /// Try to update the inode for the given name in the parent directory with only a read lock on
+    /// the parent.
+    fn try_update_fast_path(
         parent_state: &InodeState,
         name: &str,
         remote: &Option<RemoteLookup>,
-    ) -> Result<UpdateStatus, InodeError> {
+    ) -> Result<Option<LookedUp>, InodeError> {
         let inode = match &parent_state.kind_data {
             InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
             InodeKindData::Directory { children, .. } => children.get(name),
         };
         match (remote, inode) {
-            (None, None) => Ok(UpdateStatus::Neither),
-            (None, Some(inode)) => Ok(UpdateStatus::LocalOnly(inode.clone())),
-            (Some(remote), None) => Ok(UpdateStatus::RemoteKey(remote.clone())),
-            (
-                Some(
-                    remote @ RemoteLookup {
-                        kind: remote_kind,
-                        stat,
-                    },
-                ),
-                Some(existing_inode),
-            ) => {
-                let mut inode_state = existing_inode.get_mut_inode_state()?;
-                match (existing_inode.kind(), remote_kind) {
-                    // If the kind has changed, we need a new inode.
-                    (InodeKind::File, InodeKind::Directory) | (InodeKind::Directory, InodeKind::File) => {
-                        warn!(
-                            parent=?existing_inode.parent(),
-                            name=?existing_inode.name(),
-                            ino=?existing_inode.ino(),
-                            "inode changed from {:?} to {:?}, will recreate it",
-                            existing_inode.kind(),
-                            remote_kind,
-                        );
-                        Ok(UpdateStatus::RemoteKey(remote.clone()))
-                    }
-                    // Otherwise, we'll just update this inode in place.
-                    (InodeKind::File, InodeKind::File) | (InodeKind::Directory, InodeKind::Directory) => {
-                        trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "updating inode in place");
-                        inode_state.stat = stat.clone();
-                        Ok(UpdateStatus::Updated(LookedUp {
-                            inode: existing_inode.clone(),
-                            stat: stat.clone(),
-                        }))
-                    }
+            (None, None) => Err(InodeError::FileDoesNotExist),
+            (Some(remote), Some(existing_inode)) => {
+                let mut existing_state = existing_inode.get_mut_inode_state()?;
+                let existing_is_remote = existing_state.write_status == WriteStatus::Remote;
+                if remote.kind == existing_inode.kind() && existing_is_remote {
+                    trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "updating inode in place");
+                    existing_state.stat = remote.stat.clone();
+                    Ok(Some(LookedUp {
+                        inode: existing_inode.clone(),
+                        stat: remote.stat.clone(),
+                    }))
+                } else {
+                    Ok(None)
                 }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Update or create the inode for the given name in the parent directory with a write lock on
+    /// the parent. This method still needs to handle the cases handled by [try_update_fast_path]
+    /// because an intervening writer might have modified the inode we're updating.
+    fn update_slow_path(
+        &self,
+        parent: Inode,
+        name: &str,
+        remote: Option<RemoteLookup>,
+    ) -> Result<LookedUp, InodeError> {
+        let mut parent_state = parent.get_mut_inode_state()?;
+        let inode = match &parent_state.kind_data {
+            InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
+            InodeKindData::Directory { children, .. } => children.get(name).cloned(),
+        };
+        match (remote, inode) {
+            (None, None) => Err(InodeError::FileDoesNotExist),
+            (None, Some(existing_inode)) => {
+                let InodeKindData::Directory { children, writing_children, .. } = &mut parent_state.kind_data else {
+                    unreachable!("we know parent is a directory");
+                };
+                if writing_children.contains(&existing_inode.ino()) {
+                    let stat = existing_inode.get_inode_state()?.stat.clone();
+                    Ok(LookedUp {
+                        inode: existing_inode,
+                        stat,
+                    })
+                } else {
+                    // This existing inode is local-only (because `remote` is None), but is no
+                    // longer being written. It must have previously existed but been removed on the
+                    // remote side.
+                    children.remove(name);
+                    Err(InodeError::FileDoesNotExist)
+                }
+            }
+            (Some(remote), None) => {
+                let state = InodeState {
+                    stat: remote.stat.clone(),
+                    kind_data: InodeKindData::default_for(remote.kind),
+                    write_status: WriteStatus::Remote,
+                    lookup_count: 0,
+                };
+                self.create_inode_locked(&parent, &mut parent_state, name, remote.kind, state, false)
+                    .map(|inode| LookedUp {
+                        inode,
+                        stat: remote.stat,
+                    })
+            }
+            (Some(remote), Some(existing_inode)) => {
+                // We need to reconcile the existing state with the state we just got from the
+                // remote. Our goal here is for the behavior to be as unsurprising as possible while
+                // being consistent with our stated semantics about implicit directories and how
+                // directories shadow files.
+                let mut existing_state = existing_inode.get_mut_inode_state()?;
+                let existing_is_remote = existing_state.write_status == WriteStatus::Remote;
+
+                // Remote files are always shadowed by existing local files/directories, so do
+                // nothing and return the existing inode.
+                if remote.kind == InodeKind::File && !existing_is_remote {
+                    return Ok(LookedUp {
+                        inode: existing_inode.clone(),
+                        stat: existing_state.stat.clone(),
+                    });
+                }
+
+                // Try to update in place if we can. The fast path does this too, but here we can
+                // also handle the case of a local directory becoming remote, which requires
+                // updating the parent.
+                if remote.kind == existing_inode.kind() && (existing_is_remote || remote.kind == InodeKind::Directory) {
+                    trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "updating inode in place (slow path)");
+                    existing_state.stat = remote.stat.clone();
+                    if remote.kind == InodeKind::Directory && !existing_is_remote {
+                        trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "local directory has become remote");
+                        existing_state.write_status = WriteStatus::Remote;
+                        let InodeKindData::Directory { writing_children, .. } = &mut parent_state.kind_data else {
+                            unreachable!("we know parent is a directory");
+                        };
+                        writing_children.remove(&existing_inode.ino());
+                    }
+                    return Ok(LookedUp {
+                        inode: existing_inode.clone(),
+                        stat: remote.stat,
+                    });
+                }
+
+                // Otherwise, create a fresh inode, possibly merging the existing contents. Note
+                // that [create_inode_locked] takes care of unlinking the existing inode from its
+                // parent if necessary.
+                warn!(
+                    parent=?existing_inode.parent(),
+                    name=?existing_inode.name(),
+                    ino=?existing_inode.ino(),
+                    "inode changed from {:?} to {:?}, will recreate it",
+                    existing_inode.kind(),
+                    remote.kind,
+                );
+                let state = InodeState {
+                    stat: remote.stat.clone(),
+                    kind_data: InodeKindData::default_for(remote.kind),
+                    write_status: WriteStatus::Remote,
+                    lookup_count: 0,
+                };
+                let new_inode =
+                    self.create_inode_locked(&parent, &mut parent_state, name, remote.kind, state, false)?;
+                Ok(LookedUp {
+                    inode: new_inode,
+                    stat: remote.stat,
+                })
             }
         }
     }
@@ -769,9 +820,12 @@ impl SuperblockInner {
                 writing_children,
                 ..
             } => {
-                children.insert(name.to_owned(), inode.clone());
+                let existing_inode = children.insert(name.to_owned(), inode.clone());
                 if is_new_file {
                     writing_children.insert(next_ino);
+                }
+                if let Some(existing_inode) = existing_inode {
+                    writing_children.remove(&existing_inode.ino());
                 }
             }
         }
@@ -785,23 +839,6 @@ impl SuperblockInner {
 pub struct RemoteLookup {
     kind: InodeKind,
     stat: InodeStat,
-}
-
-/// Result of a call to [SuperblockInner::try_update_child].
-#[derive(Debug)]
-enum UpdateStatus {
-    /// Key not found on remote, but local inode exists.
-    LocalOnly(Inode),
-
-    /// New key on remote, no local inode.
-    RemoteKey(RemoteLookup),
-
-    /// Local inode already up to date with remote.
-    /// [LookedUp] contains the inode and its updated `stat`.
-    Updated(LookedUp),
-
-    /// No remote key, no local inode.
-    Neither,
 }
 
 /// Result of a call to [Superblock::lookup] or [Superblock::getattr]. `stat` is a copy of the


### PR DESCRIPTION
## Description of change

To date we haven't thought too carefully about what happens if objects are put/deleted from the S3 bucket while conflicting state is present locally. There are a lot of edge cases here -- the Cartesian product of existing state (local/remote file/directory) and new remote state (file/directory), as well as two paths for inodes to be updated (readdir vs lookup).

This change defines a semantics for these permutations. The overall idea is that (a) remote state shadows local state, and (b) directories shadow files. But those axioms alone aren't enough to break all ties; for example, what if the existing state is a local directory but the new state is a remote file -- which should win? I chose to break the tie by saying that remote directories > any local state > remote files. So, for example, if a user creates a local directory, and then a conflicting object appears in the remote bucket, the directory will still be visible instead of the new file.

I spent some time trying to patch the existing inode update path to do what I needed but it ended up being clearer to just refactor it. I think we could still find a better factoring for this path, but it now explicitly accounts for all the permutations above and does the right thing (at least according to our reference model) for them all. Happily, proptest has done a good job at rooting out the many edge cases, as you can see by all the new regression tests in this change.

I've tested this change by running the proptests with 100,000 test cases and didn't see any failures.

### Semantics details

Here's a table of the various permutations of new and existing state for a given inode and how we reconcile them:

| Existing state | New state from S3 | Outcome |
|----|----|----|
| Remote file | File | Update inode in place |
| Remote file | Directory | Recreate the inode, disconnect the old one from its parent |
| Remote directory | File | Recreate the inode, disconnect the old one from its parent |
| Remote directory | Directory | Update inode in place |
| Local file | File | Ignore the new state, keep the existing local file |
| Local file | Directory | Recreate the inode, disconnect old one from its parent |
| Local directory | File | Ignore the new state, keep the existing local file |
| Local directory | Directory | Update inode in place, mark it remote |

I think the two unclear cases here are (Local file, Directory) and (Local directory, File). For the first one, if we preferred the local file over the directory, the file would disappear from view as soon as it became remote, which seems more surprising than just making it invisible immediately. For the second one, if we preferred the remote file over the local directory, `rmdir` no longer works on the local directory, so it's not really "local" any more.

The other interesting case is (Local file, File). I chose to prefer the local file because otherwise a user could read from "the same file" (actually the same path but a different file) while writing to it, which would give confusing behavior (can't read your own writes).

Fixes #128.

## Does this change impact existing behavior?

Yes, this change specifies behavior for cases that previously were emergent. We've never defined the semantics for concurrent accesses before, so this change does so for the first time, and modifies some existing behaviors (mostly around remote objects changing between files and directories) to match that semantics.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
