### PR TITLE
Add new DataCache trait and InMemoryDataCache implementation

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -35,10 +35,10 @@ pub trait DataCache<Key> {
     /// Get block of data from the cache for the given [Key] and [BlockIndex], if available.
     ///
     /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
-    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<&ChecksummedBytes>>;
+    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [Key] and [BlockIndex].
-    fn put_block(&mut self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
+    fn put_block(&self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
 
     /// Returns the block size for the data cache.
     fn block_size(&self) -> u64;

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -18,9 +18,10 @@ pub type BlockIndex = u64;
 /// Errors returned by operations on a [DataCache]
 #[derive(Debug, Error)]
 pub enum DataCacheError {
-    /// It was not possible to read from the cache
-    #[error("Failed reading or writing from cache: {0}")]
-    IoFailure(#[source] anyhow::Error),
+    #[error("IO error when reading or writing from cache: {0}")]
+    IoFailure(#[from] std::io::Error),
+    #[error("Block content was not valid/readable")]
+    InvalidBlockContent,
 }
 
 pub type DataCacheResult<Value> = Result<Value, DataCacheError>;

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -4,7 +4,7 @@
 //! reducing both the number of requests as well as the latency for the reads.
 //! Ultimately, this means reduced cost in terms of S3 billing as well as compute time.
 
-mod in_memory_data_cache;
+pub mod in_memory_data_cache;
 
 use std::ops::Range;
 

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -40,12 +40,11 @@ pub trait DataCache<Key> {
     /// Put block of data to the cache for the given [Key] and [BlockIndex].
     fn put_block(&mut self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
 
-    /// For a given byte range, which blocks should contain the cached data if available?
-    ///
-    /// This does not perform any check to see if the relevant data is cached.
-    fn indices_for_byte_range(&self, range: Range<u64>) -> Range<BlockIndex>;
+    /// Returns the block size for the data cache.
+    fn block_size(&self) -> u64;
 
     /// For the given range of blocks, which are present in the cache?
+    /// Indices in the vector are already sorted.
     ///
     /// It is possible that the **blocks may be deleted before reading**, or may be corrupted or inaccessible.
     /// This method only indicates that a cache entry was present at the time of calling.

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -9,7 +9,7 @@ use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
-struct InMemoryDataCache<CacheKey> {
+pub struct InMemoryDataCache<CacheKey> {
     data: RwLock<HashMap<CacheKey, HashMap<BlockIndex, ChecksummedBytes>>>,
     block_size: u64,
 }

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -55,7 +55,6 @@ mod tests {
 
     use bytes::Bytes;
 
-    use crate::prefetch::checksummed_bytes::assert_eq_checksummed_bytes;
     use mountpoint_s3_crt::checksums::crc32c;
 
     type TestCacheKey = String;
@@ -88,9 +87,8 @@ mod tests {
             .get_block(&cache_key_1, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
-        assert_eq_checksummed_bytes!(
-            &data_1,
-            entry,
+        assert_eq!(
+            &data_1, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -102,9 +100,8 @@ mod tests {
             .get_block(&cache_key_2, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
-        assert_eq_checksummed_bytes!(
-            &data_2,
-            entry,
+        assert_eq!(
+            &data_2, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -116,9 +113,8 @@ mod tests {
             .get_block(&cache_key_1, 1)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
-        assert_eq_checksummed_bytes!(
-            &data_3,
-            entry,
+        assert_eq!(
+            &data_3, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -127,9 +123,8 @@ mod tests {
             .get_block(&cache_key_1, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
-        assert_eq_checksummed_bytes!(
-            &data_1,
-            entry,
+        assert_eq!(
+            &data_1, entry,
             "cache entry returned should match original bytes after put"
         );
     }

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -92,7 +92,7 @@ mod tests {
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
-            &data_1, entry,
+            data_1, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -105,7 +105,7 @@ mod tests {
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
-            &data_2, entry,
+            data_2, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -118,7 +118,7 @@ mod tests {
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
-            &data_3, entry,
+            data_3, entry,
             "cache entry returned should match original bytes after put"
         );
 
@@ -128,7 +128,7 @@ mod tests {
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
-            &data_1, entry,
+            data_1, entry,
             "cache entry returned should match original bytes after put"
         );
     }

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -1,0 +1,187 @@
+//! Module for the in-memory data cache implementation used for testing.
+
+use std::collections::HashMap;
+use std::default::Default;
+use std::hash::Hash;
+use std::ops::Range;
+
+use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
+
+/// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
+struct InMemoryDataCache<CacheKey> {
+    data: HashMap<CacheKey, HashMap<BlockIndex, ChecksummedBytes>>,
+    block_size: u64,
+}
+
+impl<Key> InMemoryDataCache<Key> {
+    /// Create a new instance of an [InMemoryDataCache] with the specified `block_size`.
+    pub fn new(block_size: u64) -> Self {
+        InMemoryDataCache {
+            data: Default::default(),
+            block_size,
+        }
+    }
+}
+
+impl<Key: Eq + Hash> DataCache<Key> for InMemoryDataCache<Key> {
+    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<&ChecksummedBytes>> {
+        let block_data = self.data.get(cache_key).and_then(|blocks| blocks.get(&block_idx));
+        Ok(block_data)
+    }
+
+    fn put_block(&mut self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()> {
+        let blocks = self.data.entry(cache_key).or_default();
+        blocks.insert(block_idx, bytes);
+        Ok(())
+    }
+
+    fn indices_for_byte_range(&self, range: Range<u64>) -> Range<BlockIndex> {
+        let start_block = range.start / self.block_size;
+        let mut end_block = range.end / self.block_size;
+        if !range.is_empty() && range.end % self.block_size != 0 {
+            end_block += 1;
+        }
+
+        start_block..end_block
+    }
+
+    fn cached_block_indices(&self, cache_key: &Key, range: Range<BlockIndex>) -> DataCacheResult<Vec<BlockIndex>> {
+        let result = match self.data.get(cache_key) {
+            None => Vec::new(),
+            Some(blocks) => range.into_iter().filter(|idx| blocks.contains_key(idx)).collect(),
+        };
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    use test_case::test_case;
+
+    use crate::prefetch::checksummed_bytes::assert_eq_checksummed_bytes;
+    use mountpoint_s3_crt::checksums::crc32c;
+
+    type TestCacheKey = String;
+
+    #[test]
+    fn test_put_get() {
+        let data_1 = Bytes::from_static(b"Hello world");
+        let data_1 = ChecksummedBytes::new(data_1.clone(), crc32c::checksum(&data_1));
+        let data_2 = Bytes::from_static(b"Foo bar");
+        let data_2 = ChecksummedBytes::new(data_2.clone(), crc32c::checksum(&data_2));
+        let data_3 = Bytes::from_static(b"Baz");
+        let data_3 = ChecksummedBytes::new(data_3.clone(), crc32c::checksum(&data_3));
+
+        let mut cache = InMemoryDataCache::new(8 * 1024 * 1024);
+        let cache_key_1: TestCacheKey = String::from("a");
+        let cache_key_2: TestCacheKey = String::from("b");
+
+        let block = cache.get_block(&cache_key_1, 0).expect("cache is accessible");
+        assert!(
+            block.is_none(),
+            "no entry should be available to return but got {:?}",
+            block,
+        );
+
+        // PUT and GET, OK?
+        cache
+            .put_block(cache_key_1.clone(), 0, data_1.clone())
+            .expect("cache is accessible");
+        let entry = cache
+            .get_block(&cache_key_1, 0)
+            .expect("cache is accessible")
+            .expect("cache entry should be returned");
+        assert_eq_checksummed_bytes!(
+            &data_1,
+            entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // PUT AND GET a second file, OK?
+        cache
+            .put_block(cache_key_2.clone(), 0, data_2.clone())
+            .expect("cache is accessible");
+        let entry = cache
+            .get_block(&cache_key_2, 0)
+            .expect("cache is accessible")
+            .expect("cache entry should be returned");
+        assert_eq_checksummed_bytes!(
+            &data_2,
+            entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // PUT AND GET a second block in a cache entry, OK?
+        cache
+            .put_block(cache_key_1.clone(), 1, data_3.clone())
+            .expect("cache is accessible");
+        let entry = cache
+            .get_block(&cache_key_1, 1)
+            .expect("cache is accessible")
+            .expect("cache entry should be returned");
+        assert_eq_checksummed_bytes!(
+            &data_3,
+            entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // Entry 1's first block still intact
+        let entry = cache
+            .get_block(&cache_key_1, 0)
+            .expect("cache is accessible")
+            .expect("cache entry should be returned");
+        assert_eq_checksummed_bytes!(
+            &data_1,
+            entry,
+            "cache entry returned should match original bytes after put"
+        );
+    }
+
+    #[test]
+    fn test_cached_indices() {
+        let data_1 = Bytes::from_static(b"Hello world");
+        let data_1 = ChecksummedBytes::new(data_1.clone(), crc32c::checksum(&data_1));
+        let data_2 = Bytes::from_static(b"Foo bar");
+        let data_2 = ChecksummedBytes::new(data_2.clone(), crc32c::checksum(&data_2));
+
+        let mut cache = InMemoryDataCache::new(8 * 1024 * 1024);
+        let cache_key_1: TestCacheKey = String::from("a");
+        let cache_key_2: TestCacheKey = String::from("b");
+
+        let cached_indices = cache
+            .cached_block_indices(&cache_key_1, 0..5)
+            .expect("should not error");
+        let expected: Vec<BlockIndex> = Vec::new();
+        assert_eq!(cached_indices, expected);
+
+        cache
+            .put_block(cache_key_1.clone(), 2, data_1.clone())
+            .expect("no reason to error, cache is accessible");
+        cache
+            .put_block(cache_key_1.clone(), 3, data_2.clone())
+            .expect("no reason to error, cache is accessible");
+        cache
+            .put_block(cache_key_2.clone(), 5, data_2.clone())
+            .expect("no reason to error, cache is accessible");
+
+        let cached_indices = cache
+            .cached_block_indices(&cache_key_1, 0..12)
+            .expect("should not error");
+        assert_eq!(cached_indices, vec![2, 3]);
+    }
+
+    #[test_case(8, 2..12, 0..2; "non-zero offset, multiple blocks")]
+    #[test_case(16, 2..12, 0..1; "different block size")]
+    #[test_case(8, 0..8, 0..1; "range size of block size")]
+    #[test_case(8, 0..9, 0..2; "range size of block size + 1")]
+    #[test_case(8, 80..160, 10..20; "large range")]
+    #[test_case(8, 5..5, 0..0; "empty range")]
+    fn test_blocks_for_byte_range(block_size: u64, input: Range<u64>, output: Range<BlockIndex>) {
+        let cache: InMemoryDataCache<TestCacheKey> = InMemoryDataCache::new(block_size);
+        assert_eq!(cache.indices_for_byte_range(input), output);
+    }
+}

--- a/mountpoint-s3/src/data_cache/mod.rs
+++ b/mountpoint-s3/src/data_cache/mod.rs
@@ -1,0 +1,54 @@
+//! Traits and types for data caching.
+//!
+//! The data cache aims to reduce repeated fetches of S3 object content,
+//! reducing both the number of requests as well as the latency for the reads.
+//! Ultimately, this means reduced cost in terms of S3 billing as well as compute time.
+
+mod in_memory_data_cache;
+
+use std::ops::Range;
+
+use thiserror::Error;
+
+pub use crate::prefetch::checksummed_bytes::ChecksummedBytes;
+
+/// Indexes blocks within a given object.
+pub type BlockIndex = u64;
+
+/// Errors returned by operations on a [DataCache]
+#[derive(Debug, Error)]
+pub enum DataCacheError {
+    /// It was not possible to read from the cache
+    #[error("Failed reading or writing from cache: {0}")]
+    IoFailure(#[source] anyhow::Error),
+}
+
+pub type DataCacheResult<Value> = Result<Value, DataCacheError>;
+
+/// Cache data with a checksum identified by some [Key].
+///
+/// The underlying cache is divided into blocks of equal size.
+///
+/// TODO: Deletion and eviction of cache entries.
+/// TODO: Some version information (ETag) independent from [Key] to allow smarter eviction?
+pub trait DataCache<Key> {
+    /// Get block of data from the cache for the given [Key] and [BlockIndex], if available.
+    ///
+    /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
+    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<&ChecksummedBytes>>;
+
+    /// Put block of data to the cache for the given [Key] and [BlockIndex].
+    fn put_block(&mut self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
+
+    /// For a given byte range, which blocks should contain the cached data if available?
+    ///
+    /// This does not perform any check to see if the relevant data is cached.
+    fn indices_for_byte_range(&self, range: Range<u64>) -> Range<BlockIndex>;
+
+    /// For the given range of blocks, which are present in the cache?
+    ///
+    /// It is possible that the **blocks may be deleted before reading**, or may be corrupted or inaccessible.
+    /// This method only indicates that a cache entry was present at the time of calling.
+    /// There is no guarantee that the data will still be available at the time of reading.
+    fn cached_block_indices(&self, cache_key: &Key, range: Range<BlockIndex>) -> DataCacheResult<Vec<BlockIndex>>;
+}

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,3 +1,4 @@
+mod data_cache;
 pub mod fs;
 pub mod fuse;
 mod inode;
@@ -8,6 +9,7 @@ pub mod prefetch;
 pub mod prefix;
 mod sync;
 mod upload;
+
 pub use fs::{S3Filesystem, S3FilesystemConfig};
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3/src/prefetch/checksummed_bytes.rs
+++ b/mountpoint-s3/src/prefetch/checksummed_bytes.rs
@@ -4,10 +4,11 @@ use thiserror::Error;
 
 /// A `ChecksummedBytes` is a bytes buffer that carries its checksum.
 /// The implementation guarantees that its integrity will be validated when data transformation occurs.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ChecksummedBytes {
     orig_bytes: Bytes,
     curr_slice: Bytes,
+    /// Checksum for `orig_bytes`
     checksum: Crc32c,
 }
 
@@ -123,6 +124,23 @@ pub enum IntegrityError {
     #[error("Checksum mismatch. expected: {0:?}, actual: {1:?}")]
     ChecksumMismatch(Crc32c, Crc32c),
 }
+
+/// Compare two [ChecksummedBytes].
+///
+/// Leverages existing [assert_eq!], just transforming the [ChecksummedBytes] as slices to be comparable.
+macro_rules! assert_eq_checksummed_bytes {
+    ($expected:expr, $actual:expr, $($message:expr),*) => {
+        assert_eq!(
+            $expected.to_owned().into_bytes().expect("buffer should not be corrupted")[..],
+            $actual.to_owned().into_bytes().expect("buffer should not be corrupted")[..],
+            $($message),*
+        );
+    };
+}
+
+#[cfg(test)]
+pub(crate) use assert_eq_checksummed_bytes;
+
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;


### PR DESCRIPTION
## Description of change

Part of #255, this contains some early thinking on what our trait should look like for the data cache itself. It also contains an in-memory implementation that can be used for test cases, without setting up a full data cache (which doesn't exist yet).

Relevant issues: #255

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
