### PR TITLE
erase "accept" header before add new

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -642,6 +642,14 @@ impl S3Message {
         self.inner.add_header(header)
     }
 
+    /// Erase a header with the given name from this message.
+    fn erase_header(
+        &mut self,
+        name: impl AsRef<OsStr>,
+    ) -> Result<(), mountpoint_s3_crt::common::error::Error> {
+        self.inner.erase_header(name)
+    }
+
     /// Set the request path and query for this message. The components should not be URL-encoded;
     /// this method will handle that.
     fn set_request_path_and_query<P: AsRef<OsStr>>(

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -36,6 +36,9 @@ impl S3CrtClient {
 
         // Overwrite "accept" header since this returns raw object data.
         message
+            .erase_header("accept")
+            .map_err(S3RequestError::construction_failure)?;
+        message
             .add_header(&Header::new("accept", "*/*"))
             .map_err(S3RequestError::construction_failure)?;
 


### PR DESCRIPTION


Authentication for certain object storage systems, such as Ceph RGW, does not support multi-valued headers.

## Description of change

GetObject 

Origin

```
GET /xxx/ HTTP/1.1
accept: application/xml
accept: */*
```

Now

```
GET /xxx/ HTTP/1.1
accept: */*
```


## Does this change impact existing behavior?

No