### PR TITLE
Silence unnecessary-cast clippy error on linux arm64

### DIFF
--- a/mountpoint-s3-crt/src/common/logging.rs
+++ b/mountpoint-s3-crt/src/common/logging.rs
@@ -211,6 +211,7 @@ pub struct Subject(u32);
 
 impl Subject {
     /// Generate a string representation of the subject
+    #[allow(clippy::unnecessary_cast)]
     pub fn name(&self) -> &str {
         // Safety: `aws_log_subject_name` always returns a valid C string. Technically it's possible
         // for someone to call `aws_unregister_log_subject_info_list` to unregister a subject name


### PR DESCRIPTION
## Description of change

On linux arm64 `::libc::c_char` (returned by `aws_log_subject_name`) is defined as `u8`, so a cast to `u8` is flagged as unnecessary by clippy, but it is required on other platforms.

Error before this change:
```
error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
   --> mountpoint-s3-crt/src/common/logging.rs:222:52
    |
222 |             let bytes = std::slice::from_raw_parts(s as *const u8, len);
    |                                                    ^^^^^^^^^^^^^^ help: try: `s`
```

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
