### PR TITLE
Add S3 Express One Zone tests to the CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -107,6 +107,76 @@ jobs:
           target/
         key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
 
+  s3express-test:
+    name: S3 Express One Zone tests (${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
+    runs-on: ${{ matrix.runner.tags }}
+
+    environment: ${{ inputs.environment }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fuseVersion: [2, 3]
+        runner:
+        - name: Ubuntu x86
+          tags: [ubuntu-22.04] # GitHub-hosted
+        - name: Amazon Linux arm
+          tags: [self-hosted, linux, arm64]
+        exclude:
+          # fuse3 is not available on Amazon Linux 2
+          - runner:
+              name: Amazon Linux arm
+              tags: [self-hosted, linux, arm64]
+            fuseVersion: 3
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-integration-fuse${{ matrix.fuseVersion }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: ${{ matrix.fuseVersion }}
+    - name: Build tests
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests' --no-run
+    - name: Run tests
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR integration tests'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
+
   asan:
     name: Address sanitizer
     runs-on: ubuntu-22.04

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -39,7 +39,12 @@ pub fn get_unique_test_prefix(test_name: &str) -> String {
 }
 
 pub fn get_test_bucket() -> String {
-    std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+    if cfg!(feature = "s3express_tests") {
+        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+    } else {
+        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+    }
 }
 
 pub fn get_test_client() -> S3CrtClient {

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -515,7 +515,12 @@ pub fn read_dir_to_entry_names(read_dir_iter: ReadDir) -> Vec<String> {
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests");
+    let bucket = if cfg!(feature = "s3express_tests") {
+        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+    } else {
+        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+    };
 
     // Generate a random nonce to make sure this prefix is truly unique
     let nonce = OsRng.next_u64();

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -55,7 +55,12 @@ where
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests");
+    let bucket = if cfg!(feature = "s3express_tests") {
+        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+    } else {
+        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+    };
 
     // Generate a random nonce to make sure this prefix is truly unique
     let nonce = OsRng.next_u64();


### PR DESCRIPTION
## Description of change

Add a separate CI job for S3 Express One Zone integration tests. After this change we can run the integration tests by
- Set `S3_BUCKET_NAME` variable to run integration tests with standard buckets
- Set `S3_EXPRESS_ONE_ZONE_BUCKET_NAME` variable to run integration tests with express buckets

## Does this change impact existing behavior?

No, only the test and CI changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
