### PR TITLE
Use default thread config for benchmark

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -32,7 +32,6 @@ cd ${project_dir}
 results_dir=results
 runtime_seconds=30
 startdelay_seconds=30
-max_threads=4
 iteration=10
 
 rm -rf ${results_dir}
@@ -81,8 +80,7 @@ read_bechmark () {
     # mount file system
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
-      --prefix=${S3_BUCKET_TEST_PREFIX} \
-      --max-threads=${max_threads}
+      --prefix=${S3_BUCKET_TEST_PREFIX}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
       echo "Failed to mount file system"
@@ -115,8 +113,7 @@ write_benchmark () {
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
         --allow-delete \
-        --prefix=${S3_BUCKET_TEST_PREFIX} \
-        --max-threads=${max_threads}
+        --prefix=${S3_BUCKET_TEST_PREFIX}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
         echo "Failed to mount file system"

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -30,7 +30,6 @@ project_dir="${base_dir}/../.."
 cd ${project_dir}
 
 results_dir=results
-max_threads=4
 
 rm -rf ${results_dir}
 mkdir -p ${results_dir}
@@ -50,8 +49,7 @@ do
     # mount file system
     cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
         --allow-delete \
-        --prefix=${S3_BUCKET_TEST_PREFIX} \
-        --max-threads=${max_threads}
+        --prefix=${S3_BUCKET_TEST_PREFIX}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
         echo "Failed to mount file system"
@@ -112,8 +110,7 @@ for job_file in "${jobs_dir}"/*.fio; do
   # mount file system
   cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
     --allow-delete \
-    --prefix=${S3_BUCKET_TEST_PREFIX} \
-    --max-threads=${max_threads}
+    --prefix=${S3_BUCKET_TEST_PREFIX}
   mount_status=$?
   if [ $mount_status -ne 0 ]; then
     echo "Failed to mount file system"


### PR DESCRIPTION
## Description of change

Our benchmark scripts are currently running mountpoint with a specific number of thread. However, I think we should use use default configuration instead since that is what most real users would do and it should be a baseline for benchmark.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
