### PR TITLE
Allow repeated readdir offsets

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -168,7 +168,7 @@ the following behavior:
 
 ### Directory operations
 
-Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported.
+Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported. However, seeking (`lseek`) on directory handles is not supported.
 
 Creating directories (`mkdir`) is supported, with the following behavior:
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Breaking changes
+* No breaking changes.
+
+### Other changes
+* Some applications that read directory entries out of order (for example, [PHP](https://github.com/awslabs/mountpoint-s3/issues/477)) will now work correctly. ([#581](https://github.com/awslabs/mountpoint-s3/pull/581))
+
 ## v1.1.0 (October 23, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -775,7 +775,7 @@ where
             // request offset 0 twice in a row. So we remember the last response and, if repeated,
             // we return it again.
             let last_response = dir_handle.last_response.lock().await;
-            if let Some((last_offset, entries)) = &*last_response {
+            if let Some((last_offset, entries)) = last_response.as_ref() {
                 if offset == *last_offset {
                     trace!(offset, "repeating readdir response");
                     for entry in entries {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1167,7 +1167,8 @@ impl Inode {
     pub fn dec_lookup_count(&self, n: u64) -> u64 {
         let mut state = self.inner.sync.write().unwrap();
         let lookup_count = &mut state.lookup_count;
-        *lookup_count -= n;
+        debug_assert!(n <= *lookup_count, "lookup count cannot go negative");
+        *lookup_count = lookup_count.saturating_sub(n);
         trace!(new_lookup_count = lookup_count, "decremented lookup count");
         *lookup_count
     }

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, SystemTime};
 use test_case::test_case;
 
 mod common;
-use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, ReadReply};
+use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply, ReadReply};
 
 #[test_case(""; "unprefixed")]
 #[test_case("test_prefix/"; "prefixed")]
@@ -1229,6 +1229,68 @@ async fn test_flexible_retrieval_objects() {
         } else {
             let open = open.expect("instant retrieval files are readable");
             fs.release(lookup.attr.ino, open.fh, 0, None, true).await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_readdir_rewind() {
+    let (client, fs) = make_test_filesystem("test_readdir_rewind", &Default::default(), Default::default());
+
+    for i in 0..10 {
+        client.add_object(&format!("foo{i}"), b"foo".into());
+    }
+
+    let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
+
+    let mut reply = DirectoryReply::new(5);
+    let _ = fs
+        .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut reply)
+        .await
+        .unwrap();
+    let entries = reply
+        .entries
+        .iter()
+        .map(|e| (e.ino, e.name.clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(entries.len(), 5);
+
+    fs.readdirplus(FUSE_ROOT_INODE, dir_handle, 1, &mut Default::default())
+        .await
+        .expect_err("out of order");
+
+    let mut new_reply = DirectoryReply::new(5);
+    let _ = fs
+        .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut new_reply)
+        .await
+        .unwrap();
+    let new_entries = new_reply
+        .entries
+        .iter()
+        .map(|e| (e.ino, e.name.clone()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(entries, new_entries);
+
+    let mut next_page = DirectoryReply::new(0);
+    let _ = fs
+        .readdirplus(
+            FUSE_ROOT_INODE,
+            dir_handle,
+            reply.entries.back().unwrap().offset,
+            &mut next_page,
+        )
+        .await
+        .unwrap();
+    assert_eq!(next_page.entries.len(), 7); // 10 directory entries + . + .. = 12, minus the 5 we already saw
+    assert_eq!(next_page.entries.front().unwrap().name, "foo3");
+
+    for entry in reply.entries {
+        // We know we're in the root dir, so the . and .. entries will both be FUSE_ROOT_INODE
+        if entry.ino != FUSE_ROOT_INODE {
+            // Each inode in this list should be remembered twice since we did two `readdirplus`es.
+            // Forget will panic if this makes the lookup count underflow.
+            fs.forget(entry.ino, 2).await;
         }
     }
 }


### PR DESCRIPTION
## Description of change

POSIX allows seeking an open directory handle, which in FUSE means the
`offset` can be any offset we've previously returned. This is pretty
annoying for us to implement since we're streaming directory entries
from S3 with ListObjects, which can't resume from an arbitrary index,
and can't fit its continuation tokens into a 64-bit offset anyway. So
we're probably never going to truly support seeking a directory handle.

But there's a special case we've seen come up a couple of times (#477, #520):
some applications read one page of directory entries and then seek back
to 0 and do it again. I don't fully understand _why_ they do this, but
it's common enough that it's worth special casing.

This change makes open directory handles remember their most recent
response so that they can repeat it if asked for the same offset again.
It's not too complicated other than needing to make sure we do
readdirplus correctly (managing the lookup counts for entries that are
being returned a second time).

I've tested this by running the PHP example from #477, which now works.

Related issues: fixes #477, fixes #520.

## Does this change impact existing behavior?

No, it allows a case to succeed that previously failed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
