### PR TITLE
Increase credentials duration when assuming role for benchmark ci job

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
+        role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Description of change

Increase credentials duration when assuming role for benchmark ci job.
This change needs to be in main first to unblock https://github.com/awslabs/mountpoint-s3/pull/458.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
