### PR TITLE
Fix mountpoint-s3-crt RequestType conversion

### DIFF
--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1029,17 +1029,16 @@ pub enum RequestType {
 
 impl From<aws_s3_request_type> for RequestType {
     fn from(value: aws_s3_request_type) -> Self {
-        use aws_s3_request_type::*;
         match value {
-            AWS_S3_REQUEST_TYPE_DEFAULT => RequestType::Default,
-            AWS_S3_REQUEST_TYPE_HEAD_OBJECT => RequestType::HeadObject,
-            AWS_S3_REQUEST_TYPE_GET_OBJECT => RequestType::GetObject,
-            AWS_S3_REQUEST_TYPE_LIST_PARTS => RequestType::ListParts,
-            AWS_S3_REQUEST_TYPE_CREATE_MULTIPART_UPLOAD => RequestType::CreateMultipartUpload,
-            AWS_S3_REQUEST_TYPE_UPLOAD_PART => RequestType::UploadPart,
-            AWS_S3_REQUEST_TYPE_ABORT_MULTIPART_UPLOAD => RequestType::AbortMultipartUpload,
-            AWS_S3_REQUEST_TYPE_COMPLETE_MULTIPART_UPLOAD => RequestType::CompleteMultipartUpload,
-            AWS_S3_REQUEST_TYPE_UPLOAD_PART_COPY => RequestType::UploadPartCopy,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_DEFAULT => RequestType::Default,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_HEAD_OBJECT => RequestType::HeadObject,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_GET_OBJECT => RequestType::GetObject,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_LIST_PARTS => RequestType::ListParts,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_CREATE_MULTIPART_UPLOAD => RequestType::CreateMultipartUpload,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_UPLOAD_PART => RequestType::UploadPart,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_ABORT_MULTIPART_UPLOAD => RequestType::AbortMultipartUpload,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_COMPLETE_MULTIPART_UPLOAD => RequestType::CompleteMultipartUpload,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_UPLOAD_PART_COPY => RequestType::UploadPartCopy,
             _ => panic!("unknown request type {:?}", value),
         }
     }
@@ -1169,5 +1168,21 @@ impl UploadReviewPart {
         };
         let size = part.size;
         Self { size, checksum }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use crate::aws_s3_request_type;
+    use crate::s3::client::RequestType;
+
+    #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_DEFAULT, RequestType::Default)]
+    #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_HEAD_OBJECT, RequestType::HeadObject)]
+    #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_GET_OBJECT, RequestType::GetObject)]
+    fn request_type_from_aws_s3_request_type(c_request_type: aws_s3_request_type, expected_request_type: RequestType) {
+        // Simple, but was previously broken.
+        assert_eq!(expected_request_type, RequestType::from(c_request_type));
     }
 }


### PR DESCRIPTION
## Description of change

This is mainly used in metrics, so impact should have been minimal.

What was happening before this change was that the match arms were binding the matched pattern to a new variable `AWS_S3_REQUEST_TYPE_DEFAULT`, rather than matching the Enum. This is because `AWS_S3_REQUEST_TYPE_DEFAULT` is actually a constant representing an Enum value.

I'll follow up this change with a fix to Clippy in CI to actually fail on warnings, which I believe we wanted but it does not appear to work correctly. (We should deny `warnings`, not just `clippy::all`.)

Relevant issues: N/A

## Does this change impact existing behavior?

It may fix some metric reporting, if any.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
