### PR TITLE
Correct region warning when endpoint url provided

### DIFF
--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -296,16 +296,17 @@ mod test {
     fn test_endpoint_arg_with_region() {
         let endpoint_config = EndpointConfig::new("us-east-1")
             .endpoint(Uri::new_from_str(&Allocator::default(), "https://s3.eu-west-1.amazonaws.com").unwrap());
-        let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
-            .unwrap()
-            .uri()
-            .unwrap();
+        let resolved_endpoint = endpoint_config.resolve_for_bucket("doc-example-bucket").unwrap();
+        let endpoint_uri = resolved_endpoint.uri().unwrap();
         // region is ignored when endpoint_url is specified
         assert_eq!(
             "https://doc-example-bucket.s3.eu-west-1.amazonaws.com",
             endpoint_uri.as_os_str()
         );
+        let endpoint_auth_scheme = resolved_endpoint.auth_scheme().unwrap();
+        let signing_region = endpoint_auth_scheme.signing_region();
+        //signing region is still the region provided
+        assert_eq!(signing_region, "us-east-1");
     }
 
     #[test]

--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -293,6 +293,22 @@ mod test {
     }
 
     #[test]
+    fn test_endpoint_arg_with_region() {
+        let endpoint_config = EndpointConfig::new("us-east-1")
+            .endpoint(Uri::new_from_str(&Allocator::default(), "https://s3.eu-west-1.amazonaws.com").unwrap());
+        let endpoint_uri = endpoint_config
+            .resolve_for_bucket("doc-example-bucket")
+            .unwrap()
+            .uri()
+            .unwrap();
+        // region is ignored when endpoint_url is specified
+        assert_eq!(
+            "https://doc-example-bucket.s3.eu-west-1.amazonaws.com",
+            endpoint_uri.as_os_str()
+        );
+    }
+
+    #[test]
     fn test_fips_dual_stack() {
         let endpoint_config = EndpointConfig::new("eu-west-1").use_fips(true).use_dual_stack(true);
         let endpoint_uri = endpoint_config

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -518,7 +518,7 @@ fn create_client_for_bucket(
     endpoint_config = endpoint_config.region(&region_to_try);
 
     if let Some(uri) = endpoint_url {
-        if user_provided_region {
+        if !user_provided_region {
             tracing::warn!(
                 "endpoint specified but region unspecified. using {} as the signing region.",
                 region_to_try


### PR DESCRIPTION
## Description of change
Corrected region warn message when endpoint url is provided. 
Also added unit test for endpoint resolution when endpoint_url is provided. It is to document the behaviour of resolver. endpoint_url overrides the region argument when endpoint resolution is done. But, signing region is still the region provided. In case no region is provided, Mountpoint detects the right region, so we don't need to make any further changes.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
NA

## Does this change impact existing behavior?
No.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
