### PR TITLE
Exclude unused files from mountpoint-s3-crt-sys crate

### DIFF
--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -36,6 +36,8 @@ exclude = [
     "crt/aws-lc/util/fipstools/acvp/acvptool/test/*",
     "crt/s2n-tls/compliance/*",
     "crt/s2n-tls/scram/SCRAM_paper.pdf",
+    "**/.github/**",
+    "**/*.jar",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
## Description of change

The size of the `mountpoint-s3-crt-sys` create has exceeded 10MiB. We exclude from the crate some files we know we don't use. We should also follow up and eliminate more to ensure the crate is smaller again.

Relevant issues: N/A

## Does this change impact existing behavior?

No breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
