### PR TITLE
Allow seeking within a prefetch stream

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Breaking changes
+* ...
+
+### Other changes
+* Fixed a bug that cause poor performance for sequential reads in some cases ([#488](https://github.com/awslabs/mountpoint-s3/pull/488)). A workaround we have previously shared for this issue (setting the `--max-threads` argument to `1`) is no longer necessary with this fix. ([#556](https://github.com/awslabs/mountpoint-s3/pull/556))
+
 ## v1.0.2 (September 22, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3/src/prefetch/checksummed_bytes.rs
+++ b/mountpoint-s3/src/prefetch/checksummed_bytes.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 /// A `ChecksummedBytes` is a bytes buffer that carries its checksum.
 /// The implementation guarantees that its integrity will be validated when data transformation occurs.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChecksummedBytes {
     orig_bytes: Bytes,
     curr_slice: Bytes,

--- a/mountpoint-s3/src/prefetch/part.rs
+++ b/mountpoint-s3/src/prefetch/part.rs
@@ -7,7 +7,7 @@ use super::checksummed_bytes::ChecksummedBytes;
 // TODO this is not very efficient right now -- it forces a lot of copying around of Strings. If
 // that's a bottleneck, let's think about either carrying &str (hard to make lifetimes work?) or
 // the etag or some kind of "cookie" (like the hash of the key).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Part {
     key: String,
     offset: u64,

--- a/mountpoint-s3/src/prefetch/seek_window.rs
+++ b/mountpoint-s3/src/prefetch/seek_window.rs
@@ -1,0 +1,78 @@
+use std::collections::VecDeque;
+
+use crate::prefetch::part::Part;
+
+/// A backwards seek window for a single prefetch stream. Parts can be pushed onto the end of the
+/// window (== closest to the current offset in the stream) and older parts will be dropped to
+/// remain within a maximum size.
+#[derive(Debug)]
+pub struct SeekWindow {
+    parts: VecDeque<Part>,
+    max_size: usize,
+    current_size: usize,
+}
+
+impl SeekWindow {
+    pub fn new(max_size: usize) -> Self {
+        assert!(max_size > 0);
+        SeekWindow {
+            parts: VecDeque::new(),
+            max_size,
+            current_size: 0,
+        }
+    }
+
+    /// Add a new part to the front of the window, and drop any parts necessary to fit the new part
+    /// within the maximum size.
+    pub fn push(&mut self, part: Part) {
+        if part.len() > self.max_size {
+            self.clear();
+            return;
+        }
+
+        while self.max_size - self.current_size < part.len() {
+            let p = self
+                .parts
+                .pop_front()
+                .expect("window is non-empty if current size is non-zero");
+            self.current_size -= p.len();
+        }
+
+        self.current_size += part.len();
+        self.parts.push_back(part);
+    }
+
+    /// Read off the back of the window. Returns None if there's not enough data in the window to
+    /// satisfy the desired length.
+    pub fn read_back(&mut self, mut length: usize) -> Option<Vec<Part>> {
+        if length > self.current_size {
+            return None;
+        }
+
+        let mut result = VecDeque::new();
+        loop {
+            if length == 0 {
+                break;
+            }
+            let mut part = self.parts.pop_back().expect("we checked that current_size >= length");
+            // If we only need some of this part, split it up and put the rest back onto the window
+            if part.len() > length {
+                let back = part.split_off(part.len() - length);
+                self.parts.push_back(part);
+                part = back;
+            }
+            length -= part.len();
+            self.current_size -= part.len();
+            // We're walking backwards through the queue, so to keep the result in object offset
+            // order, push to the front.
+            result.push_front(part);
+        }
+        Some(result.into())
+    }
+
+    /// Reset the seek window to an empty state
+    pub fn clear(&mut self) {
+        self.parts.drain(..);
+        self.current_size = 0;
+    }
+}


### PR DESCRIPTION
## Description of change

This change addresses two problems:
1. Linux asynchronous readahead confuses our prefetcher by sometimes making the stream appear to go backwards, even though the customer is actually just reading sequentially (#488). The problem is that with parallel FUSE threads, the two asynchronous read operations can arrive to the prefetcher out of order.
2. Request patterns that seek forwards through an object (say, reading a byte at every 1MB interval) currently don't benefit from prefetching at all, even though it would be dramatically faster and cheaper to stream the entire object.

To solve these problems, this change allows the prefetcher to tolerate a little bit of seeking in both directions.
* For forwards seeking, when we see a seek of an acceptable distance, we fast-forward through the stream to the desired target offset, ignoring the skipped bytes (except for later use in backwards seeking, see below). 
* For backwards seeking, we keep around a little bit of previously read data (or data skipped by forwards seeking) and can reload it in the event that a seek goes backwards. We do this by creating a fake new request containing the rewound bytes, so that the existing read logic will pick them up.

These seek mechanisms are protected by two new configurations for maximum forwards and backwards seek distance. Forwards seek distance is a trade-off between waiting to stream many unneeded bytes from S3 versus the latency of starting a new request. Backwards seek distance is a memory usage trade-off. In both cases, I chose fairly arbitrary numbers, except that the buffers are big enough to tolerate Linux async readahead (which manifests as 256k backwards then 512k forwards).

I tested the effectiveness of this change in two ways:
* To check we fixed #488 I tried some sequential reads. They're no longer sometimes slow, and the metrics confirm the new seek logic is being triggered the way we expect.
* To check that forwards seeking works well, I wrote a benchmark that reads 1024 bytes at every 1MiB interval in an object. That benchmark went from ~25s without this change to ~0.7s with this change, for a 2GiB file.

Relevant issues: #488

## Does this change impact existing behavior?

No, this is a bug fix that improves performance.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
