### PR TITLE
Implement setattr to support changing time attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1910,7 @@ dependencies = [
  "crc32c",
  "ctor",
  "ctrlc",
+ "filetime",
  "fuser",
  "futures",
  "hdrhistogram",
@@ -2485,6 +2498,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -2943,7 +2965,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -77,6 +77,8 @@ further writes.
 
 Space allocation (`fallocate`, `posix_fallocate`) are not supported.
 
+Changing file last access and modification times (`utime`) are supported on files that are being written only.
+
 #### Deletes
 
 File deletion (`unlink`) is planned but not yet supported (see [#78](https://github.com/awslabs/mountpoint-s3/issues/78)).

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -77,7 +77,7 @@ further writes.
 
 Space allocation (`fallocate`, `posix_fallocate`) are not supported.
 
-Changing file last access and modification times (`utime`) are supported on files that are being written only.
+Changing last access and modification times (`utime`) is supported only on files that are being written.
 
 #### Deletes
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -42,6 +42,7 @@ aws-config = "0.54.1"
 aws-sdk-s3 = "0.24.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
 ctor = "0.1.23"
+filetime = "0.2.21"
 predicates = "2.1.2"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -189,6 +189,39 @@ impl Superblock {
         self.inner.lookup(client, inode.parent(), inode.name().as_ref()).await
     }
 
+    /// Set the attributes for an inode
+    pub async fn setattr<OC: ObjectClient>(
+        &self,
+        _client: &OC,
+        ino: InodeNo,
+        atime: Option<OffsetDateTime>,
+        mtime: Option<OffsetDateTime>,
+    ) -> Result<LookedUp, InodeError> {
+        let inode = self.inner.get(ino)?;
+        let mut sync = inode.get_mut_inode_state()?;
+
+        if sync.write_status == WriteStatus::Remote {
+            return Err(InodeError::SetAttrNotPermittedOnRemoteInode(ino));
+        }
+
+        // Should be impossible since local file stat never expire.
+        if !sync.stat.is_valid() {
+            warn!(?ino, "local inode stat already expired");
+            return Err(InodeError::SetAttrOnExpiredStat(ino));
+        }
+
+        if let Some(t) = atime {
+            sync.stat.atime = t;
+        }
+        if let Some(t) = mtime {
+            sync.stat.mtime = t;
+        };
+
+        let stat = sync.stat.clone();
+        drop(sync);
+        Ok(LookedUp { inode, stat })
+    }
+
     /// Create a new write handle to be used for state transition
     pub async fn write<OC: ObjectClient>(
         &self,
@@ -1250,6 +1283,10 @@ pub enum InodeError {
     UnlinkNotPermittedWhileWriting(InodeNo),
     #[error("corrupted metadata for inode {0}, remote key {1:?}")]
     CorruptedMetadata(InodeNo, String),
+    #[error("inode {0} is a remote inode and its attributes cannot be modified")]
+    SetAttrNotPermittedOnRemoteInode(InodeNo),
+    #[error("inode {0} stat is already expired")]
+    SetAttrOnExpiredStat(InodeNo),
 }
 
 #[cfg(test)]
@@ -2120,6 +2157,106 @@ mod tests {
                 .await;
             assert!(matches!(lookup, Err(InodeError::InvalidFileName(_))));
         }
+    }
+
+    #[test_case(""; "unprefixed")]
+    #[test_case("test_prefix/"; "prefixed")]
+    #[tokio::test]
+    async fn test_setattr(prefix: &str) {
+        let client_config = MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024 * 1024,
+        };
+        let client = Arc::new(MockClient::new(client_config));
+        let prefix = Prefix::new(prefix).expect("valid prefix");
+        let superblock = Superblock::new("test_bucket", &prefix, Default::default());
+
+        // Create a new file
+        let filename = "newfile.txt";
+        let new_inode = superblock
+            .create(
+                &client,
+                FUSE_ROOT_INODE,
+                OsStr::from_bytes(filename.as_bytes()),
+                InodeKind::File,
+            )
+            .await
+            .unwrap();
+
+        let writehandle = superblock
+            .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE)
+            .await
+            .unwrap();
+
+        let atime = OffsetDateTime::UNIX_EPOCH + Duration::days(90);
+        let mtime = OffsetDateTime::UNIX_EPOCH + Duration::days(60);
+
+        // Call setattr and verify the stat
+        let lookup = superblock
+            .setattr(&client, new_inode.inode.ino(), Some(atime), Some(mtime))
+            .await
+            .expect("setattr should be successful");
+        let stat = lookup.stat;
+        assert_eq!(stat.atime, atime);
+        assert_eq!(stat.mtime, mtime);
+
+        let lookup = superblock
+            .getattr(&client, new_inode.inode.ino(), false)
+            .await
+            .expect("getattr should be successful");
+        let stat = lookup.stat;
+        assert_eq!(stat.atime, atime);
+        assert_eq!(stat.mtime, mtime);
+
+        // Invoke [finish_writing] to make the file remote
+        writehandle.finish_writing().unwrap();
+
+        // Should get an error back when calling setattr
+        let result = superblock
+            .setattr(&client, new_inode.inode.ino(), Some(atime), Some(mtime))
+            .await;
+        assert!(matches!(result, Err(InodeError::SetAttrNotPermittedOnRemoteInode(_))));
+    }
+
+    #[tokio::test]
+    async fn test_setattr_invalid_stat() {
+        let client_config = MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024 * 1024,
+        };
+        let client = Arc::new(MockClient::new(client_config));
+        let superblock = Superblock::new("test_bucket", &Default::default(), Default::default());
+
+        let ino = 42;
+        let inode_name = "made-up-inode";
+        let inode = Inode {
+            inner: Arc::new(InodeInner {
+                ino,
+                parent: ROOT_INODE_NO,
+                name: inode_name.to_owned(),
+                full_key: inode_name.to_owned(),
+                kind: InodeKind::File,
+                checksum: Crc32c::new(0),
+                sync: RwLock::new(InodeState {
+                    write_status: WriteStatus::LocalOpen,
+                    stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, Default::default()),
+                    kind_data: InodeKindData::File {},
+                    lookup_count: 5,
+                }),
+            }),
+        };
+        superblock.inner.inodes.write().unwrap().insert(ino, inode.clone());
+
+        // Verify that the stat is invalid
+        let inode = superblock.inner.get(ino).unwrap();
+        let stat = inode.get_inode_state().unwrap().stat.clone();
+        assert!(!stat.is_valid());
+
+        // Should get an error back when calling setattr
+        let atime = OffsetDateTime::UNIX_EPOCH + Duration::days(90);
+        let mtime = OffsetDateTime::UNIX_EPOCH + Duration::days(60);
+        let result = superblock.setattr(&client, ino, Some(atime), Some(mtime)).await;
+        assert!(matches!(result, Err(InodeError::SetAttrOnExpiredStat(_))));
     }
 
     #[test]

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -2227,8 +2227,12 @@ mod tests {
         let client = Arc::new(MockClient::new(client_config));
         let superblock = Superblock::new("test_bucket", &Default::default(), Default::default());
 
-        let ino = 42;
+        let ino: u64 = 42;
         let inode_name = "made-up-inode";
+        let mut hasher = crc32c::Hasher::new();
+        hasher.update(ino.to_be_bytes().as_ref());
+        hasher.update(inode_name.as_bytes());
+        let checksum = hasher.finalize();
         let inode = Inode {
             inner: Arc::new(InodeInner {
                 ino,
@@ -2236,7 +2240,7 @@ mod tests {
                 name: inode_name.to_owned(),
                 full_key: inode_name.to_owned(),
                 kind: InodeKind::File,
-                checksum: Crc32c::new(0),
+                checksum,
                 sync: RwLock::new(InodeState {
                     write_status: WriteStatus::LocalOpen,
                     stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, Default::default()),

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -7,6 +7,7 @@ mod prefetch_test;
 mod readdir_test;
 mod rmdir_test;
 mod semantics_doc_test;
+mod setattr_test;
 #[cfg(feature = "delete")]
 mod unlink_test;
 mod write_test;

--- a/mountpoint-s3/tests/fuse_tests/setattr_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/setattr_test.rs
@@ -1,0 +1,79 @@
+use std::fs::{metadata, File};
+use std::os::unix::prelude::MetadataExt;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use filetime::FileTime;
+use fuser::BackgroundSession;
+use tempfile::TempDir;
+use test_case::test_case;
+
+use crate::fuse_tests::{TestClientBox, TestSessionConfig};
+
+fn open_for_write(path: impl AsRef<Path>, append: bool) -> std::io::Result<File> {
+    let mut options = File::options();
+    if append {
+        options.append(true);
+    } else {
+        options.write(true);
+    }
+    options.create(true).open(path)
+}
+
+fn setattr_test<F>(creator_fn: F, prefix: &str, append: bool)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Make sure there's an existing directory
+    test_client.put_object("dir/hello.txt", b"hello world").unwrap();
+
+    let path = mount_point.path().join("dir/new.txt");
+
+    let f = open_for_write(&path, append).unwrap();
+
+    let expected_atime = SystemTime::now().checked_add(Duration::from_secs(10)).unwrap();
+    let expected_mtime = SystemTime::now().checked_add(Duration::from_secs(5)).unwrap();
+    filetime::set_file_atime(&path, FileTime::from_system_time(expected_atime))
+        .expect("set atime should be successful");
+    filetime::set_file_mtime(&path, FileTime::from_system_time(expected_mtime))
+        .expect("set mtime should be successful");
+
+    // Verify that time attributes are changed
+    let m = metadata(&path).unwrap();
+    assert_eq!(
+        m.atime() as u64,
+        expected_atime.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
+    );
+    assert_eq!(
+        m.mtime() as u64,
+        expected_mtime.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
+    );
+
+    // Complete the upload and wait for the write status to be WriteStatus::Remote
+    f.sync_all().unwrap();
+    drop(f);
+    std::thread::sleep(Duration::from_secs(5));
+
+    // Verify that we get an error when setting time attributes for remote files
+    let err = filetime::set_file_atime(&path, FileTime::from_system_time(expected_atime))
+        .expect_err("set atime should fail on remote files");
+    assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+    let err = filetime::set_file_mtime(&path, FileTime::from_system_time(expected_mtime))
+        .expect_err("set mtime should fail on remote files");
+    assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(true; "append")]
+#[test_case(false; "no append")]
+fn setattr_test_s3(append: bool) {
+    setattr_test(crate::fuse_tests::s3_session::new, "setattr_test_s3", append);
+}
+
+#[test_case(true; "append")]
+#[test_case(false; "no append")]
+fn setattr_test_mock(append: bool) {
+    setattr_test(crate::fuse_tests::mock_session::new, "setattr_test_mock", append);
+}


### PR DESCRIPTION
## Description of change

Some applications like `touch` requires the file system to support changing file last access and modification times. We don't support this operation because the last modification time for objects can't be set via S3 API. However, it's possible to allow this only for the files that are being written because at that time it's still a temporary stat in Mountpoint.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/358

## Does this change impact existing behavior?

Yes, `setattr` will now work for the files that are being written.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
