### PR TITLE
Allow reading restored GFR/GDA objects (#434)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,17 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,15 +1486,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1766,16 +1746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lasso"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4644821e1c3d7a560fe13d842d13f587c07348a1a05d3a797152d41c90c56df2"
-dependencies = [
- "dashmap",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,7 +1895,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "metrics-macros",
  "portable-atomic 0.3.20",
 ]
@@ -1992,7 +1962,6 @@ dependencies = [
  "fuser",
  "futures",
  "hdrhistogram",
- "lasso",
  "lazy_static",
  "libc",
  "metrics",

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -18,7 +18,7 @@ Mountpoint uses the same [credentials configuration options](https://docs.aws.am
 
 We recommend you use short-term AWS credentials whenever possible. Mountpoint supports several options for short-term AWS credentials:
 * When running Mountpoint on an Amazon EC2 instance, you can [associate an IAM role with your instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) using an instance profile, and Mountpoint will automatically assume that IAM role.
-* When running Mountpoint in an Amazon ECS task, you can similarly [associate an IAM role with the task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) for Mountpoint to automatically assume. 
+* When running Mountpoint in an Amazon ECS task, you can similarly [associate an IAM role with the task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) for Mountpoint to automatically assume.
 * Otherwise, you can [acquire temporary AWS credentials for an IAM role](https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-short-term.html) from the AWS Console or with the `aws sts assume-role` AWS CLI command, and store them in the `~/.aws/credentials` file.
 
 If you need to use long-term AWS credentials, you can [store them in the configuration and credentials files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) in `~/.aws`, or [specify them with environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
@@ -164,7 +164,7 @@ Amazon S3 offers a [range of storage classes](https://aws.amazon.com/s3/storage-
 
 For the full list of possible storage classes, see the [PutObject documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-StorageClass) in the Amazon S3 User Guide.
 
-Mountpoint supports reading existing objects from your S3 bucket when they are stored in any instant-retrieval storage class. You cannot use Mountpoint to read objects stored in the S3 Glacier Flexible Retrieval or S3 Glacier Deep Archive storage classes, or the Archive Access or Deep Archive Access tiers of S3 Intelligent-Tiering. This limitation exists even if you have restored the object. However, you can still use Mountpoint to write new objects into these storage classes or S3 Intelligent-Tiering.
+Mountpoint supports reading existing objects from your S3 bucket when they are stored in any instant-retrieval storage class. You cannot use Mountpoint to read objects stored in the S3 Glacier Flexible Retrieval or S3 Glacier Deep Archive storage classes, or the Archive Access or Deep Archive Access tiers of S3 Intelligent-Tiering, unless they've been [restored](https://docs.aws.amazon.com/AmazonS3/latest/userguide/restoring-objects.html). You can use Mountpoint to write new objects into these storage classes or S3 Intelligent-Tiering.
 
 ### File and directory permissions
 

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -19,7 +19,7 @@ By default, Mountpoint does not allow deleting existing objects with commands li
 
 You cannot rename an existing file using Mountpoint.
 
-Objects in the S3 Glacier Flexible Retrieval and S3 Glacier Deep Archive storage classes, and the Archive Access and Deep Archive Access tiers of S3 Intelligent-Tiering, are not accessible with Mountpoint even if they have been restored. To access these objects with Mountpoint, copy them to another storage class first.
+Objects in the S3 Glacier Flexible Retrieval and S3 Glacier Deep Archive storage classes, and the Archive Access and Deep Archive Access tiers of S3 Intelligent-Tiering, are only accessible with Mountpoint if they have been restored. To access these objects with Mountpoint, [restore](https://docs.aws.amazon.com/AmazonS3/latest/userguide/restoring-objects.html) them first.
 
 ## Directories
 
@@ -108,13 +108,13 @@ S3 places fewer restrictions on [valid object keys](https://docs.aws.amazon.com/
   * `blue/`
   * `blue/image.jpg`
   * `red/`
-  
+
   then mounting your bucket would give a file system with a `blue` directory containing an `image.jpg` file, and an empty `red` directory. The `blue/` and `red/` objects will not be accessible. Note that the S3 Console creates zero-byte objects like `blue/` and `red/` when creating directories in a bucket, and so these directories will work as expected.
 * Files will be shadowed by directories with the same name. For example, if your bucket has the following object keys:
 
   * `blue`
   * `blue/image.jpg`
-  
+
   then mounting your bucket would give a file system with a `blue` directory, containing the file `image.jpg`. The `blue` object will not be accessible. Deleting the key `blue/image.jpg` will remove the `blue` directory, and cause the `blue` file to become visible.
 
 We test Mountpoint against these restrictions using a [reference model](https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/tests/reftests/reference.rs) that programmatically encodes the expected mapping between S3 objects and file system structure.

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -2,10 +2,13 @@
 
 pub mod common;
 
+use std::time::{Duration, Instant};
+
 use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{GlacierJobParameters, RestoreRequest, Tier};
 use bytes::Bytes;
 use common::*;
-use mountpoint_s3_client::{HeadObjectError, ObjectClientError, S3CrtClient, S3RequestError};
+use mountpoint_s3_client::{HeadObjectError, ObjectClientError, RestoreStatus, S3CrtClient, S3RequestError};
 use test_case::test_case;
 
 #[tokio::test]
@@ -58,6 +61,7 @@ async fn test_head_object_storage_class(storage_class: &str) {
     assert_eq!(result.object.key, key);
     assert_eq!(result.object.size as usize, body.len());
     assert_eq!(result.object.storage_class.as_deref(), Some(storage_class));
+    assert!(result.object.restore_status.is_none());
 }
 
 #[tokio::test]
@@ -104,4 +108,66 @@ async fn test_head_object_no_perm() {
         result,
         Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_)))
     ));
+}
+
+// This test relies on s3's expedited object restoration, it takes 1-5 minutes to complete
+#[tokio::test]
+async fn test_head_object_restored() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_head_object_restored");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .storage_class("GLACIER".into())
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+
+    assert_eq!(result.bucket, bucket);
+    assert_eq!(result.object.key, key);
+    assert!(
+        result.object.restore_status.is_none(),
+        "object should become restored only after restoration"
+    );
+
+    sdk_client
+        .restore_object()
+        .bucket(&bucket)
+        .key(&key)
+        .restore_request(
+            RestoreRequest::builder()
+                .set_days(Some(1))
+                .set_glacier_job_parameters(Some(
+                    GlacierJobParameters::builder().set_tier(Some(Tier::Expedited)).build(),
+                ))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let timeout = Duration::from_secs(300);
+    let start = Instant::now();
+    let mut timeouted = true;
+    while start.elapsed() < timeout {
+        let object = client
+            .head_object(&bucket, &key)
+            .await
+            .expect("head_object failed")
+            .object;
+        if let Some(RestoreStatus::Restored { expiry: _ }) = object.restore_status {
+            timeouted = false;
+            break;
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    assert!(!timeouted, "timeouted while waiting for object become restored");
 }

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -20,7 +20,6 @@ ctrlc = { version = "3.2.3", features = ["termination"] }
 dashmap = "5.5.0"
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
-lasso = { version = "0.7.2", features = ["multi-threaded"] }
 lazy_static = "1.4.0"
 libc = "0.2.126"
 metrics = "0.20.1"

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -169,6 +169,7 @@ impl ReaddirHandle {
                     object_info.last_modified,
                     Some(object_info.etag.clone()),
                     object_info.storage_class.clone(),
+                    object_info.restore_status,
                     self.inner.cache_config.file_ttl,
                 );
                 Some(RemoteLookup {


### PR DESCRIPTION
## Description of change

- Adjusting `mountpoint-s3-client` to propagate information about object's restoration status from `head` and `list` methods, this is accounted in `ObjectInfo::restored` boolean field;
- This information is accounted in `InodeStat::restored` boolean field in `mountpoint-s3`;
- Based on `InodeStat::restored` I adjust  `crate::fs::is_archived` function (`is_flexible_retrieval_storage_class ` previously) which is used to restrict permissions for GLACIER/DEEP_ARCHIVE objects. 
- Two long-running (~2 mins) tests are added to `mountpoint-s3-client/tests/head_object.rs` and `mountpoint-s3/tests/fuse_tests/read_test.rs` -- these are communicating with s3 and wait for it to restore objects.
- Manually tested that for objects that previously have been restored but expired permissions are 000 (corresponding `RestoreStatus`/`x-amz-restore` field not returned by list/head API)

API reference (ctrl+f: "restore"):
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html

Relevant issues: #434 

## Does this change impact existing behavior?

This is not a breaking change. This change will change permissions for restored GLACIER/DEEP_ARCHIVE objects, which previously were reported as 000. This also will allow reading those objects. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
