### PR TITLE
Improve benchmark script

### DIFF
--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -15,7 +15,7 @@ In general, we run each IO operation for 30 seconds against a 100 GiB file. But 
 
 ***readdir workload*** - we measure how long it takes to run `ls` command against directories with different size. Each directory has no subdirectory and contains a specific number of files, range from 100 to 100000 files, which we have to create manually using fio then upload them to S3 bucket before running the benchmark. The fio configuration files for creating them can be found at path [mountpoint-s3/scripts/fio/create/](../mountpoint-s3/scripts/fio/create).
 
-***write workload*** - we measure write throughput by using [dd](https://man7.org/linux/man-pages/man1/dd.1.html) command to simulate sequential write workloads. We plan to use fio in the future for consistency with other benchmarks but its current write pattern is not supported by Mountpoint. Firstly, fio creates a file with 0 byte and close it. Secondly, fio opens the file again with `O_RDWR` flag to do the IO workloads. To support fio, Mountpoint has to allow file overwrites and allow file opens with `O_RDWR` flag.
+***write workload*** - we measure write throughput by using fio to simulate sequential write workloads. The fio configuration files for write workloads can be found at path [mountpoint-s3/scripts/fio/write/](../mountpoint-s3/scripts/fio/write).
 
 ### Regression Testing
 Our CI runs the benchmark automatically for any new commits to the main branch or specific pull requests that we have reviewed and tagged with **performance** label. Every benchmark from the CI workflow will be running on `m5n.24xlarge` EC2 instances (100 Gbps network speed) with Ubuntu 22.04 in us-east-1 against a bucket in us-east-1.

--- a/mountpoint-s3/scripts/fio/write/seq_write.fio
+++ b/mountpoint-s3/scripts/fio/write/seq_write.fio
@@ -1,0 +1,16 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=10s
+time_based
+group_reporting
+
+[sequential_write]
+size=100G
+rw=write
+ioengine=sync
+fallocate=none
+create_on_open=1
+fsync_on_close=1
+unlink=1
+startdelay=1s

--- a/mountpoint-s3/scripts/fio/write/seq_write.fio
+++ b/mountpoint-s3/scripts/fio/write/seq_write.fio
@@ -1,7 +1,7 @@
 [global]
 name=fs_bench
 bs=256k
-runtime=10s
+runtime=30s
 time_based
 group_reporting
 
@@ -13,4 +13,4 @@ fallocate=none
 create_on_open=1
 fsync_on_close=1
 unlink=1
-startdelay=1s
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
+++ b/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
@@ -1,7 +1,7 @@
 [global]
 name=fs_bench
 bs=256k
-runtime=10s
+runtime=30s
 time_based
 group_reporting
 
@@ -14,4 +14,4 @@ fallocate=none
 create_on_open=1
 fsync_on_close=1
 unlink=1
-startdelay=1s
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
+++ b/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
@@ -5,7 +5,7 @@ runtime=10s
 time_based
 group_reporting
 
-[sequential_write]
+[sequential_write_direct_io]
 size=100G
 rw=write
 ioengine=sync

--- a/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
+++ b/mountpoint-s3/scripts/fio/write/seq_write_direct.fio
@@ -1,0 +1,17 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=10s
+time_based
+group_reporting
+
+[sequential_write]
+size=100G
+rw=write
+ioengine=sync
+direct=1
+fallocate=none
+create_on_open=1
+fsync_on_close=1
+unlink=1
+startdelay=1s


### PR DESCRIPTION
## Description of change

Increase number of iteration we run the throughput benchmarks from 1 to 10. This should make the benchmark result more stable. Also change the tool we use  for write benchmark from `dd` to `fio` for consistency with other benchmarks.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
