### PR TITLE
Updates encryption documentation for SSE-KMS, DSSE-KMS

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -130,7 +130,7 @@ In most scenarios, Mountpoint automatically infers the appropriate Amazon S3 end
 
 ### Data encryption
 
-Amazon S3 supports a number of [server-side encryption types](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingEncryption.html). Mountpoint supports reading objects that are encrypted with Amazon S3 managed keys (SSE-S3), with AWS KMS keys (SSE-KMS), or with dual-layer encryption with AWS KMS keys (DSSE-KMS). It does not currently support reading objects encrypted with customer-provided keys (SSE-C). For new objects written by Mountpoint, Amazon S3 automatically applies server-side encryption with Amazon S3 managed keys (SSE-S3), and Mountpoint does not support using other encryption types.
+Amazon S3 supports a number of [server-side encryption types](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingEncryption.html). Mountpoint supports buckets that are configured with Amazon S3 managed keys (SSE-S3), with AWS KMS keys (SSE-KMS), or with dual-layer encryption with AWS KMS keys (DSSE-KMS) as the default encryption method. It does not currently support reading objects encrypted with customer-provided keys (SSE-C). Mountpoint does not allow configuring encryption, and you cannot encrypt objects with a different encryption setting than that of the bucket. 
 
 Mountpoint does not support client-side encryption using the Amazon S3 Encryption Client.
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -130,7 +130,7 @@ In most scenarios, Mountpoint automatically infers the appropriate Amazon S3 end
 
 ### Data encryption
 
-Amazon S3 supports a number of [server-side encryption types](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingEncryption.html). Mountpoint supports buckets that are configured with Amazon S3 managed keys (SSE-S3), with AWS KMS keys (SSE-KMS), or with dual-layer encryption with AWS KMS keys (DSSE-KMS) as the default encryption method. It does not currently support reading objects encrypted with customer-provided keys (SSE-C). Mountpoint does not allow configuring encryption, and you cannot encrypt objects with a different encryption setting than that of the bucket. 
+Amazon S3 supports a number of [server-side encryption types](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingEncryption.html). Mountpoint supports reading and writing to buckets that are configured with Amazon S3 managed keys (SSE-S3), with AWS KMS keys (SSE-KMS), or with dual-layer encryption with AWS KMS keys (DSSE-KMS) as the default encryption method. It does not currently support reading objects encrypted with customer-provided keys (SSE-C). Mountpoint does not allow further configuring encryption, and you cannot encrypt new objects written with Mountpoint using a different encryption setting than the bucket's default.
 
 Mountpoint does not support client-side encryption using the Amazon S3 Encryption Client.
 


### PR DESCRIPTION
## Description of change

Updates documentation for encryption, making it clear that MP works if SSE-KMS or DSSE-KMS is the default encryption on the bucket.

Ran test suite with both SSE-KMS and DSSE-KMS enabled buckets, and all tests pass.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
