### PR TITLE
Change local file/directory expiry TTL from NEVER_EXPIRE to 100ms

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Future creates for file that are deleted remotely should now succeed. ([#584](https://github.com/awslabs/mountpoint-s3/pull/584))
 
 ### Breaking changes
 * No breaking changes.

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -127,7 +127,6 @@ impl ToErrno for InodeError {
             InodeError::UnlinkNotPermittedWhileWriting(_) => libc::EPERM,
             InodeError::CorruptedMetadata(_) => libc::EIO,
             InodeError::SetAttrNotPermittedOnRemoteInode(_) => libc::EPERM,
-            InodeError::SetAttrOnExpiredStat(_) => libc::EIO,
             InodeError::StaleInode { .. } => libc::ESTALE,
         }
     }

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -343,9 +343,9 @@ impl Superblock {
                 None,
                 None,
                 None,
-                Duration::from_millis(100),
+                self.inner.cache_config.file_ttl,
             ),
-            InodeKind::Directory => InodeStat::for_directory(self.inner.mount_time, Duration::from_millis(100)),
+            InodeKind::Directory => InodeStat::for_directory(self.inner.mount_time, self.inner.cache_config.dir_ttl),
         };
 
         let state = InodeState {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -846,7 +846,7 @@ impl SuperblockInner {
                     drop(sync);
 
                     Ok(LookedUp {
-                        inode: existing_inode.clone(),
+                        inode: existing_inode,
                         stat,
                     })
                 } else {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -247,6 +247,7 @@ impl Superblock {
             InodeKind::Directory => self.inner.cache_config.dir_ttl,
         };
 
+        // Resetting the InodeStat expiry because the new InodeStat should have new validity
         sync.stat.update_validity(validity);
 
         if let Some(t) = atime {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -337,8 +337,15 @@ impl Superblock {
         // Local inode stats never expire, because they can't be looked up remotely
         let stat = match kind {
             // Objects don't have an ETag until they are uploaded to S3
-            InodeKind::File => InodeStat::for_file(0, OffsetDateTime::now_utc(), None, None, None, NEVER_EXPIRE_TTL),
-            InodeKind::Directory => InodeStat::for_directory(self.inner.mount_time, NEVER_EXPIRE_TTL),
+            InodeKind::File => InodeStat::for_file(
+                0,
+                OffsetDateTime::now_utc(),
+                None,
+                None,
+                None,
+                Duration::from_millis(100),
+            ),
+            InodeKind::Directory => InodeStat::for_directory(self.inner.mount_time, Duration::from_millis(100)),
         };
 
         let state = InodeState {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -242,12 +242,6 @@ impl Superblock {
             return Err(InodeError::SetAttrNotPermittedOnRemoteInode(inode.err()));
         }
 
-        // Should be impossible since local file stat never expire.
-        if !sync.stat.is_valid() {
-            error!(?ino, "local inode stat already expired");
-            return Err(InodeError::SetAttrOnExpiredStat(inode.err()));
-        }
-
         if let Some(t) = atime {
             sync.stat.atime = t;
         }
@@ -334,7 +328,6 @@ impl Superblock {
             return Err(InodeError::FileAlreadyExists(inode.err()));
         }
 
-        // Local inode stats never expire, because they can't be looked up remotely
         let stat = match kind {
             // Objects don't have an ETag until they are uploaded to S3
             InodeKind::File => InodeStat::for_file(


### PR DESCRIPTION
## Description of change
This change allows mountpoint to rewrite to the same file which was deleted remotely using other methods like console/aws cli. Earlier, Due to large validity of files and directories, the inodes corresponding were remembered by kernel forever. So, even deleting remotely did not make kernel call `lookup` again for those files.
<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
#577 
## Does this change impact existing behavior?
No.

There is no breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
