### PR TITLE
decrease closed-channel log severity

### DIFF
--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use tracing::info;
+use tracing::trace;
 
 use crate::prefetch::part::Part;
 use crate::prefetch::PrefetchReadError;
@@ -92,7 +92,7 @@ impl<E: std::error::Error + Send + Sync> PartQueueProducer<E> {
         // Unbounded channel will never actually block
         let send_result = self.sender.send_blocking(part);
         if send_result.is_err() {
-            info!("closed channel");
+            trace!("closed channel");
         }
     }
 }

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use tracing::warn;
+use tracing::info;
 
 use crate::prefetch::part::Part;
 use crate::prefetch::PrefetchReadError;
@@ -92,7 +92,7 @@ impl<E: std::error::Error + Send + Sync> PartQueueProducer<E> {
         // Unbounded channel will never actually block
         let send_result = self.sender.send_blocking(part);
         if send_result.is_err() {
-            warn!("closed channel");
+            info!("closed channel");
         }
     }
 }


### PR DESCRIPTION
## Description of change

This is more of a proposal/asking for thoughts.

I've noticed this log is extremely noisy. There's a few bad omens here:
1. The log message doesn't contain much data itself:
    ```
    WARN mountpoint_s3::prefetch::part_queue: closed channel
    ```
2. It's noisy
3. It doesn't feel actionable - what am I supposed to do with this

Given the above, it feels `WARN` is too high. Feels more like info or debug. However I'm not sure if the log is useful in other contexts. Open to guidance!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
