### PR TITLE
Dynamically scale fuse threads

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
   Logs will no longer be written to `$HOME/.mountpoint-s3/` and should be configured using `--log-directory <DIRECTORY>`.
 * Bucket options of `--virtual-addressing` is now removed and `--path-addressing` is changed to `--force-path-style`.
   If `--force-path-style` is not provided, addressing style of endpoint will be resolved automatically.
+* The `--thread-count` option has been removed and replaced with `--max-threads` which sets the maximum
+  number of threads the FUSE daemon will dynamically spawn to handle requests.
 
 Other changes:
 

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -32,7 +32,7 @@ cd ${project_dir}
 results_dir=results
 runtime_seconds=30
 startdelay_seconds=30
-thread_count=4
+max_threads=4
 
 rm -rf ${results_dir}
 mkdir -p ${results_dir}
@@ -51,7 +51,7 @@ read_bechmark () {
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
-      --thread-count=${thread_count}
+      --max-threads=${max_threads}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
       echo "Failed to mount file system"
@@ -97,7 +97,7 @@ write_benchmark () {
   cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
-      --thread-count=${thread_count}
+      --max-threads=${max_threads}
   mount_status=$?
   if [ $mount_status -ne 0 ]; then
       echo "Failed to mount file system"

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -30,7 +30,7 @@ project_dir="${base_dir}/../.."
 cd ${project_dir}
 
 results_dir=results
-thread_count=4
+max_threads=4
 
 rm -rf ${results_dir}
 mkdir -p ${results_dir}
@@ -51,7 +51,7 @@ do
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
         --allow-delete \
         --prefix=${S3_BUCKET_TEST_PREFIX} \
-        --thread-count=${thread_count}
+        --max-threads=${max_threads}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
         echo "Failed to mount file system"
@@ -113,7 +113,7 @@ for job_file in "${jobs_dir}"/*.fio; do
   cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
     --allow-delete \
     --prefix=${S3_BUCKET_TEST_PREFIX} \
-    --thread-count=${thread_count}
+    --max-threads=${max_threads}
   mount_status=$?
   if [ $mount_status -ne 0 ]; then
     echo "Failed to mount file system"

--- a/mountpoint-s3/src/fuse/session.rs
+++ b/mountpoint-s3/src/fuse/session.rs
@@ -1,11 +1,13 @@
-use std::sync::Arc;
+use std::io;
 
 use anyhow::Context;
 use fuser::{Filesystem, Session, SessionUnmounter};
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
-use crate::sync::mpsc;
-use crate::sync::thread;
+use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::mpsc::{self, Sender};
+use crate::sync::thread::{self, JoinHandle};
+use crate::sync::Arc;
 
 /// A multi-threaded FUSE session that can be joined to wait for the FUSE filesystem to unmount or
 /// this process to be interrupted.
@@ -18,32 +20,15 @@ impl FuseSession {
     /// Create worker threads to dispatch requests for a FUSE session.
     pub fn new<FS: Filesystem + Send + Sync + 'static>(
         mut session: Session<FS>,
-        worker_threads: usize,
+        max_worker_threads: usize,
     ) -> anyhow::Result<Self> {
-        assert!(worker_threads > 0);
+        assert!(max_worker_threads > 0);
 
         let unmounter = session.unmount_callable();
 
-        let session = Arc::new(session);
-
         let (tx, rx) = mpsc::channel();
 
-        let workers: Vec<_> = (0..worker_threads)
-            .map(|i| {
-                let session = session.clone();
-                thread::Builder::new().name(format!("fuse-worker-{i}")).spawn(move || {
-                    #[cfg(target_os = "linux")]
-                    {
-                        // SAFETY: this syscall is available since Linux 2.4.11 but glibc didn't
-                        // wrap it until very recently.
-                        let tid = unsafe { libc::syscall(libc::SYS_gettid) };
-                        debug!("fuse worker {i} is thread ID {tid}");
-                    }
-                    session.run()
-                })
-            })
-            .collect::<Result<_, _>>()
-            .context("failed to spawn worker threads")?;
+        let (workers_tx, workers_rx) = mpsc::channel::<JoinHandle<io::Result<()>>>();
 
         // A thread that waits for all workers to exit and then sends a message on the channel
         let _waiter = {
@@ -51,7 +36,7 @@ impl FuseSession {
             thread::Builder::new()
                 .name("fuse-worker-waiter".to_owned())
                 .spawn(move || {
-                    for thd in workers {
+                    while let Ok(thd) = workers_rx.recv() {
                         let thread_name = thd.thread().name().map(ToOwned::to_owned);
                         match thd.join() {
                             Err(panic_param) => {
@@ -80,6 +65,8 @@ impl FuseSession {
         })
         .context("failed to set interrupt handler")?;
 
+        WorkerPool::start(session, workers_tx, max_worker_threads).context("failed to start worker thread pool")?;
+
         Ok(Self {
             unmounter,
             receiver: rx,
@@ -100,4 +87,345 @@ impl FuseSession {
 enum Message {
     WorkersExited,
     Interrupted,
+}
+
+trait Work: Send + Sync + 'static {
+    type Result: Send;
+
+    /// Run the process loop for a worker, notifying the caller
+    /// before and after each unit of work is processed.
+    fn run<FB, FA>(&self, before: FB, after: FA) -> Self::Result
+    where
+        FB: FnMut(),
+        FA: FnMut();
+}
+
+#[derive(Debug)]
+struct WorkerPool<W: Work> {
+    state: Arc<WorkerPoolState<W>>,
+    workers: Sender<JoinHandle<W::Result>>,
+    max_workers: usize,
+}
+
+#[derive(Debug)]
+struct WorkerPoolState<W: Work> {
+    work: W,
+    worker_count: AtomicUsize,
+    idle_worker_count: AtomicUsize,
+}
+
+impl<W: Work> WorkerPool<W> {
+    fn start(work: W, workers: Sender<JoinHandle<W::Result>>, max_workers: usize) -> anyhow::Result<()> {
+        assert!(max_workers > 0);
+
+        let state = WorkerPoolState {
+            work,
+            worker_count: AtomicUsize::new(0),
+            idle_worker_count: AtomicUsize::new(0),
+        };
+        let pool = Self {
+            state: state.into(),
+            workers,
+            max_workers,
+        };
+        if !pool.try_add_worker()? {
+            unreachable!("should always create at least 1 worker (max_workers > 0)");
+        }
+        Ok(())
+    }
+
+    /// Try to add a new worker.
+    /// Returns `Ok(false)` if there are already [`WorkerPool::max_workers`].
+    fn try_add_worker(&self) -> anyhow::Result<bool> {
+        let Ok(i) = self.state.worker_count.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |i| {
+            if i < self.max_workers {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }) else {
+            return Ok(false);
+        };
+        self.state.idle_worker_count.fetch_add(1, Ordering::SeqCst);
+        let clone = (*self).clone();
+        let worker = thread::Builder::new()
+            .name(format!("fuse-worker-{i}"))
+            .spawn(move || clone.run(i))
+            .context("failed to spawn worker threads")?;
+        self.workers.send(worker).unwrap();
+        Ok(true)
+    }
+
+    fn run(self, worker_index: usize) -> W::Result {
+        debug!("starting fuse worker {} ({})", worker_index, get_thread_id_string());
+
+        self.state.work.run(
+            || {
+                let previous_idle_count = self.state.idle_worker_count.fetch_sub(1, Ordering::SeqCst);
+                if previous_idle_count == 1 {
+                    // This was the only idle thread, try to spawn a new one.
+                    if let Err(error) = self.try_add_worker() {
+                        warn!(?error, "unable to spawn fuse worker");
+                    }
+                }
+            },
+            || {
+                self.state.idle_worker_count.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+    }
+}
+
+impl<W: Work> Clone for WorkerPool<W> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            workers: self.workers.clone(),
+            max_workers: self.max_workers,
+        }
+    }
+}
+
+impl<FS> Work for Session<FS>
+where
+    FS: Filesystem + Send + Sync + 'static,
+{
+    type Result = io::Result<()>;
+
+    fn run<FB, FA>(&self, mut before: FB, mut after: FA) -> Self::Result
+    where
+        FB: FnMut(),
+        FA: FnMut(),
+    {
+        self.run_with_callbacks(
+            |req| {
+                // Do not scale threads on bursts of forget messages.
+                if req.is_forget() {
+                    return;
+                }
+                before();
+            },
+            |req| {
+                // Do not scale threads on bursts of forget messages.
+                if req.is_forget() {
+                    return;
+                }
+                after();
+            },
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn get_thread_id_string() -> String {
+    // SAFETY: this syscall is available since Linux 2.4.11 but glibc didn't
+    // wrap it until very recently.
+    let tid = unsafe { libc::syscall(libc::SYS_gettid) };
+    format!("thread id {tid}")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn get_thread_id_string() -> String {
+    "unknown thread id".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sync::{
+        mpsc::{self, Receiver},
+        Condvar, Mutex,
+    };
+    use std::time::Duration;
+    use test_case::test_case;
+
+    use super::*;
+
+    struct TestMessage {
+        _id: usize,
+        mutex: Mutex<bool>,
+        cond: Condvar,
+    }
+
+    impl TestMessage {
+        fn new(_id: usize) -> Self {
+            Self {
+                _id,
+                mutex: Mutex::new(false),
+                cond: Condvar::new(),
+            }
+        }
+
+        fn process(&self) {
+            let mut done = self.mutex.lock().unwrap();
+            while !*done {
+                done = self.cond.wait(done).unwrap();
+            }
+        }
+
+        fn complete(&self) {
+            let mut done = self.mutex.lock().unwrap();
+            *done = true;
+            self.cond.notify_one();
+        }
+    }
+    struct TestWork {
+        receiver: Arc<Mutex<Receiver<Arc<TestMessage>>>>,
+    }
+
+    impl Work for TestWork {
+        type Result = ();
+
+        fn run<FB, FA>(&self, mut before: FB, mut after: FA) -> Self::Result
+        where
+            FB: FnMut(),
+            FA: FnMut(),
+        {
+            while let Ok(message) = {
+                let receiver = self.receiver.lock().unwrap();
+                receiver.recv()
+            } {
+                before();
+                message.process();
+                after();
+            }
+        }
+    }
+
+    #[test_case(10, 10)]
+    #[test_case(10, 30)]
+    #[test_case(30, 10)]
+    fn test_worker_pool_scales_threads(max_worker_threads: usize, concurrent_messages: usize) {
+        let (tx, rx) = mpsc::channel();
+        let work = TestWork {
+            receiver: Arc::new(Mutex::new(rx)),
+        };
+
+        let (workers_tx, workers_rx) = mpsc::channel::<JoinHandle<()>>();
+        WorkerPool::start(work, workers_tx, max_worker_threads).unwrap();
+
+        // Send messages: when processed, they will just wait
+        // until we mark them as completed.
+        let messages = (0..concurrent_messages)
+            .map(|i| {
+                let message = Arc::new(TestMessage::new(i));
+                tx.send(message.clone()).unwrap();
+                message
+            })
+            .collect::<Vec<_>>();
+
+        let mut workers = Vec::new();
+
+        // Expect that the pool will spawn enough workers to handle all
+        // messages (or reach max_worker_threads).
+        let min_expected_workers = concurrent_messages.min(max_worker_threads);
+        for _ in 0..min_expected_workers {
+            let worker = workers_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            workers.push(worker);
+        }
+
+        // Mark all messages as completed.
+        for m in messages {
+            m.complete();
+        }
+
+        drop(tx);
+
+        // The pool tries to spawn an extra idle worker.
+        if let Ok(worker) = workers_rx.recv() {
+            workers.push(worker);
+            assert_eq!(workers.len(), min_expected_workers + 1);
+        } else {
+            assert_eq!(workers.len(), min_expected_workers);
+        }
+    }
+
+    struct CountWork {
+        receiver: Arc<Mutex<Receiver<Arc<AtomicUsize>>>>,
+    }
+
+    impl Work for CountWork {
+        type Result = ();
+
+        fn run<FB, FA>(&self, mut before: FB, mut after: FA) -> Self::Result
+        where
+            FB: FnMut(),
+            FA: FnMut(),
+        {
+            while let Ok(count) = {
+                let receiver = self.receiver.lock().unwrap();
+                receiver.recv()
+            } {
+                before();
+                count.fetch_add(1, Ordering::SeqCst);
+                after();
+            }
+        }
+    }
+
+    #[test_case(30, 10)]
+    #[test_case(10, 1_000_000)]
+    #[test_case(1, 10)]
+    fn test_worker_pool_limits_thread_count(max_worker_threads: usize, message_count: usize) {
+        let (tx, rx) = mpsc::channel();
+        let work = CountWork {
+            receiver: Arc::new(Mutex::new(rx)),
+        };
+
+        let (workers_tx, workers_rx) = mpsc::channel::<JoinHandle<()>>();
+        WorkerPool::start(work, workers_tx, max_worker_threads).unwrap();
+
+        // Messages will increment counter when processed.
+        let counter = Arc::new(AtomicUsize::new(0));
+        for _ in 0..message_count {
+            tx.send(counter.clone()).unwrap();
+        }
+        drop(tx);
+
+        // Join and count all spawned threads.
+        let mut workers_count = 0usize;
+        while let Ok(worker) = workers_rx.recv_timeout(Duration::from_secs(1)) {
+            let _ = worker.join();
+            workers_count += 1;
+        }
+
+        assert!(
+            workers_count <= max_worker_threads,
+            "spawned threads: {workers_count}, max threads: {max_worker_threads}"
+        );
+
+        let count = counter.load(Ordering::SeqCst);
+        assert_eq!(count, message_count, "the pool should have processed all messages");
+    }
+
+    #[cfg(feature = "shuttle")]
+    mod shuttle_tests {
+        use shuttle::rand::Rng;
+        use shuttle::{check_pct, check_random};
+
+        #[test]
+        fn test_worker_pool_scales_threads() {
+            fn test_helper() {
+                let mut rng = shuttle::rand::thread_rng();
+                let num_worker_threads = rng.gen_range(1..=8);
+                let num_concurrent_messages = rng.gen_range(1..=16);
+                super::test_worker_pool_scales_threads(num_worker_threads, num_concurrent_messages);
+            }
+
+            check_random(test_helper, 10000);
+            check_pct(test_helper, 10000, 3);
+        }
+
+        #[test]
+        fn test_worker_pool_limits_thread_count() {
+            fn test_helper() {
+                let mut rng = shuttle::rand::thread_rng();
+                let num_worker_threads = rng.gen_range(1..=8);
+                let num_concurrent_messages = rng.gen_range(1..=16);
+                super::test_worker_pool_limits_thread_count(num_worker_threads, num_concurrent_messages);
+            }
+
+            check_random(test_helper, 10000);
+            check_pct(test_helper, 10000, 3);
+        }
+    }
 }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -129,13 +129,13 @@ struct CliArgs {
 
     #[clap(
         long,
-        help = "Number of FUSE daemon threads",
+        help = "Maximum number of FUSE daemon threads",
         value_name = "N",
-        default_value = "1",
+        default_value = "16",
         value_parser = value_parser!(u64).range(1..),
         help_heading = CLIENT_OPTIONS_HEADER
     )]
-    pub thread_count: Option<u64>,
+    pub max_threads: u64,
 
     #[clap(
         long,
@@ -457,8 +457,8 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 
     let session = Session::new(fs, &args.mount_point, &options).context("Failed to create FUSE session")?;
 
-    let thread_count = args.thread_count.unwrap_or(1) as usize;
-    let session = FuseSession::new(session, thread_count).context("Failed to start FUSE session")?;
+    let max_threads = args.max_threads as usize;
+    let session = FuseSession::new(session, max_threads).context("Failed to start FUSE session")?;
 
     tracing::info!("successfully mounted {:?}", args.mount_point);
 

--- a/vendor/fuser/src/ll/request.rs
+++ b/vendor/fuser/src/ll/request.rs
@@ -2114,10 +2114,14 @@ impl_request!(AnyRequest<'_>);
 impl<'a> AnyRequest<'a> {
     pub fn operation(&self) -> Result<Operation<'a>, RequestError> {
         // Parse/check opcode
-        let opcode = fuse_opcode::try_from(self.header.opcode)
+        let opcode = self.opcode()
             .map_err(|_: InvalidOpcodeError| RequestError::UnknownOperation(self.header.opcode))?;
         // Parse/check operation arguments
         op::parse(self.header, &opcode, self.data).ok_or(RequestError::InsufficientData)
+    }
+
+    pub fn opcode(&self) -> Result<fuse_opcode, InvalidOpcodeError> {
+        fuse_opcode::try_from(self.header.opcode)
     }
 }
 

--- a/vendor/fuser/src/request.rs
+++ b/vendor/fuser/src/request.rs
@@ -651,4 +651,14 @@ impl<'a> Request<'a> {
     pub fn pid(&self) -> u32 {
         self.request.pid()
     }
+
+    /// Returns whether this is a forget request
+    pub fn is_forget(&self) -> bool {
+        match self.request.opcode() {
+            Ok(abi::fuse_opcode::FUSE_FORGET) => true,
+            #[cfg(feature = "abi-7-16")]
+            Ok(abi::fuse_opcode::FUSE_BATCH_FORGET) => true,
+            _ => false,
+        }
+    }
 }


### PR DESCRIPTION
## Description of change

Introduce a pool of fuse worker threads that will scale dynamically up to a `max_workers` limit when receiving kernel requests.

The implementation relies on the following changes in `fuser/fork`:
* `Session::run_with_callbacks()`: version of `Session::run()` with callbacks before/after dispatch.
* `Request::is_forget()`: we do not want to spawn new threads on spikes of forget/batch_forget requests.

Relevant issues: #7 

## Does this change impact existing behavior?

New `--max-threads` option replaces `--thread-count` and sets the **maximum** number of threads to spawn. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
