### PR TITLE
Use new ChecksummedBlock in DataCache

### DIFF
--- a/mountpoint-s3/src/checksums.rs
+++ b/mountpoint-s3/src/checksums.rs
@@ -1,0 +1,39 @@
+mod block;
+mod bytes;
+
+use mountpoint_s3_crt::checksums::crc32c::Crc32c;
+
+use thiserror::Error;
+
+pub use block::ChecksummedBlock;
+pub use bytes::ChecksummedBytes;
+
+/// Calculates the combined checksum for `AB` where `prefix_crc` is the checksum for `A`,
+/// `suffix_crc` is the checksum for `B`, and `suffic_len` is the length of `B`.
+pub fn combine_checksums(prefix_crc: Crc32c, suffix_crc: Crc32c, suffix_len: usize) -> Crc32c {
+    let combined = ::crc32c::crc32c_combine(prefix_crc.value(), suffix_crc.value(), suffix_len);
+    Crc32c::new(combined)
+}
+
+#[derive(Debug, Error)]
+pub enum IntegrityError {
+    #[error("Checksum mismatch. expected: {0:?}, actual: {1:?}")]
+    ChecksumMismatch(Crc32c, Crc32c),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mountpoint_s3_crt::checksums::crc32c;
+
+    #[test]
+    fn test_combine_checksums() {
+        let buf: &[u8] = b"123456789";
+        let (buf1, buf2) = buf.split_at(4);
+        let crc = crc32c::checksum(buf);
+        let crc1 = crc32c::checksum(buf1);
+        let crc2 = crc32c::checksum(buf2);
+        let combined = combine_checksums(crc1, crc2, buf2.len());
+        assert_eq!(combined, crc);
+    }
+}

--- a/mountpoint-s3/src/checksums.rs
+++ b/mountpoint-s3/src/checksums.rs
@@ -9,7 +9,7 @@ pub use block::ChecksummedBlock;
 pub use bytes::ChecksummedBytes;
 
 /// Calculates the combined checksum for `AB` where `prefix_crc` is the checksum for `A`,
-/// `suffix_crc` is the checksum for `B`, and `suffic_len` is the length of `B`.
+/// `suffix_crc` is the checksum for `B`, and `suffix_len` is the length of `B`.
 pub fn combine_checksums(prefix_crc: Crc32c, suffix_crc: Crc32c, suffix_len: usize) -> Crc32c {
     let combined = ::crc32c::crc32c_combine(prefix_crc.value(), suffix_crc.value(), suffix_len);
     Crc32c::new(combined)

--- a/mountpoint-s3/src/checksums/block.rs
+++ b/mountpoint-s3/src/checksums/block.rs
@@ -94,6 +94,20 @@ impl From<ChecksummedBlock> for ChecksummedBytes {
     }
 }
 
+impl From<Bytes> for ChecksummedBlock {
+    fn from(value: Bytes) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl TryFrom<ChecksummedBlock> for Bytes {
+    type Error = IntegrityError;
+
+    fn try_from(value: ChecksummedBlock) -> Result<Self, Self::Error> {
+        value.into_bytes()
+    }
+}
+
 // Implement equality for tests only. We implement equality, and will panic if the data is corrupted.
 #[cfg(test)]
 impl PartialEq for ChecksummedBlock {
@@ -162,8 +176,7 @@ mod tests {
         let expected = Bytes::from_static(b"some bytes extended");
 
         let mut checksummed_block = ChecksummedBlock::from_bytes(bytes);
-        let extend_block = ChecksummedBlock::from_bytes(extend);
-        checksummed_block.extend(extend_block);
+        checksummed_block.extend(extend.into());
         let actual = checksummed_block.bytes;
         assert_eq!(expected, actual);
     }
@@ -175,8 +188,7 @@ mod tests {
         let mut checksummed_block = ChecksummedBlock::new(currupted_bytes, checksum);
 
         let extend = Bytes::from_static(b" extended");
-        let extend_block = ChecksummedBlock::from_bytes(extend);
-        checksummed_block.extend(extend_block);
+        checksummed_block.extend(extend.into());
         assert!(matches!(
             checksummed_block.validate(),
             Err(IntegrityError::ChecksumMismatch(_, _))

--- a/mountpoint-s3/src/checksums/block.rs
+++ b/mountpoint-s3/src/checksums/block.rs
@@ -1,0 +1,211 @@
+use bytes::{Bytes, BytesMut};
+use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};
+
+use crate::checksums::{bytes::ChecksummedBytes, combine_checksums, IntegrityError};
+
+/// A `ChecksummedBlock` is a bytes buffer that carries its checksum.
+/// The implementation guarantees that its integrity will be validated when data is accessed.
+#[derive(Debug, Clone)]
+pub struct ChecksummedBlock {
+    bytes: Bytes,
+    checksum: Crc32c,
+}
+
+impl ChecksummedBlock {
+    pub fn new(bytes: Bytes, checksum: Crc32c) -> Self {
+        Self { bytes, checksum }
+    }
+
+    /// Create `ChecksummedBlock` from `Bytes`, calculating its checksum.
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        let checksum = crc32c::checksum(&bytes);
+        Self::new(bytes, checksum)
+    }
+
+    /// Convert the `ChecksummedBlock` into `Bytes`, data integrity will be validated before converting.
+    ///
+    /// Return `IntegrityError` on data corruption.
+    pub fn into_bytes(self) -> Result<Bytes, IntegrityError> {
+        self.validate()?;
+
+        Ok(self.bytes)
+    }
+
+    /// Convert into a `ChecksummedBytes`.
+    pub fn into_checksummed_bytes(self) -> ChecksummedBytes {
+        ChecksummedBytes::new(self.bytes, self.checksum)
+    }
+
+    /// Returns the number of bytes contained in this `ChecksummedBlock`.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Returns true if the `ChecksummedBlock` has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Append the given bytes to current `ChecksummedBlock`.
+    pub fn extend(&mut self, extend: ChecksummedBlock) {
+        if self.is_empty() {
+            *self = extend;
+            return;
+        }
+        if extend.is_empty() {
+            return;
+        }
+
+        let total_len = self.bytes.len() + extend.len();
+        let mut bytes_mut = BytesMut::with_capacity(total_len);
+        bytes_mut.extend_from_slice(&self.bytes);
+        bytes_mut.extend_from_slice(&extend.bytes);
+        let new_bytes = bytes_mut.freeze();
+        let new_checksum = combine_checksums(self.checksum, extend.checksum, extend.len());
+        *self = ChecksummedBlock {
+            bytes: new_bytes,
+            checksum: new_checksum,
+        };
+    }
+
+    /// Validate data integrity in this `ChecksummedBlock`.
+    ///
+    /// Return `IntegrityError` on data corruption.
+    pub fn validate(&self) -> Result<(), IntegrityError> {
+        let checksum = crc32c::checksum(&self.bytes);
+        if self.checksum != checksum {
+            return Err(IntegrityError::ChecksumMismatch(self.checksum, checksum));
+        }
+        Ok(())
+    }
+}
+
+impl Default for ChecksummedBlock {
+    fn default() -> Self {
+        let bytes = Bytes::new();
+        let checksum = Crc32c::new(0);
+        Self { bytes, checksum }
+    }
+}
+
+impl From<ChecksummedBlock> for ChecksummedBytes {
+    fn from(value: ChecksummedBlock) -> Self {
+        value.into_checksummed_bytes()
+    }
+}
+
+// Implement equality for tests only. We implement equality, and will panic if the data is corrupted.
+#[cfg(test)]
+impl PartialEq for ChecksummedBlock {
+    fn eq(&self, other: &Self) -> bool {
+        if self.bytes != other.bytes {
+            return false;
+        }
+
+        if self.checksum == other.checksum {
+            return true;
+        }
+
+        self.validate().expect("should be valid");
+        other.validate().expect("should be valid");
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use mountpoint_s3_crt::checksums::crc32c;
+
+    use super::*;
+
+    #[test]
+    fn test_into_bytes() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let expected = bytes.clone();
+        let checksum = crc32c::checksum(&bytes);
+        let checksummed_block = ChecksummedBlock::new(bytes, checksum);
+
+        let actual = checksummed_block.into_bytes().unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_into_bytes_integrity_error() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let checksum = crc32c::checksum(&bytes);
+        let mut checksummed_block = ChecksummedBlock::new(bytes, checksum);
+        checksummed_block.bytes = Bytes::from_static(b"new bytes");
+
+        let actual = checksummed_block.into_bytes();
+        assert!(matches!(actual, Err(IntegrityError::ChecksumMismatch(_, _))));
+    }
+
+    #[test]
+    fn test_into_checksummed_bytes() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let checksum = crc32c::checksum(&bytes);
+        let checksummed_block = ChecksummedBlock::new(bytes, checksum);
+        let checksummed_bytes = checksummed_block.clone().into_checksummed_bytes();
+
+        assert_eq!(
+            checksummed_block.into_bytes().unwrap(),
+            checksummed_bytes.into_bytes().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_extend() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let expected = Bytes::from_static(b"some bytes extended");
+        let checksum = crc32c::checksum(&bytes);
+        let mut checksummed_block = ChecksummedBlock::new(bytes, checksum);
+
+        let extend = Bytes::from_static(b" extended");
+        let extend_checksum = crc32c::checksum(&extend);
+        let extend = ChecksummedBlock::new(extend, extend_checksum);
+        checksummed_block.extend(extend);
+        let actual = checksummed_block.bytes;
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_extend_self_corrupted() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let checksum = crc32c::checksum(&bytes);
+        let mut checksummed_block = ChecksummedBlock::new(bytes, checksum);
+
+        let currupted_bytes = Bytes::from_static(b"corrupted data");
+        checksummed_block.bytes = currupted_bytes.clone();
+
+        let extend = Bytes::from_static(b" extended");
+        let extend_checksum = crc32c::checksum(&extend);
+        let extend = ChecksummedBlock::new(extend, extend_checksum);
+        checksummed_block.extend(extend);
+        assert!(matches!(
+            checksummed_block.validate(),
+            Err(IntegrityError::ChecksumMismatch(_, _))
+        ));
+    }
+
+    #[test]
+    fn test_extend_other_corrupted() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let checksum = crc32c::checksum(&bytes);
+        let mut checksummed_block = ChecksummedBlock::new(bytes, checksum);
+
+        let extend = Bytes::from_static(b" extended");
+        let extend_checksum = crc32c::checksum(&extend);
+        let mut extend = ChecksummedBlock::new(extend, extend_checksum);
+
+        let currupted_bytes = Bytes::from_static(b"corrupted data");
+        extend.bytes = currupted_bytes.clone();
+
+        checksummed_block.extend(extend);
+        assert!(matches!(
+            checksummed_block.validate(),
+            Err(IntegrityError::ChecksumMismatch(_, _))
+        ));
+    }
+}

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 
 use thiserror::Error;
 
-pub use crate::prefetch::checksummed_bytes::ChecksummedBytes;
+pub use crate::checksums::ChecksummedBlock;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;
@@ -36,10 +36,10 @@ pub trait DataCache<Key> {
     /// Get block of data from the cache for the given [Key] and [BlockIndex], if available.
     ///
     /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
-    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<ChecksummedBytes>>;
+    fn get_block(&self, cache_key: &Key, block_idx: BlockIndex) -> DataCacheResult<Option<ChecksummedBlock>>;
 
     /// Put block of data to the cache for the given [Key] and [BlockIndex].
-    fn put_block(&self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
+    fn put_block(&self, cache_key: Key, block_idx: BlockIndex, bytes: ChecksummedBlock) -> DataCacheResult<()>;
 
     /// Returns the block size for the data cache.
     fn block_size(&self) -> u64;

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,3 +1,4 @@
+mod checksums;
 mod data_cache;
 pub mod fs;
 pub mod fuse;

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -7,7 +7,6 @@
 //! we increase the size of the GetObject requests up to some maximum. If the reader ever makes a
 //! non-sequential read, we abandon the prefetching and start again with the minimum request size.
 
-pub mod checksummed_bytes;
 mod feed;
 mod part;
 mod part_queue;
@@ -26,7 +25,7 @@ use mountpoint_s3_client::ObjectClient;
 use thiserror::Error;
 use tracing::{debug_span, error, trace, Instrument};
 
-use crate::prefetch::checksummed_bytes::{ChecksummedBytes, IntegrityError};
+use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::prefetch::feed::{ClientPartFeed, ObjectPartFeed};
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueue};

--- a/mountpoint-s3/src/prefetch/feed.rs
+++ b/mountpoint-s3/src/prefetch/feed.rs
@@ -11,7 +11,8 @@ use mountpoint_s3_client::{
 use mountpoint_s3_crt::checksums::crc32c;
 use tracing::{error, trace};
 
-use crate::prefetch::{checksummed_bytes::ChecksummedBytes, part::Part, part_queue::PartQueueProducer};
+use crate::checksums::ChecksummedBytes;
+use crate::prefetch::{part::Part, part_queue::PartQueueProducer};
 
 /// A generic interface to retrieve data from objects in a S3-like store.
 #[async_trait]

--- a/mountpoint-s3/src/prefetch/part.rs
+++ b/mountpoint-s3/src/prefetch/part.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use super::checksummed_bytes::ChecksummedBytes;
+use crate::checksums::ChecksummedBytes;
 
 /// A self-identifying part of an S3 object. Users can only retrieve the bytes from this part if
 /// they can prove they have the correct offset and key.

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -99,7 +99,7 @@ impl<E: std::error::Error + Send + Sync> PartQueueProducer<E> {
 
 #[cfg(test)]
 mod tests {
-    use crate::prefetch::checksummed_bytes::ChecksummedBytes;
+    use crate::checksums::ChecksummedBytes;
 
     use super::*;
 


### PR DESCRIPTION
## Description of change

Introduce a new `ChecksummedBlock` type which represents a bytes buffer and its matching checksum. It is a simpler version of `ChecksummedBytes` in that the checksum is always matching the exposed bytes buffer, rather than potentially a containing larger buffer. The new type is better suited to be used in the `DataCache` because it can be more efficiently serialized/deserialized preserving its checksum.

This change also introduces a new `checksums` module, containing both `ChecksummedBytes` and `ChecksummedBlock`, in addition to other checksum functions and types.

Relevant issues: #255 

## Does this change impact existing behavior?

No changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
