### PR TITLE
Implement cache eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +1779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,12 +1932,14 @@ dependencies = [
  "ctrlc",
  "dashmap",
  "filetime",
+ "fs2",
  "fuser",
  "futures",
  "hdrhistogram",
  "hex",
  "lazy_static",
  "libc",
+ "linked-hash-map",
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -40,6 +40,8 @@ serde = { version = "1.0.190", features = ["derive"] }
 bincode = "1.3.3"
 sha2 = "0.10.6"
 hex = "0.4.3"
+linked-hash-map = "0.5.6"
+fs2 = "0.4.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15.1", default-features = false }

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -11,7 +11,7 @@ use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
-pub use crate::data_cache::disk_data_cache::DiskDataCache;
+pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 
 /// Struct representing a key for accessing an entry in a [DataCache].


### PR DESCRIPTION
## Description of change

Introduce a `CacheLimit` argument for the `DiskDataCache` to configure the eviction policy. If a limit is set, the cache will track usage of the stored blocks. On put, it will check if the limit has been exceeded and start removing the least recently used blocks if required.

Relevant issues: #255 

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
