### PR TITLE
Maintain metadata checksums and verify on unlink

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -804,7 +804,7 @@ impl From<InodeError> for i32 {
             InodeError::CannotRemoveRemoteDirectory(_) => libc::EPERM,
             InodeError::DirectoryNotEmpty(_) => libc::ENOTEMPTY,
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,
-            InodeError::CorruptedMetadata(_, _) => libc::EPERM,
+            InodeError::CorruptedMetadata(_, _) => libc::EIO,
         }
     }
 }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -804,6 +804,7 @@ impl From<InodeError> for i32 {
             InodeError::CannotRemoveRemoteDirectory(_) => libc::EPERM,
             InodeError::DirectoryNotEmpty(_) => libc::ENOTEMPTY,
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,
+            InodeError::CorruptedMetadata(_, _) => libc::EPERM,
         }
     }
 }


### PR DESCRIPTION
## Description of change

Adds a checksum to each inode computed on the inode number and the full key. On unlink, verifies the checksum before deleting the object from the bucket.

## Does this change impact existing behavior?

No impact on the happy path. Unlink could fail if inode metadata gets corrupted.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
