### PR TITLE
Improve the instructions to add benchmark files manually

### DIFF
--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -41,9 +41,9 @@ You can use the following steps.
 
 3. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
 
-        mount-s3 DOC-EXAMPLE-BUCKET path/to/mount/ --prefix benchmark/ --part-size=16777216
-        cd mountpoint-s3/scripts/fio/
         MOUNT_DIR = path/to/mount
+        mount-s3 DOC-EXAMPLE-BUCKET $MOUNT_DIR/ --prefix benchmark/ --part-size=16777216
+        cd mountpoint-s3/scripts/fio/
         fio --directory=$MOUNT_DIR/ --filename=bench5MB.bin --create_only=1 read/seq_read_small.fio
         fio --directory=$MOUNT_DIR/ --filename=bench100GB.bin --create_only=1 read/seq_read.fio
         mkdir $MOUNT_DIR/bench_dir_100/ $MOUNT_DIR/bench_dir_1000/ $MOUNT_DIR/bench_dir_10000/ $MOUNT_DIR/bench_dir_100000/

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -26,7 +26,7 @@ We keep the records of benchmarking results in `gh-pages` branch and the perform
 While our benchmark script is written for CI testing only, it is possible to run manually.
 You can use the following steps.
 
-1. Install dependencies and configure FUSE by running the following script in the repository:
+1. Install dependencies and configure FUSE by running the following script in the `mountpoint-s3` repository:
 
         bash .github/actions/install-dependencies/install.sh \
                 --fuse-version 2 \
@@ -39,10 +39,15 @@ You can use the following steps.
         export S3_BUCKET_BENCH_FILE=bench_file_name
         export S3_BUCKET_SMALL_BENCH_FILE=small_bench_file_name
 
-3. Create the bench files manually in your bucket. The size of the files must be exactly the same as the size defined in fio configuration files. The easiest way to do this is running fio against your local file system first to let fio create the files for you, and then upload them to your S3 bucket using the AWS CLI. For example:
+3. Create the bench files manually in your bucket. The size of the files must be exactly the same as the size defined in fio configuration files. The easiest way to do this is mounting your bucket on local file system using mountpoint-s3.Then, running fio against your mount directory to let fio create the files for you. For example:
+* To create small benchmark file for read workload use:
 
-        fio --directory=your_local_dir --filename=your_file_name mountpoint-s3/scripts/fio/read/seq_read_small.fio
-        aws s3 cp your_local_dir/your_file_name s3://${S3_BUCKET_NAME}/${S3_BUCKET_TEST_PREFIX}
+        fio --directory=your_mount_dir --filename=your_file_name mountpoint-s3/scripts/fio/read/seq_read_small.fio
+
+* To create directory with 10000 files for readdir workload use:
+
+        mkdir bench_dir_10000
+        fio --directory=your_mount_dir/bench_dir_10000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_10000.fio
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -43,13 +43,14 @@ You can use the following steps.
 
         mount-s3 DOC-EXAMPLE-BUCKET path/to/mount/ --prefix benchmark/ --part-size=16777216
         cd mountpoint-s3/scripts/fio/
-        fio --directory=path/to/mount/ --filename=bench5MB.bin read/seq_read_small.fio --create-only=1
-        fio --directory=path/to/mount/ --filename=bench100GB.bin read/seq_read.fio --create-only=1
-        mkdir path/to/mount/bench_dir_100/ path/to/mount/bench_dir_1000/ path/to/mount/bench_dir_10000/ path/to/mount/bench_dir_100000/
-        fio --directory=path/to/mount/bench_dir_100 create/create_files_100.fio --create-only=1
-        fio --directory=path/to/mount/bench_dir_1000 create/create_files_1000.fio --create-only=1
-        fio --directory=path/to/mount/bench_dir_10000 create/create_files_10000.fio --create-only=1
-        fio --directory=path/to/mount/bench_dir_100000 create/create_files_100000.fio --create-only=1
+        MOUNT_DIR = path/to/mount
+        fio --directory=$MOUNT_DIR/ --filename=bench5MB.bin --create_only=1 read/seq_read_small.fio
+        fio --directory=$MOUNT_DIR/ --filename=bench100GB.bin --create_only=1 read/seq_read.fio
+        mkdir $MOUNT_DIR/bench_dir_100/ $MOUNT_DIR/bench_dir_1000/ $MOUNT_DIR/bench_dir_10000/ $MOUNT_DIR/bench_dir_100000/
+        fio --directory=$MOUNT_DIR/bench_dir_100 create/create_files_100.fio
+        fio --directory=$MOUNT_DIR/bench_dir_1000 create/create_files_1000.fio
+        fio --directory=$MOUNT_DIR/bench_dir_10000 create/create_files_10000.fio
+        fio --directory=$MOUNT_DIR/bench_dir_100000 create/create_files_100000.fio
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -39,15 +39,17 @@ You can use the following steps.
         export S3_BUCKET_BENCH_FILE=bench_file_name
         export S3_BUCKET_SMALL_BENCH_FILE=small_bench_file_name
 
-3. Create the bench files manually in your bucket. The size of the files must be exactly the same as the size defined in fio configuration files. The easiest way to do this is mounting your bucket on local file system using mountpoint-s3.Then, running fio against your mount directory to let fio create the files for you. For example:
-* To create small benchmark file for read workload use:
+3. Create the bench files manually in your bucket(create a `benchmark` directory in it if not present). The size of the files must be exactly the same as the size defined in fio configuration files. The easiest way to do this is mounting your bucket on local file system using mountpoint-s3. Then, running fio against your mount directory to let fio create the files for you.
 
-        fio --directory=your_mount_dir --filename=your_file_name mountpoint-s3/scripts/fio/read/seq_read_small.fio
-
-* To create directory with 10000 files for readdir workload use:
-
-        mkdir bench_dir_10000
+        mount-s3 your-bucket-name your_mount_dir/ --allow-delete --prefix benchmark/
+        cd your_mount_dir/
+        fio --directory=your_mount_dir --filename=bench5MB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
+        fio --directory=your_mount_dir --filename=bench100GB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
+        mkdir bench_dir_100/ bench_dir_1000/ bench_dir_10000/ bench_dir_100000/
+        fio --directory=your_mount_dir/bench_dir_100 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_100.fio
+        fio --directory=your_mount_dir/bench_dir_1000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_1000.fio
         fio --directory=your_mount_dir/bench_dir_10000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_10000.fio
+        fio --directory=your_mount_dir/bench_dir_100000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_100000.fio
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -41,7 +41,7 @@ You can use the following steps.
 
 3. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
 
-        MOUNT_DIR = path/to/mount
+        MOUNT_DIR=path/to/mount
         mount-s3 DOC-EXAMPLE-BUCKET $MOUNT_DIR/ --prefix benchmark/ --part-size=16777216
         cd mountpoint-s3/scripts/fio/
         fio --directory=$MOUNT_DIR/ --filename=bench5MB.bin --create_only=1 read/seq_read_small.fio

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -46,10 +46,10 @@ You can use the following steps.
         fio --directory=your_mount_dir --filename=bench5MB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
         fio --directory=your_mount_dir --filename=bench100GB.bin mountpoint-s3/scripts/fio/read/seq_read.fio
         mkdir bench_dir_100/ bench_dir_1000/ bench_dir_10000/ bench_dir_100000/
-        fio --directory=your_mount_dir/bench_dir_100 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_100.fio
-        fio --directory=your_mount_dir/bench_dir_1000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_1000.fio
-        fio --directory=your_mount_dir/bench_dir_10000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_10000.fio
-        fio --directory=your_mount_dir/bench_dir_100000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_100000.fio
+        fio --directory=your_mount_dir/bench_dir_100 mountpoint-s3/scripts/fio/create/create_files_100.fio
+        fio --directory=your_mount_dir/bench_dir_1000 mountpoint-s3/scripts/fio/create/create_files_1000.fio
+        fio --directory=your_mount_dir/bench_dir_10000 mountpoint-s3/scripts/fio/create/create_files_10000.fio
+        fio --directory=your_mount_dir/bench_dir_100000 mountpoint-s3/scripts/fio/create/create_files_100000.fio
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -44,7 +44,7 @@ You can use the following steps.
         mount-s3 your-bucket-name your_mount_dir/ --allow-delete --prefix benchmark/
         cd your_mount_dir/
         fio --directory=your_mount_dir --filename=bench5MB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
-        fio --directory=your_mount_dir --filename=bench100GB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
+        fio --directory=your_mount_dir --filename=bench100GB.bin mountpoint-s3/scripts/fio/read/seq_read.fio
         mkdir bench_dir_100/ bench_dir_1000/ bench_dir_10000/ bench_dir_100000/
         fio --directory=your_mount_dir/bench_dir_100 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_100.fio
         fio --directory=your_mount_dir/bench_dir_1000 --filename=your_file_name mountpoint-s3/scripts/fio/create/create_files_1000.fio

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -39,17 +39,17 @@ You can use the following steps.
         export S3_BUCKET_BENCH_FILE=bench_file_name
         export S3_BUCKET_SMALL_BENCH_FILE=small_bench_file_name
 
-3. Create the bench files manually in your bucket(create a `benchmark` directory in it if not present). The size of the files must be exactly the same as the size defined in fio configuration files. The easiest way to do this is mounting your bucket on local file system using mountpoint-s3. Then, running fio against your mount directory to let fio create the files for you.
+3. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
 
-        mount-s3 your-bucket-name your_mount_dir/ --allow-delete --prefix benchmark/
-        cd your_mount_dir/
-        fio --directory=your_mount_dir --filename=bench5MB.bin mountpoint-s3/scripts/fio/read/seq_read_small.fio
-        fio --directory=your_mount_dir --filename=bench100GB.bin mountpoint-s3/scripts/fio/read/seq_read.fio
-        mkdir bench_dir_100/ bench_dir_1000/ bench_dir_10000/ bench_dir_100000/
-        fio --directory=your_mount_dir/bench_dir_100 mountpoint-s3/scripts/fio/create/create_files_100.fio
-        fio --directory=your_mount_dir/bench_dir_1000 mountpoint-s3/scripts/fio/create/create_files_1000.fio
-        fio --directory=your_mount_dir/bench_dir_10000 mountpoint-s3/scripts/fio/create/create_files_10000.fio
-        fio --directory=your_mount_dir/bench_dir_100000 mountpoint-s3/scripts/fio/create/create_files_100000.fio
+        mount-s3 DOC-EXAMPLE-BUCKET path/to/mount/ --prefix benchmark/ --part-size=16777216
+        cd mountpoint-s3/scripts/fio/
+        fio --directory=path/to/mount/ --filename=bench5MB.bin read/seq_read_small.fio --create-only=1
+        fio --directory=path/to/mount/ --filename=bench100GB.bin read/seq_read.fio --create-only=1
+        mkdir path/to/mount/bench_dir_100/ path/to/mount/bench_dir_1000/ path/to/mount/bench_dir_10000/ path/to/mount/bench_dir_100000/
+        fio --directory=path/to/mount/bench_dir_100 create/create_files_100.fio --create-only=1
+        fio --directory=path/to/mount/bench_dir_1000 create/create_files_1000.fio --create-only=1
+        fio --directory=path/to/mount/bench_dir_10000 create/create_files_10000.fio --create-only=1
+        fio --directory=path/to/mount/bench_dir_100000 create/create_files_100000.fio --create-only=1
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 


### PR DESCRIPTION
Improved the instructions to add benchmark files manually in doc/BENCHMARKING.md.

## Description of change
As write is enabled on mountpoint, easiest way to manually add benchmark files is using fio on mounted directory for the bucket. Also, added instruction for adding directories for `readdir` workload using fio.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
NA

## Does this change impact existing behavior?
No
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
