### PR TITLE
Remove duplicate S3 test helper functions

### DIFF
--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -3,10 +3,7 @@ use std::fs::ReadDir;
 use std::path::Path;
 use std::sync::Arc;
 
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts::config::Region;
 use fuser::{BackgroundSession, MountOption, Session};
-use futures::Future;
 use mountpoint_s3::data_cache::DataCache;
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::prefetch::{Prefetch, PrefetcherConfig};
@@ -14,8 +11,6 @@ use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::types::PutObjectParams;
 use mountpoint_s3_client::ObjectClient;
-use rand::RngCore;
-use rand_chacha::rand_core::OsRng;
 use tempfile::TempDir;
 
 pub trait TestClient: Send {
@@ -248,8 +243,6 @@ pub mod mock_session {
 pub mod s3_session {
     use super::*;
 
-    use std::future::Future;
-
     use aws_sdk_s3::config::Region;
     use aws_sdk_s3::operation::head_object::HeadObjectError;
     use aws_sdk_s3::primitives::ByteStream;
@@ -258,6 +251,8 @@ pub mod s3_session {
     use mountpoint_s3::prefetch::{caching_prefetch, default_prefetch};
     use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
     use mountpoint_s3_client::S3CrtClient;
+
+    use crate::common::s3::{get_s3express_endpoint, get_test_bucket_and_prefix, get_test_region, tokio_block_on};
 
     /// Create a FUSE mount backed by a real S3 client
     pub fn new(test_name: &str, test_config: TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox) {
@@ -330,21 +325,12 @@ pub mod s3_session {
     }
 
     async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {
-        let mut config = aws_config::from_env().region(Region::new(get_test_region()));
+        let mut config = aws_config::from_env().region(Region::new(region.to_owned()));
         if cfg!(feature = "s3express_tests") {
             config = config.endpoint_url(get_s3express_endpoint());
         }
         let config = config.load().await;
         aws_sdk_s3::Client::new(&config)
-    }
-
-    fn tokio_block_on<F: Future>(future: F) -> F::Output {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap();
-        runtime.block_on(future)
     }
 
     struct SDKTestClient {
@@ -512,71 +498,4 @@ pub fn read_dir_to_entry_names(read_dir_iter: ReadDir) -> Vec<String> {
             name.to_owned()
         })
         .collect::<Vec<_>>()
-}
-
-pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = if cfg!(feature = "s3express_tests") {
-        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
-            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
-    } else {
-        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
-    };
-
-    // Generate a random nonce to make sure this prefix is truly unique
-    let nonce = OsRng.next_u64();
-
-    // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
-    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
-    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
-
-    let prefix = format!("{prefix}{test_name}/{nonce}/");
-
-    (bucket, prefix)
-}
-
-pub fn get_test_bucket_forbidden() -> String {
-    std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
-}
-
-pub fn get_test_region() -> String {
-    std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
-}
-
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
-pub fn get_s3express_endpoint() -> String {
-    std::env::var("S3_EXPRESS_ONE_ZONE_ENDPOINT").expect("Set S3_EXPRESS_ONE_ZONE_ENDPOINT to run integration tests")
-}
-
-pub fn create_objects(bucket: &str, prefix: &str, region: &str, key: &str, value: &[u8]) {
-    let mut config = aws_config::from_env().region(Region::new(get_test_region()));
-    if cfg!(feature = "s3express_tests") {
-        config = config.endpoint_url(get_s3express_endpoint());
-    }
-    let config = tokio_block_on(config.load());
-    let sdk_client = aws_sdk_s3::Client::new(&config);
-    let full_key = format!("{prefix}{key}");
-    let mut request = sdk_client.put_object();
-    if cfg!(not(feature = "s3express_tests")) {
-        request = request.bucket(bucket);
-    }
-    tokio_block_on(async move {
-        request
-            .key(full_key)
-            .body(ByteStream::from(value.to_vec()))
-            .send()
-            .await
-            .unwrap()
-    });
-}
-
-pub fn tokio_block_on<F: Future>(future: F) -> F::Output {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .unwrap();
-    runtime.block_on(future)
 }

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -1,15 +1,15 @@
 //! Functions and types shared across integration test modules.
-//! Allow for unused code since this is included independently in each module.
-#![allow(unused)]
+//! Allow for unused items since this is included independently in each module.
+#![allow(dead_code)]
 
 #[cfg(feature = "fuse_tests")]
 pub mod fuse;
 
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts::config::Region;
+#[cfg(feature = "s3_tests")]
+pub mod s3;
+
 use fuser::{FileAttr, FileType};
 use futures::executor::ThreadPool;
-use futures::Future;
 use mountpoint_s3::fs::{self, DirectoryEntry, DirectoryReplier, ReadReplier, ToErrno};
 use mountpoint_s3::prefetch::{default_prefetch, DefaultPrefetcher};
 use mountpoint_s3::prefix::Prefix;
@@ -17,8 +17,6 @@ use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
 use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
 use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
-use rand::RngCore;
-use rand_chacha::rand_core::OsRng;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -52,73 +50,6 @@ where
     let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
     let prefetcher = default_prefetch(runtime, Default::default());
     S3Filesystem::new(client, prefetcher, bucket, prefix, config)
-}
-
-pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = if cfg!(feature = "s3express_tests") {
-        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
-            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
-    } else {
-        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
-    };
-
-    // Generate a random nonce to make sure this prefix is truly unique
-    let nonce = OsRng.next_u64();
-
-    // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
-    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
-    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
-
-    let prefix = format!("{prefix}{test_name}/{nonce}/");
-
-    (bucket, prefix)
-}
-
-pub fn get_test_bucket_forbidden() -> String {
-    std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
-}
-
-pub fn get_test_region() -> String {
-    std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
-}
-
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
-pub fn get_s3express_endpoint() -> String {
-    std::env::var("S3_EXPRESS_ONE_ZONE_ENDPOINT").expect("Set S3_EXPRESS_ONE_ZONE_ENDPOINT to run integration tests")
-}
-
-pub fn create_objects(bucket: &str, prefix: &str, region: &str, key: &str, value: &[u8]) {
-    let mut config = aws_config::from_env().region(Region::new(region.to_string()));
-    if cfg!(feature = "s3express_tests") {
-        config = config.endpoint_url(get_s3express_endpoint());
-    }
-    let config = tokio_block_on(config.load());
-    let sdk_client = aws_sdk_s3::Client::new(&config);
-    let full_key = format!("{prefix}{key}");
-    tokio_block_on(async move {
-        let mut request = sdk_client.put_object();
-        if cfg!(not(feature = "s3express_tests")) {
-            request = request.bucket(bucket);
-        }
-        request
-            .key(full_key)
-            .body(ByteStream::from(value.to_vec()))
-            .send()
-            .await
-            .unwrap()
-    });
-}
-
-pub fn tokio_block_on<F: Future>(future: F) -> F::Output {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .unwrap();
-    runtime.block_on(future)
 }
 
 #[track_caller]

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,0 +1,72 @@
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_sts::config::Region;
+use futures::Future;
+use rand::RngCore;
+use rand_chacha::rand_core::OsRng;
+
+pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
+    let bucket = if cfg!(feature = "s3express_tests") {
+        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+    } else {
+        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
+    };
+
+    // Generate a random nonce to make sure this prefix is truly unique
+    let nonce = OsRng.next_u64();
+
+    // Prefix always has a trailing "/" to keep meaning in sync with the S3 API.
+    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
+    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
+
+    let prefix = format!("{prefix}{test_name}/{nonce}/");
+
+    (bucket, prefix)
+}
+
+pub fn get_test_bucket_forbidden() -> String {
+    std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
+}
+
+pub fn get_test_region() -> String {
+    std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
+}
+
+pub fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
+pub fn get_s3express_endpoint() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_ENDPOINT").expect("Set S3_EXPRESS_ONE_ZONE_ENDPOINT to run integration tests")
+}
+
+pub fn create_objects(bucket: &str, prefix: &str, region: &str, key: &str, value: &[u8]) {
+    let mut config = aws_config::from_env().region(Region::new(region.to_string()));
+    if cfg!(feature = "s3express_tests") {
+        config = config.endpoint_url(get_s3express_endpoint());
+    }
+    let config = tokio_block_on(config.load());
+    let sdk_client = aws_sdk_s3::Client::new(&config);
+    let full_key = format!("{prefix}{key}");
+    tokio_block_on(async move {
+        let mut request = sdk_client.put_object();
+        if cfg!(not(feature = "s3express_tests")) {
+            request = request.bucket(bucket);
+        }
+        request
+            .key(full_key)
+            .body(ByteStream::from(value.to_vec()))
+            .send()
+            .await
+            .unwrap()
+    });
+}
+
+pub fn tokio_block_on<F: Future>(future: F) -> F::Output {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(future)
+}

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -10,11 +10,10 @@ use std::process::Stdio;
 use std::{path::PathBuf, process::Command};
 use test_case::test_case;
 
-use crate::common::fuse::{
-    create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region, read_dir_to_entry_names,
-};
+use crate::common::fuse::read_dir_to_entry_names;
+use crate::common::s3::{create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region};
 #[cfg(not(feature = "s3express_tests"))]
-use crate::common::fuse::{get_subsession_iam_role, tokio_block_on};
+use crate::common::s3::{get_subsession_iam_role, tokio_block_on};
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 


### PR DESCRIPTION
## Description of change

Some of the helper functions used in S3 tests were duplicated. This change removes the duplicates and moves them into their own `common::s3` submodule. 

Also, changes `allow(unused)` to the narrower `allow(dead_code)` for the `common` module and fixes related warning. 

## Does this change impact existing behavior?

N/A. Only refactor test functions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
