### PR TITLE
Make allow_other and allow_root mutually exclusive

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -110,8 +110,9 @@ struct CliArgs {
 
     #[clap(
         long,
-        help = "Allow other non-root users to access file system",
-        help_heading = MOUNT_OPTIONS_HEADER
+        help = "Allow other users, including root, to access file system",
+        help_heading = MOUNT_OPTIONS_HEADER,
+        conflicts_with = "allow_root"
     )]
     pub allow_other: bool,
 

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -195,3 +195,18 @@ fn validate_log_files_permissions() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn allow_other_conflict() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+
+    cmd.arg("test-bucket")
+        .arg(dir.path())
+        .arg("--allow-other")
+        .arg("--allow-root");
+    let error_message = "the argument '--allow-other' cannot be used with '--allow-root'";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}


### PR DESCRIPTION
## Description of change

Reported in https://github.com/awslabs/mountpoint-s3/pull/466 that `--allow-other` infers `--allow-root`. If both `--allow-root` and `--allow-other` are defined, only `--allow-root` will function. So, we should make the two options mutually exclusive.

## Does this change impact existing behavior?

Yes, cli arguments `--allow-root` and `--allow-other` are now mutually exclusive.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
