### PR TITLE
Use ListObjectsV2 instead of HeadBucket for region detection 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "async-lock",
  "aws-config",
  "aws-sdk-s3",
+ "aws-sdk-sts",
  "base16ct",
  "built",
  "bytes",

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -85,10 +85,7 @@ impl S3CrtClient {
             },
             move |result| {
                 if result.is_err() {
-                    let parsed = parse_get_object_error(&result);
-                    Err(parsed
-                        .map(ObjectClientError::ServiceError)
-                        .unwrap_or(ObjectClientError::ClientError(S3RequestError::ResponseError(result))))
+                    Err(parse_get_object_error(result).map(ObjectClientError::ServiceError))
                 } else {
                     Ok(())
                 }

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -149,13 +149,12 @@ impl S3CrtClient {
                 ?object_attributes
             );
 
-            self.inner
-                .make_simple_http_request(message, MetaRequestType::Default, span, |result| {
-                    let parsed = parse_get_object_attributes_error(&result);
-                    parsed
-                        .map(ObjectClientError::ServiceError)
-                        .unwrap_or(ObjectClientError::ClientError(S3RequestError::ResponseError(result)))
-                })?
+            self.inner.make_simple_http_request(
+                message,
+                MetaRequestType::Default,
+                span,
+                parse_get_object_attributes_error,
+            )?
         };
 
         let body = body.await?;
@@ -243,13 +242,6 @@ mod tests {
         let result = make_result(404, OsStr::from_bytes(&body[..]));
         let result = parse_get_object_attributes_error(&result);
         assert_eq!(result, Some(GetObjectAttributesError::NoSuchBucket));
-    }
-
-    #[test]
-    fn parse_403() {
-        let result = make_result(403, "");
-        let result = parse_get_object_attributes_error(&result);
-        assert_eq!(result, None);
     }
 
     #[test]

--- a/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
@@ -1,60 +1,39 @@
-use crate::object_client::{ObjectClientError, ObjectClientResult};
+use crate::object_client::ObjectClientResult;
 use crate::{S3CrtClient, S3RequestError};
-use mountpoint_s3_crt::s3::client::{MetaRequestResult, MetaRequestType};
+use mountpoint_s3_crt::s3::client::MetaRequestType;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum HeadBucketError {
-    #[error("Wrong region: should be {0}")]
-    IncorrectRegion(String),
-
     #[error("The bucket did not exist")]
     NoSuchBucket,
-
-    #[error("Permission denied")]
-    PermissionDenied(MetaRequestResult),
 }
 
 impl S3CrtClient {
     pub async fn head_bucket(&self, bucket: &str) -> ObjectClientResult<(), HeadBucketError, S3RequestError> {
-        let body = {
-            let mut message = self
-                .inner
-                .new_request_template("HEAD", bucket)
-                .map_err(S3RequestError::construction_failure)?;
+        let body =
+            {
+                let mut message = self
+                    .inner
+                    .new_request_template("HEAD", bucket)
+                    .map_err(S3RequestError::construction_failure)?;
 
-            message
-                .set_request_path("/")
-                .map_err(S3RequestError::construction_failure)?;
+                message
+                    .set_request_path("/")
+                    .map_err(S3RequestError::construction_failure)?;
 
-            let span = request_span!(self.inner, "head_bucket", bucket);
+                let span = request_span!(self.inner, "head_bucket");
 
-            self.inner
-                .make_simple_http_request(message, MetaRequestType::Default, span, |request_result| {
-                    match request_result.response_status {
-                        301 => try_parse_redirect(&request_result)
-                            .map(ObjectClientError::ServiceError)
-                            .unwrap_or(ObjectClientError::ClientError(S3RequestError::ResponseError(
-                                request_result,
-                            ))),
-                        // S3 returns 400 for invalid or expired STS tokens
-                        // TODO: Multiregion accesspoints, transfer acceleration endpoints gives 400 for incorrect region which needs to be redirected.
-                        400 | 403 => ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(request_result)),
-                        404 => ObjectClientError::ServiceError(HeadBucketError::NoSuchBucket),
-                        _ => ObjectClientError::ClientError(S3RequestError::ResponseError(request_result)),
-                    }
-                })?
-        };
+                self.inner
+                    .make_simple_http_request(message, MetaRequestType::Default, span, |request_result| {
+                        match request_result.response_status {
+                            404 => Some(HeadBucketError::NoSuchBucket),
+                            _ => None,
+                        }
+                    })?
+            };
 
         body.await.map(|_body| ())
     }
-}
-
-fn try_parse_redirect(request_result: &MetaRequestResult) -> Option<HeadBucketError> {
-    // Try to parse the correct region out of the headers
-    let error_response_headers = request_result.error_response_headers.as_ref()?;
-    let region_header = error_response_headers.get("x-amz-bucket-region").ok()?;
-    let region = region_header.value().to_owned().into_string().ok()?;
-    Some(HeadBucketError::IncorrectRegion(region))
 }

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -72,8 +72,8 @@ impl S3CrtClient {
         bucket: &str,
         key: &str,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, S3RequestError> {
-        // We use this header to stash the response from the head_object during the on_headers
-        // callback, and send it back on the oneshot when we finish.
+        // Stash the response from the head_object in this lock during the on_headers
+        // callback, and pull them out once the request is done.
         let header: Arc<Mutex<Option<Result<HeadObjectResult, ParseError>>>> = Default::default();
         let header1 = header.clone();
 

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::object_client::{ObjectClientResult, PutObjectError, PutObjectParams};
-use crate::{ObjectClientError, PutObjectRequest, PutObjectResult, S3CrtClient, S3RequestError};
+use crate::{PutObjectRequest, PutObjectResult, S3CrtClient, S3RequestError};
 use async_trait::async_trait;
 use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::io::async_stream::{self, AsyncStreamWriter};
@@ -49,9 +49,7 @@ impl S3CrtClient {
         options.on_upload_review(move |review| callback.invoke(review));
         let body = self
             .inner
-            .make_simple_http_request_from_options(options, span, |result| {
-                ObjectClientError::ClientError(S3RequestError::ResponseError(result))
-            })?;
+            .make_simple_http_request_from_options(options, span, |_| None)?;
 
         Ok(S3PutObjectRequest {
             body,

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -270,18 +270,16 @@ async fn test_scoped_credentials() {
         .await
         .unwrap()
         .expect_err("should fail in different prefix");
-    if let ObjectClientError::ClientError(S3RequestError::ResponseError(err)) = &err {
-        assert!(err.response_status == 403, "should get a permissions error");
-    } else {
-        panic!("Unexpected result, expected a ResponseError with 403 if there's no permission");
-    }
+    assert!(matches!(
+        err,
+        ObjectClientError::ClientError(S3RequestError::PermissionDenied(_))
+    ));
     let err = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}/"))
         .await
         .expect_err("should fail in different prefix");
-    if let ObjectClientError::ClientError(S3RequestError::ResponseError(err)) = &err {
-        assert!(err.response_status == 403, "should get a permissions error");
-    } else {
-        panic!("Unexpected result, expected a ResponseError with 403 if there's no permission");
-    }
+    assert!(matches!(
+        err,
+        ObjectClientError::ClientError(S3RequestError::PermissionDenied(_))
+    ));
 }

--- a/mountpoint-s3-client/tests/delete_object.rs
+++ b/mountpoint-s3-client/tests/delete_object.rs
@@ -89,9 +89,8 @@ async fn test_delete_object_no_perm() {
 
     let result = client.delete_object(&bucket, &key).await;
 
-    if let Err(ObjectClientError::ClientError(S3RequestError::ResponseError(err))) = &result {
-        assert!(err.response_status == 403);
-    } else {
-        panic!("Unexpected result, expected a ResponseError with 403 if there's no permission");
-    }
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+    ));
 }

--- a/mountpoint-s3-client/tests/get_object_attributes.rs
+++ b/mountpoint-s3-client/tests/get_object_attributes.rs
@@ -472,9 +472,8 @@ async fn test_get_attributes_no_perm() {
         .get_object_attributes(&bucket, &key, None, None, object_attributes.as_ref())
         .await;
 
-    if let Err(ObjectClientError::ClientError(S3RequestError::ResponseError(err))) = &result {
-        assert!(err.response_status == 403);
-    } else {
-        panic!("Unexpected result, expected a ResponseError with 403 if there's no permission");
-    }
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+    ));
 }

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -3,7 +3,9 @@
 pub mod common;
 
 use common::*;
-use mountpoint_s3_client::{EndpointConfig, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient};
+use mountpoint_s3_client::{
+    EndpointConfig, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient, S3RequestError,
+};
 
 #[tokio::test]
 async fn test_head_bucket_correct_region() {
@@ -24,7 +26,7 @@ async fn test_head_bucket_wrong_region() {
     let result = client.head_bucket(&bucket).await;
 
     match result {
-        Err(ObjectClientError::ServiceError(HeadBucketError::IncorrectRegion(actual_region))) => {
+        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(actual_region))) => {
             assert_eq!(actual_region, expected_region, "wrong region returned")
         }
         _ => panic!("incorrect result {result:?}"),
@@ -40,7 +42,7 @@ async fn test_head_bucket_forbidden() {
 
     assert!(matches!(
         result,
-        Err(ObjectClientError::ServiceError(HeadBucketError::PermissionDenied(_)))
+        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
     ));
 }
 

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -868,7 +868,7 @@ impl RequestMetrics {
         unsafe { Some(Headers::from_crt(NonNull::new_unchecked(out))) }
     }
 
-    /// Get the IP address the request connected to
+    /// Get the path and query fragment of the request URL
     pub fn request_path_query(&self) -> Option<String> {
         let mut out: *const aws_string = std::ptr::null();
         // SAFETY: `inner` is a valid aws_s3_request_metrics

--- a/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
+++ b/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
@@ -19,8 +19,8 @@ use super::s3_library_init;
 /// Errors returned on operations from `resolve()`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ResolverError {
-    /// The header was not found
-    #[error("endpoint not resolved: {0}")]
+    /// Pass through an error from the resolver rules
+    #[error("{0}")]
     EndpointNotResolved(String),
 
     /// Internal CRT error

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -42,6 +42,7 @@ assert_cmd = "2.0.6"
 assert_fs = "1.0.9"
 aws-config = "0.54.1"
 aws-sdk-s3 = "0.24.0"
+aws-sdk-sts = "0.24.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
 ctor = "0.1.23"
 filetime = "0.2.21"

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -509,8 +509,8 @@ fn create_client_for_bucket(
         Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(region))) if supposed_region.is_none() => {
             tracing::warn!("bucket {bucket} is in region {region}, not {region_to_try}. redirecting...");
             let new_client = S3CrtClient::new(client_config.endpoint_config(endpoint_config.region(&region)))?;
-            let head_request = new_client.list_objects(bucket, None, "", 0, prefix.as_str());
-            futures::executor::block_on(head_request)
+            let list_request = new_client.list_objects(bucket, None, "", 0, prefix.as_str());
+            futures::executor::block_on(list_request)
                 .map(|_| new_client)
                 .with_context(|| format!("initial ListObjectsV2 failed for bucket {bucket} in region {region}"))
         }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -15,7 +15,7 @@ use mountpoint_s3::logging::{init_logging, LoggingConfig};
 use mountpoint_s3::metrics::{MetricsSink, METRICS_TARGET_NAME};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::{
-    AddressingStyle, EndpointConfig, HeadBucketError, ObjectClientError, S3ClientConfig, S3CrtClient, S3RequestError,
+    AddressingStyle, EndpointConfig, ObjectClientError, S3ClientConfig, S3CrtClient, S3RequestError,
 };
 use mountpoint_s3_client::{ImdsCrtClient, S3ClientAuthConfig};
 use mountpoint_s3_crt::common::allocator::Allocator;
@@ -404,8 +404,11 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
         client_config = client_config.bucket_owner(&owner);
     }
 
+    let prefix = args.prefix.unwrap_or_default();
+
     let client = create_client_for_bucket(
         &args.bucket_name,
+        &prefix,
         args.region,
         args.endpoint_url,
         endpoint_config,
@@ -431,7 +434,6 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     filesystem_config.prefetcher_config.part_alignment = args.part_size as usize;
     filesystem_config.allow_delete = args.allow_delete;
 
-    let prefix = args.prefix.unwrap_or_default();
     let fs = S3FuseFilesystem::new(client, runtime, &args.bucket_name, &prefix, filesystem_config);
 
     let fs_name = String::from("mountpoint-s3");
@@ -463,14 +465,15 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     Ok(session)
 }
 
-/// Create a client for a bucket in the given region and send a HeadBucket request to validate it's
-/// accessible. If no region is provided, attempt to infer it by first sending a HeadBucket to the
-/// default region.
+/// Create a client for a bucket in the given region and send a ListObjectsV2 request to validate
+/// that it's accessible. If no region is provided, attempt to infer it by first sending a
+/// ListObjectsV2 to the default region.
 ///
 /// This also has the nice side effect of triggering the CRT's DNS resolver to start pooling
 /// responses, which means we don't have to wait for the first file read to start the rampup period.
 fn create_client_for_bucket(
     bucket: &str,
+    prefix: &Prefix,
     supposed_region: Option<String>,
     endpoint_url: Option<String>,
     mut endpoint_config: EndpointConfig,
@@ -499,19 +502,20 @@ fn create_client_for_bucket(
 
     let client = S3CrtClient::new(client_config.clone().endpoint_config(endpoint_config.clone()))?;
 
-    let head_request = client.head_bucket(bucket);
-    match futures::executor::block_on(head_request) {
+    let list_request = client.list_objects(bucket, None, "", 0, prefix.as_str());
+    match futures::executor::block_on(list_request) {
         Ok(_) => Ok(client),
         // Don't try to automatically correct the region if it was manually specified incorrectly
         Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(region))) if supposed_region.is_none() => {
             tracing::warn!("bucket {bucket} is in region {region}, not {region_to_try}. redirecting...");
             let new_client = S3CrtClient::new(client_config.endpoint_config(endpoint_config.region(&region)))?;
-            let head_request = new_client.head_bucket(bucket);
+            let head_request = new_client.list_objects(bucket, None, "", 0, prefix.as_str());
             futures::executor::block_on(head_request)
                 .map(|_| new_client)
-                .with_context(|| format!("HeadBucket failed for bucket {bucket} in region {region}"))
+                .with_context(|| format!("initial ListObjectsV2 failed for bucket {bucket} in region {region}"))
         }
-        Err(e) => Err(e).with_context(|| format!("HeadBucket failed for bucket {bucket} in region {region_to_try}")),
+        Err(e) => Err(e)
+            .with_context(|| format!("initial ListObjectsV2 failed for bucket {bucket} in region {region_to_try}")),
     }
 }
 

--- a/mountpoint-s3/src/prefix.rs
+++ b/mountpoint-s3/src/prefix.rs
@@ -25,6 +25,10 @@ impl Prefix {
             })
         }
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.path
+    }
 }
 
 impl Display for Prefix {


### PR DESCRIPTION
## Description of change

HeadBucket requires `s3:ListBucket` permissions for the root of the bucket, but some customers scope their users' access down to only a prefix of the bucket. This makes it impossible for them to use prefix mounts today. Instead, we want to use ListObjects on the prefix as the region detection mechanism.

It turned out that the cleanest way to do this was to refactor how the S3CrtClient does error handling, to centralize the generic cases like permission denied or incorrect region. So this PR is two commits that might be easier to read individually: the first one is that refactoring, and the second does the actual change to `mount-s3`.

## Does this change impact existing behavior?

Yes, Mountpoint no longer uses HeadBucket at mount time, preferring ListObjects instead.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
