### PR TITLE
Update `--profile` flag to override default chain's profile rather than replacing default chain

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+Breaking changes:
+
+* `S3ClientAuthConfig` variant `Default` is now `DefaultChain` with optional field; `Default` trait implementation works as before.
+* `S3ClientAuthConfig` variant `Profile` has been removed.
+  Instead, you should create a new profile credential provider and use the `Provider(CredentialProvider)` variant.
+
 # v0.3.0 (June 20, 2023)
 
 Breaking changes:

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -9,9 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use mountpoint_s3_crt::auth::credentials::{
-    CredentialsProvider, CredentialsProviderChainDefaultOptions, CredentialsProviderProfileOptions,
-};
+use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderChainDefaultOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
 use mountpoint_s3_crt::common::uri::Uri;
 use mountpoint_s3_crt::http::request_response::{Header, Headers, Message};

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -150,7 +150,6 @@ async fn test_default_chain_custom_profile_provider_async() {
         "Statement": [
             {
                 "Effect": "Deny",
-                "Principal": { "AWS": "*" },
                 "Action": [ "s3:GetObject" ],
                 "Resource": "*"
             }
@@ -266,7 +265,6 @@ async fn test_profile_only_provider_async() {
         "Statement": [
             {
                 "Effect": "Deny",
-                "Principal": { "AWS": "*" },
                 "Action": [ "s3:GetObject" ],
                 "Resource": "*"
             }

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -5,8 +5,7 @@ pub mod common;
 use std::io::Write;
 use std::option::Option::None;
 
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
-use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
 use aws_sdk_s3::types::ByteStream;
 use aws_sdk_s3::Region;
 use bytes::Bytes;
@@ -15,8 +14,13 @@ use futures::StreamExt;
 use mountpoint_s3_client::{
     EndpointConfig, ObjectClient, ObjectClientError, S3ClientAuthConfig, S3ClientConfig, S3CrtClient, S3RequestError,
 };
-use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
+use mountpoint_s3_crt::auth::credentials::{
+    CredentialsProvider, CredentialsProviderProfileOptions, CredentialsProviderStaticOptions,
+};
 use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::io::channel_bootstrap;
+use mountpoint_s3_crt::io::event_loop;
+use mountpoint_s3_crt::io::host_resolver;
 use rusty_fork::rusty_fork_test;
 use tempfile::NamedTempFile;
 
@@ -37,15 +41,8 @@ async fn test_static_provider() {
         .await
         .unwrap();
 
-    // Get some static credentials by just using the SDK's default provider, which we know works
-    let sdk_provider = DefaultCredentialsChain::builder()
-        .region(Region::new(get_test_region()))
-        .build()
-        .await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("static credentials should be available");
+    // Get some static credentials using the SDK's default provider chain
+    let credentials = get_sdk_default_chain_creds().await;
 
     // Build a S3CrtClient that uses a static credentials provider with the creds we just got
     let config = CredentialsProviderStaticOptions {
@@ -92,15 +89,20 @@ async fn test_static_provider() {
         .expect_err("bogus credentials should not work");
 }
 
-/// Test creating a client with the profile credentials provider
+/// Test creating a client with the default credentials provider with a profile name override
 ///
 /// This is complicated because CLI profiles are inherently global state, but we want to isolate the
-/// test. So the [test_profile_provider] test below is forked into its own process, where it can set
+/// test. So the [test_default_chain_with_profile_override] test below is forked into its own process, where it can set
 /// the environment variables it needs to point to an isolated CLI configuration file without
 /// affecting the rest of the real test runner.
-async fn test_profile_provider_async() {
+///
+/// This test will cover the following three cases:
+/// * Default chain with valid AWS profile credential configuration
+/// * Default chain with invalid AWS profile credential configuration
+/// * Default chain with existing profile but no credential configuration, falling back on the rest of credential chain
+async fn test_default_chain_custom_profile_provider_async() {
     let sdk_client = get_test_sdk_client().await;
-    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider");
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_custom_profile_provider");
 
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
@@ -113,40 +115,24 @@ async fn test_profile_provider_async() {
         .await
         .unwrap();
 
-    // Get some static credentials by just using the SDK's default provider chain
-    let sdk_provider = DefaultCredentialsChain::builder()
-        .region(Region::new(get_test_region()))
-        .build()
-        .await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("static credentials should be available");
-
-    // Write the credentials in CLI config format into a temp file
-    let profile_name = "mountpoint-profile";
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
     let mut config_file = NamedTempFile::new().unwrap();
-    writeln!(
-        config_file,
-        "[profile {}]
-aws_access_key_id = {}
-aws_secret_access_key = {}",
-        profile_name,
-        credentials.access_key_id(),
-        credentials.secret_access_key()
-    )
-    .unwrap();
-    if let Some(session_token) = credentials.session_token() {
-        writeln!(config_file, "aws_session_token = {}", session_token).unwrap()
-    }
-
     // Set up the environment variables to use this new config file. This is only OK to do because
     // this test is run in a forked process, so won't affect any other concurrently running tests.
     std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
 
-    // Build a S3CrtClient that uses the config file
+    // Get some static credentials using the SDK's default provider chain
+    let credentials = get_sdk_default_chain_creds().await;
+    let profile_name = "mountpoint-profile";
+    write_credentials_to_named_profile(&mut config_file, profile_name, credentials).await;
+
+    // Build a S3CrtClient that uses the new profile
     let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .auth_config(S3ClientAuthConfig::DefaultChain {
+            profile_name_override: Some(profile_name.to_owned()),
+        })
         .endpoint_config(EndpointConfig::new(&get_test_region()));
     let client = S3CrtClient::new(config).unwrap();
 
@@ -156,43 +142,227 @@ aws_secret_access_key = {}",
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
 
-    // Try it again, but scribble over the credentials, so we know it's not succeeding by accident.
-    // The client can't tell that the corrupted session token is invalid, so the request gets sent,
-    // but fails.
-    let length = config_file.as_file().metadata().unwrap().len();
-    config_file.as_file_mut().set_len(length - 5).unwrap();
+    // Try it again, but this time we'll use a profile with credentials that cannot access the object.
+    // This way, we know the test isn't passing by accident.
+    let profile_name = "mountpoint-bad-profile";
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Deny",
+                "Principal": { "AWS": "*" },
+                "Action": [ "s3:GetObject" ],
+                "Resource": "*"
+            }
+        ]
+    }"#;
+    let scoped_down_creds = get_scoped_down_credentials(policy.to_owned()).await;
+    write_credentials_to_named_profile(&mut config_file, profile_name, scoped_down_creds).await;
 
     let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .auth_config(S3ClientAuthConfig::DefaultChain {
+            profile_name_override: Some(profile_name.to_owned()),
+        })
         .endpoint_config(EndpointConfig::new(&get_test_region()));
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
         .get_object(&bucket, &key, None, None)
         .await
-        .expect("get_object should be sent");
-
+        .expect("get_object should be accepted by CRT");
     let _error = request
         .next()
         .await
         .unwrap()
-        .expect_err("bogus credentials should not work");
+        .expect_err("first GET for profile with no permissions should not work");
+
+    // Finally, try a profile with no credentials which should follow the rest of the chain.
+    let profile_name = "profile-with-no-creds-config";
+    writeln!(&config_file, "[profile {profile_name}]").unwrap();
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::DefaultChain {
+            profile_name_override: Some(profile_name.to_owned()),
+        })
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(config).unwrap();
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
 
     // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
     // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
     // be constructed.
     let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
+        .auth_config(S3ClientAuthConfig::DefaultChain {
+            profile_name_override: Some("not-the-right-profile-name".to_owned()),
+        })
         .endpoint_config(EndpointConfig::new(&get_test_region()));
     let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
 }
 
+/// Test creating a client with the profile credentials provider
+///
+/// This is complicated because CLI profiles are inherently global state, but we want to isolate the
+/// test. So the [test_profile_provider] test below is forked into its own process, where it can set
+/// the environment variables it needs to point to an isolated CLI configuration file without
+/// affecting the rest of the real test runner.
+async fn test_profile_only_provider_async() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_only_provider");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    // Get some static credentials using the SDK's default provider chain
+    let credentials = get_sdk_default_chain_creds().await;
+
+    // Write the credentials in CLI config format into a temp file
+    let mut config_file = NamedTempFile::new().unwrap();
+    let profile_name = "mountpoint-profile";
+    write_credentials_to_named_profile(&mut config_file, profile_name, credentials).await;
+
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    // Build a S3CrtClient that uses the config file
+    let mut client_bootstrap = setup_crt_bootstrap();
+    let profile_provider = CredentialsProvider::new_profile(
+        &Allocator::default(),
+        CredentialsProviderProfileOptions {
+            bootstrap: &mut client_bootstrap,
+            profile_name_override: profile_name,
+        },
+    )
+    .unwrap();
+
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Provider(profile_provider))
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(config).unwrap();
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+
+    // Try it again, but this time we'll use a profile that cannot access the object.
+    // This way, we know the test isn't passing by accident.
+    let profile_name = "mountpoint-bad-profile";
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Deny",
+                "Principal": { "AWS": "*" },
+                "Action": [ "s3:GetObject" ],
+                "Resource": "*"
+            }
+        ]
+    }"#;
+
+    let scoped_down_creds = get_scoped_down_credentials(policy.to_owned()).await;
+    write_credentials_to_named_profile(&mut config_file, profile_name, scoped_down_creds).await;
+
+    let profile_provider = CredentialsProvider::new_profile(
+        &Allocator::default(),
+        CredentialsProviderProfileOptions {
+            bootstrap: &mut client_bootstrap,
+            profile_name_override: profile_name,
+        },
+    )
+    .unwrap();
+
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Provider(profile_provider))
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(config).unwrap();
+
+    let mut request = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should be accepted by CRT");
+    let _error = request
+        .next()
+        .await
+        .unwrap()
+        .expect_err("first GET for profile with no permissions should not work");
+
+    // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
+    // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
+    // be constructed.
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::DefaultChain {
+            profile_name_override: Some("not-the-right-profile-name".to_owned()),
+        })
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
+}
+
+fn setup_crt_bootstrap() -> channel_bootstrap::ClientBootstrap {
+    let allocator = Allocator::default();
+
+    let mut event_loop_group = event_loop::EventLoopGroup::new_default(&allocator, None, || {}).unwrap();
+
+    let resolver_options = host_resolver::HostResolverDefaultOptions {
+        max_entries: 8,
+        event_loop_group: &mut event_loop_group,
+    };
+
+    let mut host_resolver = host_resolver::HostResolver::new_default(&allocator, &resolver_options).unwrap();
+
+    let bootstrap_options = channel_bootstrap::ClientBootstrapOptions {
+        event_loop_group: &mut event_loop_group,
+        host_resolver: &mut host_resolver,
+    };
+
+    channel_bootstrap::ClientBootstrap::new(&allocator, &bootstrap_options).unwrap()
+}
+
+/// Takes something writable (such as an open file) and writes a new entry for the given name and SDK credentials.
+async fn write_credentials_to_named_profile<B: std::io::Write>(
+    mut config_buffer: B,
+    profile_name: &str,
+    credentials: Credentials,
+) {
+    writeln!(config_buffer, "[profile {profile_name}]").unwrap();
+    writeln!(config_buffer, "aws_access_key_id = {}", credentials.access_key_id()).unwrap();
+    writeln!(
+        config_buffer,
+        "aws_secret_access_key = {}",
+        credentials.secret_access_key()
+    )
+    .unwrap();
+    if let Some(session_token) = credentials.session_token() {
+        writeln!(config_buffer, "aws_session_token = {}", session_token).unwrap();
+    }
+}
+
 rusty_fork_test! {
     #[test]
-    fn test_profile_provider() {
+    fn test_profile_only_provider() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-        runtime.block_on(test_profile_provider_async());
+        runtime.block_on(test_profile_only_provider_async());
+    }
+
+    #[test]
+    fn test_default_chain_with_profile_override() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_custom_profile_provider_async());
     }
 }
 
@@ -201,7 +371,6 @@ rusty_fork_test! {
 async fn test_scoped_credentials() {
     let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_scoped_credentials");
-    let subsession_role = get_subsession_iam_role();
 
     for key in ["foo/foo.txt", "bar/bar.txt", "baz.txt"] {
         sdk_client
@@ -228,20 +397,12 @@ async fn test_scoped_credentials() {
     let policy = policy
         .replace("__BUCKET__", &bucket)
         .replace("__PREFIX__", &format!("{prefix}foo"));
-    let credentials = sts_client
-        .assume_role()
-        .role_arn(subsession_role)
-        .role_session_name("test_scoped_credentials")
-        .policy(policy)
-        .send()
-        .await
-        .unwrap();
-    let credentials = credentials.credentials().unwrap();
+    let credentials = get_scoped_down_credentials(policy).await;
 
     // Build a S3CrtClient that uses a static credentials provider with the creds we just got
     let config = CredentialsProviderStaticOptions {
-        access_key_id: credentials.access_key_id().unwrap(),
-        secret_access_key: credentials.secret_access_key().unwrap(),
+        access_key_id: credentials.access_key_id(),
+        secret_access_key: credentials.secret_access_key(),
         session_token: credentials.session_token(),
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -7,7 +7,6 @@ use std::option::Option::None;
 
 use aws_credential_types::Credentials;
 use aws_sdk_s3::types::ByteStream;
-use aws_sdk_s3::Region;
 use bytes::Bytes;
 use common::*;
 use futures::StreamExt;
@@ -375,12 +374,6 @@ async fn test_scoped_credentials() {
             .await
             .unwrap();
     }
-
-    let config = aws_config::from_env()
-        .region(Region::new(get_test_region()))
-        .load()
-        .await;
-    let sts_client = aws_sdk_sts::Client::new(&config);
 
     // Scope down to the `foo` prefix
     let policy = r#"{"Statement": [

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -288,19 +288,15 @@ async fn test_profile_only_provider_async() {
         .expect_err("first GET for profile with no permissions should not work");
 
     // Try it again with a bogus profile name. The profile provider alone should not return any credentials.
-    // It shouldn't be possible to even construct the client.
-    let profile_provider = CredentialsProvider::new_profile(
+    // It shouldn't be possible to even construct the credential provider.
+    CredentialsProvider::new_profile(
         &Allocator::default(),
         CredentialsProviderProfileOptions {
             bootstrap: &mut client_bootstrap,
             profile_name_override: "not-the-right-profile-name",
         },
     )
-    .unwrap();
-    let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Provider(profile_provider))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
-    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
+    .expect_err("cannot create provider if profile doesn't exist");
 }
 
 fn setup_crt_bootstrap() -> channel_bootstrap::ClientBootstrap {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -102,6 +102,7 @@ pub async fn get_scoped_down_credentials(policy: String) -> Credentials {
     let assume_role_response = sts_client
         .assume_role()
         .role_arn(get_subsession_iam_role())
+        .role_session_name("mountpoint-s3-client_tests")
         .policy(policy)
         .send()
         .await

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -21,6 +21,8 @@ use crate::{CrtError as _, ToAwsByteCursor as _};
 pub struct CredentialsProviderChainDefaultOptions<'a> {
     /// The client bootstrap this credentials provider should use to setup channels
     pub bootstrap: &'a mut ClientBootstrap,
+    /// The name of profile to use.
+    pub profile_name_override: Option<&'a str>,
 }
 
 /// Options for creating a profile credentials provider
@@ -67,13 +69,19 @@ impl CredentialsProvider {
     ) -> Result<Self, Error> {
         auth_library_init(allocator);
 
-        let inner_options = aws_credentials_provider_chain_default_options {
-            bootstrap: options.bootstrap.inner.as_ptr(),
-            ..Default::default()
-        };
-
-        // SAFETY: aws_credentials_provider_new_chain_default makes a copy of the bootstrap options.
+        // SAFETY: aws_credentials_provider_new_chain_default makes a copy of the bootstrap options
+        // and uses profile_name_override only to lookup the profile in the profile collection.
         let inner = unsafe {
+            let profile_name_override = match options.profile_name_override {
+                Some(profile_name) => profile_name.as_aws_byte_cursor(),
+                None => Default::default(),
+            };
+            let inner_options = aws_credentials_provider_chain_default_options {
+                bootstrap: options.bootstrap.inner.as_ptr(),
+                profile_name_override,
+                ..Default::default()
+            };
+
             aws_credentials_provider_new_chain_default(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
         };
 
@@ -85,7 +93,7 @@ impl CredentialsProvider {
         auth_library_init(allocator);
 
         // SAFETY: aws_credentials_provider_new_profile makes a copy of bootstrap
-        // and contents of profile_name_override.
+        // and uses profile_name_override only to lookup the profile in the profile collection.
         let inner = unsafe {
             let inner_options = aws_credentials_provider_profile_options {
                 bootstrap: options.bootstrap.inner.as_ptr(),

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 * New bucket options of `--transfer-acceleration`, `--dual-stack` and `--fips` has been added.
 * ARN is now also supported as <BUCKET_NAME> to mount the corresponding resource using Mountpoint.
+* Option `--profile <AWS_PROFILE>` no longer replaces the entire default credential chain.
+  Instead, the provided name will be used with AWS config file entries when evaluating the default credential chain,
+  alike the AWS CLI and AWS SDKs.
 
 ## v0.4.0 (August 2, 2023)
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -385,10 +385,10 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 
     let auth_config = if args.no_sign_request {
         S3ClientAuthConfig::NoSigning
-    } else if let Some(profile_name) = args.profile {
-        S3ClientAuthConfig::Profile(profile_name)
     } else {
-        S3ClientAuthConfig::Default
+        S3ClientAuthConfig::DefaultChain {
+            profile_name_override: args.profile,
+        }
     };
 
     let mut client_config = S3ClientConfig::new()

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -142,6 +142,7 @@ fn s3_uri_as_bucket_name() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[ignore = "default chain does not currently fail for non-existent profile"]
 #[test]
 fn invalid_profile() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;


### PR DESCRIPTION
## Description of change

This change means that a profile can be specified that does not configure any credentials, but may configure other things. mountpoint-s3 doesn't read any other configuration from an AWS Profile today but may do in the future.

Before this change, the entire credential chain was replaced with one that would supply profile credentials or error - no fallback. This was not in line with AWS CLI or SDKs.

This should fix #389.

Relevant issues: #389.

## Does this change impact existing behavior?

Yes, it fixes the behavior of the `--profile <AWS_PROFILE>` flag to be in line with `AWS_PROFILE` environment variable, as well as `--profile <AWS_PROFILE>` flag of the AWS CLI.

**Note:** It does not validate that the AWS profile exists, like the AWS CLI does. If the profile does not exist, the parameter will be ignored. This was an issue before this change, as `AWS_PROFILE` behaves like this for Mountpoint today - although, I do think it would be good to address in a follow-up change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
