### PR TITLE
Add mount option to disable additional checksum for S3 Outposts write support

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -751,7 +751,7 @@ impl PutObjectRequest for MockPutObjectRequest {
         self,
         review_callback: impl FnOnce(UploadReview) -> bool + Send + 'static,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
-        let checksum_algorithm = if self.params.trailing_checksums {
+        let checksum_algorithm = if self.params.trailing_checksum {
             Some(ChecksumAlgorithm::Crc32c)
         } else {
             None
@@ -761,7 +761,7 @@ impl PutObjectRequest for MockPutObjectRequest {
             .chunks(self.part_size)
             .map(|part| {
                 let size = part.len() as u64;
-                let checksum = if self.params.trailing_checksums {
+                let checksum = if self.params.trailing_checksum {
                     let checksum = crc32c::checksum(part);
                     Some(crc32c_to_base64(&checksum))
                 } else {

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -271,7 +271,7 @@ pub enum GetObjectAttributesError {
 #[non_exhaustive]
 pub struct PutObjectParams {
     /// Enable Crc32c trailing checksums.
-    pub trailing_checksums: bool,
+    pub trailing_checksum: bool,
     /// Storage class to be used when creating new S3 object
     pub storage_class: Option<String>,
 }
@@ -283,8 +283,8 @@ impl PutObjectParams {
     }
 
     /// Set Crc32c trailing checksums.
-    pub fn trailing_checksums(mut self, value: bool) -> Self {
-        self.trailing_checksums = value;
+    pub fn trailing_checksum(mut self, value: bool) -> Self {
+        self.trailing_checksum = value;
         self
     }
 

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -29,7 +29,7 @@ impl S3CrtClient {
             .set_request_path(&key)
             .map_err(S3RequestError::construction_failure)?;
 
-        if params.trailing_checksums {
+        if params.trailing_checksum {
             let checksum_config = ChecksumConfig::trailing_crc32c();
             message.set_checksum_config(Some(checksum_config));
         }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -195,7 +195,7 @@ async fn test_put_checksums() {
     let mut contents = vec![0u8; PART_SIZE * 2];
     rng.fill(&mut contents[..]);
 
-    let params = PutObjectParams::new().trailing_checksums(true);
+    let params = PutObjectParams::new().trailing_checksum(true);
     let mut request = client
         .put_object(&bucket, &key, &params)
         .await
@@ -242,7 +242,7 @@ async fn test_put_review(pass_review: bool) {
     let mut contents = vec![0u8; PART_SIZE * 2];
     rng.fill(&mut contents[..]);
 
-    let params = PutObjectParams::new().trailing_checksums(true);
+    let params = PutObjectParams::new().trailing_checksum(true);
     let mut request = client
         .put_object(&bucket, &key, &params)
         .await

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -334,7 +334,7 @@ pub struct S3FilesystemConfig {
     /// S3 personality (for different S3 semantics)
     pub s3_personality: S3Personality,
     /// Allowing trailing checksums for write
-    pub trailing_checksums: bool,
+    pub trailing_checksum: bool,
 }
 
 impl Default for S3FilesystemConfig {
@@ -352,7 +352,7 @@ impl Default for S3FilesystemConfig {
             allow_delete: false,
             storage_class: None,
             s3_personality: S3Personality::Standard,
-            trailing_checksums: true,
+            trailing_checksum: true,
         }
     }
 }
@@ -422,7 +422,7 @@ where
         let uploader = Uploader::new(
             client.clone(),
             config.storage_class.to_owned(),
-            config.trailing_checksums,
+            config.trailing_checksum,
         );
 
         Self {

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -333,6 +333,8 @@ pub struct S3FilesystemConfig {
     pub storage_class: Option<String>,
     /// S3 personality (for different S3 semantics)
     pub s3_personality: S3Personality,
+    /// Allowing trailing checksums for write
+    pub trailing_checksums: bool,
 }
 
 impl Default for S3FilesystemConfig {
@@ -350,6 +352,7 @@ impl Default for S3FilesystemConfig {
             allow_delete: false,
             storage_class: None,
             s3_personality: S3Personality::Standard,
+            trailing_checksums: true,
         }
     }
 }
@@ -416,7 +419,11 @@ where
 
         let client = Arc::new(client);
 
-        let uploader = Uploader::new(client.clone(), config.storage_class.to_owned());
+        let uploader = Uploader::new(
+            client.clone(),
+            config.storage_class.to_owned(),
+            config.trailing_checksums,
+        );
 
         Self {
             config,

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -112,6 +112,13 @@ struct CliArgs {
     )]
     pub allow_delete: bool,
 
+    #[clap(
+        long,
+        help = "Disable additional checksums for write",
+        help_heading = MOUNT_OPTIONS_HEADER
+    )]
+    pub disable_checksum: bool,
+
     #[clap(long, help = "Automatically unmount on exit", help_heading = MOUNT_OPTIONS_HEADER)]
     pub auto_unmount: bool,
 
@@ -576,6 +583,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
     filesystem_config.allow_delete = args.allow_delete;
     filesystem_config.s3_personality =
         get_s3_personality(args.bucket_type, &args.bucket_name, client.endpoint_config());
+    filesystem_config.trailing_checksums = !args.disable_checksum;
 
     let prefetcher_config = Default::default();
 

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -206,8 +206,10 @@ mod tests {
     };
     use test_case::test_case;
 
+    #[test_case(true; "trailing_checksum_on")]
+    #[test_case(false; "trailing_checksum_off")]
     #[tokio::test]
-    async fn complete_test() {
+    async fn complete_test(trailing_checksum: bool) {
         let bucket = "bucket";
         let name = "hello";
         let key = name;
@@ -217,7 +219,7 @@ mod tests {
             part_size: 32,
             ..Default::default()
         }));
-        let uploader = Uploader::new(client.clone(), None, true);
+        let uploader = Uploader::new(client.clone(), None, trailing_checksum);
         let request = uploader.put(bucket, key).await.unwrap();
 
         assert!(!client.contains_key(key));
@@ -229,8 +231,10 @@ mod tests {
         assert!(!client.is_upload_in_progress(key));
     }
 
+    #[test_case(true; "trailing_checksum_on")]
+    #[test_case(false; "trailing_checksum_off")]
     #[tokio::test]
-    async fn write_order_test() {
+    async fn write_order_test(trailing_checksum: bool) {
         let bucket = "bucket";
         let name = "hello";
         let key = name;
@@ -241,7 +245,7 @@ mod tests {
             part_size: 32,
             ..Default::default()
         }));
-        let uploader = Uploader::new(client.clone(), Some(storage_class.to_owned()), true);
+        let uploader = Uploader::new(client.clone(), Some(storage_class.to_owned()), trailing_checksum);
 
         let mut request = uploader.put(bucket, key).await.unwrap();
 

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -360,7 +360,7 @@ pub mod s3_session {
             if let Some(storage_class) = params.storage_class {
                 request = request.set_storage_class(Some(storage_class.as_str().into()));
             }
-            if params.trailing_checksums {
+            if params.trailing_checksum {
                 request = request.set_checksum_algorithm(Some(ChecksumAlgorithm::Crc32C));
             }
             tokio_block_on(request.send())


### PR DESCRIPTION
## Description of change
Added the disabling of checksums based on signing name as "s3-outposts".
Commented out the mount option of Disabling additional checksums to support write in Outposts since the decision is not yet made. Users of Outposts will have to pass `--disable-checksum` to support write, if we go this path.
This is draft PR, since we have not finalised our decision on the way to do it. But, whatever decision we take we will need to make similar changes in `upload.rs` module. 

<!-- Please describe your contribution here. What and why? -->
Passed the trailing checksum boolean to S3FileSystemConfig and then to uploader. Using this config, set the trailing checksum as false  and bypassing the checksum verification for the case above.
Manually tested it works with write on Outposts. I will need to add tests.

Relevant issues: <!-- Please add issue numbers. -->
#516 

## Does this change impact existing behavior?
Yes, it disables additional checksums in case of writing on Outpost bucket (in this way, set by user). 
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
