### PR TITLE
Add request count tests for FS operations with metadata caching enabled

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -138,7 +138,7 @@ impl MockClient {
     }
 
     /// Create a new counter for the given operation, starting at 0.
-    pub fn new_counter<'a>(&'a self, operation: Operation) -> OperationCounter<'a> {
+    pub fn new_counter(&self, operation: Operation) -> OperationCounter<'_> {
         let op_counts = self.operation_counts.read().unwrap();
         let initial_count = op_counts.get(&operation).copied().unwrap_or_default();
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -1,7 +1,7 @@
 //! A mock implementation of an object client for use in tests.
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
@@ -60,6 +60,7 @@ pub struct MockClient {
     config: MockClientConfig,
     objects: Arc<RwLock<BTreeMap<String, MockObject>>>,
     in_progress_uploads: Arc<RwLock<BTreeSet<String>>>,
+    operation_counts: Arc<RwLock<HashMap<Operation, u64>>>,
 }
 
 fn add_object(objects: &Arc<RwLock<BTreeMap<String, MockObject>>>, key: &str, value: MockObject) {
@@ -73,6 +74,7 @@ impl MockClient {
             config,
             objects: Default::default(),
             in_progress_uploads: Default::default(),
+            operation_counts: Default::default(),
         }
     }
 
@@ -133,6 +135,55 @@ impl MockClient {
         } else {
             Err(MockClientError("object not found".into()))
         }
+    }
+
+    /// Create a new counter for the given operation, starting at 0.
+    pub fn new_counter<'a>(&'a self, operation: Operation) -> OperationCounter<'a> {
+        let op_counts = self.operation_counts.read().unwrap();
+        let initial_count = op_counts.get(&operation).copied().unwrap_or_default();
+
+        OperationCounter {
+            client: self.clone(),
+            initial_count,
+            operation,
+        }
+    }
+
+    /// Track number of operations for verifying API calls made by the client in testing.
+    fn inc_op_count(&self, operation: Operation) {
+        let mut op_counts = self.operation_counts.write().unwrap();
+        op_counts.entry(operation).and_modify(|count| *count += 1).or_insert(1);
+    }
+}
+
+/// Operations for use in operation counters.
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum Operation {
+    DeleteObject,
+    HeadObject,
+    GetObject,
+    GetObjectAttributes,
+    ListObjectsV2,
+    PutObject,
+}
+
+/// Counter for a specific client [Operation].
+///
+/// Obtainable via `new_counter(&Operation)` method on [MockClient]
+/// Its lifetime is bounded by the client which created it.
+pub struct OperationCounter<'a> {
+    client: &'a MockClient,
+    initial_count: u64,
+    operation: Operation,
+}
+
+impl<'a> OperationCounter<'a> {
+    /// Return number of requests for the given operation counter.
+    /// Count is **not** reset when read.
+    pub fn count(&self) -> u64 {
+        let op_counts = self.client.operation_counts.read().unwrap();
+        let total_count = op_counts.get(&self.operation).copied().unwrap_or_default();
+        total_count - self.initial_count
     }
 }
 
@@ -309,6 +360,7 @@ impl ObjectClient for MockClient {
         key: &str,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError> {
         trace!(bucket, key, "DeleteObject");
+        self.inc_op_count(Operation::DeleteObject);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(DeleteObjectError::NoSuchBucket));
@@ -327,6 +379,7 @@ impl ObjectClient for MockClient {
         if_match: Option<ETag>,
     ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
         trace!(bucket, key, ?range, ?if_match, "GetObject");
+        self.inc_op_count(Operation::GetObject);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(GetObjectError::NoSuchBucket));
@@ -367,6 +420,7 @@ impl ObjectClient for MockClient {
         key: &str,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError> {
         trace!(bucket, key, "HeadObject");
+        self.inc_op_count(Operation::HeadObject);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(HeadObjectError::NotFound));
@@ -399,6 +453,7 @@ impl ObjectClient for MockClient {
         prefix: &str,
     ) -> ObjectClientResult<ListObjectsResult, ListObjectsError, Self::ClientError> {
         trace!(bucket, ?continuation_token, delimiter, max_keys, prefix, "ListObjects");
+        self.inc_op_count(Operation::ListObjectsV2);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(ListObjectsError::NoSuchBucket));
@@ -499,6 +554,7 @@ impl ObjectClient for MockClient {
         params: &PutObjectParams,
     ) -> ObjectClientResult<Self::PutObjectRequest, PutObjectError, Self::ClientError> {
         trace!(bucket, key, "PutObject");
+        self.inc_op_count(Operation::PutObject);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(PutObjectError::NoSuchBucket));
@@ -523,6 +579,7 @@ impl ObjectClient for MockClient {
         object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError> {
         trace!(bucket, key, "GetObjectAttributes");
+        self.inc_op_count(Operation::GetObjectAttributes);
 
         if bucket != self.config.bucket {
             return Err(ObjectClientError::ServiceError(GetObjectAttributesError::NoSuchBucket));
@@ -959,5 +1016,32 @@ mod tests {
         assert!(
             matches!(&list_result.objects[..], [object] if object.key == key && object.storage_class.as_deref() == storage_class )
         );
+    }
+
+    #[tokio::test]
+    async fn counter_test() {
+        let bucket = "test_bucket";
+        let client = MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 1024,
+        });
+
+        let head_counter_1 = client.new_counter(Operation::HeadObject);
+        let delete_counter_1 = client.new_counter(Operation::DeleteObject);
+
+        let _result = client.head_object(bucket, "key").await;
+        assert_eq!(1, head_counter_1.count());
+        assert_eq!(0, delete_counter_1.count());
+
+        let head_counter_2 = client.new_counter(Operation::HeadObject);
+        assert_eq!(0, head_counter_2.count());
+
+        let _result = client.head_object(bucket, "key").await;
+        let _result = client.delete_object(bucket, "key").await;
+        let _result = client.delete_object(bucket, "key").await;
+        let _result = client.delete_object(bucket, "key").await;
+        assert_eq!(2, head_counter_1.count());
+        assert_eq!(3, delete_counter_1.count());
+        assert_eq!(1, head_counter_2.count());
     }
 }

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -143,7 +143,7 @@ impl MockClient {
         let initial_count = op_counts.get(&operation).copied().unwrap_or_default();
 
         OperationCounter {
-            client: self.clone(),
+            client: self,
             initial_count,
             operation,
         }

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -178,8 +178,8 @@ pub struct OperationCounter<'a> {
 }
 
 impl<'a> OperationCounter<'a> {
-    /// Return number of requests for the given operation counter.
-    /// Count is **not** reset when read.
+    /// Return number of requests since the counter was created.
+    /// The counter is **not** reset when read.
     pub fn count(&self) -> u64 {
         let op_counts = self.client.operation_counts.read().unwrap();
         let total_count = op_counts.get(&self.operation).copied().unwrap_or_default();

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -277,7 +277,7 @@ async fn test_readdir_then_open_cached() {
         let _ = entries.next().expect("should have parent directory");
 
         let entry = entries.next().expect("should have file1.txt in entries");
-        let expected: OsString = format!("file1.txt").into();
+        let expected = OsString::from("file1.txt");
         assert_eq!(entry.name, expected);
         assert_eq!(entry.attr.kind, FileType::RegularFile);
 
@@ -330,8 +330,7 @@ async fn test_unlink_cached() {
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
 
-    let _unlinked = fs
-        .unlink(parent_ino, "file1.txt".as_ref())
+    fs.unlink(parent_ino, "file1.txt".as_ref())
         .await
         .expect("unlink should unlink cached object");
     assert_eq!(head_counter.count(), 1);


### PR DESCRIPTION
## Description of change

When adding metadata caching, we not only want to ensure that cached data is served but also verify we aren't still making S3 requests and the repeated S3 requests are truly eliminated.

This adds counter functionality to the mock client in `mountpoint-s3-client`, and adds a few tests covering the cached cases. We may also want to add more assertions to existing tests or test the cases with caching turned off.

Relevant issues: #255 

## Does this change impact existing behavior?

No change, tests only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
