### PR TITLE
Rename CacheConfig field 'prefer_s3' to 'serve_lookup_from_cache'

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -506,7 +506,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
             // TODO: Review default for TTL
             let metadata_cache_ttl = args.metadata_cache_ttl.unwrap_or(Duration::from_secs(3600));
             filesystem_config.cache_config = CacheConfig {
-                prefer_s3: false,
+                serve_lookup_from_cache: true,
                 dir_ttl: metadata_cache_ttl,
                 file_ttl: metadata_cache_ttl,
             };

--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -111,7 +111,7 @@ where
 {
     let filesystem_config = S3FilesystemConfig {
         cache_config: CacheConfig {
-            prefer_s3: true,
+            serve_lookup_from_cache: false,
             file_ttl: Duration::ZERO,
             dir_ttl: Duration::ZERO,
         },

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -888,7 +888,7 @@ mod mutations {
             allow_delete: true,
             cache_config: CacheConfig {
                 // We are only interested in strong consistency for the reference tests. FUSE isn't even in the loop.
-                prefer_s3: true,
+                serve_lookup_from_cache: false,
                 dir_ttl: Duration::ZERO,
                 file_ttl: Duration::ZERO,
             },


### PR DESCRIPTION
## Description of change

Simple one due to one of the hardest computer science issues: naming things.

Hopefully this is a better name moving forward. This change contains only the rename, and no behavior change.

Action item from https://github.com/awslabs/mountpoint-s3/pull/567#discussion_r1369973467.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
