### PR TITLE
Add workflow to verify crate packaging

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         crate:
-        - mountpoint-s3-client
-        - mountpoint-s3-crt
-        - mountpoint-s3-crt-sys
+          - mountpoint-s3-client
+          - mountpoint-s3-crt
+          - mountpoint-s3-crt-sys
 
     steps:
       - name: Checkout code

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,48 @@
+name: Crate checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
+
+jobs:
+  verify-crate:
+    name: Verify crate
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        crate:
+        - mountpoint-s3-client
+        - mountpoint-s3-crt
+        - mountpoint-s3-crt-sys
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Package ${{ matrix.crate }} crate
+        run: cargo package -p ${{ matrix.crate }}
+      - name: Verify compressed crate size is smaller than crates.io limit
+        run: |
+          ls -alh target/package/*.crate
+          test `cat target/package/*.crate | wc -c` -le 10485760


### PR DESCRIPTION
## Description of change

We went over the 10MiB limit in #641 but didn't realize it. We had to mitigate this by removing files in #646.

To prevent this occurring again, this workflow verifies we can a) package the crates (because we should verify that!) and b) ensure we have not exceeded the crates.io size limitation.

I already tested on my fork, here is a run where I ensured the crate exceeded 10MiB: https://github.com/dannycjones/mountpoint-s3/actions/runs/7036886653/job/19150487166#step:7:7

Relevant issues: N/A

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
