### PR TITLE
Small fixes for S3 on Outposts

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Breaking change: `ListObjectsResult` no longer includes the `bucket` field.
+
 # v0.3.0 (June 20, 2023)
 
 Breaking changes:

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -449,7 +449,6 @@ impl ObjectClient for MockClient {
         let common_prefixes = common_prefixes.into_iter().collect::<Vec<_>>();
 
         Ok(ListObjectsResult {
-            bucket: bucket.to_string(),
             objects: object_vec,
             common_prefixes,
             next_continuation_token,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -162,9 +162,6 @@ pub enum GetObjectError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ListObjectsResult {
-    /// The name of the bucket.
-    pub bucket: String,
-
     /// The list of objects.
     pub objects: Vec<ObjectInfo>,
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -634,12 +634,13 @@ struct S3Message {
 }
 
 impl S3Message {
-    /// Add a header to this message.
-    fn add_header(
+    /// Add a header to this message. The header is added if necessary and any existing values for
+    /// this header are removed.
+    fn set_header(
         &mut self,
         header: &Header<impl AsRef<OsStr>, impl AsRef<OsStr>>,
     ) -> Result<(), mountpoint_s3_crt::common::error::Error> {
-        self.inner.add_header(header)
+        self.inner.set_header(header)
     }
 
     /// Set the request path and query for this message. The components should not be URL-encoded;

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -36,13 +36,13 @@ impl S3CrtClient {
 
         // Overwrite "accept" header since this returns raw object data.
         message
-            .add_header(&Header::new("accept", "*/*"))
+            .set_header(&Header::new("accept", "*/*"))
             .map_err(S3RequestError::construction_failure)?;
 
         if let Some(etag) = if_match {
             // Return the object only if its entity tag (ETag) is matched
             message
-                .add_header(&Header::new("If-Match", etag.as_str()))
+                .set_header(&Header::new("If-Match", etag.as_str()))
                 .map_err(S3RequestError::construction_failure)?;
         }
 
@@ -55,7 +55,7 @@ impl S3CrtClient {
             // Range HTTP header is bounded below *inclusive*
             let range_value = format!("bytes={}-{}", range.start, range.end.saturating_sub(1));
             message
-                .add_header(&Header::new("Range", range_value))
+                .set_header(&Header::new("Range", range_value))
                 .map_err(S3RequestError::construction_failure)?;
 
             let length = range.end.saturating_sub(range.start);

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -123,20 +123,20 @@ impl S3CrtClient {
             if let Some(max_parts) = max_parts {
                 let value = format!("{}", max_parts);
                 message
-                    .add_header(&Header::new("x-amz-max-parts", value))
+                    .set_header(&Header::new("x-amz-max-parts", value))
                     .map_err(S3RequestError::construction_failure)?;
             }
 
             if let Some(part_number_marker) = part_number_marker {
                 let value = format!("{}", part_number_marker);
                 message
-                    .add_header(&Header::new("x-amz-part-number-marker", value))
+                    .set_header(&Header::new("x-amz-part-number-marker", value))
                     .map_err(S3RequestError::construction_failure)?;
             }
 
             let object_attributes: Vec<String> = object_attributes.iter().map(|attr| attr.to_string()).collect();
             message
-                .add_header(&Header::new("x-amz-object-attributes", object_attributes.join(",")))
+                .set_header(&Header::new("x-amz-object-attributes", object_attributes.join(",")))
                 .map_err(S3RequestError::construction_failure)?;
 
             let span = request_span!(

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -43,7 +43,7 @@ impl S3CrtClient {
 
         if let Some(storage_class) = params.storage_class.to_owned() {
             message
-                .add_header(&Header::new("x-amz-storage-class", storage_class))
+                .set_header(&Header::new("x-amz-storage-class", storage_class))
                 .map_err(S3RequestError::construction_failure)?;
         }
 

--- a/mountpoint-s3-client/tests/list_objects.rs
+++ b/mountpoint-s3-client/tests/list_objects.rs
@@ -19,7 +19,6 @@ async fn test_list_objects() {
         .expect("ListObjects failed");
 
     println!("{result:?}");
-    assert_eq!(result.bucket, bucket);
     assert!(result.next_continuation_token.is_none());
     assert_eq!(result.objects.len(), 1);
     assert_eq!(result.objects[0].key, format!("{}{}", prefix, "hello"));


### PR DESCRIPTION
## Description of change

This fixes two issues that were preventing Mountpoint from working against Outposts buckets:
1. Outposts doesn't include the bucket name in ListObjectsV2 responses. We weren't actually using that output anyway, so I just removed it.
2. For GetObject requests, we were sending a HTTP header like `Accept: application/xml,*/*`. While technically valid HTTP, it's weird to accept `*/*` as well as something else, and it was confusing Outposts' request signing. So I switched to overwriting the existing header, which is what the comment suggested the code was intended to do anyway.

I also took this chance to make a little cleanup to parsing ListObjectsV2 responses: the `parse` functions shouldn't be defined on the generic `ListObjectsResult` structs, which are shared by all clients.

This change doesn't make Mountpoint completely work on Outposts. The outstanding issue is that Outposts don't support S3 additional checksums, but we turn those on by default. We'll need a way to turn those off for Outposts buckets. But read-only usage should work.

## Does this change impact existing behavior?

Yes, removing the bucket name is a breaking change to the client crate, and we now send a different `Accept` header on GetObject requests. There shouldn't be any customer-visible effects.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
