### PR TITLE
Add Access Point variables in integration.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,12 @@ env:
   S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   # An IAM role that tests can assume when they want to create session policies
   S3_SUBSESSION_IAM_ROLE: ${{ vars.S3_SUBSESSION_IAM_ROLE }}
+  # Different Access Points Aliases and ARNs
+  S3_ACCESS_POINT_ALIAS: ${{ vars.S3_ACCESS_POINT_ALIAS }}
+  S3_ACCESS_POINT_ARN: ${{ vars.S3_ACCESS_POINT_ARN }}
+  S3_OLAP_ALIAS: ${{ vars.S3_OLAP_ALIAS }}
+  S3_OLAP_ARN: ${{ vars.S3_OLAP_ARN }}
+  S3_MRAP_ARN: $${{ vars.S3_MRAP_ARN }}
   RUST_FEATURES: fuse_tests,s3_tests,fips_tests
 
 permissions:


### PR DESCRIPTION
## Description of change
Added access point alias and ARN in integration.yml to run integration tests on access points. 
<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
#4 

## Does this change impact existing behavior?
No

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
