### PR TITLE
Map all HTTP 403 errors to S3RequestError::Forbidden

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -738,9 +738,9 @@ pub enum S3RequestError {
     #[error("Wrong region (expecting {0})")]
     IncorrectRegion(String),
 
-    /// Permission denied
-    #[error("Permission denied: {0}")]
-    PermissionDenied(String),
+    /// Forbidden
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
 }
 
 impl S3RequestError {
@@ -815,33 +815,40 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
         Some(S3RequestError::IncorrectRegion(region))
     }
 
-    /// Look for permissions-related errors
-    fn try_parse_permission_denied(request_result: &MetaRequestResult) -> Option<S3RequestError> {
+    /// Look for access-related errors
+    fn try_parse_forbidden(request_result: &MetaRequestResult) -> Option<S3RequestError> {
         let Some(body) = request_result.error_response_body.as_ref() else {
             // Header-only requests like HeadObject and HeadBucket can't give us a more detailed
             // error, so just trust the response code
-            return Some(S3RequestError::PermissionDenied("<no message>".to_owned()));
+            return Some(S3RequestError::Forbidden("<no message>".to_owned()));
         };
         let error_elem = xmltree::Element::parse(body.as_bytes()).ok()?;
         let error_code = error_elem.get_child("Code")?;
         let error_code_str = error_code.get_text()?;
-        match error_code_str.deref() {
-            "AccessDenied" | "InvalidToken" | "ExpiredToken" => {
-                let message = error_elem
-                    .get_child("Message")
-                    .and_then(|e| e.get_text())
-                    .unwrap_or("<no message>".into());
-                Some(S3RequestError::PermissionDenied(message.into_owned()))
-            }
-            _ => None,
+        // Always translate 403 to Forbidden, but otherwise first check the error code, since other
+        // response statuses are overloaded and not always access-related errors.
+        if request_result.response_status == 403
+            || matches!(
+                error_code_str.deref(),
+                "AccessDenied" | "InvalidToken" | "ExpiredToken" | "SignatureDoesNotMatch"
+            )
+        {
+            let message = error_elem
+                .get_child("Message")
+                .and_then(|e| e.get_text())
+                .unwrap_or(error_code_str);
+            Some(S3RequestError::Forbidden(message.into_owned()))
+        } else {
+            None
         }
     }
 
     match request_result.response_status {
         301 => try_parse_redirect(request_result),
-        // 400 is overloaded, it can be a permission denied or (for MRAP) a bucket redirect
-        400 => try_parse_permission_denied(request_result).or_else(|| try_parse_redirect(request_result)),
-        403 => try_parse_permission_denied(request_result),
+        // 400 is overloaded, it can be an access error (invalid token) or (for MRAP) a bucket
+        // redirect
+        400 => try_parse_forbidden(request_result).or_else(|| try_parse_redirect(request_result)),
+        403 => try_parse_forbidden(request_result),
         _ => None,
     }
 }
@@ -1056,7 +1063,7 @@ mod tests {
         let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>CM0R497NB0WAQ977</RequestId><HostId>w1TqUKGaIuNAIgzqm/L2azuzgEBINxTngWPbV1iH2IvpLsVCCTKHJTh4HsGp4JnggHqVkA+KN1MGqHDw1+WEuA==</HostId></Error>"#;
         let result = make_result(403, OsStr::from_bytes(&body[..]), None);
         let result = try_parse_generic_error(&result);
-        let Some(S3RequestError::PermissionDenied(message)) = result else {
+        let Some(S3RequestError::Forbidden(message)) = result else {
             panic!("wrong result, got: {:?}", result);
         };
         assert_eq!(message, "Access Denied");
@@ -1067,7 +1074,7 @@ mod tests {
         let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidToken</Code><Message>The provided token is malformed or otherwise invalid.</Message><Token-0>THEREALTOKENGOESHERE</Token-0><RequestId>CBFNVADDAZ8661HK</RequestId><HostId>rb5dpgYeIFxi8p5BzVK8s8wG/nQ4a7C5kMBp/KWIT4bvOUihugpssMTy7xS0mispbz6IIaX8W1g=</HostId></Error>"#;
         let result = make_result(400, OsStr::from_bytes(&body[..]), None);
         let result = try_parse_generic_error(&result);
-        let Some(S3RequestError::PermissionDenied(message)) = result else {
+        let Some(S3RequestError::Forbidden(message)) = result else {
             panic!("wrong result, got: {:?}", result);
         };
         assert_eq!(message, "The provided token is malformed or otherwise invalid.");
@@ -1078,7 +1085,7 @@ mod tests {
         let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>ExpiredToken</Code><Message>The provided token has expired.</Message><Token-0>THEREALTOKENGOESHERE</Token-0><RequestId>RFXW0E15XSRPJYSW</RequestId><HostId>djitP7S+g43JSzR4pMOJpOO3RYpQUOUsmD4AqhRe3v24+JB/c+vwOEZgI8A35KDUe1cqQ5yKHwg=</HostId></Error>"#;
         let result = make_result(400, OsStr::from_bytes(&body[..]), None);
         let result = try_parse_generic_error(&result);
-        let Some(S3RequestError::PermissionDenied(message)) = result else {
+        let Some(S3RequestError::Forbidden(message)) = result else {
             panic!("wrong result, got: {:?}", result);
         };
         assert_eq!(message, "The provided token has expired.");
@@ -1096,12 +1103,26 @@ mod tests {
         assert_eq!(region, "us-west-2");
     }
 
-    // A 403 that shouldn't be parsed by the generic code
     #[test]
-    fn parse_403_glacier_storage_class() {
-        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidObjectState</Code><Message>The action is not valid for the object's storage class</Message><RequestId>9FEFFF118E15B86F</RequestId><HostId>WVQ5kzhiT+oiUfDCOiOYv8W4Tk9eNcxWi/MK+hTS/av34Xy4rBU3zsavf0aaaaa</HostId></Error>"#;
+    fn parse_403_signature_does_not_match() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>ASIASMEXAMPLE0000000</AWSAccessKeyId><StringToSign>EXAMPLE</StringToSign><SignatureProvided>EXAMPLE</SignatureProvided><StringToSignBytes>EXAMPLE</StringToSignBytes><CanonicalRequest>EXAMPLE</CanonicalRequest><CanonicalRequestBytes>EXAMPLE</CanonicalRequestBytes><RequestId>A1F516XX5M8AATSQ</RequestId><HostId>qs9dULIp5ABM7U+H8nGfzKtMYTxvqxIVvOYZ8lEFBDyTF4Fe+876Y4bLptG4mb+PTZFyG4yaUjg=</HostId></Error>"#;
         let result = make_result(403, OsStr::from_bytes(&body[..]), None);
         let result = try_parse_generic_error(&result);
-        assert!(result.is_none(), "error should not be handled, but got {:?}", result);
+        let Some(S3RequestError::Forbidden(message)) = result else {
+            panic!("wrong result, got: {:?}", result);
+        };
+        assert_eq!(message, "The request signature we calculated does not match the signature you provided. Check your key and signing method.");
+    }
+
+    #[test]
+    fn parse_403_made_up_error() {
+        // A made up error to check that we map all 403s even if we don't recognize them
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NotARealError</Code><Message>This error is made up.</Message><RequestId>CM0R497NB0WAQ977</RequestId><HostId>w1TqUKGaIuNAIgzqm/L2azuzgEBINxTngWPbV1iH2IvpLsVCCTKHJTh4HsGp4JnggHqVkA+KN1MGqHDw1+WEuA==</HostId></Error>"#;
+        let result = make_result(403, OsStr::from_bytes(&body[..]), None);
+        let result = try_parse_generic_error(&result);
+        let Some(S3RequestError::Forbidden(message)) = result else {
+            panic!("wrong result, got: {:?}", result);
+        };
+        assert_eq!(message, "This error is made up.");
     }
 }

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -272,7 +272,7 @@ async fn test_scoped_credentials() {
         .expect_err("should fail in different prefix");
     assert!(matches!(
         err,
-        ObjectClientError::ClientError(S3RequestError::PermissionDenied(_))
+        ObjectClientError::ClientError(S3RequestError::Forbidden(_))
     ));
     let err = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}/"))
@@ -280,6 +280,6 @@ async fn test_scoped_credentials() {
         .expect_err("should fail in different prefix");
     assert!(matches!(
         err,
-        ObjectClientError::ClientError(S3RequestError::PermissionDenied(_))
+        ObjectClientError::ClientError(S3RequestError::Forbidden(_))
     ));
 }

--- a/mountpoint-s3-client/tests/delete_object.rs
+++ b/mountpoint-s3-client/tests/delete_object.rs
@@ -91,6 +91,6 @@ async fn test_delete_object_no_perm() {
 
     assert!(matches!(
         result,
-        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+        Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_)))
     ));
 }

--- a/mountpoint-s3-client/tests/get_object_attributes.rs
+++ b/mountpoint-s3-client/tests/get_object_attributes.rs
@@ -474,6 +474,6 @@ async fn test_get_attributes_no_perm() {
 
     assert!(matches!(
         result,
-        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+        Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_)))
     ));
 }

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -42,7 +42,7 @@ async fn test_head_bucket_forbidden() {
 
     assert!(matches!(
         result,
-        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+        Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_)))
     ));
 }
 

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -102,6 +102,6 @@ async fn test_head_object_no_perm() {
     let result = client.head_object(&bucket, &key).await;
     assert!(matches!(
         result,
-        Err(ObjectClientError::ClientError(S3RequestError::PermissionDenied(_)))
+        Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_)))
     ));
 }


### PR DESCRIPTION
## Description of change

There's a long list of potential error codes that all map to 403, and we
only picked a few. Mapping them all makes what happened a little clearer
in logs. They're not all "permissions" errors, so I renamed it to the
more generic "forbidden" (which is what HTTP 403 is).

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
