### PR TITLE
Store block offsets in disk data cache

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -31,6 +31,8 @@ pub enum DataCacheError {
     IoFailure(#[from] std::io::Error),
     #[error("Block content was not valid/readable")]
     InvalidBlockContent,
+    #[error("Block offset does not match block index")]
+    InvalidBlockOffset,
     #[error("Error while trying to evict cache content")]
     EvictionFailure,
 }
@@ -45,10 +47,21 @@ pub trait DataCache {
     /// Get block of data from the cache for the given [CacheKey] and [BlockIndex], if available.
     ///
     /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
-    fn get_block(&self, cache_key: &CacheKey, block_idx: BlockIndex) -> DataCacheResult<Option<ChecksummedBytes>>;
+    fn get_block(
+        &self,
+        cache_key: &CacheKey,
+        block_idx: BlockIndex,
+        block_offset: u64,
+    ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [CacheKey] and [BlockIndex].
-    fn put_block(&self, cache_key: CacheKey, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()>;
+    fn put_block(
+        &self,
+        cache_key: CacheKey,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+    ) -> DataCacheResult<()>;
 
     /// Returns the block size for the data cache.
     fn block_size(&self) -> u64;

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -490,7 +490,7 @@ mod tests {
             etag: ETag::for_tests(),
             s3_key: String::from("hello-world"),
         };
-        let block = DiskBlock::new(cache_key, 100, 100 * 10, data).expect("should success as data checksum is valid");
+        let block = DiskBlock::new(cache_key, 100, 100 * 10, data).expect("should succeed as data checksum is valid");
         let expected_bytes: Vec<u8> = vec![
             100, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 116, 101, 115, 116, 95, 101,
             116, 97, 103, 11, 0, 0, 0, 0, 0, 0, 0, 104, 101, 108, 108, 111, 45, 119, 111, 114, 108, 100, 9, 85, 128,

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -329,7 +329,6 @@ impl DataCache for DiskDataCache {
         }
         let block_key = DiskBlockKey::new(cache_key, block_idx);
         let path = self.get_path_for_block_key(&block_key);
-        let block_offset = block_idx * self.block_size;
         match self.read_block(&path, cache_key, block_idx, block_offset) {
             Ok(None) => Ok(None),
             Ok(Some(bytes)) => {

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::default::Default;
 
-use super::{BlockIndex, CacheKey, ChecksummedBytes, DataCache, DataCacheResult};
+use super::{BlockIndex, CacheKey, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
@@ -23,13 +23,30 @@ impl InMemoryDataCache {
 }
 
 impl DataCache for InMemoryDataCache {
-    fn get_block(&self, cache_key: &CacheKey, block_idx: BlockIndex) -> DataCacheResult<Option<ChecksummedBytes>> {
+    fn get_block(
+        &self,
+        cache_key: &CacheKey,
+        block_idx: BlockIndex,
+        block_offset: u64,
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        if block_offset != block_idx * self.block_size {
+            return Err(DataCacheError::InvalidBlockOffset);
+        }
         let data = self.data.read().unwrap();
         let block_data = data.get(cache_key).and_then(|blocks| blocks.get(&block_idx)).cloned();
         Ok(block_data)
     }
 
-    fn put_block(&self, cache_key: CacheKey, block_idx: BlockIndex, bytes: ChecksummedBytes) -> DataCacheResult<()> {
+    fn put_block(
+        &self,
+        cache_key: CacheKey,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+    ) -> DataCacheResult<()> {
+        if block_offset != block_idx * self.block_size {
+            return Err(DataCacheError::InvalidBlockOffset);
+        }
         let mut data = self.data.write().unwrap();
         let blocks = data.entry(cache_key).or_default();
         blocks.insert(block_idx, bytes);
@@ -57,7 +74,8 @@ mod tests {
         let data_3 = Bytes::from_static(b"Baz");
         let data_3 = ChecksummedBytes::from_bytes(data_3.clone());
 
-        let cache = InMemoryDataCache::new(8 * 1024 * 1024);
+        let block_size = 8 * 1024 * 1024;
+        let cache = InMemoryDataCache::new(block_size);
         let cache_key_1 = CacheKey {
             s3_key: "a".into(),
             etag: ETag::for_tests(),
@@ -67,7 +85,7 @@ mod tests {
             etag: ETag::for_tests(),
         };
 
-        let block = cache.get_block(&cache_key_1, 0).expect("cache is accessible");
+        let block = cache.get_block(&cache_key_1, 0, 0).expect("cache is accessible");
         assert!(
             block.is_none(),
             "no entry should be available to return but got {:?}",
@@ -76,10 +94,10 @@ mod tests {
 
         // PUT and GET, OK?
         cache
-            .put_block(cache_key_1.clone(), 0, data_1.clone())
+            .put_block(cache_key_1.clone(), 0, 0, data_1.clone())
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_1, 0)
+            .get_block(&cache_key_1, 0, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -89,10 +107,10 @@ mod tests {
 
         // PUT AND GET a second file, OK?
         cache
-            .put_block(cache_key_2.clone(), 0, data_2.clone())
+            .put_block(cache_key_2.clone(), 0, 0, data_2.clone())
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_2, 0)
+            .get_block(&cache_key_2, 0, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -102,10 +120,10 @@ mod tests {
 
         // PUT AND GET a second block in a cache entry, OK?
         cache
-            .put_block(cache_key_1.clone(), 1, data_3.clone())
+            .put_block(cache_key_1.clone(), 1, block_size, data_3.clone())
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_1, 1)
+            .get_block(&cache_key_1, 1, block_size)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -115,7 +133,7 @@ mod tests {
 
         // Entry 1's first block still intact
         let entry = cache
-            .get_block(&cache_key_1, 0)
+            .get_block(&cache_key_1, 0, 0)
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(


### PR DESCRIPTION
## Description of change

Add the block offset to the header stored in each cache block. This allows for additional consistency checks when reading or writing to the cache, where the offset can be compared with the block index.

## Does this change impact existing behavior?

It does change the on disk cache format, but it is still currently under the `caching` feature flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
