### PR TITLE
Allow mounting to inherited fuse fd (part of #150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "memchr",
  "page_size",
  "pkg-config",
+ "regex",
  "serde",
  "smallvec",
  "tempfile",

--- a/vendor/fuser/Cargo.toml
+++ b/vendor/fuser/Cargo.toml
@@ -25,6 +25,7 @@ page_size = "0.4.2"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"
 zerocopy = "0.6"
+regex = "1.7.1"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/vendor/fuser/src/lib.rs
+++ b/vendor/fuser/src/lib.rs
@@ -27,6 +27,7 @@ use crate::session::MAX_WRITE_SIZE;
 #[cfg(feature = "abi-7-16")]
 pub use ll::fuse_abi::fuse_forget_one;
 pub use mnt::mount_options::MountOption;
+pub use mnt::Mount;
 #[cfg(target_os = "macos")]
 pub use reply::ReplyXTimes;
 pub use reply::ReplyXattr;

--- a/vendor/fuser/tests/integration_tests.rs
+++ b/vendor/fuser/tests/integration_tests.rs
@@ -1,8 +1,9 @@
-use fuser::{Filesystem, Session};
+use fuser::{Filesystem, Session, MountOption};
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
+use std::path::Path;
 
 #[test]
 #[cfg(target_os = "linux")]
@@ -20,4 +21,27 @@ fn unmount_no_send() {
         unmounter.unmount().unwrap();
     });
     session.run().unwrap();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn session_for_fd() {
+    struct DummyFs;
+
+    impl Filesystem for DummyFs {}
+
+    let path = Path::new("/dev/fd/3");
+    Session::new(DummyFs{}, &path, &[]).expect("shoud create a session");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn session_for_fd_auto_umount() {
+    #[derive(Debug)]
+    struct DummyFs;
+
+    impl Filesystem for DummyFs {}
+
+    let path = Path::new("/dev/fd/3");
+    Session::new(DummyFs{}, &path, &[MountOption::AutoUnmount]).expect_err("shoud not create a session");
 }


### PR DESCRIPTION
## Description of change

- This change allows passing `/dev/fd/N` as a `mount_dir`, which will make mountpoint to bypass mounting and serve fuse requests at the provided file descriptor;
- This allows mountpoint being executed without `CAP_SYS_ADMIN` and with [no_new_privs](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) flag, which [corresponds](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) to k8s's `allowPrivilegeEscalation=false` and is enabled by default;
- Similar feature is [provided](https://github.com/libfuse/libfuse/pull/291/files) by `mount.fuse3` command and by [gcs-fuse](https://github.com/GoogleCloudPlatform/gcsfuse/blob/8ab11cd07016a247f64023697383c6e88bc022b0/vendor/github.com/jacobsa/fuse/mount_linux.go#L128-L134);
- Changes are mostly located in `vendor/fuser`, making `fuser::mnt::Mount` struct public is required for testing and may be avoided.

Relevant issues: #150 

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).