### PR TITLE
Complete the upload on flush

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -143,6 +143,13 @@ but with some limitations:
 Synchronization operations (`fsync`, `fdatasync`) complete the upload of the object to S3 and disallow
 further writes.
 
+`close` also generally completes the upload of the object and reports an error if not successful. However,
+if the file is empty, or if `close` is invoked by a different process than the one that originally opened it,
+`close` returns immediately and the upload is only completed asynchronously after the last reference to the
+file is closed. These exceptions allow Mountpoint to support common usage patterns seen in tools like `dd`,
+`touch`, or in shell redirection, that hold multiple references to an open file and keep writing to one after
+closing another.
+
 Space allocation operations (`fallocate`, `posix_fallocate`) are not supported.
 
 Changing last access and modification times (`utime`) is supported only on files that are being written.

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
 ### Breaking changes
-* ...
+* Mountpoint will now complete file uploads at `close` time, and `close` will return an error if the upload was not successful. Before this change, `close` did not wait for the upload to complete, which could cause confusing results for applications that try to read a file they just wrote. ([#526](https://github.com/awslabs/mountpoint-s3/pull/526))
 
 ### Other changes
-* Fixed a bug that cause poor performance for sequential reads in some cases ([#488](https://github.com/awslabs/mountpoint-s3/pull/488)). A workaround we have previously shared for this issue (setting the `--max-threads` argument to `1`) is no longer necessary with this fix. ([#556](https://github.com/awslabs/mountpoint-s3/pull/556))
+* Fixed a bug that caused poor performance for sequential reads in some cases ([#488](https://github.com/awslabs/mountpoint-s3/pull/488)). A workaround we have previously shared for this issue (setting the `--max-threads` argument to `1`) is no longer necessary with this fix. ([#556](https://github.com/awslabs/mountpoint-s3/pull/556))
 
 ## v1.0.2 (September 22, 2023)
 

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -22,7 +22,7 @@ use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::types::PutObjectParams;
 use tempfile::TempDir;
 
-pub trait TestClient {
+pub trait TestClient: Send {
     fn put_object(&mut self, key: &str, value: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
         self.put_object_params(key, value, PutObjectParams::default())
     }

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -347,7 +347,7 @@ impl Harness {
             return;
         };
 
-        let open = self.fs.open(inflight_write.inode, libc::O_WRONLY).await;
+        let open = self.fs.open(inflight_write.inode, libc::O_WRONLY, 0).await;
         if inflight_write.file_handle.is_some() {
             // Shouldn't be able to reopen a file that's already open for writing
             assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
@@ -691,7 +691,7 @@ impl Harness {
             }
         }
 
-        let fh = match self.fs.open(fs_file, 0x8000).await {
+        let fh = match self.fs.open(fs_file, 0x8000, 0).await {
             Ok(ret) => ret.fh,
             Err(e) => panic!("failed to open {fs_file}: {e:?}"),
         };
@@ -714,7 +714,7 @@ impl Harness {
     /// readable (open should fail).
     async fn check_local_file(&self, inode: InodeNo) {
         let _stat = self.fs.getattr(inode).await.expect("stat should succeed");
-        let open = self.fs.open(inode, libc::O_RDONLY).await;
+        let open = self.fs.open(inode, libc::O_RDONLY, 0).await;
         assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
     }
 }


### PR DESCRIPTION
## Description of change

Currently, Mountpoint will complete an upload in two cases:
* on `release`, that is when the last file descriptor pointing to an open file handle is closed. This is transparent for the caller, but does not allow for reporting the outcome of the upload, nor for blocking until it is completed. This means that a read-after-close may not succeed because the upload is still in progress.
* on `fsync`, which is blocking and can return an error to the caller, but needs to be explicitly invoked before closing a file.

This change implements the `flush` operation, which is invoked when a file descriptor is closed. On `flush`, like on `fsync`, Mountpoint will complete the upload, block, and return on success or failure. In order to support common usage patterns where it is invoked multiple times, `flush`, unlike `fsync`, will be a no-op when invoked before any data has been written or by a different process than the one that originally opened the file.

## Does this change impact existing behavior?

Yes. Objects will be uploaded before `close` returns.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
