### PR TITLE
Add support for SSE-KMS and DSSE-KMS for Mountpoint

### DIFF
--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -51,7 +51,7 @@ pub mod failure_client;
 pub mod imds_crt_client;
 #[doc(hidden)]
 pub mod mock_client;
-mod object_client;
+pub mod object_client;
 mod s3_crt_client;
 mod util;
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -282,9 +282,9 @@ pub struct PutObjectParams {
     /// Storage class to be used when creating new S3 object
     pub storage_class: Option<String>,
     /// Server side encryption type for creating new S3 object
-    kms_key: Option<KmsKeys>,
+    pub kms_key: Option<KmsKeys>,
     /// Corresponding key id if SSE-KMS key type is opted
-    key_id: Option<String>
+    pub key_id: Option<String>
 }
 
 impl PutObjectParams {

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -266,6 +266,13 @@ pub enum GetObjectAttributesError {
     NoSuchKey,
 }
 
+/// Type of Server side encryption(SSE) opted for Put Object
+#[derive(Debug, Clone)]
+pub enum KmsKeys {
+    SseKms,
+    DsseKms,
+}
+
 /// Parameters to a [`put_object`](ObjectClient::put_object) request
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
@@ -274,6 +281,10 @@ pub struct PutObjectParams {
     pub trailing_checksums: bool,
     /// Storage class to be used when creating new S3 object
     pub storage_class: Option<String>,
+    /// Server side encryption type for creating new S3 object
+    kms_key: Option<KmsKeys>,
+    /// Corresponding key id if SSE-KMS key type is opted
+    key_id: Option<String>
 }
 
 impl PutObjectParams {
@@ -291,6 +302,18 @@ impl PutObjectParams {
     /// Set the storage class.
     pub fn storage_class(mut self, value: String) -> Self {
         self.storage_class = Some(value);
+        self
+    }
+
+    /// Set the KMS key type.
+    pub fn kms_key(mut self, key_type: KmsKeys) -> Self {
+        self.kms_key = Some(key_type);
+        self
+    }
+
+    /// Set the KMS key ID.
+    pub fn key_id(mut self, value: String) -> Self {
+        self.key_id = Some(value);
         self
     }
 }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -307,6 +307,8 @@ pub struct S3FilesystemConfig {
     pub allow_delete: bool,
     /// Storage class to be used for new object uploads
     pub storage_class: Option<String>,
+    /// KMS key type for Server side encryption
+    pub kms_key: Option<KmsKeys>,
 }
 
 impl Default for S3FilesystemConfig {

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -13,6 +13,7 @@ use fuser::{FileAttr, KernelConfig};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::ObjectClient;
+use mountpoint_s3_client::object_client::KmsKeys;
 
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, WriteHandle};
 use crate::prefetch::{PrefetchGetObject, PrefetchReadError, Prefetcher, PrefetcherConfig};
@@ -309,6 +310,8 @@ pub struct S3FilesystemConfig {
     pub storage_class: Option<String>,
     /// KMS key type for Server side encryption
     pub kms_key: Option<KmsKeys>,
+    /// KMS key ID for Server side encryption
+    pub key_id: Option<String>
 }
 
 impl Default for S3FilesystemConfig {
@@ -326,6 +329,8 @@ impl Default for S3FilesystemConfig {
             prefetcher_config: PrefetcherConfig::default(),
             allow_delete: false,
             storage_class: None,
+            kms_key: None,
+            key_id: None
         }
     }
 }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -121,6 +121,31 @@ struct CliArgs {
 
     #[clap(
         long,
+        help = "Add the SSE KMS encryption for PUT requests",
+        help_heading = BUCKET_OPTIONS_HEADER,
+        group = "sse_options"
+    )]
+    pub sse_kms: bool,
+
+    // Keeping [sse_kms] and [dsse_kms] in same arg group makes them mutually exclusive arguments
+    #[clap(
+        long,
+        help = "Add the DSSE KMS encryption for PUT requests",
+        help_heading = BUCKET_OPTIONS_HEADER,
+        group = "sse_options"
+    )]
+    pub dsse_kms: bool,
+
+    #[clap(
+        long,
+        help = "Add the encryption key id for KMS keys",
+        help_heading = BUCKET_OPTIONS_HEADER,
+        requires = "sse_options"
+    )]
+    pub key_id: Option<String>,
+
+    #[clap(
+        long,
         help = "Maximum throughput in Gbps [default: auto-detected on EC2 instances, 10 Gbps elsewhere]",
         value_name = "N",
         value_parser = value_parser!(u64).range(1..),
@@ -484,6 +509,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     }
     filesystem_config.storage_class = args.storage_class;
     filesystem_config.allow_delete = args.allow_delete;
+    
 
     #[cfg(feature = "caching")]
     {

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -17,6 +17,7 @@ use mountpoint_s3::logging::{init_logging, LoggingConfig};
 use mountpoint_s3::metrics;
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_client::object_client::KmsKeys;
 use mountpoint_s3_client::error::ObjectClientError;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 use mountpoint_s3_crt::common::allocator::Allocator;
@@ -507,9 +508,16 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     if let Some(file_mode) = args.file_mode {
         filesystem_config.file_mode = file_mode;
     }
+    if args.sse_kms {
+        filesystem_config.kms_key = Some(KmsKeys::SseKms)
+    }
+    if args.dsse_kms {
+        filesystem_config.kms_key = Some(KmsKeys::DsseKms)
+    }
+    filesystem_config.key_id = args.key_id;
     filesystem_config.storage_class = args.storage_class;
     filesystem_config.allow_delete = args.allow_delete;
-    
+
 
     #[cfg(feature = "caching")]
     {


### PR DESCRIPTION
## Description of change
Added KMS key type and their IDs as bucket option. Added these headers for Put Object. Still need to get these keys as PutObjectParams to be used by PutObject.
Also need to add tests and changelog.
<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
#534 
## Does this change impact existing behavior?
Yes, there will be added mount options when this change will get merged.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
Yes. It will be a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
