### PR TITLE
Fix intermittent issue with metrics tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
+ "rusty-fork",
  "serde",
  "serde_json",
  "serial_test",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -66,6 +66,7 @@ tempfile = "3.4.0"
 test-case = "2.2.2"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
 walkdir = "2.3.3"
+rusty-fork = "0.3.0"
 
 [features]
 # Test features


### PR DESCRIPTION
## Description of change

Fixes intermittent issues when testing metrics emission by using `rusty_fork_test` to make sure there isn't any global state interfering with this test.

Relevant issues: N/A

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).