### PR TITLE
Update documentation for S3 Express One Zone

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -79,7 +79,7 @@ Here is an example least-privilege policy document to add to an IAM user or role
 }
 ```
 
-Directory bucket, or S3 Express One Zone storage class in other words, has different authentication mechanism from general purpose buckets. The policy `s3:*` doesn't apply to directory buckets, you will need `s3express:CreateSession` policy in order to access them. Here is an example of least-privilege policy document.
+Directory buckets, introduced with the S3 Express One Zone storage class, use a different authentication mechanism from general purpose buckets. Instead of using `s3:*` actions, you should allow the `s3express:CreateSession` action. Here is an example of least-privilege policy document.
 
 ```
 {

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -79,6 +79,21 @@ Here is an example least-privilege policy document to add to an IAM user or role
 }
 ```
 
+Directory bucket, or S3 Express One Zone storage class in other words, has different authentication mechanism from general purpose buckets. The policy `s3:*` doesn't apply to directory buckets, you will need `s3express:CreateSession` policy in order to access them. Here is an example of least-privilege policy document.
+
+```
+{
+	"Version": "2012-10-17",
+	"Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3express:CreateSession",
+            "Resource": "arn:aws:s3express:REGION:ACCOUNT-ID:bucket/DOC-EXAMPLE-BUCKET--az_id--x-s3"
+        }
+    ]
+}
+```
+
 Mountpoint also respects access control lists (ACLs) applied to objects in your S3 bucket, but does not allow you to automatically attach ACLs to objects created with Mountpoint. A majority of modern use cases in Amazon S3 no longer require the use of ACLs. We recommend that you keep ACLs disabled for your S3 bucket, and instead use bucket policies to control access to your objects.
 
 ## S3 bucket configuration
@@ -93,7 +108,7 @@ When constructing the directory structure for your mount, Mountpoint removes the
 
 ### Region detection
 
-Amazon S3 buckets are associated with a single AWS Region. Mountpoint attempts to automatically detect the region for your S3 bucket at startup time and directs all S3 requests to that region. However, in some scenarios this region detection may fail, preventing your bucket from being mounted and displaying Access Denied or No Such Bucket errors. You can override Mountpoint's automatic bucket region detection with the `--region` command-line argument or `AWS_REGION` environment variable.
+Amazon S3 buckets are associated with a single AWS Region. Mountpoint attempts to automatically detect the region for your S3 bucket at startup time and directs all S3 requests to that region. However, in some scenarios like cross-region mount with a directory bucket, this region detection may fail, preventing your bucket from being mounted and displaying Access Denied or No Such Bucket errors. You can override Mountpoint's automatic bucket region detection with the `--region` command-line argument or `AWS_REGION` environment variable.
 
 Mountpoint uses [instance metadata (IMDS)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) to help detect the region for an S3 bucket. If you want to disable IMDS, set the `AWS_EC2_METADATA_DISABLED` environment variable to `true`.
 
@@ -174,6 +189,10 @@ Amazon S3 offers a [range of storage classes](https://aws.amazon.com/s3/storage-
 * `GLACIER_IR` for [S3 Glacier Instant Retrieval](https://aws.amazon.com/s3/storage-classes/glacier/instant-retrieval/)
 * `GLACIER` for [S3 Glacier Flexible Retrieval](https://aws.amazon.com/s3/storage-classes/glacier/)
 * `DEEP_ARCHIVE` for [S3 Glacier Deep Archive](https://aws.amazon.com/s3/storage-classes/glacier/)
+
+> [!IMPORTANT]
+> Do not set the storage class to `EXPRESS_ONEZONE` as it is a distinct storage class and cannot be set for general purpose
+buckets. If you want to use S3 Express One Zone storage class, just specify a directory bucket name when mounting.
 
 For the full list of possible storage classes, see the [PutObject documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-StorageClass) in the Amazon S3 User Guide.
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -191,8 +191,7 @@ Amazon S3 offers a [range of storage classes](https://aws.amazon.com/s3/storage-
 * `DEEP_ARCHIVE` for [S3 Glacier Deep Archive](https://aws.amazon.com/s3/storage-classes/glacier/)
 
 > [!IMPORTANT]
-> Do not set the storage class to `EXPRESS_ONEZONE` as it is a distinct storage class and cannot be set for general purpose
-buckets. If you want to use S3 Express One Zone storage class, just specify a directory bucket name when mounting.
+> `EXPRESS_ONEZONE` is a distinct storage class for directory buckets. You can neither use other storage classes in directory buckets nor use `EXPRESS_ONEZONE` in general purpose buckets. If you want to use [S3 Express One Zone](https://aws.amazon.com/s3/storage-classes/express-one-zone/) storage class, just specify a directory bucket name when mounting.
 
 For the full list of possible storage classes, see the [PutObject documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-StorageClass) in the Amazon S3 User Guide.
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -182,7 +182,7 @@ You cannot currently use Mountpoint to overwrite existing objects. However, if y
 
 ### S3 storage classes
 
-Amazon S3 offers a [range of storage classes](https://aws.amazon.com/s3/storage-classes/) that you can choose from based on the data access, resiliency, and cost requirements of your workloads. When creating new files with Mountpoint, you can control which storage class the corresponding objects are stored in. By default, Mountpoint uses the S3 Standard storage class, which is appropriate for a wide variety of use cases. To store new objects in a different storage class, use the `--storage-class` command-line flag. Possible values for this argument include:
+Amazon S3 offers a [range of storage classes](https://aws.amazon.com/s3/storage-classes/) that you can choose from based on the data access, resiliency, and cost requirements of your workloads. When creating new files with Mountpoint, you can control which storage class the corresponding objects are stored in. Mountpoint respects the default storage class from S3 unless otherwise configured, which is appropriate for a wide variety of use cases. To store new objects in a different storage class, use the `--storage-class` command-line flag. Possible values for this argument include:
 * `STANDARD` for S3 Standard
 * `STANDARD_IA` for S3 Standard-Infrequent Access
 * `INTELLIGENT_TIERING` for [S3 Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/), which automatically moves your data to the most cost-effective access tier when access patterns change

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -192,6 +192,10 @@ the following behavior:
 
 Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported. However, seeking (`lseek`) on directory handles is not supported.
 
+Sorting order of `readdir` results:
+* For general purpose buckets, `readdir` returns results in lexicographical order.
+* For directory buckets (S3 Express One Zone), `readdir` does not return results in lexicographical order.
+
 Creating directories (`mkdir`) is supported, with the following behavior:
 
 * `mkdir` will create a new empty directory in the file system, but not affect the S3 bucket.


### PR DESCRIPTION
## Description of change

Update the configuration and semantics documents to address differences on using Mountpoint with S3 Express One Zone buckets.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/651

## Does this change impact existing behavior?

No, only document updates.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
