### PR TITLE
Update CRT submodules to latest releases

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1034,10 +1034,9 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    /// Test both explicit validation in [Client::new] and implicit limits in the CRT
-    #[test_case(4 * 1024 * 1024; "less than 5MiB")] // validated in Client::new
-    #[test_case(10_000_000; "not a multiple of 1024")] // CRT constraint
-    #[test_case(6 * 1024 * 1024 * 1024; "greater than 5GiB")] // validated in Client::new
+    /// Test explicit validation in [Client::new]
+    #[test_case(4 * 1024 * 1024; "less than 5MiB")]
+    #[test_case(6 * 1024 * 1024 * 1024; "greater than 5GiB")]
     fn client_new_fails_with_invalid_part_size(part_size: usize) {
         let config = S3ClientConfig {
             part_size,


### PR DESCRIPTION
## Description of change

Updates aws-c-s3 to 0.4.3

Submodule mountpoint-s3-crt-sys/crt/aws-c-s3 dc90010..de36fee:
  > Bypass for CreateSession reqeust (awslabs/aws-c-s3#384)
  > Mem limiter validation (awslabs/aws-c-s3#385)
  > Fix tests to use net_test_case (awslabs/aws-c-s3#383)

## Does this change impact existing behavior?

Reverts part size constraints to 5MiB..5GiB, as they were before the undocumented changes in the 1.3.0 release.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
