### PR TITLE
Fix clippy warnings introduced with S3 Express tests

### DIFF
--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -13,8 +13,11 @@ use bytes::Bytes;
 use common::*;
 use futures::StreamExt;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
+#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::error::ObjectClientError;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
+#[cfg(not(feature = "s3express_tests"))]
+use mountpoint_s3_client::S3RequestError;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
 use rusty_fork::rusty_fork_test;

--- a/mountpoint-s3-client/tests/endpoint_config.rs
+++ b/mountpoint-s3-client/tests/endpoint_config.rs
@@ -128,6 +128,7 @@ async fn test_single_region_access_point(addressing_style: AddressingStyle, arn:
     .await;
 }
 
+#[cfg(not(feature = "s3express_tests"))]
 // For Object Lambda Access Point, PutObject is not supported,
 // For multi region access points, Rust SDK is not supported. Hence different helper method for these tests.
 async fn run_list_objects_test<F: FnOnce(&str) -> EndpointConfig>(f: F, prefix: &str, bucket: &str) {

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -3,9 +3,12 @@
 pub mod common;
 
 use common::*;
+#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{HeadBucketError, ObjectClientError};
-use mountpoint_s3_client::{S3CrtClient, S3RequestError};
+#[cfg(not(feature = "s3express_tests"))]
+use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::S3RequestError;
 
 #[tokio::test]
 async fn test_head_bucket_correct_region() {

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -2,15 +2,19 @@
 
 pub mod common;
 
+#[cfg(not(feature = "s3express_tests"))]
 use std::time::{Duration, Instant};
 
 use aws_sdk_s3::primitives::ByteStream;
+#[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_s3::types::{GlacierJobParameters, RestoreRequest, Tier};
 use bytes::Bytes;
 use common::*;
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError};
+#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::types::RestoreStatus;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
+#[cfg(not(feature = "s3express_tests"))]
 use test_case::test_case;
 
 #[tokio::test]

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -2,6 +2,7 @@
 #![cfg(feature = "s3_tests")]
 
 use assert_cmd::prelude::*;
+#[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_sts::config::Region;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -10,9 +11,10 @@ use std::{path::PathBuf, process::Command};
 use test_case::test_case;
 
 use crate::common::fuse::{
-    create_objects, get_subsession_iam_role, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region,
-    read_dir_to_entry_names, tokio_block_on,
+    create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region, read_dir_to_entry_names,
 };
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::fuse::{get_subsession_iam_role, tokio_block_on};
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -1,10 +1,13 @@
 use std::fs::{read_dir, File};
 use std::io::{Read as _, Seek, SeekFrom};
+#[cfg(not(feature = "s3express_tests"))]
 use std::os::unix::prelude::PermissionsExt;
+#[cfg(not(feature = "s3express_tests"))]
 use std::time::{Duration, Instant};
 
 use fuser::BackgroundSession;
 use mountpoint_s3::data_cache::InMemoryDataCache;
+#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::types::PutObjectParams;
 use rand::RngCore;
 use rand::SeedableRng as _;
@@ -91,6 +94,7 @@ fn basic_read_test_mock_with_cache(prefix: &str) {
     );
 }
 
+#[cfg(not(feature = "s3express_tests"))]
 #[derive(PartialEq)]
 enum RestorationOptions {
     None,
@@ -98,6 +102,7 @@ enum RestorationOptions {
     RestoreInProgress,
 }
 
+#[cfg(not(feature = "s3express_tests"))]
 fn read_flexible_retrieval_test<F>(creator_fn: F, prefix: &str, files: &[&str], restore: RestorationOptions)
 where
     F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -427,6 +427,7 @@ fn out_of_order_write_test_mock(offset: i64) {
     out_of_order_write_test(fuse::mock_session::new, offset);
 }
 
+#[cfg(not(feature = "s3express_tests"))]
 fn write_with_storage_class_test<F>(creator_fn: F, storage_class: Option<&str>)
 where
     F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),


### PR DESCRIPTION
## Description of change

Fix clippy warnings from S3 Express tests.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
