### PR TITLE
Replace println! with tracing::debug! to honor --no-log flag.

### DIFF
--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -447,7 +447,7 @@ fn main() -> anyhow::Result<()> {
                 let status = receiver.recv_timeout(timeout);
                 match status {
                     Ok('0') => {
-                        println!(
+                        tracing::debug!(
                             "{} is mounted at {}",
                             args.bucket_description(),
                             args.mount_point.display()


### PR DESCRIPTION
## Description of change

Replace `println!` with `tracing::debug!` to honor `--no-log` flag.

Relevant issues: [550](https://github.com/awslabs/mountpoint-s3/issues/550)

## Does this change impact existing behavior?

When using `--no-log` no messages would be printed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
