### PR TITLE
Adds support for storage class in client

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -254,6 +254,8 @@ pub enum GetObjectAttributesError {
 pub struct PutObjectParams {
     /// Enable Crc32c trailing checksums.
     pub trailing_checksums: bool,
+    /// Storage class to be used when creating new S3 object
+    pub storage_class: Option<String>,
 }
 
 impl PutObjectParams {
@@ -265,6 +267,12 @@ impl PutObjectParams {
     /// Set Crc32c trailing checksums.
     pub fn trailing_checksums(mut self, value: bool) -> Self {
         self.trailing_checksums = value;
+        self
+    }
+
+    /// Set the storage class.
+    pub fn storage_class(mut self, value: String) -> Self {
+        self.storage_class = Some(value);
         self
     }
 }
@@ -323,7 +331,7 @@ pub struct ObjectInfo {
     /// The time this object was last modified.
     pub last_modified: OffsetDateTime,
 
-    /// Storage class for this object. Optional because head_object does not return
+    /// Storage class for this object. Optional because head_object may not return
     /// the storage class in its response. See examples here:
     /// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_Examples
     pub storage_class: Option<String>,

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::object_client::{ObjectClientResult, PutObjectError, PutObjectParams};
 use crate::{ObjectClientError, PutObjectRequest, PutObjectResult, S3CrtClient, S3RequestError};
 use async_trait::async_trait;
+use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::io::async_stream::{self, AsyncStreamWriter};
 use mountpoint_s3_crt::s3::client::{ChecksumConfig, MetaRequestType, UploadReview};
 use tracing::error;
@@ -37,6 +38,12 @@ impl S3CrtClient {
 
         let review_callback = ReviewCallbackBox::default();
         let callback = review_callback.clone();
+
+        if let Some(storage_class) = params.storage_class.to_owned() {
+            message
+                .add_header(&Header::new("x-amz-storage-class", storage_class))
+                .map_err(S3RequestError::construction_failure)?;
+        }
 
         let mut options = S3CrtClientInner::new_meta_request_options(message, MetaRequestType::PutObject);
         options.on_upload_review(move |review| callback.invoke(review));

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -6,6 +6,7 @@ use aws_sdk_s3::types::ByteStream;
 use bytes::Bytes;
 use common::*;
 use mountpoint_s3_client::{HeadObjectError, ObjectClientError, S3CrtClient};
+use test_case::test_case;
 
 #[tokio::test]
 async fn test_head_object() {
@@ -29,6 +30,34 @@ async fn test_head_object() {
     assert_eq!(result.bucket, bucket);
     assert_eq!(result.object.key, key);
     assert_eq!(result.object.size as usize, body.len());
+}
+
+#[test_case("INTELLIGENT_TIERING")]
+#[test_case("GLACIER")]
+#[tokio::test]
+async fn test_head_object_storage_class(storage_class: &str) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_head_object");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .storage_class(storage_class.into())
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+
+    assert_eq!(result.bucket, bucket);
+    assert_eq!(result.object.key, key);
+    assert_eq!(result.object.size as usize, body.len());
+    assert_eq!(result.object.storage_class.as_deref(), Some(storage_class));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description of change

Support storage class in `mountpoint-s3-client`, including methods like put_object, list_objects, and head_object. Also add support to `mock_client`.

Preliminary change in support of e.g. #400 or #152 

## Does this change impact existing behavior?

No changes affecting `mountpoint-s3`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
