### PR TITLE
Simplify and rename cache configuration flags

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -11,7 +11,7 @@ use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
-pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache};
+pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 
 /// Struct representing a key for accessing an entry in a [DataCache].

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -45,7 +45,7 @@ impl Default for DiskDataCacheConfig {
     fn default() -> Self {
         Self {
             block_size: 1024 * 1024,                               // 1 MiB block size
-            limit: CacheLimit::AvailableSpace { min_ratio: 0.01 }, // Preserve 1% available space
+            limit: CacheLimit::AvailableSpace { min_ratio: 0.05 }, // Preserve 5% available space
         }
     }
 }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -223,7 +223,7 @@ struct CliArgs {
     #[cfg(feature = "caching")]
     #[clap(
         long,
-        help = "Enable caching of object metadata and content. Requires a directory path",
+        help = "Enable caching of object metadata and content. Directory provided will be used for caching object content. If running multiple Mountpoint processes concurrently, use a unique value for this argument",
         help_heading = CACHING_OPTIONS_HEADER,
         value_name = "DIRECTORY",
     )]

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -223,7 +223,7 @@ struct CliArgs {
     #[cfg(feature = "caching")]
     #[clap(
         long,
-        help = "Enable caching of object metadata and content. Directory provided will be used for caching object content. If running multiple Mountpoint processes concurrently, use a unique value for this argument",
+        help = "Enable caching of object metadata and content to the given directory",
         help_heading = CACHING_OPTIONS_HEADER,
         value_name = "DIRECTORY",
     )]
@@ -232,7 +232,7 @@ struct CliArgs {
     #[cfg(feature = "caching")]
     #[clap(
         long,
-        help = "Set time-to-live (TTL) for cached metadata in seconds [default: 1s]",
+        help = "Time-to-live (TTL) for cached metadata in seconds [default: 1s]",
         value_name = "SECONDS",
         value_parser = parse_duration_seconds,
         help_heading = CACHING_OPTIONS_HEADER,

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -243,8 +243,8 @@ struct CliArgs {
     #[cfg(feature = "caching")]
     #[clap(
         long,
-        help = "Maximum size of the cache directory in MB [default: preserve 1% of available space]",
-        value_name = "MB",
+        help = "Maximum size of the cache directory in MiB [default: preserve 5% of available space]",
+        value_name = "MiB",
         value_parser = value_parser!(u64).range(1..),
         help_heading = CACHING_OPTIONS_HEADER,
         requires = "cache",
@@ -574,9 +574,9 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
             };
 
             let mut cache_config = DiskDataCacheConfig::default();
-            if let Some(max_size_in_mb) = args.max_cache_size {
+            if let Some(max_size_in_mib) = args.max_cache_size {
                 cache_config.limit = CacheLimit::TotalSize {
-                    max_size: (max_size_in_mb * 1_000_000) as usize,
+                    max_size: (max_size_in_mib * 1024 * 1024) as usize,
                 };
             }
             let cache = DiskDataCache::new(path, cache_config);


### PR DESCRIPTION
## Description of change

Reduce the number of flags to configure the object metadata and content cache. 

This is how they will be displayed in `mount-s3 --help`:
```
Caching options:
      --cache <DIRECTORY>       Enable caching of object metadata and content to the given directory
      --metadata-ttl <SECONDS>  Time-to-live (TTL) for cached metadata in seconds [default: 1s]
      --max-cache-size <MiB>    Maximum size of the cache directory in MiB [default: preserve 5% of available space]
```

Relevant issues: #255 

## Does this change impact existing behavior?

No. All flags under the `caching` feature.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
