### PR TITLE
Add instructions on mounting S3 bucket across reboots to CONFIGURATION.md

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -223,7 +223,7 @@ ExecStart=/usr/bin/mount-s3 DOC-EXAMPLE-BUCKET /home/ec2-user/s3-bucket-mount
 ExecStop=/usr/bin/fusermount -u /home/ec2-user/s3-bucket-mount
 
 [Install]
-WantedBy=default.target
+WantedBy=remote-fs.target
 ```
 
 ## Logging

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -201,12 +201,13 @@ In its default configuration, there is no maximum on the size of objects Mountpo
 
 To increase the maximum object size for writes, use the `--part-size` command-line argument to specify a maximum number of bytes per part, which defaults to 8 MiB. The maximum object size will be 10,000 multiplied by the value you provide for this argument. Even with multipart upload, S3 allows a maximum object size of 5 TiB, and so setting this argument higher than 524.3 MiB will not further increase the object size limit.
 
-### Mounting an S3 bucket after reboot
+### Automatically mounting an S3 bucket at boot
 
-A tracking issue is open for _fstab_ support: [#44](https://github.com/awslabs/mountpoint-s3/issues/44).
+Mountpoint does not currently support automatically mounting a bucket at system boot time.
+A tracking issue is open for `fstab` support: [#44](https://github.com/awslabs/mountpoint-s3/issues/44).
 
-Until this support is implemented, we recommend using a system manager like systemd to monitor the mount process and mount during boot.
-Below is an example of a systemd unit for mountpoint-s3.
+Until this support is implemented, we recommend using a service manager like systemd to manage the mount process and mount during boot.
+Below is an example of a systemd unit that launches Mountpoint at boot time.
 Replace `/home/ec2-user/s3-bucket-mount` and `DOC-EXAMPLE-BUCKET` with your mount directory and S3 bucket.
 
 ```ini

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -201,6 +201,31 @@ In its default configuration, there is no maximum on the size of objects Mountpo
 
 To increase the maximum object size for writes, use the `--part-size` command-line argument to specify a maximum number of bytes per part, which defaults to 8 MiB. The maximum object size will be 10,000 multiplied by the value you provide for this argument. Even with multipart upload, S3 allows a maximum object size of 5 TiB, and so setting this argument higher than 524.3 MiB will not further increase the object size limit.
 
+### Mounting an S3 bucket after reboot
+
+A tracking issue is open for _fstab_ support: [#44](https://github.com/awslabs/mountpoint-s3/issues/44).
+
+Until this support is implemented, we recommend using a system manager like systemd to monitor the mount process and mount during boot.
+Below is an example of a systemd unit for mountpoint-s3.
+Replace `/home/ec2-user/s3-bucket-mount` and `DOC-EXAMPLE-BUCKET` with your mount directory and S3 bucket.
+
+```ini
+[Unit]
+Description=Mountpoint for Amazon S3 mount
+Wants=network.target
+AssertPathIsDirectory=/home/ec2-user/s3-bucket-mount
+
+[Service]
+Type=forking
+User=ec2-user
+Group=ec2-user
+ExecStart=/usr/bin/mount-s3 DOC-EXAMPLE-BUCKET /home/ec2-user/s3-bucket-mount
+ExecStop=/usr/bin/fusermount -u /home/ec2-user/s3-bucket-mount
+
+[Install]
+WantedBy=default.target
+```
+
 ## Logging
 
 By default, Mountpoint emits high-severity log information to [syslog](https://datatracker.ietf.org/doc/html/rfc5424) if available on your system. You can change what level of information is logged, and to where it is logged. See [LOGGING.md](LOGGING.md) for more details on configuring logging.


### PR DESCRIPTION
## Description of change

Many people are looking to have a bucket mounted persistently across reboots, etc.. While we don't have a preferred option implemented yet, we can recommend the best option today.

Relevant issues:

- #44 
- #441
- #583 

## Does this change impact existing behavior?

No, documentation only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
