### PR TITLE
Fix various clippy warnings about unused code and variables

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -219,8 +219,7 @@ impl<Client: ObjectClient> UploadState<Client> {
 /// Returns `None` if unable to find or parse the task status.
 /// Not supported on macOS.
 fn get_tgid(pid: u32) -> Option<u32> {
-    #[cfg(not(target_os = "macos"))]
-    {
+    if cfg!(not(target_os = "macos")) {
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1648,7 +1648,6 @@ mod tests {
         }
 
         let prefix = Prefix::new(prefix).expect("valid prefix");
-        let ts = OffsetDateTime::now_utc();
         let ttl = if cached {
             std::time::Duration::from_secs(60 * 60 * 24 * 7) // 7 days should be enough
         } else {

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use clap::{value_parser, Parser};
 use fuser::{MountOption, Session};
-use mountpoint_s3::fs::{CacheConfig, S3FilesystemConfig};
+use mountpoint_s3::fs::S3FilesystemConfig;
 use mountpoint_s3::fuse::session::FuseSession;
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::instance::InstanceInfo;
@@ -504,6 +504,8 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 
     #[cfg(feature = "caching")]
     {
+        use mountpoint_s3::fs::CacheConfig;
+
         if args.enable_metadata_caching {
             // TODO: Review default for TTL
             let metadata_cache_ttl = args.metadata_cache_ttl.unwrap_or(Duration::from_secs(3600));
@@ -632,6 +634,7 @@ fn parse_bucket_name(bucket_name: &str) -> anyhow::Result<String> {
     Ok(bucket_name.to_owned())
 }
 
+#[cfg(feature = "caching")]
 fn parse_duration_seconds(seconds_str: &str) -> anyhow::Result<Duration> {
     let seconds = seconds_str.parse()?;
     let duration = Duration::from_secs(seconds);

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -9,11 +9,10 @@ use std::process::Stdio;
 use std::{path::PathBuf, process::Command};
 use test_case::test_case;
 
-use crate::common::{
+use crate::fuse_tests::{
     create_objects, get_subsession_iam_role, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region,
-    tokio_block_on,
+    read_dir_to_entry_names, tokio_block_on,
 };
-use crate::fuse_tests::read_dir_to_entry_names;
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 


### PR DESCRIPTION
## Description of change

Fix various clippy warnings about unused code and variables.

## Does this change impact existing behavior?

No functional change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
