### PR TITLE
Add filename at Error and Warn level in logs

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -167,7 +167,7 @@ impl<Client: ObjectClient> UploadState<Client> {
                     UploadState::InProgress { handle, .. } => {
                         if let Err(err) = handle.finish_writing() {
                             // Log the issue but still return the write error.
-                            error!(?err, "error updating the inode status");
+                            error!(?err, "error updating the inode status (key={:?})", key);
                         }
                     }
                     Self::Failed(_) | Self::Completed => unreachable!("checked above"),
@@ -231,7 +231,7 @@ impl<Client: ObjectClient> UploadState<Client> {
         };
         if let Err(err) = handle.finish_writing() {
             // Log the issue but still return put_result.
-            error!(?err, "error updating the inode status");
+            error!(?err, "error updating the inode status (key={:?})", key);
         }
         put_result
     }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -6,7 +6,7 @@ use std::ffi::{OsStr, OsString};
 use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 use time::OffsetDateTime;
-use tracing::{debug, error, trace, Span};
+use tracing::{debug, error, trace};
 
 use fuser::consts::FOPEN_DIRECT_IO;
 use fuser::{FileAttr, KernelConfig};
@@ -15,6 +15,7 @@ use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::ObjectClient;
 
 use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superblock, SuperblockConfig, WriteHandle};
+use crate::logging;
 use crate::prefetch::{Prefetch, PrefetchReadError, PrefetchResult};
 use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -167,7 +168,7 @@ impl<Client: ObjectClient> UploadState<Client> {
                     UploadState::InProgress { handle, .. } => {
                         if let Err(err) = handle.finish_writing() {
                             // Log the issue but still return the write error.
-                            error!(?err, "error updating the inode status (key={:?})", key);
+                            error!(?err, ?key, "error updating the inode status");
                         }
                     }
                     Self::Failed(_) | Self::Completed => unreachable!("checked above"),
@@ -231,7 +232,7 @@ impl<Client: ObjectClient> UploadState<Client> {
         };
         if let Err(err) = handle.finish_writing() {
             // Log the issue but still return put_result.
-            error!(?err, "error updating the inode status (key={:?})", key);
+            error!(?err, ?key, "error updating the inode status");
         }
         put_result
     }
@@ -666,7 +667,7 @@ where
                 None => return reply.error(err!(libc::EBADF, "invalid file handle")),
             }
         };
-        Span::current().record("name", handle.inode.name());
+        logging::record_name(handle.inode.name());
         let file_etag: ETag;
         let mut request = match &handle.typ {
             FileHandleType::Write { .. } => return reply.error(err!(libc::EBADF, "file handle is not open for reads")),
@@ -771,7 +772,7 @@ where
                 None => return Err(err!(libc::EBADF, "invalid file handle")),
             }
         };
-        Span::current().record("name", handle.inode.name());
+        logging::record_name(handle.inode.name());
 
         let len = {
             let mut request = match &handle.typ {
@@ -973,7 +974,7 @@ where
                 None => return Err(err!(libc::EBADF, "invalid file handle")),
             }
         };
-        Span::current().record("name", file_handle.inode.name());
+        logging::record_name(file_handle.inode.name());
         let mut request = match &file_handle.typ {
             FileHandleType::Write(request) => request.lock().await,
             FileHandleType::Read { .. } => return Ok(()),
@@ -1022,7 +1023,7 @@ where
                 .remove(&fh)
                 .ok_or_else(|| err!(libc::EBADF, "invalid file handle"))?
         };
-        Span::current().record("name", file_handle.inode.name());
+        logging::record_name(file_handle.inode.name());
 
         // Unwrap the atomic reference to have full ownership.
         // The kernel should make a release call when there is no more references to the file handle,

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -113,7 +113,6 @@ impl ToErrno for InodeError {
             InodeError::ClientError(_) => libc::EIO,
             InodeError::FileDoesNotExist(_) => libc::ENOENT,
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
-            InodeError::DirectoryDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,
             InodeError::IsDirectory(_) => libc::EISDIR,

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -111,8 +111,9 @@ impl ToErrno for InodeError {
     fn to_errno(&self) -> libc::c_int {
         match self {
             InodeError::ClientError(_) => libc::EIO,
-            InodeError::FileDoesNotExist => libc::ENOENT,
+            InodeError::FileDoesNotExist(_) => libc::ENOENT,
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
+            InodeError::DirectoryDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,
             InodeError::IsDirectory(_) => libc::EISDIR,

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -111,7 +111,7 @@ impl ToErrno for InodeError {
     fn to_errno(&self) -> libc::c_int {
         match self {
             InodeError::ClientError(_) => libc::EIO,
-            InodeError::FileDoesNotExist(_) => libc::ENOENT,
+            InodeError::FileDoesNotExist(_, _) => libc::ENOENT,
             InodeError::InodeDoesNotExist(_) => libc::ENOENT,
             InodeError::InvalidFileName(_) => libc::EINVAL,
             InodeError::NotADirectory(_) => libc::ENOTDIR,

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 use time::OffsetDateTime;
-use tracing::{instrument, Instrument};
+use tracing::{field, instrument, Instrument};
 
 use crate::fs::{
     self, DirectoryEntry, DirectoryReplier, InodeNo, ReadReplier, S3Filesystem, S3FilesystemConfig, ToErrno,
@@ -92,7 +92,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=field::Empty))]
     fn getattr(&self, _req: &Request<'_>, ino: InodeNo, reply: ReplyAttr) {
         match block_on(self.fs.getattr(ino).in_current_span()) {
             Ok(attr) => reply.attr(&attr.ttl, &attr.attr),
@@ -100,12 +100,12 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino, nlookup))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino, nlookup, name=field::Empty))]
     fn forget(&self, _req: &Request<'_>, ino: u64, nlookup: u64) {
         block_on(self.fs.forget(ino, nlookup));
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, pid=req.pid()))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, pid=req.pid(), name=field::Empty))]
     fn open(&self, req: &Request<'_>, ino: InodeNo, flags: i32, reply: ReplyOpen) {
         match block_on(self.fs.open(ino, flags, req.pid()).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
@@ -113,7 +113,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, size=size))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, size=size, name=field::Empty))]
     fn read(
         &self,
         _req: &Request<'_>,
@@ -164,7 +164,7 @@ where
         metrics::histogram!("fuse.io_size", bytes_sent as f64, "type" => "read");
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent, name=field::Empty))]
     fn opendir(&self, _req: &Request<'_>, parent: InodeNo, flags: i32, reply: ReplyOpen) {
         match block_on(self.fs.opendir(parent, flags).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
@@ -250,7 +250,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync, name=field::Empty))]
     fn fsync(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
         match block_on(self.fs.fsync(ino, fh, datasync).in_current_span()) {
             Ok(()) => reply.ok(),
@@ -258,7 +258,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, pid=req.pid()))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, pid=req.pid(), name=field::Empty))]
     fn flush(&self, req: &Request<'_>, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
         match block_on(self.fs.flush(ino, fh, lock_owner, req.pid()).in_current_span()) {
             Ok(()) => reply.ok(),
@@ -266,7 +266,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, name=field::Empty))]
     fn release(
         &self,
         _req: &Request<'_>,
@@ -322,7 +322,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid()))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid(), name=field::Empty))]
     fn write(
         &self,
         _req: &Request<'_>,
@@ -365,7 +365,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=field::Empty))]
     fn setattr(
         &self,
         _req: &Request<'_>,

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -37,9 +37,10 @@ use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};
 use thiserror::Error;
 use time::OffsetDateTime;
-use tracing::{debug, error, trace, warn, Span};
+use tracing::{debug, error, trace, warn};
 
 use crate::fs::{CacheConfig, S3Personality};
+use crate::logging;
 use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::RwLockReadGuard;
@@ -139,7 +140,7 @@ impl Superblock {
                 error!("forget called on inode {ino} already removed from the superblock");
             }
             Some(inode) => {
-                Span::current().record("name", inode.name());
+                logging::record_name(inode.name());
                 let new_lookup_count = inode.dec_lookup_count(n);
                 if new_lookup_count == 0 {
                     // Safe to remove, kernel no longer has a reference to it.
@@ -210,7 +211,7 @@ impl Superblock {
         force_revalidate: bool,
     ) -> Result<LookedUp, InodeError> {
         let inode = self.inner.get(ino)?;
-        Span::current().record("name", inode.name());
+        logging::record_name(inode.name());
 
         if !force_revalidate {
             let sync = inode.get_inode_state()?;
@@ -245,7 +246,7 @@ impl Superblock {
         mtime: Option<OffsetDateTime>,
     ) -> Result<LookedUp, InodeError> {
         let inode = self.inner.get(ino)?;
-        Span::current().record("name", inode.name());
+        logging::record_name(inode.name());
         let mut sync = inode.get_mut_inode_state()?;
 
         if sync.write_status == WriteStatus::Remote {
@@ -297,7 +298,7 @@ impl Superblock {
         trace!(dir=?dir_ino, "readdir");
 
         let dir = self.inner.get(dir_ino)?;
-        Span::current().record("name", dir.name());
+        logging::record_name(dir.name());
         if dir.kind() != InodeKind::Directory {
             return Err(InodeError::NotADirectory(dir.err()));
         }
@@ -1243,7 +1244,7 @@ impl Inode {
     fn get_inode_state(&self) -> Result<RwLockReadGuard<InodeState>, InodeError> {
         let inode_state = self.inner.sync.read().unwrap();
         match &inode_state.kind_data {
-            InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::DirectoryDoesNotExist(self.err())),
+            InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::InodeDoesNotExist(self.ino())),
             _ => Ok(inode_state),
         }
     }
@@ -1252,7 +1253,7 @@ impl Inode {
     fn get_mut_inode_state(&self) -> Result<RwLockWriteGuard<InodeState>, InodeError> {
         let inode_state = self.inner.sync.write().unwrap();
         match &inode_state.kind_data {
-            InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::DirectoryDoesNotExist(self.err())),
+            InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::InodeDoesNotExist(self.ino())),
             _ => Ok(inode_state),
         }
     }
@@ -1491,8 +1492,6 @@ pub enum InodeError {
     ClientError(#[source] anyhow::Error),
     #[error("file does not exist {0:?}")]
     FileDoesNotExist(OsString),
-    #[error("directory does not exist at inode {0}")]
-    DirectoryDoesNotExist(InodeErrorInfo),
     #[error("inode {0} does not exist")]
     InodeDoesNotExist(InodeNo),
     #[error("invalid file name {0:?}")]

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1490,7 +1490,7 @@ impl InodeStat {
 pub enum InodeError {
     #[error("error from ObjectClient")]
     ClientError(#[source] anyhow::Error),
-    #[error("file does not exist {0:?} in parent {1}")]
+    #[error("file {0:?} does not exist in parent inode {1}")]
     FileDoesNotExist(String, InodeErrorInfo),
     #[error("inode {0} does not exist")]
     InodeDoesNotExist(InodeNo),

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -12,6 +12,7 @@ use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use time::format_description::FormatItem;
 use time::macros;
 use time::OffsetDateTime;
+use tracing::Span;
 use tracing_subscriber::filter::{EnvFilter, Filtered, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -146,4 +147,8 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
     registry.init();
 
     Ok(())
+}
+
+pub fn record_name(name: &str) -> Span {
+    Span::current().record("name", name).clone()
 }

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -196,7 +196,7 @@ where
                 {
                     Ok(get_object_result) => get_object_result,
                     Err(e) => {
-                        error!(error=?e, "GetObject request failed");
+                        error!(key, error=?e, "GetObject request failed");
                         part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                         return;
                     }
@@ -227,7 +227,7 @@ where
                             }
                         }
                         Some(Err(e)) => {
-                            error!(error=?e, "GetObject body part failed");
+                            error!(key, error=?e, "GetObject body part failed");
                             part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                             break;
                         }


### PR DESCRIPTION
## Description of change
Added filename (object key where filename was not available) at the error level and warn level logs since these are shown by default.
<!-- Please describe your contribution here. What and why? -->
Used span to add the filename on the first occurence of filename in the callstack of the method. This results in logging like -
```
getattr{req=3 ino=34 name=“hello_new1.txt”}: mountpoint_s3::fuse: getattr failed: inode error: inode 34 (full key “hello_new1.txt”) for remote key “hello_new1.txt” is stale, replaced by inode 35 (full key “hello_new1.txt”)
```
In the PR #634 , it was getting logged as -
```
getattr{req=7 ino=2}: mountpoint_s3::fuse: getattr failed: inode error: inode 2 (full key “hello_new.txt”) for remote key “hello_new.txt” is stale, replaced by inode 3 (full key “hello_new.txt”)
```
Keeping both the PRs for now, in case we dont need the way it is done in this PR.

Also, added filename in all cases of `InodeError` as it was getting multiple times.

Relevant issues: <!-- Please add issue numbers. -->
#555 

## Does this change impact existing behavior?
No, it does not change existing behaviour of any functionalities. Only change the error logs.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
