### PR TITLE
Add a dirty indicator to version strings

### DIFF
--- a/mountpoint-s3-client/src/build_info.rs
+++ b/mountpoint-s3-client/src/build_info.rs
@@ -16,7 +16,11 @@ pub const FULL_VERSION: &str = {
             // Evaluated at compile time, but never used
             None => "unreachable",
         };
-        const_format::concatcp!(built::PKG_VERSION, "-", COMMIT_HASH_STR)
+        const COMMIT_DIRTY_STR: &str = match built::GIT_DIRTY {
+            Some(true) => "-dirty",
+            _ => "",
+        };
+        const_format::concatcp!(built::PKG_VERSION, "-", COMMIT_HASH_STR, COMMIT_DIRTY_STR)
     } else {
         built::PKG_VERSION
     }

--- a/mountpoint-s3/src/build_info.rs
+++ b/mountpoint-s3/src/build_info.rs
@@ -17,10 +17,14 @@ pub const FULL_VERSION: &str = {
             Some(hash) => hash,
             None => "",
         };
+        const COMMIT_DIRTY_STR: &str = match built::GIT_DIRTY {
+            Some(true) => "-dirty",
+            _ => "",
+        };
         const UNOFFICIAL_SUFFIX: &str = if COMMIT_HASH_STR.is_empty() {
             "-unofficial"
         } else {
-            const_format::concatcp!("-unofficial+", COMMIT_HASH_STR)
+            const_format::concatcp!("-unofficial+", COMMIT_HASH_STR, COMMIT_DIRTY_STR)
         };
         const_format::concatcp!(built::PKG_VERSION, UNOFFICIAL_SUFFIX)
     }


### PR DESCRIPTION
## Description of change

This lets us distinguish between clean and dirty builds of a certain Git revision, so we know whether to trust the Git revision in the string or not. Tested by running `mount-s3 -V` and checking that it's marked as dirty when my Git repo is dirty and not otherwise.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
