### PR TITLE
Use O_APPEND for logs and log version number

### DIFF
--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -102,7 +102,7 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
         let mut dir_builder = DirBuilder::new();
         dir_builder.recursive(true).mode(0o750);
         let mut file_options = OpenOptions::new();
-        file_options.mode(0o640).write(true).create(true);
+        file_options.mode(0o640).append(true).create(true);
 
         dir_builder.create(path).context("failed to create log folder")?;
         let file = file_options

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -420,6 +420,8 @@ fn main() -> anyhow::Result<()> {
 fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     const DEFAULT_TARGET_THROUGHPUT: f64 = 10.0;
 
+    tracing::info!("mount-s3 {}", build_info::FULL_VERSION);
+
     validate_mount_point(&args.mount_point)?;
 
     let bucket_description = args.bucket_description();


### PR DESCRIPTION
## Description of change

In background mode we have two processes both racing on the log file,
and they can scribble each other's log entries (I saw this in #566).
O_APPEND should fix that. We should also log the version number as a
point of reference.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
