### PR TITLE
Add FileName/Object key in error logging

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -774,7 +774,13 @@ where
         let len = {
             let mut request = match &handle.typ {
                 FileHandleType::Write(request) => request.lock().await,
-                FileHandleType::Read { .. } => return Err(err!(libc::EBADF, "file handle is not open for writes")),
+                FileHandleType::Read { .. } => {
+                    return Err(err!(
+                        libc::EBADF,
+                        "file handle is not open for writes (key={:?})",
+                        handle.full_key
+                    ))
+                }
             };
             request.write(offset, data, &handle.full_key).await?
         };

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -112,6 +112,7 @@ impl ToErrno for InodeError {
         match self {
             InodeError::ClientError(_) => libc::EIO,
             InodeError::FileDoesNotExist(_) => libc::ENOENT,
+            InodeError::DirectoryDoesNotExist(_) => libc::ENOENT,
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -111,7 +111,7 @@ impl ToErrno for InodeError {
     fn to_errno(&self) -> libc::c_int {
         match self {
             InodeError::ClientError(_) => libc::EIO,
-            InodeError::FileDoesNotExist => libc::ENOENT,
+            InodeError::FileDoesNotExist(_) => libc::ENOENT,
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 use time::OffsetDateTime;
-use tracing::{instrument, Instrument};
+use tracing::{field, instrument, Instrument};
 
 use crate::fs::{
     self, DirectoryEntry, DirectoryReplier, InodeNo, ReadReplier, S3Filesystem, S3FilesystemConfig, ToErrno,
@@ -322,7 +322,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid()))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid(), key=field::Empty))]
     fn write(
         &self,
         _req: &Request<'_>,

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 use time::OffsetDateTime;
-use tracing::{field, instrument, Instrument};
+use tracing::{instrument, Instrument};
 
 use crate::fs::{
     self, DirectoryEntry, DirectoryReplier, InodeNo, ReadReplier, S3Filesystem, S3FilesystemConfig, ToErrno,
@@ -322,7 +322,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid(), key=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid()))]
     fn write(
         &self,
         _req: &Request<'_>,

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -196,7 +196,7 @@ where
                 {
                     Ok(get_object_result) => get_object_result,
                     Err(e) => {
-                        error!(error=?e, "GetObject request failed");
+                        error!(key, error=?e, "GetObject request failed");
                         part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                         return;
                     }
@@ -227,7 +227,7 @@ where
                             }
                         }
                         Some(Err(e)) => {
-                            error!(error=?e, "GetObject body part failed");
+                            error!(key, error=?e, "GetObject body part failed");
                             part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                             break;
                         }


### PR DESCRIPTION
## Description of change
`InodeError` is logged mutliple times directly at error level. So, added Filename in FileDoesNotExist type. Could not add InodeErrorInfo for InodeDoesNotExist error type because it is called by [get()](https://github.com/awslabs/mountpoint-s3/blob/801e4c175cb85e21f713cf919e0f18ac8d2a9188/mountpoint-s3/src/inode.rs#L527) of `SuperBlockInner`. It only has Inode number as a parameter. 
Also added object key in UploadWriteError types. 
For rest of the errors added object key wherever it was available. 
<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
#555 
## Does this change impact existing behavior?
No, it does not impact existing behaviour.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
