### PR TITLE
Fix region detection with specified region

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -435,7 +435,7 @@ fn create_client_for_bucket(
         if endpoint_url.is_some() {
             tracing::warn!(
                 "endpoint specified but region unspecified. using {} as the signing region.",
-                endpoint_config.get_region()
+                DEFAULT_REGION
             );
         }
         DEFAULT_REGION


### PR DESCRIPTION
## Description of change

We weren't setting the region in the endpoint config if it was specified manually (with `--region`). This passed our tests because it was defaulting to us-east-1 and that's where our CI is. Instead, let's start with an obviously wrong placeholder region and fill it in when creating the client.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
