### PR TITLE
Introduce option to allow delete

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,7 +62,7 @@ jobs:
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
-      run: cargo build --release --features delete
+      run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Save Cargo cache
@@ -131,7 +131,7 @@ jobs:
           target/
         key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
-      run: cargo build --release --features delete
+      run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_latency_bench.sh
     - name: Save Cargo cache

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ env:
   # A bucket our IAM role has no access to, but is in the right region, for permissions tests
   S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   S3_REGION: ${{ vars.S3_REGION }}
-  RUST_FEATURES: fuse_tests,s3_tests,delete,fips_tests
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests
 
 permissions:
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_FEATURES: fuse_tests,delete
+  RUST_FEATURES: fuse_tests
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Mountpoint for Amazon S3 is **currently an alpha release and should not be used 
 This release has some notable restrictions:
 * The only way to install the alpha release of Mountpoint for Amazon S3 is by compiling from source (see [Installation](#installation) below). This will change in a future release.
 * Manual endpoint configuration might be required for some S3 customers (see [Configuration and usage](#configuration-and-usage) below).
-* Mountpoint for Amazon S3 does not currently support [deleting objects](https://github.com/awslabs/mountpoint-s3/issues/78).
 * Objects written with Mountpoint for Amazon S3 are [always stored in the S3 Standard storage class](https://github.com/awslabs/mountpoint-s3/issues/34).
 
 ## Getting started

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -81,16 +81,15 @@ Changing last access and modification times (`utime`) is supported only on files
 
 #### Deletes
 
-File deletion (`unlink`) is planned but not yet supported (see [#78](https://github.com/awslabs/mountpoint-s3/issues/78)).
-When `unlink` is implemented, the following semantics are proposed.
+File deletion (`unlink`) can be enabled by setting the `--allow-delete` option and is implemented with
+the following behavior:
 
-For files not yet committed to S3, the client will not permit `unlink` operations.
-The file should be closed and thus committed to S3, at which point an `unlink` can be performed on the remote file.
-
-For files already committed to S3, the client will _immediately_ delete the corresponding object from S3,
-and remove the file from its directory.
-If there are still open file handles to the file, future reads to them will fail.
-Because the object is immediately deleted from S3, future reads from other hosts will also fail.
+* For files not yet committed to S3, the client does not permit `unlink` operations.
+* The file should be closed and thus committed to S3, at which point an `unlink` can be performed on the remote file.
+* For files already committed to S3, the client _immediately_ deletes the corresponding object from S3,
+  and removes the file from its directory.
+* If there are still open file handles to the file, future reads to them will fail.
+* Because the object is immediately deleted from S3, future reads from other hosts will also fail.
 
 ### Directory operations
 

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -48,7 +48,8 @@ read_bechmark () {
     echo "Running ${job_name}"
 
     # mount file system
-    cargo run --release --features delete ${S3_BUCKET_NAME} ${mount_dir} \
+    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+      --allow-delete \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
       --thread-count=${thread_count}
     mount_status=$?
@@ -93,7 +94,8 @@ read_bechmark () {
 write_benchmark () {
   # mount file system
   mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
-  cargo run --release --features delete ${S3_BUCKET_NAME} ${mount_dir} \
+  cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+      --allow-delete \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
       --thread-count=${thread_count}
   mount_status=$?

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -48,7 +48,8 @@ do
     echo "Running ${job_name}"
 
     # mount file system
-    cargo run --release --features delete ${S3_BUCKET_NAME} ${mount_dir} \
+    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+        --allow-delete \
         --prefix=${S3_BUCKET_TEST_PREFIX} \
         --thread-count=${thread_count}
     mount_status=$?
@@ -109,7 +110,8 @@ for job_file in "${jobs_dir}"/*.fio; do
   echo "Running ${job_name}"
 
   # mount file system
-  cargo run --release --features delete ${S3_BUCKET_NAME} ${mount_dir} \
+  cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+    --allow-delete \
     --prefix=${S3_BUCKET_TEST_PREFIX} \
     --thread-count=${thread_count}
   mount_status=$?

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -224,6 +224,8 @@ pub struct S3FilesystemConfig {
     pub file_mode: u16,
     /// Prefetcher configuration
     pub prefetcher_config: PrefetcherConfig,
+    /// Allow delete
+    pub allow_delete: bool,
 }
 
 impl Default for S3FilesystemConfig {
@@ -239,6 +241,7 @@ impl Default for S3FilesystemConfig {
             dir_mode: 0o755,
             file_mode: 0o644,
             prefetcher_config: PrefetcherConfig::default(),
+            allow_delete: false,
         }
     }
 }
@@ -806,6 +809,9 @@ where
     }
 
     pub async fn unlink(&self, parent_ino: InodeNo, name: &OsStr) -> Result<(), libc::c_int> {
+        if !self.config.allow_delete {
+            return Err(libc::EPERM);
+        }
         match self.superblock.unlink(&self.client, parent_ino, name).await {
             Ok(()) => Ok(()),
             Err(e) => {

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -290,7 +290,6 @@ where
         }
     }
 
-    #[cfg(feature = "delete")]
     #[instrument(level="debug", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
     fn unlink(&self, _req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
         match block_on(self.fs.unlink(parent, name).in_current_span()) {

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -94,6 +94,13 @@ struct CliArgs {
     )]
     pub read_only: bool,
 
+    #[clap(
+        long,
+        help = "Allow delete operations on file system",
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
+    pub allow_delete: bool,
+
     #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
     pub auto_unmount: bool,
 
@@ -370,6 +377,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
         filesystem_config.file_mode = file_mode;
     }
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
+    filesystem_config.allow_delete = args.allow_delete;
 
     let prefix = args.prefix.unwrap_or_default();
     let fs = S3FuseFilesystem::new(client, runtime, &args.bucket_name, &prefix, filesystem_config);

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -8,7 +8,6 @@ mod readdir_test;
 mod rmdir_test;
 mod semantics_doc_test;
 mod setattr_test;
-#[cfg(feature = "delete")]
 mod unlink_test;
 mod write_test;
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -878,6 +878,7 @@ mod mutations {
         let test_prefix = Prefix::new("").expect("valid prefix");
         let config = S3FilesystemConfig {
             readdir_size: 5,
+            allow_delete: true,
             ..Default::default()
         };
         let (client, fs) = make_test_filesystem(BUCKET_NAME, &test_prefix, config);


### PR DESCRIPTION
## Description of change

This change introduces a new `--allow-delete` option for mountpoint to allow 
users to delete object from S3. The new option is not enabled by default: operations
like `unlink` will fail with `EPERM`. When enabled, `unlink` on files on S3 will 
delete the object for the corresponding key.

As part of the change, the temporary build feature "delete" has been removed and tests 
for `unlink` have been modified to use the new option.

Relevant issues: #78 

## Does this change impact existing behavior?

It adds a new cli option. When set, allows users to delete files.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
