### PR TITLE
Use top-level file in write benchmark

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -153,7 +153,7 @@ write_benchmark () {
     fi
 
     # set bench file
-    bench_file=${mount_dir}/${job_name}_${RANDOM}.dat
+    bench_file=${job_name}_${RANDOM}.dat
 
     # run the benchmark
     run_fio_job $job_file $bench_file $mount_dir $log_dir


### PR DESCRIPTION
The write throughput benchmarks were failing when running the second iteration because fio would not re-create the nested path for the benchmark file. This appears to have started since #584. Further investigation required to determine if there is an issue with Mountpoint.
This change only unblocks the benchmarks by configuring fio to use a file at the top-level in the mount directory, which was likely the intention in the first place (fio's `--filename` path is relative to `--directory`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
