### PR TITLE
Present flexible retrieval objects with 000 permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1105,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1501,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1736,6 +1769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasso"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4644821e1c3d7a560fe13d842d13f587c07348a1a05d3a797152d41c90c56df2"
+dependencies = [
+ "dashmap",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +1928,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "metrics-macros",
  "portable-atomic 0.3.20",
 ]
@@ -1940,6 +1993,8 @@ dependencies = [
  "fuser",
  "futures",
  "hdrhistogram",
+ "lasso",
+ "lazy_static",
  "libc",
  "metrics",
  "mountpoint-s3-client",
@@ -2193,6 +2248,19 @@ checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -331,8 +331,8 @@ pub struct ObjectInfo {
     /// The time this object was last modified.
     pub last_modified: OffsetDateTime,
 
-    /// Storage class for this object. Optional because head_object may not return
-    /// the storage class in its response. See examples here:
+    /// Storage class for this object. Optional because head_object does not return
+    /// the storage class in its response for Standard objects. See examples here:
     /// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_Examples
     pub storage_class: Option<String>,
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -19,6 +19,8 @@ crc32c = "0.6.3"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
+lasso = { version = "0.7.2", features = ["multi-threaded"] }
+lazy_static = "1.4.0"
 libc = "0.2.126"
 metrics = "0.20.1"
 once_cell = "1.16.0"

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -15,7 +15,7 @@ use mountpoint_s3_client::{ETag, GetObjectError, ObjectClient, ObjectClientError
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, WriteHandle};
 use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
 use crate::prefix::Prefix;
-use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use crate::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use crate::sync::{Arc, AsyncMutex, AsyncRwLock};
 use crate::upload::{UploadRequest, Uploader};
 
@@ -92,6 +92,12 @@ impl<Client: ObjectClient, Runtime> FileHandleType<Client, Runtime> {
     }
 
     async fn new_read_handle(lookup: &LookedUp) -> Result<FileHandleType<Client, Runtime>, Error> {
+        if is_flexible_retrieval_storage_class(lookup) {
+            return Err(err!(
+                libc::EACCES,
+                "objects in flexible retrieval storage classes are not accessible",
+            ));
+        }
         lookup.inode.start_reading()?;
         let handle = FileHandleType::Read {
             request: Default::default(),
@@ -344,6 +350,25 @@ pub trait ReadReplier {
     fn error(self, error: Error) -> Self::Replied;
 }
 
+/// Objects in flexible retrieval storage classes can't be accessed via GetObject, and so we
+/// override their permissions to 000 and reject reads to them. We also warn the first time we see
+/// an object like this, because FUSE enforces the 000 permissions on our behalf so we might not
+/// see an attempted `open` call.
+fn is_flexible_retrieval_storage_class(lookup: &LookedUp) -> bool {
+    static HAS_SENT_WARNING: AtomicBool = AtomicBool::new(false);
+    match lookup.stat.storage_class.as_deref() {
+        Some("GLACIER") | Some("DEEP_ARCHIVE") => {
+            if !HAS_SENT_WARNING.swap(true, Ordering::SeqCst) {
+                tracing::warn!(
+                    "objects in the GLACIER and DEEP_ARCHIVE storage classes are not readable with Mountpoint"
+                );
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
 impl<Client, Runtime> S3Filesystem<Client, Runtime>
 where
     Client: ObjectClient + Send + Sync + 'static,
@@ -366,7 +391,13 @@ where
         // hard links, so we just assume one link for files (itself) and two links for directories
         // (itself + the "." link).
         let (perm, nlink) = match lookup.inode.kind() {
-            InodeKind::File => (self.config.file_mode, 1),
+            InodeKind::File => {
+                if is_flexible_retrieval_storage_class(lookup) {
+                    (0o000, 1)
+                } else {
+                    (self.config.file_mode, 1)
+                }
+            }
             InodeKind::Directory => (self.config.dir_mode, 2),
         };
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -356,7 +356,7 @@ pub trait ReadReplier {
 /// see an attempted `open` call.
 fn is_flexible_retrieval_storage_class(lookup: &LookedUp) -> bool {
     static HAS_SENT_WARNING: AtomicBool = AtomicBool::new(false);
-    match lookup.stat.storage_class.as_deref() {
+    match lookup.stat.storage_class() {
         Some("GLACIER") | Some("DEEP_ARCHIVE") => {
             if !HAS_SENT_WARNING.swap(true, Ordering::SeqCst) {
                 tracing::warn!(

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -168,6 +168,7 @@ impl ReaddirHandle {
                     object_info.size as usize,
                     object_info.last_modified,
                     Some(object_info.etag.clone()),
+                    object_info.storage_class.clone(),
                     self.inner.cache_config.file_ttl,
                 );
                 Some(RemoteLookup {

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -1,11 +1,14 @@
 use std::fs::{read_dir, File};
 use std::io::{Read as _, Seek, SeekFrom};
+use std::os::unix::prelude::PermissionsExt;
 
 use fuser::BackgroundSession;
+use mountpoint_s3_client::PutObjectParams;
 use rand::RngCore;
 use rand::SeedableRng as _;
 use rand_chacha::ChaChaRng;
 use tempfile::TempDir;
+use test_case::test_case;
 
 use crate::fuse_tests::{read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 
@@ -70,4 +73,53 @@ fn basic_read_test_mock() {
 #[test]
 fn basic_read_test_mock_prefix() {
     basic_read_test(crate::fuse_tests::mock_session::new, "basic_read_test");
+}
+
+fn read_flexible_retrieval_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const FILES: &[&str] = &["STANDARD", "GLACIER_IR", "GLACIER", "DEEP_ARCHIVE"];
+
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    for file in FILES {
+        let mut put_params = PutObjectParams::default();
+        if *file != "STANDARD" {
+            put_params.storage_class = Some(file.to_string());
+        }
+        test_client
+            .put_object_params(&format!("{file}.txt"), b"hello world", put_params)
+            .unwrap();
+    }
+
+    let read_dir_iter = read_dir(mount_point.path()).unwrap();
+    for file in read_dir_iter {
+        let file = file.unwrap();
+        let file_name = file.file_name().to_string_lossy().into_owned();
+
+        let metadata = file.metadata().unwrap();
+        if file_name == "GLACIER.txt" || file_name == "DEEP_ARCHIVE.txt" {
+            assert_eq!(metadata.permissions().mode() & !libc::S_IFMT, 0o000);
+            let err = File::open(file.path()).expect_err("read of flexible retrieval object should fail");
+            assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        } else {
+            let mut f = File::open(file.path()).expect("instant retrieval file should succeed");
+            let mut contents = String::new();
+            f.read_to_string(&mut contents).unwrap();
+            assert_eq!(contents, "hello world");
+        }
+    }
+}
+
+#[cfg(feature = "s3_tests")]
+#[test]
+fn read_flexible_retrieval_test_s3() {
+    read_flexible_retrieval_test(crate::fuse_tests::s3_session::new, "read_flexible_retrieval_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("read_flexible_retrieval_test"; "prefix")]
+fn read_flexible_retrieval_test_mock(prefix: &str) {
+    read_flexible_retrieval_test(crate::fuse_tests::mock_session::new, prefix);
 }

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -461,6 +461,7 @@ fn write_with_storage_class_test_s3_mock(storage_class: Option<&str>) {
     write_with_storage_class_test(crate::fuse_tests::mock_session::new, storage_class);
 }
 
+#[cfg_attr(not(feature = "s3_tests"), allow(unused))] // Mock client doesn't validate storage classes
 fn write_with_invalid_storage_class_test<F>(creator_fn: F, storage_class: &str)
 where
     F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),


### PR DESCRIPTION
## Description of change

Objects in the Glacier Flexible Retrieval and Glacier Deep Archive
storage classes (and their corresponding Intelligent Tiering tiers) are
not readable with GetObject without first triggering a restoration. We
don't offer the ability to do that (and it likely wouldn't make sense
for us given the latency), but these objects will still appear in the
file tree, so we give them 000 permissions and EACCES failures to make
clear they're not accessible.

It would be nice to make this work for objects that have already been
restored, which still carry the GLACIER/DEEP_ARCHIVE storage class but
also return their restore state with HeadObject. But ListObjectsV2 gives
us no way to find that out. We could probably make this work since we
know we always send a HeadObject on `open`, but it was more work than I
wanted to do right now, and this at least prevents customers getting EIO
errors on these objects.

Relevant issues: fixes #152.

## Does this change impact existing behavior?

Yes, this changes the permissions for Glacier Flexible Retrieval and Glacier Deep Archive objects.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
