### PR TITLE
Implement CacheConfig field permitting some operations to return non-expired cache data

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -111,6 +111,7 @@ where
 {
     let filesystem_config = S3FilesystemConfig {
         cache_config: CacheConfig {
+            prefer_s3: true,
             file_ttl: Duration::ZERO,
             dir_ttl: Duration::ZERO,
         },

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -2,11 +2,12 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use fuser::FileType;
 use futures::executor::ThreadPool;
 use futures::future::{BoxFuture, FutureExt};
-use mountpoint_s3::fs::{self, InodeNo, ReadReplier, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{self, CacheConfig, InodeNo, ReadReplier, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
 use mountpoint_s3_client::mock_client::{MockClient, MockObject};
@@ -885,6 +886,12 @@ mod mutations {
         let config = S3FilesystemConfig {
             readdir_size: 5,
             allow_delete: true,
+            cache_config: CacheConfig {
+                // We are only interested in strong consistency for the reference tests. FUSE isn't even in the loop.
+                prefer_s3: true,
+                dir_ttl: Duration::ZERO,
+                file_ttl: Duration::ZERO,
+            },
             ..Default::default()
         };
         let (client, fs) = make_test_filesystem(BUCKET_NAME, &test_prefix, config);


### PR DESCRIPTION
## Description of change

This plumbs in checks for if the filesystem should check with S3 to ensure we're consistent with S3 at open, create, etc.

There is no way to configure mountpoint-s3 itself to relax the consistency model - this change only impacts internals.

Relevant issues: #255

## Does this change impact existing behavior?

If the new field is set to false, it does impact the consistency model of the `mountpoint-s3::fs::S3Filesystem`. This is not configurable during mounting at this time, but may be in the future.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
