### PR TITLE
Replace use of Range with RangeBounds in DataCache trait

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -6,7 +6,7 @@
 
 pub mod in_memory_data_cache;
 
-use std::ops::Range;
+use std::ops::RangeBounds;
 
 use thiserror::Error;
 
@@ -50,5 +50,9 @@ pub trait DataCache<Key> {
     /// It is possible that the **blocks may be deleted before reading**, or may be corrupted or inaccessible.
     /// This method only indicates that a cache entry was present at the time of calling.
     /// There is no guarantee that the data will still be available at the time of reading.
-    fn cached_block_indices(&self, cache_key: &Key, range: Range<BlockIndex>) -> DataCacheResult<Vec<BlockIndex>>;
+    fn cached_block_indices<R: RangeBounds<BlockIndex>>(
+        &self,
+        cache_key: &Key,
+        range: R,
+    ) -> DataCacheResult<Vec<BlockIndex>>;
 }


### PR DESCRIPTION
## Description of change

[RangeBounds](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) is better than [Range](https://doc.rust-lang.org/std/ops/struct.Range.html), which represents only a range where both start and end is defined. IDE wasn't working last time I tried to use it, now I see the light.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
