### PR TITLE
Cleanup cache dir at mount and exit

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -4,6 +4,7 @@
 //! reducing both the number of requests as well as the latency for the reads.
 //! Ultimately, this means reduced cost in terms of S3 billing as well as compute time.
 
+mod cache_directory;
 mod disk_data_cache;
 mod in_memory_data_cache;
 
@@ -11,6 +12,7 @@ use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
+pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -1,0 +1,168 @@
+//! Provides functionality related to the inner cache directory Mountpoint creates or uses.
+//! Mountpoint attempts to cleanup the contents during mount and exit.
+//!
+//! Mountpoint uses a directory inside the user-provided cache directory
+//! to mitigate any impact from the user providing a directory that already contains data.
+//! Using a new sub-directory minimizes the interference with the existing directory structure,
+//! and limits the risk from deleting or overwriting data to files written within this sub-directory.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Cache directory that has been created and emptied, and will be emptied when dropped.
+#[derive(Debug)]
+pub struct ManagedCacheDir {
+    managed_path: PathBuf,
+    /// Used to prevent double cleanup with `close(self)` and [Drop]
+    closed: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ManagedCacheDirError {
+    #[error("creation of cache sub-directory failed due to IO error: {0}")]
+    CreationFailure(#[source] io::Error),
+    #[error("cleanup of cache sub-directory failed due to IO error: {0}")]
+    CleanupFailure(#[source] io::Error),
+}
+
+impl ManagedCacheDir {
+    /// Create a new directory inside the provided parent path, cleaning it of any contents if it already exists.
+    pub fn new_from_parent<P: AsRef<Path>>(parent_path: P) -> Result<Self, ManagedCacheDirError> {
+        let managed_path = parent_path.as_ref().join("mountpoint-cache");
+
+        if let Err(mkdir_err) = fs::create_dir(&managed_path) {
+            match mkdir_err.kind() {
+                io::ErrorKind::AlreadyExists => (),
+                _kind => return Err(ManagedCacheDirError::CreationFailure(mkdir_err)),
+            }
+        }
+
+        let managed_cache_dir = Self {
+            managed_path,
+            closed: false,
+        };
+        managed_cache_dir.clean()?;
+
+        Ok(managed_cache_dir)
+    }
+
+    /// Remove the cache sub-directory
+    fn clean(&self) -> Result<(), ManagedCacheDirError> {
+        tracing::debug!(cache_subdirectory = ?self.managed_path, "cleaning up contents of cache sub-directory");
+        if let Err(e) = fs::remove_dir_all(&self.managed_path) {
+            match e.kind() {
+                io::ErrorKind::NotFound => (),
+                _kind => return Err(ManagedCacheDirError::CleanupFailure(e)),
+            }
+        }
+        tracing::trace!(cache_subdirectory = ?self.managed_path, "cleanup complete");
+        Ok(())
+    }
+
+    /// Delete the managed cache directory, waiting until complete.
+    ///
+    /// This directory should also be cleaned as part of [Drop], however this is not always guaranteed.
+    pub fn close(mut self) -> Result<(), ManagedCacheDirError> {
+        let result = self.clean();
+        if result.is_ok() {
+            self.closed = true;
+        }
+        result
+    }
+
+    /// Retrieve a reference to the managed path
+    pub fn as_path(&self) -> &Path {
+        self.managed_path.as_path()
+    }
+
+    /// Create an owned copy of the managed path
+    pub fn as_path_buf(&self) -> PathBuf {
+        self.managed_path.clone()
+    }
+}
+
+impl Drop for ManagedCacheDir {
+    fn drop(&mut self) {
+        if !self.closed {
+            if let Err(err) = self.clean() {
+                tracing::error!(managed_cache_path = ?self.managed_path, "failed to clean cache directory: {err}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ManagedCacheDir;
+
+    use std::fs;
+
+    #[test]
+    fn test_unused() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let expected_path = temp_dir.path().join("mountpoint-cache");
+
+        let managed_dir =
+            ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
+        assert!(expected_path.try_exists().unwrap(), "{expected_path:?} should exist");
+
+        drop(managed_dir);
+        assert!(
+            !expected_path.try_exists().unwrap(),
+            "{expected_path:?} should not exist"
+        );
+
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_used() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let expected_path = temp_dir.path().join("mountpoint-cache");
+
+        let managed_dir =
+            ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
+        assert!(expected_path.try_exists().unwrap(), "{expected_path:?} should exist");
+
+        fs::File::create(expected_path.join("file.txt"))
+            .expect("should be able to create file within managed directory");
+        fs::create_dir(expected_path.join("dir")).expect("should be able to create dir within managed directory");
+        fs::File::create(expected_path.join("dir/file.txt"))
+            .expect("should be able to create file within subdirectory");
+
+        drop(managed_dir);
+        assert!(
+            !expected_path.try_exists().unwrap(),
+            "{expected_path:?} should not exist"
+        );
+
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_already_exists() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let expected_path = temp_dir.path().join("mountpoint-cache");
+
+        fs::create_dir_all(expected_path.join("dir")).unwrap();
+        fs::File::create(expected_path.join("dir/file.txt")).unwrap();
+
+        let managed_dir =
+            ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
+        assert!(expected_path.try_exists().unwrap(), "{expected_path:?} should exist");
+
+        let dir_entries = fs::read_dir(&expected_path).unwrap().count();
+        assert!(dir_entries == 0, "directory should be empty");
+
+        drop(managed_dir);
+        assert!(
+            !expected_path.try_exists().unwrap(),
+            "{expected_path:?} should not exist"
+        );
+
+        temp_dir.close().unwrap();
+    }
+}

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -217,7 +217,7 @@ impl DiskDataCache {
 
     /// Get the relative path for the given block.
     fn get_path_for_block_key(&self, block_key: &DiskBlockKey) -> PathBuf {
-        let mut path = self.cache_directory.as_path().join(CACHE_VERSION);
+        let mut path = self.cache_directory.join(CACHE_VERSION);
         block_key.append_to_path(&mut path);
         path
     }
@@ -293,7 +293,7 @@ impl DiskDataCache {
             CacheLimit::Unbounded => false,
             CacheLimit::TotalSize { max_size } => size > max_size,
             CacheLimit::AvailableSpace { min_ratio } => {
-                let stats = match fs2::statvfs(self.cache_directory.as_path()) {
+                let stats = match fs2::statvfs(&self.cache_directory) {
                     Ok(stats) if stats.total_space() == 0 => {
                         warn!("unable to determine available space");
                         return false;

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -217,7 +217,7 @@ impl DiskDataCache {
 
     /// Get the relative path for the given block.
     fn get_path_for_block_key(&self, block_key: &DiskBlockKey) -> PathBuf {
-        let mut path = self.cache_directory.join(CACHE_VERSION);
+        let mut path = self.cache_directory.as_path().join(CACHE_VERSION);
         block_key.append_to_path(&mut path);
         path
     }
@@ -287,7 +287,7 @@ impl DiskDataCache {
             CacheLimit::Unbounded => false,
             CacheLimit::TotalSize { max_size } => size > max_size,
             CacheLimit::AvailableSpace { min_ratio } => {
-                let stats = match fs2::statvfs(&self.cache_directory) {
+                let stats = match fs2::statvfs(self.cache_directory.as_path()) {
                     Ok(stats) if stats.total_space() == 0 => {
                         warn!("unable to determine available space");
                         return false;

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use clap::{value_parser, Parser};
 use fuser::{MountOption, Session};
+#[cfg(feature = "caching")]
+use mountpoint_s3::data_cache::ManagedCacheDir;
 use mountpoint_s3::fs::S3FilesystemConfig;
 use mountpoint_s3::fuse::session::FuseSession;
 use mountpoint_s3::fuse::S3FuseFilesystem;
@@ -579,9 +581,11 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
                     max_size: (max_size_in_mib * 1024 * 1024) as usize,
                 };
             }
-            let cache = DiskDataCache::new(path, cache_config);
+            let managed_cache_dir =
+                ManagedCacheDir::new_from_parent(path).context("failed to create cache directory")?;
+            let cache = DiskDataCache::new(managed_cache_dir.as_path_buf(), cache_config);
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
-            return create_filesystem(
+            let mut fuse_session = create_filesystem(
                 client,
                 prefetcher,
                 &args.bucket_name,
@@ -590,6 +594,18 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
                 fuse_config,
                 &bucket_description,
             );
+
+            if let Ok(session) = &mut fuse_session {
+                let handler = Box::new(move || {
+                    let path = managed_cache_dir.as_path_buf();
+                    if let Err(err) = managed_cache_dir.close() {
+                        tracing::error!(?path, "failed to clean cache directory: {err}");
+                    }
+                });
+                session.run_on_close(handler);
+            }
+
+            return fuse_session;
         }
     }
 

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -603,13 +603,9 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
                 );
 
                 if let Ok(session) = &mut fuse_session {
-                    let handler = Box::new(move || {
-                        let path = managed_cache_dir.as_path_buf();
-                        if let Err(err) = managed_cache_dir.close() {
-                            tracing::error!(?path, "failed to clean cache directory: {err}");
-                        }
-                    });
-                    session.run_on_close(handler);
+                    session.run_on_close(Box::new(move || {
+                        drop(managed_cache_dir);
+                    }));
                 }
 
                 return fuse_session;


### PR DESCRIPTION
## Description of change

We want to clean the directory used for caching at mount time and exit time to keep usage of the disk under control, especially since we do not intend to support cache re-use (at least initially).

This change adds a new managed directory type, which will create the directory we expect and deleted it on drop, if `close(mut self)` was not already called. We introduce `close` since the drop implementation did not appear to always be invoked. 

Relevant issues: #255 

## Does this change impact existing behavior?

No change to released features. Only impacts caching, currently behind a feature flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
