### PR TITLE
Added default signing config for each request

### DIFF
--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -59,6 +59,11 @@ pub struct CredentialsProvider {
     pub(crate) inner: NonNull<aws_credentials_provider>,
 }
 
+// SAFETY: aws_credentials_provider is thread-safe.
+unsafe impl Send for CredentialsProvider {}
+// SAFETY: aws_credentials_provider is thread-safe.
+unsafe impl Sync for CredentialsProvider {}
+
 impl CredentialsProvider {
     /// Creates the default credential provider chain as used by most AWS SDKs
     pub fn new_chain_default(

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -47,9 +47,6 @@ pub struct ClientConfig {
     /// The [ClientBootstrap] to use to create connections to S3
     client_bootstrap: Option<ClientBootstrap>,
 
-    /// The [SigningConfig] configuration for signing API requests to S3
-    signing_config: Option<SigningConfig>,
-
     /// The [RetryStrategy] to use to reschedule failed requests to S3. This is reference counted,
     /// so we only need to hold onto it until this [ClientConfig] is consumed, at which point the
     /// client will take ownership.
@@ -60,14 +57,6 @@ impl ClientConfig {
     /// Create a new [ClientConfig] with default options.
     pub fn new() -> Self {
         Default::default()
-    }
-
-    /// Signing options to be used for each request. Leave out to not sign requests.
-    pub fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
-        // Safety: Cast the signing config to mut pointer since we know creating the client won't modify it.
-        self.inner.signing_config = signing_config.to_inner_ptr() as *mut aws_signing_config_aws;
-        self.signing_config = Some(signing_config);
-        self
     }
 
     /// Client bootstrap used for common staples such as event loop group, host resolver, etc.
@@ -280,7 +269,7 @@ impl MetaRequestOptions {
 
     /// Set the signing config used for this message. Not public because we copy it from the client
     /// when making a request.
-    fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
+    pub fn signing_config(&mut self, signing_config: SigningConfig) -> &mut Self {
         // SAFETY: we aren't moving out of the struct.
         let options = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.0)) };
         options.signing_config = Some(signing_config);
@@ -570,16 +559,11 @@ impl Client {
 
     /// Make a meta request to S3 using this [Client]. A meta request is an HTTP request that
     /// the CRT might internally split up into multiple requests for performance.
-    pub fn make_meta_request(&self, mut options: MetaRequestOptions) -> Result<MetaRequest, Error> {
+    pub fn make_meta_request(&self, options: MetaRequestOptions) -> Result<MetaRequest, Error> {
         // SAFETY: The inner struct pointed to by MetaRequestOptions will live as long as the
         // request does, since we only drop it in the shutdown callback. That struct owns everything
         // related to the request, like the message, signing config, etc.
         unsafe {
-            // The client holds a copy of the signing config, copy it again for this request.
-            if let Some(signing_config) = self.config.signing_config.as_ref() {
-                options.signing_config(signing_config.clone());
-            }
-
             // Unpin the options (we won't move out of it, nor will the callbacks).
             let options = Pin::into_inner_unchecked(options.0);
 


### PR DESCRIPTION
## Description of change
Now the signing config is set for each request in request template (although still with default values) rather than once in the client.

<!-- Please describe your contribution here. What and why? -->
Added credential provider in S3CrtClientInner to have signing config set for each request template of S3CrtClient. Added the signing config in S3Message which later get set in options.

Relevant issues: <!-- Please add issue numbers. -->
#4 

## Does this change impact existing behavior?
No

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No, there’s no breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
