### PR TITLE
Disable data cache when setting --max_cache_size=0

### DIFF
--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -270,6 +270,12 @@ impl DiskDataCache {
             .expect("path should include cache key in directory name");
         fs::create_dir_all(cache_path_for_key)?;
 
+        trace!(
+            key = block.header.s3_key,
+            offset = block.header.block_offset,
+            "writing block at {}",
+            path.as_ref().display()
+        );
         let mut file = fs::File::create(path.as_ref())?;
         file.write_all(CACHE_VERSION.as_bytes())?;
         let serialize_result = bincode::serialize_into(&mut file, &block);
@@ -314,6 +320,7 @@ impl DiskDataCache {
                 return Err(DataCacheError::EvictionFailure);
             };
             let path_to_remove = self.get_path_for_block_key(&to_remove);
+            trace!("evicting block at {}", path_to_remove.display());
             if let Err(remove_err) = fs::remove_file(&path_to_remove) {
                 error!("unable to remove invalid block: {:?}", remove_err);
             }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -245,7 +245,7 @@ struct CliArgs {
         long,
         help = "Maximum size of the cache directory in MiB [default: preserve 5% of available space]",
         value_name = "MiB",
-        value_parser = value_parser!(u64).range(1..),
+        value_parser = value_parser!(u64),
         help_heading = CACHING_OPTIONS_HEADER,
         requires = "cache",
     )]
@@ -573,23 +573,31 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
                 file_ttl: metadata_cache_ttl,
             };
 
-            let mut cache_config = DiskDataCacheConfig::default();
-            if let Some(max_size_in_mib) = args.max_cache_size {
-                cache_config.limit = CacheLimit::TotalSize {
-                    max_size: (max_size_in_mib * 1024 * 1024) as usize,
-                };
+            let cache_config = match args.max_cache_size {
+                // Fallback to no data cache.
+                Some(0) => None,
+                Some(max_size_in_mib) => Some(DiskDataCacheConfig {
+                    limit: CacheLimit::TotalSize {
+                        max_size: (max_size_in_mib * 1024 * 1024) as usize,
+                    },
+                    ..Default::default()
+                }),
+                None => Some(DiskDataCacheConfig::default()),
+            };
+
+            if let Some(cache_config) = cache_config {
+                let cache = DiskDataCache::new(path, cache_config);
+                let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
+                return create_filesystem(
+                    client,
+                    prefetcher,
+                    &args.bucket_name,
+                    &prefix,
+                    filesystem_config,
+                    fuse_config,
+                    &bucket_description,
+                );
             }
-            let cache = DiskDataCache::new(path, cache_config);
-            let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
-            return create_filesystem(
-                client,
-                prefetcher,
-                &args.bucket_name,
-                &prefix,
-                filesystem_config,
-                fuse_config,
-                &bucket_description,
-            );
         }
     }
 
@@ -613,7 +621,7 @@ fn create_filesystem<Client, Prefetcher>(
     filesystem_config: S3FilesystemConfig,
     fuse_session_config: FuseSessionConfig,
     bucket_description: &str,
-) -> Result<FuseSession, anyhow::Error>
+) -> anyhow::Result<FuseSession>
 where
     Client: ObjectClient + Send + Sync + 'static,
     Prefetcher: Prefetch + Send + Sync + 'static,


### PR DESCRIPTION
## Description of change

Do not use the data cache if the user sets `--max_cache_size` to `0`. Caching of metadata is not affected.

Relevant issues: #255 

## Does this change impact existing behavior?

No breaking changes, changes only to a feature has not been released yet.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
