### PR TITLE
Build SigningConfig from AuthScheme for each request

### DIFF
--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -220,9 +220,7 @@ impl ResolvedEndpointInfo {
         let scheme_name = match scheme_name {
             "sigv4" => SigningAlgorithm::SigV4,
             "sigv4a" => SigningAlgorithm::SigV4A,
-            _ => {
-                return Err(EndpointError::InvalidAuthSchemeField("name", scheme_name.to_owned()));
-            }
+            _ => return Err(EndpointError::InvalidAuthSchemeField("name", scheme_name.to_owned())),
         };
 
         let signing_name = auth_scheme_value["signingName"]
@@ -253,7 +251,7 @@ pub enum EndpointError {
     ParseError(#[from] serde_json::Error),
     #[error("AuthScheme field missing: {0}")]
     MissingAuthSchemeField(&'static str),
-    #[error("invalid value {0} for AuthScheme field: {1}")]
+    #[error("invalid value {1} for AuthScheme field {0}")]
     InvalidAuthSchemeField(&'static str, String),
 }
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -302,7 +302,14 @@ impl S3CrtClientInner {
         trace!(?uri, "resolved endpoint");
 
         let signing_config = if let Some(credentials_provider) = &self.credentials_provider {
-            let auth_scheme = endpoint.auth_scheme()?;
+            let auth_scheme = match endpoint.auth_scheme() {
+                Ok(auth_scheme) => auth_scheme,
+                Err(e) => {
+                    error!(error=?e, "no auth scheme for endpoint");
+                    return Err(e.into());
+                }
+            };
+            trace!(?auth_scheme, "resolved auth scheme");
             Some(init_default_signing_config(
                 auth_scheme.signing_region(),
                 auth_scheme.scheme_name(),

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -59,6 +59,11 @@ pub struct CredentialsProvider {
     pub(crate) inner: NonNull<aws_credentials_provider>,
 }
 
+// SAFETY: aws_credentials_provider is thread-safe.
+unsafe impl Send for CredentialsProvider {}
+// SAFETY: aws_credentials_provider is thread-safe.
+unsafe impl Sync for CredentialsProvider {}
+
 impl CredentialsProvider {
     /// Creates the default credential provider chain as used by most AWS SDKs
     pub fn new_chain_default(

--- a/mountpoint-s3-crt/src/auth/signing_config.rs
+++ b/mountpoint-s3-crt/src/auth/signing_config.rs
@@ -1,7 +1,7 @@
 //! Configuration for signing requests to AWS APIs
 
 use crate::auth::credentials::CredentialsProvider;
-use mountpoint_s3_crt_sys::aws_signing_config_aws;
+use mountpoint_s3_crt_sys::{aws_signing_algorithm, aws_signing_config_aws};
 use std::ffi::OsString;
 use std::fmt::Debug;
 use std::marker::PhantomPinned;
@@ -15,8 +15,11 @@ pub(crate) struct SigningConfigInner {
     /// An owned copy of the region string, since the `aws_signing_config_aws` holds a pointer to it.
     pub(crate) region: OsString,
 
-    /// An owned CredentialProvider, since the holds `aws_signing_config_aws` a pointer to it inner.
+    /// An owned CredentialProvider, since the `aws_signing_config_aws` holds a pointer to it.
     pub(crate) credentials_provider: CredentialsProvider,
+
+    /// An owned copy of the service string, since the `aws_signing_config_aws` holds a pointer to it.
+    pub(crate) service: OsString,
 
     /// This forces the struct to be !Unpin, because the signing config can contain pointers to itself
     pub(crate) _pinned: PhantomPinned,
@@ -40,5 +43,23 @@ impl SigningConfig {
     /// Get out the inner pointer to the signing config
     pub(crate) fn to_inner_ptr(&self) -> *const aws_signing_config_aws {
         &Pin::as_ref(&self.0).get_ref().inner
+    }
+}
+
+/// The version of the AWS signing process.
+#[derive(Debug, Copy, Clone)]
+pub enum SigningAlgorithm {
+    /// Signature Version 4 (SigV4)
+    SigV4,
+    /// Signature Version 4 Asymmetric (SigV4A)
+    SigV4A,
+}
+
+impl From<SigningAlgorithm> for aws_signing_algorithm {
+    fn from(typ: SigningAlgorithm) -> Self {
+        match typ {
+            SigningAlgorithm::SigV4 => aws_signing_algorithm::AWS_SIGNING_ALGORITHM_V4,
+            SigningAlgorithm::SigV4A => aws_signing_algorithm::AWS_SIGNING_ALGORITHM_V4_ASYMMETRIC,
+        }
     }
 }

--- a/mountpoint-s3-crt/src/auth/signing_config.rs
+++ b/mountpoint-s3-crt/src/auth/signing_config.rs
@@ -6,7 +6,6 @@ use std::ffi::OsString;
 use std::fmt::Debug;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::sync::Arc;
 
 pub(crate) struct SigningConfigInner {
     /// The raw `aws_signing_config` for this config
@@ -33,16 +32,14 @@ impl Debug for SigningConfigInner {
     }
 }
 
-/// Wrap the SigningConfigInner struct into a Pin<Box<_>>, so that it cannot be moved. Then wrap
-/// in an Arc so that we can make copies. If there were a way to convert Pin<Box<_>> into Pin<Arc<_>>
-/// then we could avoid needing both.
-#[derive(Debug, Clone)]
-pub struct SigningConfig(pub(crate) Arc<Pin<Box<SigningConfigInner>>>);
+/// Wrap the SigningConfigInner struct into a Pin<Box<_>>, so that it cannot be moved.
+#[derive(Debug)]
+pub struct SigningConfig(pub(crate) Pin<Box<SigningConfigInner>>);
 
 impl SigningConfig {
     /// Get out the inner pointer to the signing config
     pub(crate) fn to_inner_ptr(&self) -> *const aws_signing_config_aws {
-        &Pin::as_ref(&self.0).get_ref().inner
+        &self.0.as_ref().get_ref().inner
     }
 }
 

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -18,7 +18,6 @@ use std::marker::PhantomPinned;
 use std::os::unix::prelude::OsStrExt;
 use std::pin::Pin;
 use std::ptr::NonNull;
-use std::sync::Arc;
 use std::time::Duration;
 
 /// A client for high-throughput access to Amazon S3
@@ -1071,7 +1070,7 @@ pub fn init_default_signing_config(
         .set_use_double_uri_encode(use_double_uri_encode as u32);
     signing_config.inner.algorithm = algorithm.into();
 
-    SigningConfig(Arc::new(Box::into_pin(signing_config)))
+    SigningConfig(Box::into_pin(signing_config))
 }
 
 /// The checksum configuration.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -30,7 +30,7 @@ pub struct Client {
     /// Hold on to an owned copy of the configuration so that it doesn't get dropped while the
     /// client still exists. This is because the client config holds ownership of some strings
     /// (like the region) that could still be used while the client exists.
-    config: ClientConfig,
+    _config: ClientConfig,
 }
 
 // SAFETY: We assume that the CRT allows making requests using the same client from multiple threads.
@@ -47,9 +47,6 @@ pub struct ClientConfig {
     /// The [ClientBootstrap] to use to create connections to S3
     client_bootstrap: Option<ClientBootstrap>,
 
-    /// The [SigningConfig] configuration for signing API requests to S3
-    signing_config: Option<SigningConfig>,
-
     /// The [RetryStrategy] to use to reschedule failed requests to S3. This is reference counted,
     /// so we only need to hold onto it until this [ClientConfig] is consumed, at which point the
     /// client will take ownership.
@@ -60,14 +57,6 @@ impl ClientConfig {
     /// Create a new [ClientConfig] with default options.
     pub fn new() -> Self {
         Default::default()
-    }
-
-    /// Signing options to be used for each request. Leave out to not sign requests.
-    pub fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
-        // Safety: Cast the signing config to mut pointer since we know creating the client won't modify it.
-        self.inner.signing_config = signing_config.to_inner_ptr() as *mut aws_signing_config_aws;
-        self.signing_config = Some(signing_config);
-        self
     }
 
     /// Client bootstrap used for common staples such as event loop group, host resolver, etc.
@@ -280,7 +269,7 @@ impl MetaRequestOptions {
 
     /// Set the signing config used for this message. Not public because we copy it from the client
     /// when making a request.
-    fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
+    pub fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
         // SAFETY: we aren't moving out of the struct.
         let options = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.0)) };
         options.signing_config = Some(signing_config);
@@ -565,21 +554,16 @@ impl Client {
         // guaranteed to be a valid allocator because of the type-safe wrapper.
         let inner = unsafe { aws_s3_client_new(allocator.inner.as_ptr(), &config.inner).ok_or_last_error()? };
 
-        Ok(Self { inner, config })
+        Ok(Self { inner, _config: config })
     }
 
     /// Make a meta request to S3 using this [Client]. A meta request is an HTTP request that
     /// the CRT might internally split up into multiple requests for performance.
-    pub fn make_meta_request(&self, mut options: MetaRequestOptions) -> Result<MetaRequest, Error> {
+    pub fn make_meta_request(&self, options: MetaRequestOptions) -> Result<MetaRequest, Error> {
         // SAFETY: The inner struct pointed to by MetaRequestOptions will live as long as the
         // request does, since we only drop it in the shutdown callback. That struct owns everything
         // related to the request, like the message, signing config, etc.
         unsafe {
-            // The client holds a copy of the signing config, copy it again for this request.
-            if let Some(signing_config) = self.config.signing_config.as_ref() {
-                options.signing_config(signing_config.clone());
-            }
-
             // Unpin the options (we won't move out of it, nor will the callbacks).
             let options = Pin::into_inner_unchecked(options.0);
 


### PR DESCRIPTION
## Description of change

Use the `AuthScheme` obtained from the `EndpointResolver` to build the `SigningConfig`
for each request. Also extend the initializer for `SigningConfig` to accept the
additional parameters: service name, signing algorithm, and the `use_double_uri_encode`
flag.

The `AuthScheme` will now validate the `scheme_name` field (i.e. signing algorithm)
on parsing and store it as a `SigningAlgorithm`.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
