### PR TITLE
Remove unused 'cached_block_indices' method in DataCache trait

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -7,8 +7,6 @@
 mod disk_data_cache;
 mod in_memory_data_cache;
 
-use std::ops::RangeBounds;
-
 use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
@@ -52,16 +50,4 @@ pub trait DataCache {
 
     /// Returns the block size for the data cache.
     fn block_size(&self) -> u64;
-
-    /// For the given range of blocks, which are present in the cache?
-    /// Indices in the vector are already sorted.
-    ///
-    /// It is possible that the **blocks may be deleted before reading**, or may be corrupted or inaccessible.
-    /// This method only indicates that a cache entry was present at the time of calling.
-    /// There is no guarantee that the data will still be available at the time of reading.
-    fn cached_block_indices<R: RangeBounds<BlockIndex>>(
-        &self,
-        cache_key: &CacheKey,
-        range: R,
-    ) -> DataCacheResult<Vec<BlockIndex>>;
 }

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -2,7 +2,6 @@
 
 use std::fs;
 use std::io::{ErrorKind, Read, Write};
-use std::ops::RangeBounds;
 use std::path::PathBuf;
 
 use bytes::Bytes;
@@ -247,14 +246,6 @@ impl DataCache for DiskDataCache {
 
     fn block_size(&self) -> u64 {
         self.block_size
-    }
-
-    fn cached_block_indices<R: RangeBounds<BlockIndex>>(
-        &self,
-        _cache_key: &CacheKey,
-        _range: R,
-    ) -> DataCacheResult<Vec<BlockIndex>> {
-        todo!("implement or deprecate");
     }
 }
 


### PR DESCRIPTION
## Description of change

This method (for caching) was no longer used, let's remove it.

Relevant issues: #255

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
