### PR TITLE
Build releases on CentOS 7

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,12 +1,11 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/docker/library/centos:7
 
-RUN amazon-linux-extras install -y epel
+RUN yum install -y epel-release centos-release-scl
 RUN yum install -y \
         fuse \
         fuse-devel \
         make \
         cmake3 \
-        clang \
         git \
         pkgconfig \
         dpkg \
@@ -14,11 +13,15 @@ RUN yum install -y \
         rpmdevtools \
         tar \
         python3 \
-        wget && \
+        python3-pip \
+        wget \
+        devtoolset-10-gcc \
+        devtoolset-10-gcc-c++ \
+        llvm-toolset-7.0-clang \
+        && \
     yum clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.5.6/cargo-about-0.5.6-$(uname -p)-unknown-linux-musl.tar.gz" && \
     wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.5.6/cargo-about-0.5.6-$(uname -p)-unknown-linux-musl.tar.gz.sha256" && \
@@ -27,6 +30,13 @@ RUN wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.5.
     tar xzf cargo-about-*.tar.gz && \
     cp cargo-about-*/cargo-about /usr/bin && \
     rm -rf cargo-about-* checksum.sha256
+
+RUN python3 -m pip install dataclasses
+
+ENV PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/devtoolset-10/root/usr/bin:/root/.cargo/bin:$PATH"
+ENV LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib"
+ENV CC="/opt/rh/devtoolset-10/root/usr/bin/gcc"
+ENV CXX="/opt/rh/devtoolset-10/root/usr/bin/g++"
 
 WORKDIR /mountpoint
 ENTRYPOINT ["/mountpoint/package/package.py"]

--- a/package/package.py
+++ b/package/package.py
@@ -133,6 +133,9 @@ def build_mountpoint_binary(metadata: BuildMetadata, args: argparse.Namespace) -
     if args.official:
         # Remove the commit from the User-agent version number
         env["MOUNTPOINT_S3_AWS_RELEASE"] = "true"
+    for var in ["CC", "CXX", "LD_LIBRARY_PATH"]:
+        if var in os.environ:
+            env[var] = os.environ[var]
 
     # Build the binary
     cmd = ["cargo", "build", "--bin", "mount-s3", "--release"]


### PR DESCRIPTION
## Description of change

This gets us compatibility back to glibc 2.17. The tricky part is that CentOS 7 by default packages a GCC that's too old to build the CRT and a Clang that's too old to run bindgen. But they also distribute optional packages (devtoolsets) that update these toolchains and stick them in a separate directory. So this change adopts those, and tweaks the environment variables on the builder to point at the newer tools.

Relevant issues: #454

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
