### PR TITLE
Add new metrics for IO, handles, throughput

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+* Added new metrics for object writes, IO sizes, file handles, and directory operations. The existing `fuse.bytes_read` metric has been renamed to `fuse.total_bytes` and is now keyed by operation (`read`/`write`).
+
 ## v1.0.0 (August 8, 2023)
 
 ### Breaking changes


### PR DESCRIPTION
## Description of change

This change adds a bunch of new metrics for investigating performance.
It lets us track per-IO read/write size, number of open read/write
handles, directory listing throughput, and meta request throughput for
uploads and downloads.

## Does this change impact existing behavior?

The existing `fuse.bytes_read` metric was renamed to `fuse.total_bytes` and has `op` tags for `read`/`write`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
