### PR TITLE
Improve logging and error handling in benchmark script

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if ! command -v fio &> /dev/null; then
   echo "fio must be installed to run this benchmark"
@@ -32,7 +33,7 @@ cd ${project_dir}
 results_dir=results
 runtime_seconds=30
 startdelay_seconds=30
-iteration=10
+iterations=10
 
 rm -rf ${results_dir}
 mkdir -p ${results_dir}
@@ -45,43 +46,43 @@ run_fio_job() {
   job_name=$(basename "${job_file}")
   job_name="${job_name%.*}"
 
-  for i in $(seq 1 $iteration);
+  echo -n "Running job ${job_name} for ${iterations} iterations... "
+
+  for i in $(seq 1 $iterations);
   do
+    echo -n "${i};"
     fio --thread \
-      --output=${results_dir}/${job_name}_${i}.json \
+      --output=${results_dir}/${job_name}_iter${i}.json \
       --output-format=json \
       --directory=${mount_dir} \
       --filename=${bench_file} \
+      --eta=never \
       ${job_file}
   done
+  echo "done"
 
   # combine the results and find an average value
   jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw == "read")
       then $job.read.bw / 1024
       elif ($job."job options".rw == "randread") then $job.read.bw / 1024
       elif ($job."job options".rw == "randwrite") then $job.write.bw / 1024
-      else $job.write.bw / 1024 end)) | {name: .name, value: (.value / .len), unit: "MiB/s"}' ${results_dir}/${job_name}_*.json | tee ${results_dir}/${job_name}_parsed.json
-
-  # delete the raw output files
-  for i in $(seq 1 $iteration);
-  do
-    rm ${results_dir}/${job_name}_${i}.json
-  done
+      else $job.write.bw / 1024 end)) | {name: .name, value: (.value / .len), unit: "MiB/s"}' ${results_dir}/${job_name}_iter*.json | tee ${results_dir}/${job_name}_parsed.json
 }
 
-read_bechmark () {
+read_benchmark () {
   jobs_dir=mountpoint-s3/scripts/fio/read
 
   for job_file in "${jobs_dir}"/*.fio; do
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
 
-    echo "Running ${job_name}"
-
     # mount file system
-    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+    set +e
+    cargo run --quiet --release -- \
+      ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
       --prefix=${S3_BUCKET_TEST_PREFIX}
     mount_status=$?
+    set -e
     if [ $mount_status -ne 0 ]; then
       echo "Failed to mount file system"
       exit 1
@@ -111,13 +112,16 @@ write_benchmark () {
   for job_file in "${jobs_dir}"/*.fio; do
     # mount file system
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
-    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
-        --allow-delete \
-        --prefix=${S3_BUCKET_TEST_PREFIX}
+    set +e
+    cargo run --quiet --release -- \
+      ${S3_BUCKET_NAME} ${mount_dir} \
+      --allow-delete \
+      --prefix=${S3_BUCKET_TEST_PREFIX}
     mount_status=$?
+    set -e
     if [ $mount_status -ne 0 ]; then
-        echo "Failed to mount file system"
-        exit 1
+      echo "Failed to mount file system"
+      exit 1
     fi
 
     # set bench file
@@ -134,8 +138,8 @@ write_benchmark () {
   done
 }
 
-read_bechmark
+read_benchmark
 write_benchmark
 
 # combine all bench results into one json file
-jq -n '[inputs]' ${results_dir}/*.json | tee ${results_dir}/output.json
+jq -n '[inputs]' ${results_dir}/*_parsed.json | tee ${results_dir}/output.json


### PR DESCRIPTION
## Description of change

I've been running some benchmarks on my own EC2 instance and found the output messy (since fio is rewriting stdout) and also it failed to exit when jq wasn't working. This change ensures the script exits (unless we want to check for exit code), and cleans up the script output a bit.

It also retains intermediary files since we don't need to delete them. They are ignored by the benchmark job in the end.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
