### PR TITLE
Add ETag into DiskDataCache hashed block path

### DIFF
--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -176,11 +176,13 @@ impl DiskDataCache {
     }
 }
 
-/// Hash the cache key using its fields, returning the hash encoded as hexadecimal in a new [String].
+/// Hash the cache key using its fields as well as the [CACHE_VERSION],
+/// returning the hash encoded as hexadecimal in a new [String].
 fn hash_cache_key(cache_key: &CacheKey) -> String {
     let CacheKey { s3_key, etag } = cache_key;
 
     let mut hasher = Sha256::new();
+    hasher.update(CACHE_VERSION.as_bytes());
     hasher.update(s3_key.as_bytes());
     hasher.update(etag.as_str().as_bytes());
     hex::encode(hasher.finalize())
@@ -293,7 +295,7 @@ mod tests {
             etag,
             s3_key: s3_key.to_owned(),
         };
-        let expected_hash = "5931fd6bf1fe4eb26db321dda8c5a8917750d8e3a8a984fdbf028b3df59e89ae";
+        let expected_hash = "b717d5a78ed63238b0778e7295d83e963758aa54db6e969a822f2b13ce9a3067";
         assert_eq!(expected_hash, hash_cache_key(&key));
     }
 


### PR DESCRIPTION
## Description of change

We discussed in #593 to hash the S3 key, ETag, and possibly block ID together when defining a path for the disk-based data cache. This is the PR that implements that change.

I'm encoding only the ETag as I still see value in keeping the block ID visible in the path. This allows us to do things like invalidate all of the blocks for a given S3 object version (version defined by its ETag).

Previous discussions:
- https://github.com/awslabs/mountpoint-s3/pull/593#discussion_r1379502875
- https://github.com/awslabs/mountpoint-s3/pull/593#discussion_r1381392422

Relevant issues:
- #255 
- #593

## Does this change impact existing behavior?

No change to released behavior. This changes file paths for the blocks on disk for the data cache, which is behind a build-time feature flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
