### PR TITLE
fuse: log all operation failures

### DIFF
--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -126,7 +126,7 @@ impl ToErrno for InodeError {
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,
             InodeError::CorruptedMetadata(_, _) => libc::EIO,
             InodeError::SetAttrNotPermittedOnRemoteInode(_) => libc::EPERM,
-            InodeError::SetAttrOnExpiredStat(_) => libc::EINVAL,
+            InodeError::SetAttrOnExpiredStat(_) => libc::EIO,
             InodeError::StaleInode { .. } => libc::ESTALE,
         }
     }


### PR DESCRIPTION
## Description of change

I was going to do this in a proc macro but this is way simpler. This
just follows up on #404 by recording all the errors, using a small macro
in place of the existing calls to `reply.error(libc::c_int)`.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
