### PR TITLE
Expose DataCache module and CacheKey fields

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -4,8 +4,8 @@
 //! reducing both the number of requests as well as the latency for the reads.
 //! Ultimately, this means reduced cost in terms of S3 billing as well as compute time.
 
-pub mod disk_data_cache;
-pub mod in_memory_data_cache;
+mod disk_data_cache;
+mod in_memory_data_cache;
 
 use std::ops::RangeBounds;
 
@@ -13,12 +13,14 @@ use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
+pub use crate::data_cache::disk_data_cache::DiskDataCache;
+pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 
 /// Struct representing a key for accessing an entry in a [DataCache].
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct CacheKey {
-    s3_key: String,
-    etag: ETag,
+    pub s3_key: String,
+    pub etag: ETag,
 }
 
 /// Indexes blocks within a given object.

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -1,5 +1,5 @@
 mod checksums;
-mod data_cache;
+pub mod data_cache;
 pub mod fs;
 pub mod fuse;
 mod inode;


### PR DESCRIPTION
## Description of change

Expose the `DataCache` module and the cache implementations so they can be used from `main`. Also make `CacheKey` fields public so it can be used outside the module.

Relevant issues: #255 

## Does this change impact existing behavior?

No, internal change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
