### PR TITLE
Use AWS_REGION and IMDS to determine region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2056,6 +2056,7 @@ dependencies = [
  "rand_chacha",
  "regex",
  "rusty-fork",
+ "serde_json",
  "static_assertions",
  "tempfile",
  "test-case",
@@ -2293,7 +2294,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2863,29 +2864,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -3048,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -3150,7 +3151,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3242,7 +3243,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3364,7 +3365,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3575,7 +3576,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -3597,7 +3598,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0.34"
 time = { version = "0.3.17", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 xmltree = "0.10.3"
+serde_json = "1.0.104"
 
 [dev-dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/mountpoint-s3-client/src/imds_crt_client.rs
+++ b/mountpoint-s3-client/src/imds_crt_client.rs
@@ -1,16 +1,11 @@
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
-
 use futures::channel::oneshot;
-use futures::Future;
 use mountpoint_s3_crt::auth::imds_client::{ImdsClient, ImdsClientConfig};
 use mountpoint_s3_crt::common::allocator::Allocator;
 use mountpoint_s3_crt::common::error;
 use mountpoint_s3_crt::io::channel_bootstrap::{ClientBootstrap, ClientBootstrapOptions};
 use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 use mountpoint_s3_crt::io::host_resolver::{HostResolver, HostResolverDefaultOptions};
-use pin_project::pin_project;
+use serde_json::Value;
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -56,33 +51,73 @@ impl ImdsCrtClient {
     }
 
     /// Query the type of the EC2 instance this code is executed on.
-    pub fn make_instance_type_query(&self) -> Result<ImdsQueryRequest, ImdsQueryRequestError> {
+    pub async fn get_instance_type(&self) -> Result<String, ImdsQueryRequestError> {
         let (tx, rx) = oneshot::channel();
         self.imds_client.get_instance_type(move |result| {
-            let _ = tx.send(result.map_err(ImdsQueryRequestError::CrtError));
+            let _ = tx.send(result);
         })?;
 
-        Ok(ImdsQueryRequest { receiver: rx })
+        match rx.await {
+            Ok(result) => result.map_err(ImdsQueryRequestError::CrtError),
+            Err(err) => Err(ImdsQueryRequestError::InternalError(Box::new(err))),
+        }
+    }
+
+    /// Query the region of the EC2 instance this code is executed on.
+    pub async fn get_region(&self) -> Result<String, ImdsQueryRequestError> {
+        const REGION_PATH: &str = "/latest/meta-data/placement/region";
+        let (tx, rx) = oneshot::channel();
+        self.imds_client.get_resource(REGION_PATH, move |result| {
+            let _ = tx.send(result);
+        })?;
+
+        match rx.await {
+            Ok(result) => result.map_err(ImdsQueryRequestError::CrtError),
+            Err(err) => Err(ImdsQueryRequestError::InternalError(Box::new(err))),
+        }
+    }
+
+    /// Query the identity document of the EC2 instance this code is executed on.
+    pub async fn get_identity_document(&self) -> Result<IdentityDocument, ImdsQueryRequestError> {
+        const IDENTITY_DOCUMENT_PATH: &str = "/latest/dynamic/instance-identity/document";
+
+        let (tx, rx) = oneshot::channel();
+        self.imds_client.get_resource(IDENTITY_DOCUMENT_PATH, move |result| {
+            let _ = tx.send(result);
+        })?;
+
+        let json = match rx.await {
+            Ok(Ok(json)) => json,
+            Ok(Err(err)) => return Err(ImdsQueryRequestError::CrtError(err)),
+            Err(err) => return Err(ImdsQueryRequestError::InternalError(Box::new(err))),
+        };
+
+        let json = &json;
+        let parsed: Value =
+            serde_json::from_str(json).map_err(|_| ImdsQueryRequestError::InvalidResponse(json.to_owned()))?;
+        let instance_type = parsed
+            .get("instanceType")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ImdsQueryRequestError::InvalidResponse(json.to_owned()))?
+            .to_owned();
+        let region = parsed
+            .get("region")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ImdsQueryRequestError::InvalidResponse(json.to_owned()))?
+            .to_owned();
+
+        Ok(IdentityDocument { instance_type, region })
     }
 }
 
+/// Information about an EC2 instance.
 #[derive(Debug)]
-#[pin_project]
-/// ImdsQueryRequest is a data encapsulation wrapper for asnychronous instance metadata query.
-pub struct ImdsQueryRequest {
-    #[pin]
-    receiver: oneshot::Receiver<Result<String, ImdsQueryRequestError>>,
-}
-
-impl Future for ImdsQueryRequest {
-    type Output = Result<String, ImdsQueryRequestError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        this.receiver
-            .poll(cx)
-            .map(|result| result.unwrap_or_else(|err| Err(ImdsQueryRequestError::InternalError(Box::new(err)))))
-    }
+pub struct IdentityDocument {
+    // TODO: Add more fields as required.
+    /// The instance type of the instance.
+    pub instance_type: String,
+    /// The Region in which the instance is running.
+    pub region: String,
 }
 
 /// ImdsQueryRequestError is returned by an asynchronous query.
@@ -95,4 +130,8 @@ pub enum ImdsQueryRequestError {
     /// An internal error from within the AWS Common Runtime. The request may have been sent.
     #[error("Unknown CRT error")]
     CrtError(#[from] error::Error),
+
+    /// The response from Imds was not valid.
+    #[error("Invalid response from Imds: {0}")]
+    InvalidResponse(String),
 }

--- a/mountpoint-s3-client/src/imds_crt_client.rs
+++ b/mountpoint-s3-client/src/imds_crt_client.rs
@@ -50,33 +50,6 @@ impl ImdsCrtClient {
         })
     }
 
-    /// Query the type of the EC2 instance this code is executed on.
-    pub async fn get_instance_type(&self) -> Result<String, ImdsQueryRequestError> {
-        let (tx, rx) = oneshot::channel();
-        self.imds_client.get_instance_type(move |result| {
-            let _ = tx.send(result);
-        })?;
-
-        match rx.await {
-            Ok(result) => result.map_err(ImdsQueryRequestError::CrtError),
-            Err(err) => Err(ImdsQueryRequestError::InternalError(Box::new(err))),
-        }
-    }
-
-    /// Query the region of the EC2 instance this code is executed on.
-    pub async fn get_region(&self) -> Result<String, ImdsQueryRequestError> {
-        const REGION_PATH: &str = "/latest/meta-data/placement/region";
-        let (tx, rx) = oneshot::channel();
-        self.imds_client.get_resource(REGION_PATH, move |result| {
-            let _ = tx.send(result);
-        })?;
-
-        match rx.await {
-            Ok(result) => result.map_err(ImdsQueryRequestError::CrtError),
-            Err(err) => Err(ImdsQueryRequestError::InternalError(Box::new(err))),
-        }
-    }
-
     /// Query the identity document of the EC2 instance this code is executed on.
     pub async fn get_identity_document(&self) -> Result<IdentityDocument, ImdsQueryRequestError> {
         const IDENTITY_DOCUMENT_PATH: &str = "/latest/dynamic/instance-identity/document";

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -9,7 +9,7 @@ mod s3_crt_client;
 mod util;
 
 pub use endpoint_config::{AddressingStyle, EndpointConfig};
-pub use imds_crt_client::ImdsCrtClient;
+pub use imds_crt_client::{IdentityDocument, ImdsCrtClient};
 pub use object_client::*;
 pub use s3_crt_client::head_bucket::HeadBucketError;
 pub use s3_crt_client::{S3ClientAuthConfig, S3ClientConfig, S3CrtClient, S3RequestError};

--- a/mountpoint-s3-client/tests/imds_crt_client.rs
+++ b/mountpoint-s3-client/tests/imds_crt_client.rs
@@ -1,0 +1,33 @@
+use std::assert_eq;
+
+use aws_config::imds::Client;
+use mountpoint_s3_client::ImdsCrtClient;
+use serde_json::Value;
+
+#[tokio::test]
+async fn test_get_identity_document() {
+    let sdk_client = Client::builder().build().await.unwrap();
+    match sdk_client.get("/latest/dynamic/instance-identity/document").await {
+        Ok(expected_json) => {
+            let expected_doc: Value = serde_json::from_str(&expected_json).unwrap();
+            let expected_region = expected_doc.get("region").unwrap().as_str().unwrap();
+            let expected_instance_type = expected_doc.get("instanceType").unwrap().as_str().unwrap();
+
+            let client = ImdsCrtClient::new().unwrap();
+            let identity_document = client
+                .get_identity_document()
+                .await
+                .expect("should return a valid document");
+
+            assert_eq!(identity_document.region, expected_region);
+            assert_eq!(identity_document.instance_type, expected_instance_type);
+        }
+        Err(_) => {
+            let client = ImdsCrtClient::new().unwrap();
+            let _ = client
+                .get_identity_document()
+                .await
+                .expect_err("should not return a valid document");
+        }
+    }
+}

--- a/mountpoint-s3-crt/src/auth/imds_client.rs
+++ b/mountpoint-s3-crt/src/auth/imds_client.rs
@@ -1,14 +1,14 @@
 //! A client for retrieving ec2 instance metadata.
 
-use crate::auth::auth_library_init;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::io::channel_bootstrap::ClientBootstrap;
 use crate::io::retry_strategy::RetryStrategy;
 use crate::CrtError;
+use crate::{auth::auth_library_init, ToAwsByteCursor};
 use mountpoint_s3_crt_sys::{
-    aws_byte_buf, aws_imds_client, aws_imds_client_get_instance_type, aws_imds_client_new, aws_imds_client_options,
-    aws_imds_client_release,
+    aws_byte_buf, aws_imds_client, aws_imds_client_get_instance_type, aws_imds_client_get_resource_async,
+    aws_imds_client_new, aws_imds_client_options, aws_imds_client_release,
 };
 use std::ptr::NonNull;
 
@@ -81,6 +81,29 @@ impl ImdsClient {
         unsafe {
             aws_imds_client_get_instance_type(self.inner.as_ptr(), get_resource_callback_fn_ptr, callback_raw_ptr)
                 .ok_or_last_error()
+        }
+    }
+
+    /// Get the value for the given resource path.
+    pub fn get_resource<F>(&self, resource_path: &str, callback: F) -> Result<(), Error>
+    where
+        F: FnOnce(Result<String, Error>) + 'static,
+    {
+        let callback_wrapper = Box::new(ImdsClientGetResourceCallback(Box::new(callback)));
+        let callback_raw_ptr = Box::into_raw(callback_wrapper) as *mut libc::c_void;
+        let get_resource_callback_fn_ptr: Option<unsafe extern "C" fn(*const aws_byte_buf, i32, *mut libc::c_void)> =
+            Some(imds_client_get_resource_callback);
+
+        // SAFETY: `self.inner` is a valid `aws_imds_client`. `get_resource_callback_fn_ptr` is leaked by [Box::into_raw]
+        // and so will live until the `imds_client_get_resource_callback` function is invoked.
+        unsafe {
+            aws_imds_client_get_resource_async(
+                self.inner.as_ptr(),
+                resource_path.as_aws_byte_cursor(),
+                get_resource_callback_fn_ptr,
+                callback_raw_ptr,
+            )
+            .ok_or_last_error()
         }
     }
 }

--- a/mountpoint-s3/src/instance.rs
+++ b/mountpoint-s3/src/instance.rs
@@ -1,0 +1,107 @@
+use std::env;
+
+use anyhow::{anyhow, Context};
+use mountpoint_s3_client::{IdentityDocument, ImdsCrtClient};
+use once_cell::unsync::Lazy;
+
+/// Information on the EC2 instance from the Imds client.
+/// The client is queried lazily and only if AWS_EC2_METADATA_DISABLED
+/// is not set.
+#[derive(Debug, Default)]
+pub struct InstanceInfo {
+    document: Lazy<Option<IdentityDocument>>,
+}
+
+impl InstanceInfo {
+    /// Create a new instance. The Imds client will only be queried
+    /// when a methon on the instance is called, and only if
+    /// AWS_EC2_METADATA_DISABLED is not set.
+    pub fn new() -> Self {
+        Self {
+            document: Lazy::new(|| {
+                if !imds_disabled() {
+                    match retrieve_instance_identity_document() {
+                        Ok(identity_document) => {
+                            tracing::debug!(?identity_document, "got instance info from IMDS");
+                            Some(identity_document)
+                        }
+                        Err(err) => {
+                            tracing::warn!("EC2 instance info not retrieved: {err:?}");
+                            None
+                        }
+                    }
+                } else {
+                    tracing::debug!("EC2 instance info not retrieved: IMDS was disabled");
+                    None
+                }
+            }),
+        }
+    }
+
+    /// The region for the current instance, if it can be
+    /// retrieved using the Imds client.
+    pub fn region(&self) -> Option<&str> {
+        self.document.as_ref().map(|d| d.region.as_str())
+    }
+
+    /// The network throughput for the current instance. Returns an
+    /// error if the instance type either cannot be retrieved using the Imds
+    /// client or does not have a known network throughput.
+    pub fn network_throughput(&self) -> anyhow::Result<f64> {
+        let instance_type = self
+            .document
+            .as_ref()
+            .map(|d| &d.instance_type)
+            .context("failed to retrieve instance type")?;
+        let throughput = get_maximum_network_throughput(instance_type).context("failed to get network throughput")?;
+        Ok(throughput)
+    }
+}
+
+fn retrieve_instance_identity_document() -> anyhow::Result<IdentityDocument> {
+    let imds_crt_client = ImdsCrtClient::new().context("failed to create IMDS client")?;
+
+    let identity_document =
+        futures::executor::block_on(imds_crt_client.get_identity_document()).context("IMDS query failed")?;
+    Ok(identity_document)
+}
+
+fn imds_disabled() -> bool {
+    match env::var_os("AWS_EC2_METADATA_DISABLED") {
+        Some(val) => val.to_ascii_lowercase() != "false",
+        None => false,
+    }
+}
+
+fn get_maximum_network_throughput(ec2_instance_type: &str) -> anyhow::Result<f64> {
+    const INSTANCE_THROUGHPUT: &str = "instance_throughput";
+    let file = include_str!("../scripts/network_performance.json");
+
+    let data: serde_json::Value = serde_json::from_str(file).context("failed to parse network_performance.json")?;
+    let instance_throughput = data
+        .get(INSTANCE_THROUGHPUT)
+        .context("instance throughput missing from json")?;
+    instance_throughput
+        .get(ec2_instance_type)
+        .and_then(|t| t.as_f64())
+        .ok_or_else(|| anyhow!("no throughput configuration for EC2 instance type {ec2_instance_type}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("c4.large", None)] // We let "Moderate" fall through to default
+    #[test_case("c5.large", Some(10.0))]
+    #[test_case("c5n.large", Some(25.0))]
+    #[test_case("c5n.18xlarge", Some(100.0))]
+    #[test_case("c6i.large", Some(12.5))]
+    #[test_case("p4d.24xlarge", Some(400.0))] // 4x 100 Gigabit
+    #[test_case("trn1.32xlarge", Some(800.0))] // 8x 100 Gigabit
+    #[test_case("dl1.24xlarge", Some(400.0))] // 4x 100 Gigabit
+    fn test_get_maximum_network_throughput(instance_type: &str, throughput: Option<f64>) {
+        let actual = get_maximum_network_throughput(instance_type).ok();
+        assert_eq!(actual, throughput);
+    }
+}

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,13 +1,13 @@
 pub mod fs;
 pub mod fuse;
 mod inode;
+pub mod instance;
 pub mod logging;
 pub mod metrics;
 pub mod prefetch;
 pub mod prefix;
 mod sync;
 mod upload;
-
 pub use fs::{S3Filesystem, S3FilesystemConfig};
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -591,13 +591,10 @@ fn imds_disabled() -> bool {
 fn retrieve_instance_type() -> anyhow::Result<String> {
     let imds_crt_client = ImdsCrtClient::new().context("failed to create IMDS client")?;
 
-    let query = imds_crt_client
-        .make_instance_type_query()
-        .context("failed to send IMDS query")?;
-
-    let result = futures::executor::block_on(query).context("IMDS query failed")?;
-    tracing::debug!("detected EC2 instance type {result}");
-    Ok(result)
+    let instance_type =
+        futures::executor::block_on(imds_crt_client.get_instance_type()).context("IMDS query failed")?;
+    tracing::debug!("detected EC2 instance type {instance_type}");
+    Ok(instance_type)
 }
 
 fn get_maximum_network_throughput(ec2_instance_type: &str) -> anyhow::Result<f64> {

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -55,8 +55,45 @@ fn run_in_background() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn run_in_background_region_from_env() -> Result<(), Box<dyn std::error::Error>> {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_run_in_background_region_from_env");
+    let region = get_test_region();
+    let mount_point = assert_fs::TempDir::new()?;
+
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+    let mut child = cmd
+        .arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .env("AWS_REGION", region.clone())
+        .spawn()
+        .expect("unable to spawn child");
+
+    let st = std::time::Instant::now();
+
+    let exit_status = loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match child.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    };
+
+    // verify mount status and mount entry
+    assert!(exit_status.success());
+    assert!(mount_exists("mountpoint-s3", mount_point.path().to_str().unwrap()));
+
+    test_read_files(&bucket, &prefix, &region, &mount_point.to_path_buf());
+
+    Ok(())
+}
+
+#[test]
 fn run_in_background_automatic_region_resolution() -> Result<(), Box<dyn std::error::Error>> {
-    let (bucket, prefix) = get_test_bucket_and_prefix("test_run_in_background");
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_run_in_background_automatic_region_resolution");
     let region = get_test_region();
     let mount_point = assert_fs::TempDir::new()?;
 


### PR DESCRIPTION
## Description of change

Determine the region using the following sources (in order):
  * `--region` flag,
  * `AWS_REGION` environment variable,
  * EC2 instance region (using the IMDS client),
  * default region (us-east-1).
 

Relevant issues: #274 

## Does this change impact existing behavior?

The change extends existing behavior by adding support for the `AWS_REGION` environment variable and by using IMDS to retrieve the EC2 instance region (if the user did not specify a region).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
