### PR TITLE
Add configurable user agent prefix flag for mount-s3

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Breaking changes
+* ...
+
+### Other changes
+* Introduced `--user-agent-prefix <PREFIX>` CLI argument ([#548](https://github.com/awslabs/mountpoint-s3/pull/548)) to optionally allow invoker of `mount-s3` to specify an additional prefix for the HTTP User-Agent header.
+
 ## v1.0.2 (September 22, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -4,8 +4,8 @@
 * ...
 
 ### Other changes
-* Introduced `--user-agent-prefix <PREFIX>` CLI argument ([#548](https://github.com/awslabs/mountpoint-s3/pull/548)) to optionally allow invoker of `mount-s3` to specify an additional prefix for the HTTP User-Agent header.
 * Fixed a bug that cause poor performance for sequential reads in some cases ([#488](https://github.com/awslabs/mountpoint-s3/pull/488)). A workaround we have previously shared for this issue (setting the `--max-threads` argument to `1`) is no longer necessary with this fix. ([#556](https://github.com/awslabs/mountpoint-s3/pull/556))
+* Introduced `--user-agent-prefix <PREFIX>` CLI argument ([#548](https://github.com/awslabs/mountpoint-s3/pull/548)) to optionally allow invoker of `mount-s3` to specify an additional prefix for the HTTP User-Agent header.
 
 ## v1.0.2 (September 22, 2023)
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -35,6 +35,7 @@ const AWS_CREDENTIALS_OPTIONS_HEADER: &str = "AWS credentials options";
 const LOGGING_OPTIONS_HEADER: &str = "Logging options";
 #[cfg(feature = "caching")]
 const CACHING_OPTIONS_HEADER: &str = "Caching options";
+const ADVANCED_OPTIONS_HEADER: &str = "Advanced options";
 
 #[derive(Parser)]
 #[clap(name = "mount-s3", about = "Mountpoint for Amazon S3", version = build_info::FULL_VERSION)]
@@ -241,7 +242,7 @@ struct CliArgs {
         long,
         help = "Configure a string to be prepended to the 'User-Agent' HTTP request header for all S3 requests",
         value_name = "PREFIX",
-        help_heading = CLIENT_OPTIONS_HEADER
+        help_heading = ADVANCED_OPTIONS_HEADER,
     )]
     pub user_agent_prefix: Option<String>,
 }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -121,14 +121,6 @@ struct CliArgs {
 
     #[clap(
         long,
-        help = "Configure a string to be prepended to the 'User-Agent' HTTP request header for all S3 requests",
-        value_name = "PREFIX",
-        help_heading = CLIENT_OPTIONS_HEADER
-    )]
-    pub user_agent_prefix: Option<String>,
-
-    #[clap(
-        long,
         help = "Maximum throughput in Gbps [default: auto-detected on EC2 instances, 10 Gbps elsewhere]",
         value_name = "N",
         value_parser = value_parser!(u64).range(1..),
@@ -244,6 +236,14 @@ struct CliArgs {
         requires = "enable_metadata_caching",
     )]
     pub metadata_cache_ttl: Option<Duration>,
+
+    #[clap(
+        long,
+        help = "Configure a string to be prepended to the 'User-Agent' HTTP request header for all S3 requests",
+        value_name = "PREFIX",
+        help_heading = CLIENT_OPTIONS_HEADER
+    )]
+    pub user_agent_prefix: Option<String>,
 }
 
 impl CliArgs {


### PR DESCRIPTION
## Description of change

If mountpoint-s3 is run as part of a larger application, user/customer may want to configure a prefix for the user agent to indicate S3 requests came from that particular application.

This change adds a new `--user-agent-prefix <PREFIX>` flag to achieve this.

Relevant issues: #546

## Does this change impact existing behavior?

No change to existing behaviour. Users can now add a prefix to the HTTP 'User-Agent' header.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
