### PR TITLE
Update Clippy CI to deny warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ DISABLED_LINTS += -A clippy::arc-with-non-send-sync  # https://github.com/propte
 .PHONY: clippy
 clippy:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
-	cargo clippy $$packages --no-deps --all-targets --all-features -- -D clippy::all $(DISABLED_LINTS)
+	cargo clippy $$packages --no-deps --all-targets --all-features -- -D warnings -D clippy::all $(DISABLED_LINTS)


### PR DESCRIPTION
## Description of change

Our intention is for there to be no Clippy warnings, and our CI should enforce this. Today, it only enforces Clippy's own warnings but not more generic ones. This change fixes that!

It would have caught a regression we discovered in #633 earlier, which we only noticed by reviewing warnings when debugging another issue.

Relevant issues: #633

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
