### PR TITLE
Split cache hashed directory keys to avoid any FS-specific limits

### DIFF
--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -20,6 +20,9 @@ use super::{BlockIndex, CacheKey, ChecksummedBytes, DataCache, DataCacheResult};
 /// Disk and file-layout versioning.
 const CACHE_VERSION: &str = "V1";
 
+/// Index where hashed directory names for the cache are split to avoid FS-specific limits.
+const HASHED_DIR_SPLIT_INDEX: usize = 2;
+
 /// On-disk implementation of [DataCache].
 pub struct DiskDataCache {
     block_size: u64,
@@ -162,9 +165,11 @@ impl DiskDataCache {
         // The risk of collisions is mitigated as we ignore blocks read that contain the wrong S3 key, etc..
         let hashed_cache_key = hash_cache_key(cache_key);
 
-        // TODO: Split directory into subdirectories.
-        //       Take the first few chars of hash to avoid hitting any FS-specific maximum number of directory entries.
-        path.push(hashed_cache_key);
+        // Split directories by taking the first few chars of hash to avoid hitting any FS-specific maximum number of directory entries.
+        let (first, second) = hashed_cache_key.split_at(HASHED_DIR_SPLIT_INDEX);
+        path.push(first);
+        path.push(second);
+
         path
     }
 
@@ -312,7 +317,13 @@ mod tests {
             s3_key: s3_key.to_owned(),
         };
         let hashed_cache_key = hash_cache_key(&key);
-        let expected = vec!["mountpoint-cache", CACHE_VERSION, hashed_cache_key.as_str()];
+        let split_hashed_key = hashed_cache_key.split_at(HASHED_DIR_SPLIT_INDEX);
+        let expected = vec![
+            "mountpoint-cache",
+            CACHE_VERSION,
+            split_hashed_key.0,
+            split_hashed_key.1,
+        ];
         let path = data_cache.get_path_for_key(&key);
         let results: Vec<OsString> = path.iter().map(ToOwned::to_owned).collect();
         assert_eq!(expected, results);
@@ -331,7 +342,14 @@ mod tests {
             s3_key: s3_key.to_owned(),
         };
         let hashed_cache_key = hash_cache_key(&key);
-        let expected = vec!["mountpoint-cache", CACHE_VERSION, hashed_cache_key.as_str(), "5.block"];
+        let split_hashed_key = hashed_cache_key.split_at(HASHED_DIR_SPLIT_INDEX);
+        let expected = vec![
+            "mountpoint-cache",
+            CACHE_VERSION,
+            split_hashed_key.0,
+            split_hashed_key.1,
+            "5.block",
+        ];
         let path = data_cache.get_path_for_block(&key, 5);
         let results: Vec<OsString> = path.iter().map(ToOwned::to_owned).collect();
         assert_eq!(expected, results);


### PR DESCRIPTION
## Description of change

This change ended up being nice and small!

To mitigate risk from FS-specific limits on the number of directory entries, we split the hashed cache key used as a directory name into two, and have two levels of directories. The index where we split is totally arbitrary, this is just what Git uses and I'm sure it works well.

I'm opening this in draft to avoid conflicting with #598. I'd prefer to rebase and merge this after that PR is merged.

Relevant issues:

- #255 

## Does this change impact existing behavior?

No change, this is behind a feature flag for `caching`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
