### PR TITLE
Refactor signing config and set a default signing config for s3 client

### DIFF
--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -5,8 +5,9 @@ use std::ptr::NonNull;
 
 use mountpoint_s3_crt_sys::{
     aws_credentials_provider, aws_credentials_provider_acquire, aws_credentials_provider_chain_default_options,
-    aws_credentials_provider_new_chain_default, aws_credentials_provider_new_profile,
-    aws_credentials_provider_new_static, aws_credentials_provider_profile_options, aws_credentials_provider_release,
+    aws_credentials_provider_new_anonymous, aws_credentials_provider_new_chain_default,
+    aws_credentials_provider_new_profile, aws_credentials_provider_new_static,
+    aws_credentials_provider_profile_options, aws_credentials_provider_release,
     aws_credentials_provider_static_options,
 };
 
@@ -80,6 +81,19 @@ impl CredentialsProvider {
         // SAFETY: aws_credentials_provider_new_chain_default makes a copy of the bootstrap options.
         let inner = unsafe {
             aws_credentials_provider_new_chain_default(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
+        };
+
+        Ok(Self { inner })
+    }
+
+    /// Creates the anonymous credential provider.
+    /// Anonynous credentials provider gives you anonymous credentials which can be used to skip the signing process.
+    pub fn new_anonymous(allocator: &Allocator) -> Result<Self, Error> {
+        auth_library_init(allocator);
+
+        // SAFETY: allocator is a valid aws_allocator and shutdown_options is optional
+        let inner = unsafe {
+            aws_credentials_provider_new_anonymous(allocator.inner.as_ptr(), std::ptr::null_mut()).ok_or_last_error()?
         };
 
         Ok(Self { inner })

--- a/mountpoint-s3-crt/src/auth/signing_config.rs
+++ b/mountpoint-s3-crt/src/auth/signing_config.rs
@@ -1,7 +1,8 @@
 //! Configuration for signing requests to AWS APIs
 
 use crate::auth::credentials::CredentialsProvider;
-use mountpoint_s3_crt_sys::{aws_signing_algorithm, aws_signing_config_aws};
+use crate::ToAwsByteCursor;
+use mountpoint_s3_crt_sys::{aws_s3_init_default_signing_config, aws_signing_algorithm, aws_signing_config_aws};
 use std::ffi::OsString;
 use std::fmt::Debug;
 use std::marker::PhantomPinned;
@@ -18,7 +19,7 @@ pub(crate) struct SigningConfigInner {
     pub(crate) credentials_provider: CredentialsProvider,
 
     /// An owned copy of the service string, since the `aws_signing_config_aws` holds a pointer to it.
-    pub(crate) service: OsString,
+    pub(crate) service: Option<OsString>,
 
     /// This forces the struct to be !Unpin, because the signing config can contain pointers to itself
     pub(crate) _pinned: PhantomPinned,
@@ -29,6 +30,49 @@ impl Debug for SigningConfigInner {
         f.debug_struct("SigningConfigInner")
             .field("region", &self.region)
             .finish()
+    }
+}
+
+impl SigningConfigInner {
+    /// Create a new [SigningConfig] with default options.
+    pub fn new(region: &str, credentials_provider: CredentialsProvider) -> Self {
+        let mut signing_config = SigningConfigInner {
+            inner: Default::default(),
+            region: region.to_owned().into(),
+            credentials_provider,
+            service: None,
+            _pinned: Default::default(),
+        };
+
+        let credentials_provider = signing_config.credentials_provider.inner.as_ptr();
+        // SAFETY: `region` is owned by signing_config (see `region.to_owned()` above),
+        // so the byte cursors we create here will point to bytes that are valid as long as this SigningConfig is.
+        // singing_config owns `credential_provider` that is valid as long as this SingingConfig is.
+        unsafe {
+            let region_cursor = signing_config.region.as_aws_byte_cursor();
+            aws_s3_init_default_signing_config(&mut signing_config.inner, region_cursor, credentials_provider);
+        }
+
+        signing_config
+    }
+
+    /// Set the service name
+    pub fn service(&mut self, service: &str) {
+        self.service = Some(service.to_owned().into());
+        // SAFETY: `service` is owned by signing_config,
+        // so the byte cursors we create here will point to bytes that are valid as long as this SigningConfig is.
+        let service_cursor = unsafe { self.service.as_ref().unwrap().as_aws_byte_cursor() };
+        self.inner.service = service_cursor;
+    }
+
+    /// Set whether to use double URI encode or not
+    pub fn use_double_uri_encode(&mut self, use_double_uri_encode: bool) {
+        self.inner.flags.set_use_double_uri_encode(use_double_uri_encode as u32);
+    }
+
+    /// Set the signing algorithm
+    pub fn algorithm(&mut self, algorithm: SigningAlgorithm) {
+        self.inner.algorithm = algorithm.into();
     }
 }
 


### PR DESCRIPTION
## Description of change

This PR refactors the signing config and also set a default signing config for s3 client to prepare for upcoming changes.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
