### PR TITLE
Introduce ObjectId type to reference specific versions of S3 objects

### DIFF
--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -8,7 +8,6 @@ mod cache_directory;
 mod disk_data_cache;
 mod in_memory_data_cache;
 
-use mountpoint_s3_client::types::ETag;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
@@ -16,12 +15,7 @@ pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 
-/// Struct representing a key for accessing an entry in a [DataCache].
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct CacheKey {
-    pub s3_key: String,
-    pub etag: ETag,
-}
+use crate::object::ObjectId;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;
@@ -44,22 +38,22 @@ pub type DataCacheResult<Value> = Result<Value, DataCacheError>;
 /// Data cache for fixed-size checksummed buffers.
 ///
 /// TODO: Deletion and eviction of cache entries.
-/// TODO: Some version information (ETag) independent from [CacheKey] to allow smarter eviction?
+/// TODO: Some version information (ETag) independent from [ObjectId] to allow smarter eviction?
 pub trait DataCache {
-    /// Get block of data from the cache for the given [CacheKey] and [BlockIndex], if available.
+    /// Get block of data from the cache for the given [ObjectId] and [BlockIndex], if available.
     ///
     /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
     fn get_block(
         &self,
-        cache_key: &CacheKey,
+        cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
-    /// Put block of data to the cache for the given [CacheKey] and [BlockIndex].
+    /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].
     fn put_block(
         &self,
-        cache_key: CacheKey,
+        cache_key: ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
         bytes: ChecksummedBytes,

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -3,12 +3,13 @@
 use std::collections::HashMap;
 use std::default::Default;
 
-use super::{BlockIndex, CacheKey, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
+use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
+use crate::object::ObjectId;
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
 pub struct InMemoryDataCache {
-    data: RwLock<HashMap<CacheKey, HashMap<BlockIndex, ChecksummedBytes>>>,
+    data: RwLock<HashMap<ObjectId, HashMap<BlockIndex, ChecksummedBytes>>>,
     block_size: u64,
 }
 
@@ -25,7 +26,7 @@ impl InMemoryDataCache {
 impl DataCache for InMemoryDataCache {
     fn get_block(
         &self,
-        cache_key: &CacheKey,
+        cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
@@ -39,7 +40,7 @@ impl DataCache for InMemoryDataCache {
 
     fn put_block(
         &self,
-        cache_key: CacheKey,
+        cache_key: ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
         bytes: ChecksummedBytes,
@@ -76,14 +77,8 @@ mod tests {
 
         let block_size = 8 * 1024 * 1024;
         let cache = InMemoryDataCache::new(block_size);
-        let cache_key_1 = CacheKey {
-            s3_key: "a".into(),
-            etag: ETag::for_tests(),
-        };
-        let cache_key_2 = CacheKey {
-            s3_key: "b".into(),
-            etag: ETag::for_tests(),
-        };
+        let cache_key_1 = ObjectId::new("a".into(), ETag::for_tests());
+        let cache_key_2 = ObjectId::new("b".into(), ETag::for_tests());
 
         let block = cache.get_block(&cache_key_1, 0, 0).expect("cache is accessible");
         assert!(

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fuse;
 mod inode;
 pub mod logging;
 pub mod metrics;
+mod object;
 pub mod prefetch;
 pub mod prefix;
 mod sync;

--- a/mountpoint-s3/src/object.rs
+++ b/mountpoint-s3/src/object.rs
@@ -1,0 +1,32 @@
+use mountpoint_s3_client::types::ETag;
+
+use crate::sync::Arc;
+
+/// Identifier for a specific version of an S3 object.
+/// Formed by the object key and etag. Holds its components in an [Arc], so it can be cheaply cloned.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ObjectId {
+    inner: Arc<InnerObjectId>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct InnerObjectId {
+    key: String,
+    etag: ETag,
+}
+
+impl ObjectId {
+    pub fn new(key: String, etag: ETag) -> Self {
+        Self {
+            inner: Arc::new(InnerObjectId { key, etag }),
+        }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.inner.key
+    }
+
+    pub fn etag(&self) -> &ETag {
+        &self.inner.etag
+    }
+}

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -8,6 +8,7 @@ use mountpoint_s3_crt::checksums::crc32c;
 use tracing::{debug_span, error, trace, Instrument};
 
 use crate::checksums::ChecksummedBytes;
+use crate::object::ObjectId;
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::unbounded_part_queue;
 use crate::prefetch::task::RequestTask;
@@ -186,17 +187,17 @@ where
         let request_task = {
             let client = client.clone();
             let bucket = bucket.to_owned();
-            let key = key.to_owned();
+            let id = ObjectId::new(key.to_owned(), if_match);
             let span = debug_span!("prefetch", range=?request_range);
 
             async move {
                 let get_object_result = match client
-                    .get_object(&bucket, &key, Some(request_range.into()), Some(if_match))
+                    .get_object(&bucket, id.key(), Some(request_range.into()), Some(id.etag().clone()))
                     .await
                 {
                     Ok(get_object_result) => get_object_result,
                     Err(e) => {
-                        error!(key, error=?e, "GetObject request failed");
+                        error!(key=id.key(), error=?e, "GetObject request failed");
                         part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                         return;
                     }
@@ -221,13 +222,13 @@ where
                                 // object part boundaries, so we're computing our own checksum here.
                                 let checksum = crc32c::checksum(&chunk);
                                 let checksum_bytes = ChecksummedBytes::new(chunk, checksum);
-                                let part = Part::new(&key, curr_offset, checksum_bytes);
+                                let part = Part::new(id.clone(), curr_offset, checksum_bytes);
                                 curr_offset += part.len() as u64;
                                 part_queue_producer.push(Ok(part));
                             }
                         }
                         Some(Err(e)) => {
-                            error!(key, error=?e, "GetObject body part failed");
+                            error!(key=id.key(), error=?e, "GetObject body part failed");
                             part_queue_producer.push(Err(PrefetchReadError::GetRequestFailed(e)));
                             break;
                         }


### PR DESCRIPTION
## Description of change

The new `ObjectId` type holds an S3 object key and etag to identify a specific version of an object. It is used in the data cache, where it is a 1-1 replacement for `CacheKey`, and also in the prefetcher, where it replaces the S3 key previously used in `Part`.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
