### PR TITLE
Test access points

### DIFF
--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -62,3 +62,4 @@ doctest = false
 
 [features]
 s3_tests = []
+fips_tests = []

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -21,24 +21,62 @@ fn init_tracing_subscriber() {
     let _ = tracing_subscriber::fmt::try_init();
 }
 
+pub enum AccessPointType {
+    SingleRegion,
+    ObjectLambda,
+    MultiRegion,
+}
+
+pub fn get_unique_test_prefix(test_name: &str) -> String {
+    // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
+    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
+    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
+    // Generate a random nonce to make sure this prefix is truly unique
+    let nonce = OsRng.next_u64();
+    let prefix = format!("{prefix}{test_name}/{nonce}/");
+    prefix
+}
+
+pub fn get_test_bucket() -> String {
+    std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+}
+
 pub fn get_test_client() -> S3CrtClient {
     let endpoint_config = EndpointConfig::new(&get_test_region());
     S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests");
-
-    // Generate a random nonce to make sure this prefix is truly unique
-    let nonce = OsRng.next_u64();
-
-    // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
-    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
-    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
-
-    let prefix = format!("{prefix}{test_name}/{nonce}/");
+    let bucket = get_test_bucket();
+    let prefix = get_unique_test_prefix(test_name);
 
     (bucket, prefix)
+}
+
+pub fn get_test_access_point(arn: bool, access_point_type: AccessPointType) -> String {
+    match access_point_type {
+        AccessPointType::SingleRegion => {
+            if arn {
+                std::env::var("S3_ACCESS_POINT_ARN").expect("Set S3_ACCESS_POINT_ARN to run integration tests")
+            } else {
+                std::env::var("S3_ACCESS_POINT_ALIAS").expect("Set S3_ACCESS_POINT_ALIAS to run integration tests")
+            }
+        }
+        AccessPointType::ObjectLambda => {
+            if arn {
+                std::env::var("S3_OLAP_ARN").expect("Set S3_OLAP_ARN to run integration tests")
+            } else {
+                std::env::var("S3_OLAP_ALIAS").expect("Set S3_OLAP_ALIAS to run integration tests")
+            }
+        }
+        AccessPointType::MultiRegion => {
+            // Multi region accesspoints should only be accessed using their ARN
+            // (since endpoint for alias needs to be in format `<mrap-alias>.accesspoint.s3-global.amazonaws.com`. But this endpoint could not be formed using
+            // CRT endpoint resolver any bucket alias with '.' in it will be resolved in path style addressing. Similar is the case with CLI)
+            assert!(arn);
+            std::env::var("S3_MRAP_ARN").expect("Set S3_MRAP_ARN to run integration tests")
+        }
+    }
 }
 
 pub fn get_test_region() -> String {

--- a/mountpoint-s3-client/tests/endpoint_config.rs
+++ b/mountpoint-s3-client/tests/endpoint_config.rs
@@ -8,12 +8,11 @@ use common::*;
 use mountpoint_s3_client::{AddressingStyle, EndpointConfig, ObjectClient, S3ClientConfig, S3CrtClient};
 use test_case::test_case;
 
-async fn run_test<F: FnOnce(&str) -> EndpointConfig>(f: F) {
+async fn run_test<F: FnOnce(&str) -> EndpointConfig>(f: F, prefix: &str, bucket: String) {
     let sdk_client = get_test_sdk_client().await;
-    let (bucket, prefix) = get_test_bucket_and_prefix("test_region");
 
     // Create one object named "hello"
-    let key = format!("{prefix}/hello");
+    let key = format!("{prefix}hello");
     let body = b"hello world!";
     sdk_client
         .put_object()
@@ -36,33 +35,122 @@ async fn run_test<F: FnOnce(&str) -> EndpointConfig>(f: F) {
     check_get_result(result, None, &body[..]).await;
 }
 
-#[test_case(AddressingStyle::Automatic)]
-#[test_case(AddressingStyle::Path)]
+#[test_case(AddressingStyle::Automatic, "test_default_addressing_style")]
+#[test_case(AddressingStyle::Path, "test_path_addressing_style")]
 #[tokio::test]
-async fn test_addressing_style_region(addressing_style: AddressingStyle) {
-    run_test(|region| EndpointConfig::new(region).addressing_style(addressing_style)).await;
+async fn test_addressing_style(addressing_style: AddressingStyle, prefix: &str) {
+    run_test(
+        |region| EndpointConfig::new(region).addressing_style(addressing_style),
+        &get_unique_test_prefix(prefix),
+        get_test_bucket(),
+    )
+    .await;
 }
 
 #[cfg(feature = "fips_tests")]
 #[tokio::test]
-async fn test_fips_mount_option() {
-    run_test(|region| EndpointConfig::new(region).use_fips(true)).await;
+async fn test_use_fips() {
+    let prefix = get_unique_test_prefix("test_fips");
+    run_test(
+        |region| EndpointConfig::new(region).use_fips(true),
+        &prefix,
+        get_test_bucket(),
+    )
+    .await;
 }
 
-#[test_case(AddressingStyle::Automatic)]
-#[test_case(AddressingStyle::Path)]
+// Transfer acceleration do not work with path style
 #[tokio::test]
-async fn test_addressing_style_dualstack_option(addressing_style: AddressingStyle) {
-    run_test(|region| {
-        EndpointConfig::new(region)
-            .addressing_style(addressing_style)
-            .use_dual_stack(true)
-    })
+async fn test_use_accelerate() {
+    let prefix = get_unique_test_prefix("test_transfer_acceleration");
+    run_test(
+        |region| EndpointConfig::new(region).use_accelerate(true),
+        &prefix,
+        get_test_bucket(),
+    )
+    .await;
+}
+
+#[test_case(AddressingStyle::Automatic, "test_dual_stack")]
+#[test_case(AddressingStyle::Path, "test_dual_stack_path_style")]
+#[tokio::test]
+async fn test_addressing_style_dualstack_option(addressing_style: AddressingStyle, prefix: &str) {
+    let prefix = get_unique_test_prefix(prefix);
+    run_test(
+        |region| {
+            EndpointConfig::new(region)
+                .addressing_style(addressing_style)
+                .use_dual_stack(true)
+        },
+        &prefix,
+        get_test_bucket(),
+    )
     .await;
 }
 
 #[cfg(feature = "fips_tests")]
 #[tokio::test]
 async fn test_fips_dual_stack_mount_option() {
-    run_test(|region| EndpointConfig::new(region).use_fips(true).use_dual_stack(true)).await;
+    let prefix = get_unique_test_prefix("test_fips_dual_stack");
+    run_test(
+        |region| EndpointConfig::new(region).use_fips(true).use_dual_stack(true),
+        &prefix,
+        get_test_bucket(),
+    )
+    .await;
+}
+
+#[test_case(AddressingStyle::Automatic, true, "test_accesspoint_arn")]
+#[test_case(AddressingStyle::Automatic, false, "test_accesspoint_alias")]
+#[test_case(AddressingStyle::Path, false, "test_accesspoint_alias")]
+// Path-style addressing cannot be used with ARN buckets for the endpoint resolution
+// Also, path-style addressing is not supported for Access Points. But it seems to be supported for single region access point for now.
+#[tokio::test]
+async fn test_single_region_access_point(addressing_style: AddressingStyle, arn: bool, prefix: &str) {
+    run_test(
+        |region| EndpointConfig::new(region).addressing_style(addressing_style),
+        &get_unique_test_prefix(prefix),
+        get_test_access_point(arn, AccessPointType::SingleRegion),
+    )
+    .await;
+}
+
+// For Object Lambda Access Point, PutObject is not supported,
+// For multi region access points, Rust SDK is not supported. Hence different helper method for these tests.
+async fn run_list_objects_test<F: FnOnce(&str) -> EndpointConfig>(f: F, prefix: &str, bucket: &str) {
+    let region = get_test_region();
+    let endpoint_config = f(&region);
+    let config = S3ClientConfig::new().endpoint_config(endpoint_config.clone());
+    let client = S3CrtClient::new(config).expect("could not create test client");
+
+    client
+        .list_objects(bucket, None, "/", 10, prefix)
+        .await
+        .expect("list_object should succeed");
+}
+
+#[test_case(false, "test_OLAP_alias")]
+#[test_case(true, "test_OLAP_ARN")]
+// Path-style addressing is not supported for Access points
+#[tokio::test]
+async fn test_object_lambda_access_point(arn: bool, prefix: &str) {
+    run_list_objects_test(
+        EndpointConfig::new,
+        &get_unique_test_prefix(prefix),
+        &get_test_access_point(arn, AccessPointType::ObjectLambda),
+    )
+    .await;
+}
+
+// Path-style addressing is not supported for Access points
+// Only ARN is supported for Multi Region access point as AWS CLI.
+#[tokio::test]
+async fn test_multi_region_access_point() {
+    let prefix = "test_MRAP";
+    run_list_objects_test(
+        EndpointConfig::new,
+        &get_unique_test_prefix(prefix),
+        &get_test_access_point(true, AccessPointType::MultiRegion),
+    )
+    .await;
 }


### PR DESCRIPTION
## Description of change
Added accesspoint tests. Test and document the behaviour of accesspoints with mountpoint.

<!-- Please describe your contribution here. What and why? -->
Refactored tests for accesspoints. They are still under 'access_points_tests' as we dont have accesspoint resource in our CI.

Relevant issues: <!-- Please add issue numbers. -->
#4 

## Does this change impact existing behavior?
No

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
