### PR TITLE
Prepare release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,27 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
       - mountpoint-s3-[0-9]+.*
-      - mountpoint-s3-[a-z]+-[0-9]+.*
+
+permissions:
+  contents: write
+
 
 jobs:
-  create-release:
+  create-github-release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: taiki-e/create-gh-release-action@v1
       with:
-        prefix: mountpoint-s3(-[a-z]+)?
+        title: "Mountpoint for Amazon S3 v$version"
+        # Strip this prefix off the tag to discover the version number
+        prefix: mountpoint-s3
         draft: true
-        # TODO: set it true after we have changlog template reviewed.
-        changelog: false
-        # TODO: set it false after we have changlog template reviewed.
+        changelog: mountpoint-s3/CHANGELOG.md
+        # TODO: make this mandatory once we have the format nailed down
         allow-missing-changelog: true
         branch: main
-        title: "Mountpoint for Amazon S3 v$version"
         token: ${{ secrets.GITHUB_TOKEN }}
-
-  upload-assets:
-    name: Build and release on target ${{ matrix.runner.target}}
-    runs-on: ${{ matrix.runner.tags }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-        - tags: [ubuntu-20.04] # GitHub-hosted
-          target: x86_64-unknown-linux-gnu
-        - tags: [self-hosted, linux, arm64] 
-          target: aarch64-unknown-linux-gnu
-
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Install operating system dependencies
-      uses: ./.github/actions/install-dependencies
-      with:
-        fuseVersion: 2 
-    - name: Release mount-s3 binary
-      uses: taiki-e/upload-rust-binary-action@v1
-      with:
-        bin: mount-s3
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checksum: sha512
-        asset: LICENSE
-
-

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+## v1.0.0 (Unreleased)
 
-Breaking changes:
+### Breaking changes
 
 * Logging to disk is now disabled by default.
   Logs will no longer be written to `$HOME/.mountpoint-s3/` and should be configured using `--log-directory <DIRECTORY>`.
@@ -9,11 +9,11 @@ Breaking changes:
 * The `--thread-count` option has been removed and replaced with `--max-threads` which sets the maximum
   number of threads the FUSE daemon will dynamically spawn to handle requests.
 
-Other changes:
+### Other changes
 
 * New bucket options of `--transfer-acceleration`, `--dual-stack` and `--fips` has been added.
 * ARN is now also supported as <BUCKET_NAME> to mount the corresponding resource using Mountpoint.
 
-# v0.3.0 (June 30, 2023)
+## v0.3.0 (June 30, 2023)
 
 Initial change log entry.


### PR DESCRIPTION
## Description of change

This updates the release workflow for our new process.

As always, CI changes are annoying to test. I tested in my fork, with the following steps:
1. Create a new release through the UI. The only part of the form I filled out was to create a new tag `mountpoint-s3-1.0.0`, and checked "Set as a pre-release", then clicked Publish. (I'm only doing this to get a tag, we could just as easily push a tag from the command line instead).
2. The workflow ran: https://github.com/jamesbornholt/mountpoint-s3/actions/runs/5733448132
3. The workflow updated the release I created to fill in the title and release notes. It saved it as a draft. I clicked edit on it just so I could click Publish release. This was the result: https://github.com/jamesbornholt/mountpoint-s3/releases/tag/mountpoint-s3-1.0.0

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
