### PR TITLE
Add merge_group as workflow trigger for tests and integ tests

### DIFF
--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -3,6 +3,8 @@ name: Integration tests
 on:
   push:
     branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
 
 permissions:
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Description of change

We would like to introduce merge queue on the main branch: https://github.blog/changelog/2023-07-12-pull-request-merge-queue-is-now-generally-available/

This change lets a merge queue trigger the CI, for workflows which are marked as required to approve a change merged in.

It's not possible to test since Merge Queues are not available for non-organization repositories.

## Does this change impact existing behavior?

No change to Mountpoint.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
