### PR TITLE
Remove the temporary caching feature flag

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### New features 
+* Introduced optional caching of object metadata and content, in order to allow reduced cost and improved performance for repeated reads to the same files. ([#622](https://github.com/awslabs/mountpoint-s3/pull/622))
+
+### Breaking changes
+* No breaking changes.
+
 ## v1.1.1 (November 14, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -67,9 +67,6 @@ tokio = { version = "1.24.2", features = ["rt", "macros"] }
 walkdir = "2.3.3"
 
 [features]
-# Experimental features
-caching = []
-
 # Test features
 fips_tests = []
 fuse_tests = []


### PR DESCRIPTION
## Description of change

Remove the "caching" build feature. With this change, the new command line flag `--cache` and related options to support caching are generally available.

Relevant issues: #255 

## Does this change impact existing behavior?

No. The new caching behavior is optional and needs to be explicitly enabled with a command line flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
