### PR TITLE
Testing benchmark timeouts

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -51,7 +51,7 @@ run_fio_job() {
   for i in $(seq 1 $iterations);
   do
     echo -n "${i};"
-    fio --thread \
+    timeout 1 fio --thread \
       --output=${results_dir}/${job_name}_iter${i}.json \
       --output-format=json \
       --directory=${mount_dir} \

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -51,7 +51,7 @@ run_fio_job() {
   for i in $(seq 1 $iterations);
   do
     echo -n "${i};"
-    timeout 1 fio --thread \
+    timeout 100 fio --thread \
       --output=${results_dir}/${job_name}_iter${i}.json \
       --output-format=json \
       --directory=${mount_dir} \


### PR DESCRIPTION
## Description of change
Adding timeouts to test which job gets stuck for benchmark in github CI.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
NA

## Does this change impact existing behavior?
No. It is just for benchmarks.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No, there is no breaking change due to it.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
