### PR TITLE
Update CONFIGURATION.md to mention HTTPS endpoint explicitly

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -74,7 +74,7 @@ Mountpoint also respects access control lists (ACLs) applied to objects in your 
 
 ## S3 bucket configuration
 
-By default, Mountpoint will automatically mount your S3 bucket given only the bucket name, and will automatically select the appropriate S3 network endpoint. However, you can override this automation if you need finer control over how Mountpoint connects to your bucket.
+By default, Mountpoint will automatically mount your S3 bucket given only the bucket name, and will automatically select the appropriate S3 HTTPS endpoint. However, you can override this automation if you need finer control over how Mountpoint connects to your bucket.
 
 ### Mounting a bucket prefix
 


### PR DESCRIPTION
## Description of change

Some users reached out to clarify if mountpoint-s3 will use HTTPS or HTTP to access Amazon S3. By updating this documentation, it is clearer mountpoint-s3 will use HTTPS by default and can be found when performing text searches, etc..

It also adds a newline to the end of the file, which I can't avoid on GitHub editor. 🙈 

## Does this change impact existing behavior?

No, documentation only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
