### PR TITLE
Improve logging for ETags and FUSE operation flags

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -21,27 +21,23 @@ pub type GetBodyPart = (u64, Box<[u8]>);
 ///
 /// New ETags can be created with the [`FromStr`] implementation.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ETag {
-    etag: String,
-}
+pub struct ETag(String);
 
 impl ETag {
     /// Get the ETag as a string
     pub fn as_str(&self) -> &str {
-        &self.etag
+        &self.0
     }
 
     /// Unpack the [String] contained by the [ETag] wrapper
     pub fn into_inner(self) -> String {
-        self.etag
+        self.0
     }
 
     /// Creating default etag for tests
     #[doc(hidden)]
     pub fn for_tests() -> Self {
-        Self {
-            etag: "test_etag".to_string(),
-        }
+        Self("test_etag".to_string())
     }
 
     /// Creating unique etag from bytes
@@ -52,16 +48,15 @@ impl ETag {
 
         let hash = hasher.finalize();
         let result = format!("{:x}", hash);
-        Self { etag: result }
+        Self(result)
     }
 }
 
 impl FromStr for ETag {
     type Err = ParseError;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(ETag {
-            etag: value.to_string(),
-        })
+        let etag = value.to_string();
+        Ok(ETag(etag))
     }
 }
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -560,7 +560,7 @@ where
     }
 
     pub async fn open(&self, ino: InodeNo, flags: i32, pid: u32) -> Result<Opened, Error> {
-        trace!("fs:open with ino {:?} flags {:?} pid {:?}", ino, flags, pid);
+        trace!("fs:open with ino {:?} flags {:#b} pid {:?}", ino, flags, pid);
 
         let force_revalidate = !self.config.cache_config.serve_lookup_from_cache;
         let lookup = self.superblock.getattr(&self.client, ino, force_revalidate).await?;
@@ -594,6 +594,7 @@ where
             object_size: lookup.stat.size as u64,
             typ: handle_type,
         };
+        debug!(fh, ino, "new file handle created");
         self.file_handles.write().await.insert(fh, Arc::new(handle));
 
         Ok(Opened { fh, flags: 0 })
@@ -742,7 +743,7 @@ where
     }
 
     pub async fn opendir(&self, parent: InodeNo, _flags: i32) -> Result<Opened, Error> {
-        trace!("fs:opendir with parent {:?} flags {:?}", parent, _flags);
+        trace!("fs:opendir with parent {:?} flags {:#b}", parent, _flags);
 
         let inode_handle = self.superblock.readdir(&self.client, parent, 1000).await?;
 


### PR DESCRIPTION
## Description of change

Small logging improvements I wanted to make while debugging #614.

- It was useful to include the ETag at different points, but the named-field struct for ETag meant the `Debug` format was noisy. Moving to a tuple struct is simple and ETag is now formatted as `ETag("etag")`.
- FUSE operations which take flags were originally formatting the flags as decimal numbers. It's appears easier to interpret the flags when using binary usually, so we update the logs to format those numbers as binary like `0b10010101`.
- Some of the logs on their own weren't useful. For example, we know an Inode lookup count was incremented but we only know the parent Inode. Fix that by including the Inode number that actually had its count incremented.
- We never emitted the new file handle number before use - now we do that.

Relevant issues: N/A

## Does this change impact existing behavior?

No breaking changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
