### PR TITLE
Add CRT error to CRT request logs, move CRT per-request logs to DEBUG

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -449,6 +449,7 @@ impl S3CrtClientInner {
 
                 let http_status = metrics.status_code().unwrap_or(-1);
                 let request_failure = !(200..299).contains(&http_status);
+                let crt_error = Some(metrics.error()).filter(|e| e.is_err());
                 let request_type = request_type_to_metrics_string(metrics.request_type());
                 let request_id = metrics.request_id().unwrap_or_else(|| "<unknown>".into());
                 let duration = metrics.total_duration();
@@ -458,12 +459,12 @@ impl S3CrtClientInner {
                 let log_level = status_code_to_log_level(http_status);
 
                 let message = if request_failure {
-                    "request failed"
+                    "CRT request failed"
                 } else {
-                    "request finished"
+                    "CRT request finished"
                 };
-                event!(log_level, %request_type, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
-                trace!(detailed_metrics=?metrics, "request completed");
+                event!(log_level, %request_type, ?crt_error, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
+                trace!(detailed_metrics=?metrics, "CRT request completed");
 
                 let op = span_telemetry.metadata().map(|m| m.name()).unwrap_or("unknown");
                 if let Some(ttfb) = ttfb {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -447,8 +447,8 @@ impl S3CrtClientInner {
             .on_telemetry(move |metrics| {
                 let _guard = span_telemetry.enter();
 
-                let http_status = metrics.status_code().unwrap_or(-1);
-                let request_failure = !(200..299).contains(&http_status);
+                let http_status = metrics.status_code();
+                let request_failure = http_status.map(|status| !(200..299).contains(&status)).unwrap_or(true);
                 let crt_error = Some(metrics.error()).filter(|e| e.is_err());
                 let request_type = request_type_to_metrics_string(metrics.request_type());
                 let request_id = metrics.request_id().unwrap_or_else(|| "<unknown>".into());
@@ -456,14 +456,12 @@ impl S3CrtClientInner {
                 let ttfb = metrics.time_to_first_byte();
                 let range = metrics.response_headers().and_then(|headers| extract_range_header(&headers));
 
-                let log_level = status_code_to_log_level(http_status);
-
                 let message = if request_failure {
                     "CRT request failed"
                 } else {
                     "CRT request finished"
                 };
-                event!(log_level, %request_type, ?crt_error, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
+                debug!(%request_type, ?crt_error, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
                 trace!(detailed_metrics=?metrics, "CRT request completed");
 
                 let op = span_telemetry.metadata().map(|m| m.name()).unwrap_or("unknown");
@@ -473,7 +471,7 @@ impl S3CrtClientInner {
                 metrics::histogram!("s3.requests.total_latency_us", duration.as_micros() as f64, "op" => op, "type" => request_type);
                 metrics::counter!("s3.requests", 1, "op" => op, "type" => request_type);
                 if request_failure {
-                    metrics::counter!("s3.requests.failures", 1, "op" => op, "type" => request_type, "status" => format!("{http_status}"));
+                    metrics::counter!("s3.requests.failures", 1, "op" => op, "type" => request_type, "status" => http_status.unwrap_or(-1).to_string());
                 }
             })
             .on_headers(move |headers, response_status| {


### PR DESCRIPTION
## Description of change

At the moment, errors for individual requests made by the CRT client (inside of a meta request) can fail and we log that they failed, but only with the HTTP Status (or lack thereof as "-1").

For example, these three requests failed for different reasons.

```
WARNING request failed request_type=GetObject http_status=-1 range=None duration=3.048089489s ttfb=None request_id=<unknown>
WARNING request failed request_type=GetObject http_status=500 range=None duration=2.968672313s ttfb=Some(2.713102782s) request_id=0H2C1MFGVVR9ARMV
WARNING request failed request_type=GetObject http_status=-1 range=None duration=290.737317ms ttfb=None request_id=<unknown>
```

We have access to a CRT error code here, so we should surface that. These also log on success, so I've wrapped it in an `Option<>`.

I've also updated the message itself to be "CRT request" to try and highlight that these are inner requests made by the CRT that can be retried or be part of a much larger _meta_ request.

An error message may look like this now:

```
WARNING CRT request failed request_type=GetObject crt_error=Some(Error(1048, "aws-c-io: AWS_IO_SOCKET_TIMEOUT, socket operation timed out.")) http_status=-1 range=None duration=3.126663123s ttfb=None request_id=<unknown>
```

I almost wonder if we should be logging these as warning, as it has caused some confusion around what has actually happened and if the data was really retrieved or the application failed to handle that error. For now, I'll leave them as warning.

Relevant issues: N/A

## Does this change impact existing behavior?

No behavior change, logs contain new information. Message changes slightly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
