### PR TITLE
Print successful mount for both foreground and background modes. Also update documentation for the `--no-log` argument.

### DIFF
--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -21,7 +21,8 @@ Log files are not automatically rotated or cleaned up.
 
 ## Disabling logging
 
-If you do not want to record any logs, use the `--no-log` command-line argument. This argument cannot be combined with other logging-related command-line arguments.
+If you do not want to record any logs, use the `--no-log` command-line argument. This argument cannot be combined with other logging-related command-line arguments. The `--no-log` argument has
+no effect on messages sent to the standard output. If no output is desired, consider redirecting it.
 
 ## Verbose logging
 


### PR DESCRIPTION
## Description of change

Print successful mount for both foreground and background modes. Also update documentation for the `--no-log` argument.

Relevant issues: N/A

## Does this change impact existing behavior?

Yes. When running on foreground mode, we print a message to stdout after a successful mount. As noted in the documentation, the `--no-log` argument has no effects on this or any messages sent to stdout.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
