### PR TITLE
Remove --fips command-line flag

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Other changes
 
-* New bucket options of `--transfer-acceleration`, `--dual-stack` and `--fips` has been added.
+* New bucket options of `--transfer-acceleration` and `--dual-stack` have been added.
 * ARN is now also supported as <BUCKET_NAME> to mount the corresponding resource using Mountpoint.
 
 ## v0.4.1 (August 4, 2023)

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -72,9 +72,6 @@ struct CliArgs {
     #[clap(long, help = "Use dual-stack endpoints when accessing S3", help_heading = BUCKET_OPTIONS_HEADER)]
     pub dual_stack: bool,
 
-    #[clap(long, help = "Use FIPS-compliant endpoints when accessing S3", help_heading = BUCKET_OPTIONS_HEADER)]
-    pub fips: bool,
-
     #[clap(long, help = "Set the 'x-amz-request-payer' to 'requester' on S3 requests", help_heading = BUCKET_OPTIONS_HEADER)]
     pub requester_pays: bool,
 
@@ -391,7 +388,6 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     // Placeholder region will be filled in by [create_client_for_bucket]
     let endpoint_config = EndpointConfig::new("PLACEHOLDER")
         .addressing_style(args.addressing_style())
-        .use_fips(args.fips)
         .use_accelerate(args.transfer_acceleration)
         .use_dual_stack(args.dual_stack);
 


### PR DESCRIPTION
## Description of change

Remove --fips command-line flag.

## Does this change impact existing behavior?

FIPS endpoints need to be manually specified.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
