### PR TITLE
Add flags for logging configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,6 +1964,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "walkdir",
 ]

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -17,7 +17,7 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-Logs are also valuable for bug reports. Please read the [logging documentation](LOGGING.md) for details on how to capture logs.
+Logs are also valuable for bug reports. Please read the [logging documentation](LOGGING.md) for details on how to capture verbose logs.
 
 ## Contributing via Pull Requests
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -40,7 +40,10 @@ use crate::{build_info, EndpointConfig};
 macro_rules! request_span {
     ($self:expr, $method:expr, $($field:tt)*) => {{
         let counter = $self.next_request_counter();
-        let span = tracing::debug_span!($method, id = counter, $($field)*);
+        // I have confused myself at least 4 times about how to choose the level for tracing spans.
+        // We want this span to be constructed whenever events at WARN or lower severity (INFO,
+        // DEBUG, TRACE) are emitted. So we set its severity to WARN too.
+        let span = tracing::warn_span!($method, id = counter, $($field)*);
         span.in_scope(|| tracing::debug!("new request"));
         span
     }};

--- a/mountpoint-s3-crt/src/common/rust_log_adapter.rs
+++ b/mountpoint-s3-crt/src/common/rust_log_adapter.rs
@@ -7,10 +7,14 @@ use smallstr::SmallString;
 use crate::common::allocator::Allocator;
 use crate::common::logging::{Level, Logger, LoggerImpl, LoggerInitError, Subject};
 
+/// The log target name for metrics emitted by the CRT
+pub const AWSCRT_LOG_TARGET: &str = "awscrt";
+
 /// This is an implementation of `LoggerImpl` that can be used to pipe CRT log messages into the
 /// Rust `log` facade. To install it, call `RustLogAdapter::try_init()`, and then CRT log messages
 /// will be sent to the `log` facade. These messages will follow that facade's logic for when to
-/// emit log messages. All CRT log messages will have a target that starts with "awscrt::".
+/// emit log messages. All CRT log messages will have a target that starts with the value of
+/// [AWSCRT_LOG_TARGET].
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct RustLogAdapter;
@@ -28,7 +32,7 @@ impl RustLogAdapter {
 impl LoggerImpl for RustLogAdapter {
     fn log(&self, log_level: Level, subject: Subject, message: &str) {
         let mut target = SmallString::<[u8; 64]>::new();
-        let _ = write!(target, "awscrt::{}", subject.name());
+        let _ = write!(target, "{}::{}", AWSCRT_LOG_TARGET, subject.name());
         log::log!(target: target.as_str(), log_level.into(), "{}", message);
     }
     fn get_log_level(&self, _subject: Subject) -> Level {

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -27,6 +27,7 @@ supports-color = "2.0.0"
 syslog = "6.1.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
+tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 nix = "0.26.2"
 time = { version = "0.3.17", features = ["macros", "formatting"] }

--- a/mountpoint-s3/src/metrics.rs
+++ b/mountpoint-s3/src/metrics.rs
@@ -14,6 +14,7 @@ use crate::sync::mpsc::{channel, RecvTimeoutError, Sender};
 use crate::sync::{Arc, Mutex};
 
 mod data;
+pub use data::METRICS_TARGET_NAME;
 use data::*;
 
 mod recorder;

--- a/mountpoint-s3/src/metrics/data.rs
+++ b/mountpoint-s3/src/metrics/data.rs
@@ -4,6 +4,8 @@ use std::fmt::{self, Display, Formatter};
 use metrics::Key;
 use tracing::info;
 
+pub const METRICS_TARGET_NAME: &str = "mountpoint_s3::metrics";
+
 /// A map of metrics data
 #[derive(Debug, Default)]
 pub struct Metrics(HashMap<Key, Metric>);
@@ -49,7 +51,7 @@ impl Metrics {
                 )
             };
             info!(
-                target: "mountpoint_s3::aggregate_metrics",
+                target: METRICS_TARGET_NAME,
                 "{}{}: {}",
                 key.name(),
                 labels,


### PR DESCRIPTION
## Description of change

This simplifies how we ask customers to configure logging by no longer
exposing them to RUST_LOG or filtering directives. Instead, we add a
`--debug` flag to enable verbose logs, and `--debug-crt` to enable
verbose CRT logs (which are spammier). We also add a `--no-log` flag to
completely turn off logging, and `--log-metrics` to emit the summarized
performance metrics.

This change also fixes a bug in the syslog implementation with events
that come via `tracing-log` (the adapter for emitting `tracing` events
from the `log` facade). We use this adapter for adapting CRT logs into
`tracing`, since `tracing` is very picky about log events having static
metadata but CRT logs are necessarily dynamic. The `tracing-log` adapter
records metadata in some custom fields, which we weren't correctly
handling, so our log messages had the wrong `target` and a bunch of
extra fields. This change is annoying to write a test for because `log`
is global, but I tested it manually.

Relevant issues: fixes #377.

## Does this change impact existing behavior?

No, it only adds new command-line flags for controlling logging behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
