### PR TITLE
Fix sequential write test with O_RDWR flag

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -111,6 +111,7 @@ where
     }
 
     // We shouldn't be able to read from a file mid-write
+    f.seek(std::io::SeekFrom::End(-1)).unwrap();
     let err = f.read(&mut [0u8; 1]).expect_err("can't read file while writing");
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
 


### PR DESCRIPTION
## Description of change

Some of the sequential write tests were testing that once a new file is opened with O_RDWR and written to, a read on it will fail with EBADF. The issue was that the read in the test was performed at the EOF, which would result in different fuse calls depending on the kernel version: for example on 5.15, fuse `read` would be called with a "valid" offset and the expected EBADF would be returned (as we were observing in GitHub Actions), but on 6.1, a `getattr` would check that the current position was EOF and succeed the `read` call by returning `0`. 

The fix seeks back `1` byte before trying to read it.

## Does this change impact existing behavior?

No. Only tests are affected.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
