### PR TITLE
Add always-successful workflow for DCO on merge_group event only

### DIFF
--- a/.github/workflows/merge_queue_dco_mock.yml
+++ b/.github/workflows/merge_queue_dco_mock.yml
@@ -1,4 +1,7 @@
 ---
+# Workflow that always succeeds with name "DCO".
+# This is temporarily needed to ensure we can keep DCO requirement on PRs and allow merge queue to succeed.
+# It can be removed once DCO runs against `merge_group` events. See: https://github.com/dcoapp/app/issues/199
 name: DCO
 "on":
   merge_group:

--- a/.github/workflows/merge_queue_dco_mock.yml
+++ b/.github/workflows/merge_queue_dco_mock.yml
@@ -1,0 +1,12 @@
+---
+name: DCO
+"on":
+  merge_group:
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "This workflow always succeeds to unlock GitHub's Merge Queue."
+      - run: echo "DCO should already be completed during PR workflows."


### PR DESCRIPTION
## Description of change

The DCO app that currently gates pushes to `main` to ensure that all commits have DCO trailers does not appear to run on the `merge_group` event. There is an open ticket at dcoapp/app#199.

This change introduces a workaround by having a workflow always succeed with the same name as the DCO app. We already check for DCO at PR approval time.

If dcoapp/app#199 is resolved, we should be able to remove this workflow.

Relevant issues: #392, dcoapp/app#199

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
