### PR TITLE
Emit warning-level logs to syslog when log directory is unset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1516,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1944,7 @@ dependencies = [
  "sha2",
  "shuttle",
  "supports-color",
+ "syslog",
  "tempfile",
  "test-case",
  "thiserror",
@@ -2071,6 +2098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.1",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -2929,6 +2965,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7434e95bcccce1215d30f4bf84fe8c00e8de1b9be4fb736d747ca53d36e7f96f"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3077,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -40,7 +40,8 @@ use crate::s3_crt_client::put_object::S3PutObjectRequest;
 macro_rules! request_span {
     ($self:expr, $method:expr) => {{
         let counter = $self.next_request_counter();
-        tracing::debug_span!($method, id = counter)
+        // Request failures are emitted at warning verbosity, so emit their spans there too
+        tracing::warn_span!($method, id = counter)
     }};
 }
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -40,8 +40,7 @@ use crate::s3_crt_client::put_object::S3PutObjectRequest;
 macro_rules! request_span {
     ($self:expr, $method:expr) => {{
         let counter = $self.next_request_counter();
-        // Request failures are emitted at warning verbosity, so emit their spans there too
-        tracing::warn_span!($method, id = counter)
+        tracing::debug_span!($method, id = counter)
     }};
 }
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -24,6 +24,7 @@ metrics = "0.20.1"
 once_cell = "1.16.0"
 regex = "1.7.1"
 supports-color = "1.3.0"
+syslog = "6.1.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod fs;
 pub mod fuse;
 mod inode;
+pub mod logging;
 pub mod metrics;
 pub mod prefetch;
 pub mod prefix;

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -1,0 +1,122 @@
+use std::backtrace::Backtrace;
+use std::fs::{DirBuilder, OpenOptions};
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::prelude::OpenOptionsExt;
+use std::panic::{self, PanicInfo};
+use std::path::Path;
+use std::thread;
+
+use crate::metrics::metrics_tracing_span_layer;
+use anyhow::Context;
+use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
+use time::format_description::FormatItem;
+use time::macros;
+use time::OffsetDateTime;
+use tracing_subscriber::{
+    filter::EnvFilter, filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, Layer,
+};
+
+/// Set up all our logging infrastructure.
+///
+/// This method:
+/// - initializes the `tracing` subscriber for capturing log output
+/// - sets up the logging adapters for the CRT and for metrics
+/// - installs a panic hook to capture panics and log them with `tracing`
+pub fn init_logging(is_foreground: bool, log_directory: Option<&Path>) -> anyhow::Result<()> {
+    init_tracing_subscriber(is_foreground, log_directory)?;
+    install_panic_hook();
+    Ok(())
+}
+
+fn tracing_panic_hook(panic_info: &PanicInfo) {
+    let location = panic_info
+        .location()
+        .map(|l| format!("{}", l))
+        .unwrap_or_else(|| String::from("<unknown>"));
+
+    let payload = panic_info.payload();
+    let payload = if let Some(s) = payload.downcast_ref::<&'static str>() {
+        *s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<unknown payload>"
+    };
+
+    let thd = thread::current();
+
+    let backtrace = Backtrace::force_capture();
+
+    tracing::error!("panic on {thd:?} at {location}: {payload}");
+    tracing::error!("backtrace:\n{backtrace}");
+}
+
+fn install_panic_hook() {
+    let old_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        tracing_panic_hook(panic_info);
+        old_hook(panic_info);
+    }))
+}
+
+fn init_tracing_subscriber(is_foreground: bool, log_directory: Option<&Path>) -> anyhow::Result<()> {
+    /// Create the logging config from the RUST_LOG environment variable or the default config if
+    /// that variable is unset. We do this in a function because [EnvFilter] isn't [Clone] and we
+    /// need a second copy of it in the foreground case to replicate logs to stdout.
+    fn create_env_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,awscrt=off,fuser=error"))
+    }
+    let env_filter = create_env_filter();
+
+    // Don't create the files or subscribers if we'll never emit any logs
+    if env_filter.max_level_hint() == Some(LevelFilter::OFF) {
+        return Ok(());
+    }
+
+    RustLogAdapter::try_init().context("failed to initialize CRT logger")?;
+
+    let file_layer = if let Some(path) = log_directory {
+        const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
+            macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
+        let filename = OffsetDateTime::now_utc()
+            .format(LOG_FILE_NAME_FORMAT)
+            .context("couldn't format log file name")?;
+
+        // log directories and files created by Mountpoint should not be accessible by other users
+        let mut dir_builder = DirBuilder::new();
+        dir_builder.recursive(true).mode(0o750);
+        let mut file_options = OpenOptions::new();
+        file_options.mode(0o640).write(true).create(true);
+
+        dir_builder.create(path).context("failed to create log folder")?;
+        let file = file_options
+            .open(path.join(filename))
+            .context("failed to create log file")?;
+
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(file)
+            .with_filter(env_filter);
+        Some(file_layer)
+    } else {
+        None
+    };
+
+    let console_layer = if is_foreground {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(supports_color::on(supports_color::Stream::Stdout).is_some())
+            .with_filter(create_env_filter());
+        Some(fmt_layer)
+    } else {
+        None
+    };
+
+    let registry = tracing_subscriber::registry()
+        .with(console_layer)
+        .with(file_layer)
+        .with(metrics_tracing_span_layer());
+
+    registry.init();
+
+    Ok(())
+}

--- a/mountpoint-s3/src/logging/syslog.rs
+++ b/mountpoint-s3/src/logging/syslog.rs
@@ -192,7 +192,7 @@ mod tests {
             let _enter2 = span2.enter();
             tracing::info!(field5 = 5, field6 = 6, "msg3={:?}", 3);
         });
-        let vec = std::mem::replace(&mut *buf.inner.lock().unwrap(), Vec::new());
+        let vec = std::mem::take(&mut *buf.inner.lock().unwrap());
         let output = String::from_utf8(vec).unwrap();
         // The actual output is syslog-formatted, so includes the current time and PID. Let's just
         // check the parts of the payload we really care about.

--- a/mountpoint-s3/src/logging/syslog.rs
+++ b/mountpoint-s3/src/logging/syslog.rs
@@ -1,0 +1,217 @@
+use std::fmt::Write;
+use std::sync::Mutex;
+
+use syslog::{Facility, Formatter3164, Logger, LoggerBackend};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing::{Event, Id, Level, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+/// A [tracing_subscribrer::Layer] that emits log events to syslog. This layer does no filtering,
+/// and so should be paired with a [tracing_subscriber::Filter].
+pub struct SyslogLayer<Backend: std::io::Write = LoggerBackend> {
+    logger: Mutex<Logger<Backend, Formatter3164>>,
+}
+
+impl SyslogLayer {
+    pub fn new() -> Result<Self, syslog::Error> {
+        let formatter = Self::formatter();
+        let logger = syslog::unix(formatter)?;
+        Ok(Self {
+            logger: Mutex::new(logger),
+        })
+    }
+}
+
+impl<B: std::io::Write> SyslogLayer<B> {
+    #[cfg(test)]
+    pub fn new_generic(backend: B) -> Self {
+        let formatter = Self::formatter();
+        let logger = Logger::new(backend, formatter);
+        Self {
+            logger: Mutex::new(logger),
+        }
+    }
+
+    fn formatter() -> Formatter3164 {
+        Formatter3164 {
+            facility: Facility::LOG_USER,
+            hostname: None,
+            process: "mount-s3".into(),
+            pid: unsafe { libc::getpid() as u32 },
+        }
+    }
+}
+
+impl<S, B> Layer<S> for SyslogLayer<B>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    B: std::io::Write + 'static,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("span must exist");
+        let mut extensions = span.extensions_mut();
+        if extensions.get_mut::<FormattedFields>().is_none() {
+            let mut fields = String::new();
+            FormatFields::format_attributes(&mut fields, attrs);
+            extensions.insert(FormattedFields(fields));
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("span must exist");
+        let mut extensions = span.extensions_mut();
+        if let Some(fields) = extensions.get_mut::<FormattedFields>() {
+            FormatFields::format_record(&mut fields.0, values);
+            return;
+        }
+        let mut fields = String::new();
+        FormatFields::format_record(&mut fields, values);
+        extensions.insert(FormattedFields(fields));
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        // No need to do any filtering -- we assume this layer is paired with a filter. So just
+        // build the message and ship it.
+        let metadata = event.metadata();
+        let mut message = format!("[{}] {}: ", metadata.level(), metadata.target());
+        // First deal with any spans
+        if let Some(scope) = ctx.event_scope(event) {
+            let mut seen = false;
+            for span in scope.from_root() {
+                seen = true;
+                let _ = write!(message, "{}", span.metadata().name());
+                if let Some(fields) = span.extensions().get::<FormattedFields>() {
+                    let _ = write!(message, "{{{}}}", fields.0);
+                }
+                let _ = write!(message, ":");
+            }
+            if seen {
+                let _ = write!(message, " ");
+            }
+        }
+        // Now deal with the event
+        FormatFields::format_event(&mut message, event);
+
+        let mut logger = self.logger.lock().unwrap();
+        let _ = match *event.metadata().level() {
+            Level::ERROR => logger.err(message),
+            Level::WARN => logger.warning(message),
+            Level::INFO => logger.info(message),
+            Level::DEBUG => logger.debug(message),
+            Level::TRACE => logger.debug(message),
+        };
+    }
+}
+
+/// Convert `tracing` events/attributes into strings with a visitor pattern
+struct FormatFields<'a> {
+    buf: &'a mut String,
+}
+
+impl<'a> FormatFields<'a> {
+    fn format_event(buf: &'a mut String, event: &Event<'_>) {
+        let mut fmt = Self { buf };
+        event.record(&mut fmt);
+    }
+
+    fn format_attributes(buf: &'a mut String, attrs: &Attributes<'_>) {
+        let mut fmt = Self { buf };
+        attrs.record(&mut fmt);
+    }
+
+    fn format_record(buf: &'a mut String, record: &Record<'_>) {
+        let mut fmt = Self { buf };
+        record.record(&mut fmt);
+    }
+}
+
+impl Visit for FormatFields<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.buf, "{:?}", value);
+        } else {
+            if !self.buf.is_empty() {
+                let _ = write!(self.buf, " ");
+            }
+            let _ = write!(self.buf, "{}={:?}", field.name(), value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            let _ = write!(self.buf, "{}", value);
+        } else {
+            if !self.buf.is_empty() {
+                let _ = write!(self.buf, " ");
+            }
+            let _ = write!(self.buf, "{}={}", field.name(), value);
+        }
+    }
+}
+
+/// A newtype to store the formatted representation of a `tracing` Span's fields
+struct FormattedFields(String);
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[derive(Debug, Clone, Default)]
+    struct LockedWriter {
+        inner: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl std::io::Write for LockedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut inner = self.inner.lock().unwrap();
+            inner.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_syslog_layer() {
+        let buf = LockedWriter::default();
+        let layer = SyslogLayer::new_generic(buf.clone());
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("span1", field1 = 1, field2 = 2, "msg1={:?}", 1);
+            let _enter = span.enter();
+            let span2 = tracing::warn_span!("span2", field3 = 3, field4 = 4, "msg2={:?}", 2);
+            let _enter2 = span2.enter();
+            tracing::info!(field5 = 5, field6 = 6, "msg3={:?}", 3);
+        });
+        let vec = std::mem::replace(&mut *buf.inner.lock().unwrap(), Vec::new());
+        let output = String::from_utf8(vec).unwrap();
+        // The actual output is syslog-formatted, so includes the current time and PID. Let's just
+        // check the parts of the payload we really care about.
+        let expected = "mountpoint_s3::logging::syslog::tests: span1{msg1=1 field1=1 field2=2}:span2{msg2=2 field3=3 field4=4}: msg3=3 field5=5 field6=6";
+        assert!(
+            output.ends_with(expected),
+            "expected payload {:?} to end with {:?}",
+            output,
+            expected
+        );
+        assert!(
+            output.contains("mount-s3"),
+            "expected payload {:?} to contain mount-s3",
+            output
+        );
+        assert!(
+            output.starts_with("<14>"),
+            "expected payload {:?} to start with syslog PRI <14>",
+            output
+        );
+    }
+}

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{Read, Write};
-use std::os::unix::prelude::{FromRawFd, OpenOptionsExt};
+use std::os::unix::prelude::FromRawFd;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -10,6 +10,7 @@ use fuser::{MountOption, Session};
 use mountpoint_s3::fs::S3FilesystemConfig;
 use mountpoint_s3::fuse::session::FuseSession;
 use mountpoint_s3::fuse::S3FuseFilesystem;
+use mountpoint_s3::logging::init_logging;
 use mountpoint_s3::metrics::MetricsSink;
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::{
@@ -21,130 +22,6 @@ use nix::unistd::ForkResult;
 use regex::Regex;
 
 mod build_info;
-
-mod logging {
-    use super::*;
-
-    use std::backtrace::Backtrace;
-    use std::fs::{DirBuilder, OpenOptions};
-    use std::os::unix::fs::DirBuilderExt;
-    use std::panic::{self, PanicInfo};
-    use std::thread;
-
-    use mountpoint_s3::metrics::metrics_tracing_span_layer;
-    use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
-    use time::format_description::FormatItem;
-    use time::macros;
-    use time::OffsetDateTime;
-    use tracing_subscriber::{
-        filter::EnvFilter, filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, Layer,
-    };
-
-    /// Set up all our logging infrastructure.
-    ///
-    /// This method:
-    /// - initializes the `tracing` subscriber for capturing log output
-    /// - sets up the logging adapters for the CRT and for metrics
-    /// - installs a panic hook to capture panics and log them with `tracing`
-    pub(super) fn init_logging(is_foreground: bool, log_directory: Option<&Path>) -> anyhow::Result<()> {
-        init_tracing_subscriber(is_foreground, log_directory)?;
-        install_panic_hook();
-        Ok(())
-    }
-
-    fn tracing_panic_hook(panic_info: &PanicInfo) {
-        let location = panic_info
-            .location()
-            .map(|l| format!("{}", l))
-            .unwrap_or_else(|| String::from("<unknown>"));
-
-        let payload = panic_info.payload();
-        let payload = if let Some(s) = payload.downcast_ref::<&'static str>() {
-            *s
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            s.as_str()
-        } else {
-            "<unknown payload>"
-        };
-
-        let thd = thread::current();
-
-        let backtrace = Backtrace::force_capture();
-
-        tracing::error!("panic on {thd:?} at {location}: {payload}");
-        tracing::error!("backtrace:\n{backtrace}");
-    }
-
-    fn install_panic_hook() {
-        let old_hook = panic::take_hook();
-        panic::set_hook(Box::new(move |panic_info| {
-            tracing_panic_hook(panic_info);
-            old_hook(panic_info);
-        }))
-    }
-
-    fn init_tracing_subscriber(is_foreground: bool, log_directory: Option<&Path>) -> anyhow::Result<()> {
-        /// Create the logging config from the RUST_LOG environment variable or the default config if
-        /// that variable is unset. We do this in a function because [EnvFilter] isn't [Clone] and we
-        /// need a second copy of it in the foreground case to replicate logs to stdout.
-        fn create_env_filter() -> EnvFilter {
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,awscrt=off,fuser=error"))
-        }
-        let env_filter = create_env_filter();
-
-        // Don't create the files or subscribers if we'll never emit any logs
-        if env_filter.max_level_hint() == Some(LevelFilter::OFF) {
-            return Ok(());
-        }
-
-        RustLogAdapter::try_init().context("failed to initialize CRT logger")?;
-
-        let file_layer = if let Some(path) = log_directory {
-            const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
-                macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
-            let filename = OffsetDateTime::now_utc()
-                .format(LOG_FILE_NAME_FORMAT)
-                .context("couldn't format log file name")?;
-
-            // log directories and files created by Mountpoint should not be accessible by other users
-            let mut dir_builder = DirBuilder::new();
-            dir_builder.recursive(true).mode(0o750);
-            let mut file_options = OpenOptions::new();
-            file_options.mode(0o640).write(true).create(true);
-
-            dir_builder.create(path).context("failed to create log folder")?;
-            let file = file_options
-                .open(path.join(filename))
-                .context("failed to create log file")?;
-
-            let file_layer = tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .with_writer(file)
-                .with_filter(env_filter);
-            Some(file_layer)
-        } else {
-            None
-        };
-
-        let console_layer = if is_foreground {
-            let fmt_layer = tracing_subscriber::fmt::layer()
-                .with_ansi(supports_color::on(supports_color::Stream::Stdout).is_some())
-                .with_filter(create_env_filter());
-            Some(fmt_layer)
-        } else {
-            None
-        };
-
-        let registry = tracing_subscriber::registry()
-            .with(console_layer)
-            .with(file_layer)
-            .with(metrics_tracing_span_layer());
-
-        registry.init();
-
-        Ok(())
-    }
-}
 
 const CLIENT_OPTIONS_HEADER: &str = "Client options";
 const MOUNT_OPTIONS_HEADER: &str = "Mount options";
@@ -318,8 +195,7 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     if args.foreground {
-        logging::init_logging(args.foreground, args.log_directory.as_deref())
-            .context("failed to initialize logging")?;
+        init_logging(args.foreground, args.log_directory.as_deref()).context("failed to initialize logging")?;
 
         let _metrics = MetricsSink::init();
 
@@ -340,7 +216,7 @@ fn main() -> anyhow::Result<()> {
         match pid.expect("Failed to fork mount process") {
             ForkResult::Child => {
                 let child_args = CliArgs::parse();
-                logging::init_logging(child_args.foreground, child_args.log_directory.as_deref())
+                init_logging(child_args.foreground, child_args.log_directory.as_deref())
                     .context("failed to initialize logging")?;
 
                 let _metrics = MetricsSink::init();
@@ -374,8 +250,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
             ForkResult::Parent { child } => {
-                logging::init_logging(args.foreground, args.log_directory.as_deref())
-                    .context("failed to initialize logging")?;
+                init_logging(args.foreground, args.log_directory.as_deref()).context("failed to initialize logging")?;
                 // close unused file descriptor, we only read from this end.
                 nix::unistd::close(write_fd).context("Failed to close unused file descriptor")?;
 


### PR DESCRIPTION
## Description of change

We disabled logging to a file by default in #373. But we'd still like to have a default home for high-severity messages, which is exactly what syslog is for.

This PR is the bare minimum to get `tracing`-style structured logging into syslog. I hardcoded the verbosity to `warn,awscrt=off` and didn't think too hard about configuration: the syslog logger is on whenever the `--log-directory` flag isn't set. Because I didn't think too hard about it, I also didn't update docs/LOGGING.md yet.

This PR is two commits:
1. Move the logging module from `main.rs` to its own file, just because it was getting big. No other code changes here.
2. Actually implement the syslog logger and plumb it into `logging.rs`.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
