### PR TITLE
Allow file overwrites

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### New features
+* Allow file overwrites when mounting with `--allow-overwrite` option. The upload will start as soon as Mountpoint receives `write` request and cannot be aborted. Once it is started the file is guaranteed to be overwritten.
+
 ## v1.3.2 (January 11, 2024)
 
 ### Breaking changes

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -122,6 +122,7 @@ impl ToErrno for InodeError {
             InodeError::InodeNotWritable(_) => libc::EPERM,
             InodeError::InodeAlreadyWriting(_) => libc::EPERM,
             InodeError::InodeNotReadableWhileWriting(_) => libc::EPERM,
+            InodeError::InodeNotWritableWhileReading(_) => libc::EPERM,
             InodeError::CannotRemoveRemoteDirectory(_) => libc::EPERM,
             InodeError::DirectoryNotEmpty(_) => libc::ENOTEMPTY,
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1098,14 +1098,14 @@ impl WriteHandle {
             WriteStatus::Remote => {
                 if !self.allow_overwrite {
                     tracing::warn!(
-                        "file overwrite is disabled by default, you can remount with --allow-overwrite to enable it"
+                        "file overwrite is disabled by default, you need to remount with --allow-overwrite flag and open the file in truncate mode (O_TRUNC) to overwrite it"
                     );
                     return Err(InodeError::InodeNotWritable(inode.err()));
                 }
 
                 if !self.is_truncate {
                     tracing::warn!(
-                        "modifying an existing file is only allowed when the file is opened in truncate mode"
+                        "modifying an existing file is only allowed when the file is opened in truncate mode (O_TRUNC)"
                     );
                     return Err(InodeError::InodeNotWritable(inode.err()));
                 }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -112,6 +112,13 @@ struct CliArgs {
     )]
     pub allow_delete: bool,
 
+    #[clap(
+        long,
+        help = "Allow overwrite operations on file system",
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
+    pub allow_overwrite: bool,
+
     #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
     pub auto_unmount: bool,
 
@@ -574,6 +581,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     }
     filesystem_config.storage_class = args.storage_class;
     filesystem_config.allow_delete = args.allow_delete;
+    filesystem_config.allow_overwrite = args.allow_overwrite;
     filesystem_config.s3_personality =
         get_s3_personality(args.bucket_type, &args.bucket_name, client.endpoint_config());
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -296,8 +296,9 @@ impl Harness {
         Ok(inode)
     }
 
-    /// Create a new file ready for writing. We don't allow overwrites of existing files, so this
+    /// Create a new file ready for writing. We don't allow overwrites of existing files by default, so this
     /// can return None if the name already exists in the chosen directory.
+    /// TODO: Update this function to support overwrites
     async fn perform_create_file(
         &mut self,
         name: &str,
@@ -346,12 +347,20 @@ impl Harness {
             return;
         };
 
-        let open = self.fs.open(inflight_write.inode, libc::O_WRONLY, 0).await;
-        if inflight_write.file_handle.is_some() {
-            // Shouldn't be able to reopen a file that's already open for writing
-            assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
+        let open = self
+            .fs
+            .open(inflight_write.inode, libc::O_WRONLY, 0)
+            .await
+            .expect("open should succeed");
+        if inflight_write.written > 0 {
+            // Shouldn't be able to write to a file that is being written
+            let write = self
+                .fs
+                .write(inflight_write.inode, open.fh, 0, &[0; 8], 0, 0, None)
+                .await
+                .expect_err("write from another file handle should fail");
+            assert_eq!(write.to_errno(), libc::EPERM);
         } else {
-            let open = open.expect("open should succeed");
             let inflight_write = self.inflight_writes.get_mut(index).unwrap();
             inflight_write.file_handle = Some(open.fh);
         }
@@ -701,8 +710,14 @@ impl Harness {
     /// readable (open should fail).
     async fn check_local_file(&self, inode: InodeNo) {
         let _stat = self.fs.getattr(inode).await.expect("stat should succeed");
-        let open = self.fs.open(inode, libc::O_RDONLY, 0).await;
-        assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
+        let open = self
+            .fs
+            .open(inode, libc::O_RDONLY, 0)
+            .await
+            .expect("open should succeed");
+        let read_result = self.fs.read(inode, open.fh, 0, 4096, 0, None).await;
+        let error = read_result.expect_err("read should fail");
+        assert_eq!(error.to_errno(), libc::EPERM);
     }
 }
 


### PR DESCRIPTION
## Description of change

Allow file overwrites on mountpoint. This is quite straightforward for files opened with `O_WRONLY`, we can just return a new write handle instead of `InodeNotWritable` error when the write status is remote. However, it's a bit tricky for files opened with `O_RDWR` because we can either read or write to remote files and it means we can't decide that at `open()` time. So, I changed the concept of file handle to be able to do both write and read based on the operation that comes after `open()`.

Same as "delete", I disable this feature by default and provide a new option `--allow-overwrite` to enable it.

## Does this change impact existing behavior?

Yes, mountpoint now supports overwrites when mounting with `--allow-overwrite` option.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
