### PR TITLE
Add new subsession IAM role for auth integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-sdk-sts",
  "base64ct",
  "built",
  "bytes",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 aws-config = "0.54.1"
 aws-credential-types = "0.54.1"
 aws-sdk-s3 = "0.24.0"
+aws-sdk-sts = "0.24.0"
 bytes = "1.2.1"
 clap = "4.1.9"
 ctor = "0.1.23"

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -53,6 +53,10 @@ pub fn get_test_domain() -> String {
     std::env::var("S3_DOMAIN").unwrap_or(String::from("amazonaws.com"))
 }
 
+pub fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
 pub async fn get_test_sdk_client() -> s3::Client {
     let config = aws_config::from_env()
         .region(Region::new(get_test_region()))


### PR DESCRIPTION
## Description of change

We want to be able to write tests with various permutations of IAM
credentials and policies (read only, prefix only, etc). Rather than
manually building new infrastructure for them, we're creating a single
new IAM role that tests can call AssumeRole on, using a session policy
to scope down the credentials to those they want to test.

I'll be using this in a follow-up commit to switch from HeadBucket to
ListObjects for region detection. I suspect we can also use it to get
rid of our "forbidden" bucket, but don't plan on doing that right now.

## Does this change impact existing behavior?

No, only new tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
