### PR TITLE
Fix clippy error on macOS

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -100,7 +100,7 @@ where
 
         let metadata = file.metadata().unwrap();
         if file_name == "GLACIER.txt" || file_name == "DEEP_ARCHIVE.txt" {
-            assert_eq!(metadata.permissions().mode() & !libc::S_IFMT, 0o000);
+            assert_eq!(metadata.permissions().mode() as libc::mode_t & !libc::S_IFMT, 0o000);
             let err = File::open(file.path()).expect_err("read of flexible retrieval object should fail");
             assert_eq!(err.raw_os_error(), Some(libc::EACCES));
         } else {


### PR DESCRIPTION
## Description of change

`libc::mode_t` has a different width on macOS (`u16` vs `u32`), so we need to cast the result of `metadata.permissions().mode()` before masking it.

## Does this change impact existing behavior?

No. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
