### PR TITLE
Update `--profile` flag to override default chain's profile rather than replacing default chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "aws-sdk-sts 0.29.0",
  "base16ct",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Breaking changes
+
+* `S3ClientAuthConfig` variant `Default` is now `DefaultChain` with optional field.
+  `Default` trait implementation works as before and should be used instead.
+* `S3ClientAuthConfig` variant `Profile` has been removed.
+  Instead, a new profile credential provider should be created and used with the `Provider(CredentialProvider)` variant.
+
 ## v0.6.1 (December 1, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -7,6 +7,10 @@
 * `S3ClientAuthConfig` variant `Profile` has been removed.
   Instead, a new profile credential provider should be created and used with the `Provider(CredentialProvider)` variant.
 
+### Other changes
+
+* Default chain credential provider can now be configured with a profile name at creation.
+
 ## v0.6.1 (December 1, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -162,7 +162,7 @@ pub enum S3ClientAuthConfig {
     /// The default AWS credentials resolution chain, similar to the AWS CLI
     DefaultChain {
         /// Optional profile override to be used when evaluating credential chain
-        profile_name_override: Option<String>,
+        profile_name: Option<String>,
     },
     /// Do not sign requests at all
     NoSigning,
@@ -172,9 +172,7 @@ pub enum S3ClientAuthConfig {
 
 impl Default for S3ClientAuthConfig {
     fn default() -> Self {
-        Self::DefaultChain {
-            profile_name_override: None,
-        }
+        Self::DefaultChain { profile_name: None }
     }
 }
 
@@ -258,10 +256,10 @@ impl S3CrtClientInner {
 
         trace!("constructing client with auth config {:?}", config.auth_config);
         let credentials_provider = match config.auth_config {
-            S3ClientAuthConfig::DefaultChain { profile_name_override } => {
+            S3ClientAuthConfig::DefaultChain { profile_name } => {
                 let credentials_chain_default_options = CredentialsProviderChainDefaultOptions {
                     bootstrap: &mut client_bootstrap,
-                    profile_name_override: profile_name_override.as_deref(),
+                    profile_name_override: profile_name.as_deref(),
                 };
                 CredentialsProvider::new_chain_default(&allocator, credentials_chain_default_options)
                     .map_err(NewClientError::ProviderFailure)?

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -488,20 +488,25 @@ async fn test_scoped_credentials() {
     let client = S3CrtClient::new(config).unwrap();
 
     // Inside the prefix, things should be fine
-    let _result = client
+    let mut request = client
         .get_object(&bucket, &format!("{prefix}foo/foo.txt"), None, None)
         .await
-        .expect("get_object should succeed");
+        .expect("get_object should be accepted by CRT");
+    let _err = request
+        .next()
+        .await
+        .unwrap()
+        .expect("get_object requests should succeed within prefix");
     let _result = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}foo/"))
         .await
-        .expect("list_objects_should_succeed");
+        .expect("list_objects should succeed within prefix");
 
     // Outside the prefix, requests should fail with permissions errors
     let mut request = client
         .get_object(&bucket, &format!("{prefix}baz.txt"), None, None)
         .await
-        .expect("request should be sent");
+        .expect("request should be accepted by CRT");
     let err = request
         .next()
         .await

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -183,6 +183,7 @@ async fn test_profile_only_provider_async() {
 
 /// Test default chain where a profile name is provided but no credentials are configured.
 /// The default chain should continue to source credentials in one of the subsequent providers instead.
+#[ignore = "passes only if another provider in the chain is available, such as IMDS"]
 async fn test_default_chain_with_profile_override_fallback_async() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_profile_override_fallback");
 

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -183,7 +183,6 @@ async fn test_profile_only_provider_async() {
 
 /// Test default chain where a profile name is provided but no credentials are configured.
 /// The default chain should continue to source credentials in one of the subsequent providers instead.
-#[ignore = "passes only if another provider in the chain is available, such as IMDS"]
 async fn test_default_chain_with_profile_override_fallback_async() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_profile_override_fallback");
 
@@ -432,6 +431,7 @@ rusty_fork_test! {
     }
 
     #[test]
+    #[ignore = "passes only if another provider in the chain is available, such as IMDS"]
     fn test_default_chain_with_profile_override_fallback() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -43,7 +43,7 @@ async fn test_static_provider() {
         .expect("simple SDK PutObject request should succeed");
 
     // Get some static credentials using the SDK's default provider chain
-    let credentials = get_sdk_default_chain_creds().await;
+    let credentials = creds::get_sdk_default_chain_creds().await;
 
     // Build a S3CrtClient that uses a static credentials provider with the creds we just got
     let config = CredentialsProviderStaticOptions {
@@ -98,7 +98,7 @@ async fn test_profile_only_provider_async() {
     // The CRT client will be configured to point to this new file.
     let mut config_file = NamedTempFile::new().unwrap();
 
-    let creds = get_sdk_default_chain_creds().await;
+    let creds = creds::get_sdk_default_chain_creds().await;
     let allowed_profile_name = "allowed";
     write_credentials_to_named_profile(&mut config_file, allowed_profile_name, creds).await;
 
@@ -111,7 +111,7 @@ async fn test_profile_only_provider_async() {
             }
         ]
     }"#;
-    let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+    let scoped_down_creds = creds::get_scoped_down_credentials(policy.to_string()).await;
     let denied_profile_name = "denied";
     write_credentials_to_named_profile(&mut config_file, denied_profile_name, scoped_down_creds).await;
 
@@ -225,7 +225,7 @@ async fn test_default_chain_with_profile_override_allowed_async() {
     // The CRT client will be configured to point to this new file.
     let mut config_file = NamedTempFile::new().unwrap();
 
-    let creds = get_sdk_default_chain_creds().await;
+    let creds = creds::get_sdk_default_chain_creds().await;
     let profile_name = String::from("allowed");
     write_credentials_to_named_profile(&mut config_file, &profile_name, creds).await;
 
@@ -266,7 +266,7 @@ async fn test_default_chain_with_profile_override_denied_async() {
             }
         ]
     }"#;
-    let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+    let scoped_down_creds = creds::get_scoped_down_credentials(policy.to_string()).await;
     let profile_name = String::from("denied");
     write_credentials_to_named_profile(&mut config_file, &profile_name, scoped_down_creds).await;
 
@@ -302,7 +302,7 @@ async fn test_default_chain_with_no_profile_override_allowed_async() {
     // The CRT client will be configured to point to this new file.
     let mut config_file = NamedTempFile::new().unwrap();
 
-    let creds = get_sdk_default_chain_creds().await;
+    let creds = creds::get_sdk_default_chain_creds().await;
     let profile_name = "default";
     write_credentials_to_named_profile(&mut config_file, profile_name, creds).await;
 
@@ -343,7 +343,7 @@ async fn test_default_chain_with_no_profile_override_denied_async() {
             }
         ]
     }"#;
-    let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+    let scoped_down_creds = creds::get_scoped_down_credentials(policy.to_string()).await;
     let profile_name = "default";
     write_credentials_to_named_profile(&mut config_file, profile_name, scoped_down_creds).await;
 
@@ -494,7 +494,7 @@ async fn test_scoped_credentials() {
     let policy = policy
         .replace("__BUCKET__", &bucket)
         .replace("__PREFIX__", &format!("{prefix}foo"));
-    let credentials = get_scoped_down_credentials(policy).await;
+    let credentials = creds::get_scoped_down_credentials(policy).await;
 
     // Build a S3CrtClient that uses a static credentials provider with the creds we just got
     let config = CredentialsProviderStaticOptions {

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -205,7 +205,7 @@ async fn test_default_chain_with_profile_override_fallback_async() {
     let client = {
         let config = S3ClientConfig::new()
             .auth_config(S3ClientAuthConfig::DefaultChain {
-                profile_name_override: Some(profile_name.to_owned()),
+                profile_name: Some(profile_name.to_owned()),
             })
             .endpoint_config(EndpointConfig::new(&get_test_region()));
         S3CrtClient::new(config).unwrap()
@@ -237,7 +237,7 @@ async fn test_default_chain_with_profile_override_allowed_async() {
     let allowed_client = {
         let config = S3ClientConfig::new()
             .auth_config(S3ClientAuthConfig::DefaultChain {
-                profile_name_override: Some(profile_name),
+                profile_name: Some(profile_name),
             })
             .endpoint_config(EndpointConfig::new(&get_test_region()));
         S3CrtClient::new(config).unwrap()
@@ -278,7 +278,7 @@ async fn test_default_chain_with_profile_override_denied_async() {
     let denied_client = {
         let config = S3ClientConfig::new()
             .auth_config(S3ClientAuthConfig::DefaultChain {
-                profile_name_override: Some(profile_name),
+                profile_name: Some(profile_name),
             })
             .endpoint_config(EndpointConfig::new(&get_test_region()));
         S3CrtClient::new(config).unwrap()
@@ -314,7 +314,7 @@ async fn test_default_chain_with_no_profile_override_allowed_async() {
     let client = {
         let config = S3ClientConfig::new()
             .auth_config(S3ClientAuthConfig::DefaultChain {
-                profile_name_override: None, // use 'default' default
+                profile_name: None, // use 'default' default
             })
             .endpoint_config(EndpointConfig::new(&get_test_region()));
         S3CrtClient::new(config).unwrap()
@@ -355,7 +355,7 @@ async fn test_default_chain_with_no_profile_override_denied_async() {
     let client = {
         let config = S3ClientConfig::new()
             .auth_config(S3ClientAuthConfig::DefaultChain {
-                profile_name_override: None, // use 'default' default
+                profile_name: None, // use 'default' default
             })
             .endpoint_config(EndpointConfig::new(&get_test_region()));
         S3CrtClient::new(config).unwrap()

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -2,7 +2,7 @@
 
 pub mod common;
 
-use std::option::Option::None;
+use std::io::Write;
 
 use aws_sdk_s3::config::Credentials;
 use aws_sdk_s3::primitives::ByteStream;
@@ -10,13 +10,16 @@ use bytes::Bytes;
 use common::*;
 use futures::StreamExt;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
-#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::error::ObjectClientError;
-#[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::S3RequestError;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
+use mountpoint_s3_crt::auth::credentials::{
+    CredentialsProvider, CredentialsProviderProfileOptions, CredentialsProviderStaticOptions,
+};
 use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::io::channel_bootstrap;
+use mountpoint_s3_crt::io::event_loop;
+use mountpoint_s3_crt::io::host_resolver;
 use rusty_fork::rusty_fork_test;
 use tempfile::NamedTempFile;
 
@@ -88,80 +91,300 @@ async fn test_static_provider() {
 }
 
 /// Test creating a client with the profile credentials provider
-///
-/// This is complicated because CLI profiles are inherently global state, but we want to isolate the
-/// test. So the [test_profile_provider] test below is forked into its own process, where it can set
-/// the environment variables it needs to point to an isolated CLI configuration file without
-/// affecting the rest of the real test runner.
 async fn test_profile_only_provider_async() {
-    let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_only_provider");
 
-    let key = format!("{prefix}/hello");
-    let body = b"hello world!";
-    let mut request = sdk_client.put_object();
-    if cfg!(not(feature = "s3express_tests")) {
-        request = request.bucket(&bucket);
-    }
-    request
-        .key(&key)
-        .body(ByteStream::from(Bytes::from_static(body)))
-        .send()
-        .await
-        .unwrap();
-
-    // Get some static credentials using the SDK's default provider chain
-    let credentials = get_sdk_default_chain_creds().await;
-
-    // Write the credentials in CLI config format into a temp file
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
     let mut config_file = NamedTempFile::new().unwrap();
-    let profile_name = "mountpoint-profile";
-    write_credentials_to_named_profile(&mut config_file, profile_name, credentials).await;
-
     // Set up the environment variables to use this new config file. This is only OK to do because
     // this test is run in a forked process, so won't affect any other concurrently running tests.
     std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
 
-    // Build a S3CrtClient that uses the config file
-    let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
-    let client = S3CrtClient::new(config).unwrap();
+    let allocator = Allocator::default();
+    let mut client_bootstrap = setup_crt_bootstrap();
 
-    let result = client
-        .get_object(&bucket, &key, None, None)
+    let allowed_client = {
+        let creds = get_sdk_default_chain_creds().await;
+        let profile_name = "allowed";
+        write_credentials_to_named_profile(&mut config_file, profile_name, creds).await;
+
+        // Build a S3CrtClient that uses the config file
+        let profile_provider = CredentialsProvider::new_profile(
+            &allocator,
+            CredentialsProviderProfileOptions {
+                bootstrap: &mut client_bootstrap,
+                profile_name_override: profile_name,
+            },
+        )
+        .unwrap();
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::Provider(profile_provider))
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let _ok = allowed_client
+        .list_objects(&bucket, None, "/", 10, &prefix)
         .await
-        .expect("get_object should succeed");
-    check_get_result(result, None, &body[..]).await;
+        .expect("list_objects should succeed");
 
-    // Try it again, but scribble over the credentials, so we know it's not succeeding by accident.
-    // The client can't tell that the corrupted session token is invalid, so the request gets sent,
-    // but fails.
-    let length = config_file.as_file().metadata().unwrap().len();
-    config_file.as_file_mut().set_len(length - 5).unwrap();
+    let denied_client = {
+        let policy = r#"{
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        }"#;
+        let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+        let profile_name = "denied";
+        write_credentials_to_named_profile(&mut config_file, profile_name, scoped_down_creds).await;
 
-    let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
-    let client = S3CrtClient::new(config).unwrap();
+        // Build a S3CrtClient that uses the config file
+        let profile_provider = CredentialsProvider::new_profile(
+            &allocator,
+            CredentialsProviderProfileOptions {
+                bootstrap: &mut client_bootstrap,
+                profile_name_override: profile_name,
+            },
+        )
+        .unwrap();
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::Provider(profile_provider))
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
 
-    let mut request = client
-        .get_object(&bucket, &key, None, None)
+    let err = denied_client
+        .list_objects(&bucket, None, "/", 10, &prefix)
         .await
-        .expect("get_object should be accepted by CRT");
-    let _error = request
-        .next()
-        .await
-        .unwrap()
-        .expect_err("bogus credentials should not work");
+        .expect_err("list_objects should fail when using session with no permissions");
+    assert!(
+        matches!(err, ObjectClientError::ClientError(S3RequestError::Forbidden(_))),
+        "expected Forbidden err, but got {err:?}",
+    );
 
-    // Try it again with a bogus profile name so we know it's not succeeding by accident. This time
-    // the client can tell that the profile is invalid (it doesn't exist), so the client can't even
-    // be constructed.
-    let config = S3ClientConfig::new()
-        .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
-    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
+    // Try it again with a bogus profile name. The profile provider alone should not return any credentials.
+    // It shouldn't be possible to even construct the credential provider.
+    CredentialsProvider::new_profile(
+        &allocator,
+        CredentialsProviderProfileOptions {
+            bootstrap: &mut client_bootstrap,
+            profile_name_override: "not-the-right-profile-name",
+        },
+    )
+    .expect_err("cannot create provider if profile doesn't exist");
+}
+
+/// Test default chain where a profile name is provided but no credentials are configured.
+/// The default chain should continue to source credentials in one of the subsequent providers instead.
+#[tokio::test]
+async fn test_default_chain_with_profile_override_fallback() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_profile_override_fallback");
+
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    let profile_name = "profile-with-no-creds-config";
+
+    // Create a profile entry in the config.
+    // At the time of writing, this client does not handle any config entries in profiles - only credentials.
+    writeln!(config_file, "[profile {profile_name}]").unwrap();
+    writeln!(config_file, "cli_pager = less").unwrap();
+
+    // Try a profile with no credentials which should follow the rest of the chain.
+    let client = {
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::DefaultChain {
+                profile_name_override: Some(profile_name.to_owned()),
+            })
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let _ok = client
+        .list_objects(&bucket, None, "/", 10, &prefix)
+        .await
+        .expect("list_objects should succeed falling back on default chain credentials");
+}
+
+/// Test creating a client with the default credentials provider with a profile name override
+async fn test_default_chain_with_profile_override_allowed_async() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_no_profile_override_allowed");
+
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    let allowed_client = {
+        let creds = get_sdk_default_chain_creds().await;
+        let profile_name = String::from("allowed");
+        write_credentials_to_named_profile(&mut config_file, &profile_name, creds).await;
+
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::DefaultChain {
+                profile_name_override: Some(profile_name),
+            })
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let _ok = allowed_client
+        .list_objects(&bucket, None, "/", 10, &prefix)
+        .await
+        .expect("list_objects should succeed when it has appropriate creds");
+}
+
+/// Test creating a client with the default credentials provider with a profile name override
+async fn test_default_chain_with_profile_override_denied_async() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_profile_override_denied");
+
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    let denied_client = {
+        let policy = r#"{
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        }"#;
+        let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+        let profile_name = String::from("denied");
+        write_credentials_to_named_profile(&mut config_file, &profile_name, scoped_down_creds).await;
+
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::DefaultChain {
+                profile_name_override: Some(profile_name),
+            })
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let err = denied_client
+        .list_objects(&bucket, None, "/", 10, &prefix)
+        .await
+        .expect_err("list_objects should fail when using session with no permissions");
+    assert!(
+        matches!(err, ObjectClientError::ClientError(S3RequestError::Forbidden(_))),
+        "expected Forbidden err, but got {err:?}",
+    );
+}
+
+/// Test creating a client with the default credentials provider with no profile name override
+async fn test_default_chain_with_no_profile_override_allowed_async() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_no_profile_override_allowed");
+
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    let creds = get_sdk_default_chain_creds().await;
+    let profile_name = "default";
+    write_credentials_to_named_profile(&mut config_file, profile_name, creds).await;
+
+    let client = {
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::DefaultChain {
+                profile_name_override: None, // use 'default' default
+            })
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let _ok = client
+        .list_objects(&bucket, None, "/", 10, &prefix)
+        .await
+        .expect("list_objects should succeed when it has appropriate creds");
+}
+
+/// Test creating a client with the default credentials provider with no profile name override
+async fn test_default_chain_with_no_profile_override_denied_async() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_no_profile_override_denied");
+
+    // Create a new config file where we can write new AWS profile configurations including credentials.
+    // Environment variables will be updated to point to this new file.
+    // This is OK only because the test runs in a forked process and won't affect any other concurrently running tests.
+    let mut config_file = NamedTempFile::new().unwrap();
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    let policy = r#"{
+        "Statement": [
+            {
+                "Effect": "Deny",
+                "Action": "*",
+                "Resource": "*"
+            }
+        ]
+    }"#;
+    let scoped_down_creds = get_scoped_down_credentials(policy.to_string()).await;
+    let profile_name = "default";
+    write_credentials_to_named_profile(&mut config_file, profile_name, scoped_down_creds).await;
+
+    let client = {
+        let config = S3ClientConfig::new()
+            .auth_config(S3ClientAuthConfig::DefaultChain {
+                profile_name_override: None, // use 'default' default
+            })
+            .endpoint_config(EndpointConfig::new(&get_test_region()));
+        S3CrtClient::new(config).unwrap()
+    };
+
+    let err = client
+        .list_objects(&bucket, None, "/", 10, &prefix)
+        .await
+        .expect_err("list_objects should fail when using session with no permissions");
+    assert!(
+        matches!(err, ObjectClientError::ClientError(S3RequestError::Forbidden(_))),
+        "expected Forbidden err, but got {err:?}",
+    );
+}
+
+fn setup_crt_bootstrap() -> channel_bootstrap::ClientBootstrap {
+    let allocator = Allocator::default();
+
+    let mut event_loop_group = event_loop::EventLoopGroup::new_default(&allocator, None, || {}).unwrap();
+
+    let resolver_options = host_resolver::HostResolverDefaultOptions {
+        max_entries: 8,
+        event_loop_group: &mut event_loop_group,
+    };
+
+    let mut host_resolver = host_resolver::HostResolver::new_default(&allocator, &resolver_options).unwrap();
+
+    let bootstrap_options = channel_bootstrap::ClientBootstrapOptions {
+        event_loop_group: &mut event_loop_group,
+        host_resolver: &mut host_resolver,
+    };
+
+    channel_bootstrap::ClientBootstrap::new(&allocator, &bootstrap_options).unwrap()
 }
 
 /// Takes something writable (such as an open file) and writes a new entry for the given name and SDK credentials.
@@ -180,6 +403,11 @@ async fn write_credentials_to_named_profile<B: std::io::Write>(
     }
 }
 
+// These tests are complicated because they need to modify AWS profiles which are global state.
+// For test purposes, we want to keep each isolated.
+// Each test below is forked into its own process, where it can set
+// the environment variables it needs to point to an isolated CLI configuration file without
+// affecting the rest of the real test runner.
 rusty_fork_test! {
     #[test]
     fn test_profile_only_provider() {
@@ -187,6 +415,35 @@ rusty_fork_test! {
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         runtime.block_on(test_profile_only_provider_async());
     }
+
+    #[test]
+    fn test_default_chain_with_profile_override_allowed() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_with_profile_override_allowed_async());
+    }
+
+    #[test]
+    fn test_default_chain_with_profile_override_denied() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_with_profile_override_denied_async());
+    }
+
+    #[test]
+    fn test_default_chain_with_no_profile_override_allowed() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_with_no_profile_override_allowed_async());
+    }
+
+    #[test]
+    fn test_default_chain_with_no_profile_override_denied() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_with_no_profile_override_denied_async());
+    }
+
 }
 
 /// Test using a client with scoped-down credentials

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -40,7 +40,7 @@ async fn test_static_provider() {
         .body(ByteStream::from(Bytes::from_static(body)))
         .send()
         .await
-        .unwrap();
+        .expect("simple SDK PutObject request should succeed");
 
     // Get some static credentials using the SDK's default provider chain
     let credentials = get_sdk_default_chain_creds().await;
@@ -183,8 +183,7 @@ async fn test_profile_only_provider_async() {
 
 /// Test default chain where a profile name is provided but no credentials are configured.
 /// The default chain should continue to source credentials in one of the subsequent providers instead.
-#[tokio::test]
-async fn test_default_chain_with_profile_override_fallback() {
+async fn test_default_chain_with_profile_override_fallback_async() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_default_chain_with_profile_override_fallback");
 
     // Create a new config file where we can write new AWS profile configurations including credentials.
@@ -432,6 +431,13 @@ rusty_fork_test! {
     }
 
     #[test]
+    fn test_default_chain_with_profile_override_fallback() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_default_chain_with_profile_override_fallback_async());
+    }
+
+    #[test]
     fn test_default_chain_with_profile_override_allowed() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
@@ -477,7 +483,7 @@ async fn test_scoped_credentials() {
             .body(ByteStream::from(Bytes::from_static(b"hello world")))
             .send()
             .await
-            .unwrap();
+            .expect("simple SDK PutObject requests should succeed");
     }
 
     // Scope down to the `foo` prefix

--- a/mountpoint-s3-client/tests/common/creds.rs
+++ b/mountpoint-s3-client/tests/common/creds.rs
@@ -2,24 +2,9 @@
 //!
 //! Some methods are duplicated in `mountpoint-s3::tests::common::creds`.
 
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
-use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::Credentials;
-use aws_sdk_sts as sts;
-use aws_sdk_sts::config::Region;
 
-use super::get_test_region;
-
-/// Grab a set of SDK [Credentials] from the default credential provider chain.
-pub async fn get_sdk_default_chain_creds() -> Credentials {
-    let sdk_provider = DefaultCredentialsChain::builder().build().await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+use crate::common::get_test_region;
 
 /// Provide some static credentials that are not valid.
 pub fn get_fake_creds() -> Credentials {
@@ -37,6 +22,35 @@ pub fn get_fake_creds() -> Credentials {
     credentials
 }
 
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
 /// Takes the provided IAM Policy and assumes the configured subsession role,
 /// applying the given policy to scope down the permissions available.
 ///
@@ -49,7 +63,14 @@ pub fn get_fake_creds() -> Credentials {
 ///
 /// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
 pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -> Credentials {
-    let sts_client = get_test_sdk_sts_client().await;
+    use aws_sdk_sts as sts;
+
+    let config = aws_config::from_env()
+        .region(sts::config::Region::new(get_test_region()))
+        .load()
+        .await;
+    let sts_client = sts::Client::new(&config);
+
     let assume_role_response = sts_client
         .assume_role()
         .role_arn(get_subsession_iam_role())
@@ -74,30 +95,7 @@ pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -
     credentials
 }
 
-/// Detect if running on GitHub Actions (GHA) and if so,
-/// emit masking string to avoid credentials accidentally being printed.
-fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
-    if std::env::var_os("GITHUB_ACTIONS").is_some() {
-        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
-        // If we think we're in GitHub Actions environment, register each in stdout.
-        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
-        println!("::add-mask::{}", credentials.access_key_id());
-        println!("::add-mask::{}", credentials.secret_access_key());
-        if let Some(token) = credentials.session_token() {
-            println!("::add-mask::{}", token);
-        }
-    }
-}
-
 /// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
 fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
-async fn get_test_sdk_sts_client() -> sts::Client {
-    let config = aws_config::from_env()
-        .region(Region::new(get_test_region()))
-        .load()
-        .await;
-    sts::Client::new(&config)
 }

--- a/mountpoint-s3-client/tests/common/creds.rs
+++ b/mountpoint-s3-client/tests/common/creds.rs
@@ -1,0 +1,103 @@
+//! Module providing methods for accessing different types of credentials for tests.
+//!
+//! Some methods are duplicated in `mountpoint-s3::tests::common::creds`.
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
+use aws_sdk_sts as sts;
+use aws_sdk_sts::config::Region;
+
+use super::get_test_region;
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Provide some static credentials that are not valid.
+pub fn get_fake_creds() -> Credentials {
+    let credentials = Credentials::new(
+        "AKIAIOSFODNN7EXAMPLE",
+        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        None,
+        None,
+        "invalid_creds",
+    );
+
+    // They aren't valid, but just to be consistent let's mask them from CI.
+    mask_aws_creds_if_on_gha(&credentials);
+
+    credentials
+}
+
+/// Takes the provided IAM Policy and assumes the configured subsession role,
+/// applying the given policy to scope down the permissions available.
+///
+/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+/// The permissions are the intersection of the identity-based policy of the principal creating the session
+/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+/// this method can only reduce the scope of permissions.
+///
+/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+///
+/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -> Credentials {
+    let sts_client = get_test_sdk_sts_client().await;
+    let assume_role_response = sts_client
+        .assume_role()
+        .role_arn(get_subsession_iam_role())
+        .role_session_name("mountpoint-s3-client_tests")
+        .policy(policy)
+        .send()
+        .await
+        .expect("assume_role with valid ARN and policy should succeed");
+    let credentials = assume_role_response
+        .credentials()
+        .expect("credentials should be present if assume_role succeeded")
+        .to_owned();
+    // Reassemble into an AWS-service-agnostic credentials type. Without this, we'll get type errors.
+    let credentials = Credentials::new(
+        credentials.access_key_id().unwrap(),
+        credentials.secret_access_key().unwrap(),
+        credentials.session_token().map(|s| s.to_owned()),
+        None,
+        "scoped_down_sts_creds",
+    );
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
+async fn get_test_sdk_sts_client() -> sts::Client {
+    let config = aws_config::from_env()
+        .region(Region::new(get_test_region()))
+        .load()
+        .await;
+    sts::Client::new(&config)
+}

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -1,14 +1,10 @@
 #![cfg(feature = "s3_tests")]
 
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
-use aws_credential_types::provider::ProvideCredentials;
-use aws_credential_types::Credentials;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::list_multipart_uploads::ListMultipartUploadsError;
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts as sts;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
@@ -18,6 +14,8 @@ use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use std::ops::Range;
+
+pub mod creds;
 
 /// Enable tracing and CRT logging when running unit tests.
 #[ctor::ctor]
@@ -105,11 +103,6 @@ pub fn get_test_domain() -> String {
     std::env::var("S3_DOMAIN").unwrap_or(String::from("amazonaws.com"))
 }
 
-/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
-fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
 pub fn get_s3express_endpoint() -> String {
     std::env::var("S3_EXPRESS_ONE_ZONE_ENDPOINT").expect("Set S3_EXPRESS_ONE_ZONE_ENDPOINT to run integration tests")
 }
@@ -121,60 +114,6 @@ pub async fn get_test_sdk_client() -> s3::Client {
     }
     let config = config.load().await;
     s3::Client::new(&config)
-}
-
-async fn get_test_sdk_sts_client() -> sts::Client {
-    let config = aws_config::from_env()
-        .region(Region::new(get_test_region()))
-        .load()
-        .await;
-    sts::Client::new(&config)
-}
-
-/// Grab a set of SDK [Credentials] from the default credential provider chain.
-pub async fn get_sdk_default_chain_creds() -> Credentials {
-    let sdk_provider = DefaultCredentialsChain::builder()
-        .region(Region::new(get_test_region()))
-        .build()
-        .await;
-    sdk_provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available")
-}
-
-/// Takes the provided IAM Policy and assumes the configured subsession role,
-/// applying the given policy to scope down the permissions available.
-///
-/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
-/// The permissions are the intersection of the identity-based policy of the principal creating the session
-/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
-/// this method can only reduce the scope of permissions.
-///
-/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
-///
-/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
-pub async fn get_scoped_down_credentials(policy: String) -> Credentials {
-    let sts_client = get_test_sdk_sts_client().await;
-    let assume_role_response = sts_client
-        .assume_role()
-        .role_arn(get_subsession_iam_role())
-        .role_session_name("mountpoint-s3-client_tests")
-        .policy(policy)
-        .send()
-        .await
-        .expect("assume_role with valid ARN and policy should succeed");
-    let credentials = assume_role_response
-        .credentials()
-        .expect("credentials should be present if assume_role succeeded")
-        .to_owned();
-    Credentials::new(
-        credentials.access_key_id().unwrap(),
-        credentials.secret_access_key().unwrap(),
-        credentials.session_token().map(|s| s.to_owned()),
-        None,
-        "scoped_down_sts_creds",
-    )
 }
 
 /// Create some objects in a prefix for testing.

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update to latest CRT dependencies
 * Return type of `common::Uri::host_port` changed from `u16` to `u32`
+* Allow setting `skip_environment_credentials_provider` on the default credential chain provider
 
 ## v0.5.1 (December 1, 2023)
 

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -24,6 +24,8 @@ pub struct CredentialsProviderChainDefaultOptions<'a> {
     pub bootstrap: &'a mut ClientBootstrap,
     /// The name of profile to use.
     pub profile_name_override: Option<&'a str>,
+    /// Set if credentials from the environment should be included when evaluating the chain or skipped.
+    pub skip_environment_credentials_provider: bool,
 }
 
 /// Options for creating a profile credentials provider
@@ -84,6 +86,7 @@ impl CredentialsProvider {
             let inner_options = aws_credentials_provider_chain_default_options {
                 bootstrap: options.bootstrap.inner.as_ptr(),
                 profile_name_override,
+                skip_environment_credentials_provider: options.skip_environment_credentials_provider,
                 ..Default::default()
             };
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Other changes
+* Option `--profile <AWS_PROFILE>` no longer replaces the entire default credential chain.
+  Instead, the provided name will be used with AWS config file entries when evaluating the default credential chain,
+  alike the AWS CLI and AWS SDKs.
+
 ## v1.3.1 (November 30, 2023)
 
 ### Breaking changes

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## Unreleased
 
 ### Other changes
-* Option `--profile <AWS_PROFILE>` no longer replaces the entire default credential chain.
-  Instead, the provided name will be used with AWS config file entries when evaluating the default credential chain,
+* Fixed a bug where `--profile <AWS_PROFILE>` did not work with `credential_process` configuration entries.
+  ([#684](https://github.com/awslabs/mountpoint-s3/pull/684))
+* Option `--profile <AWS_PROFILE>` now evaluates the default credential chain rather than only the AWS config/credential file entry for the profile,
   alike the AWS CLI and AWS SDKs.
+  ([#684](https://github.com/awslabs/mountpoint-s3/pull/684))
+
+### Breaking changes
+
+* Mountpoint will no longer error when providing a profile name that does not exist using `--profile <PROFILE_NAME>`.
+  Instead, it will continue to resolve any credentials in the default credential chain if available.
 
 ## v1.3.1 (November 30, 2023)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -49,6 +49,7 @@ procfs = { version = "0.15.1", default-features = false }
 assert_cmd = "2.0.6"
 assert_fs = "1.0.9"
 aws-config = "0.56.0"
+aws-credential-types = "0.56.0"
 aws-sdk-s3 = "0.29.0"
 aws-sdk-sts = "0.29.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -509,10 +509,10 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
 
     let auth_config = if args.no_sign_request {
         S3ClientAuthConfig::NoSigning
-    } else if let Some(profile_name) = args.profile {
-        S3ClientAuthConfig::Profile(profile_name)
     } else {
-        S3ClientAuthConfig::Default
+        S3ClientAuthConfig::DefaultChain {
+            profile_name_override: args.profile,
+        }
     };
 
     let user_agent_prefix = if let Some(custom_prefix) = args.user_agent_prefix {

--- a/mountpoint-s3/src/main.rs
+++ b/mountpoint-s3/src/main.rs
@@ -511,7 +511,7 @@ fn mount(args: CliArgs) -> anyhow::Result<FuseSession> {
         S3ClientAuthConfig::NoSigning
     } else {
         S3ClientAuthConfig::DefaultChain {
-            profile_name_override: args.profile,
+            profile_name: args.profile,
         }
     };
 

--- a/mountpoint-s3/tests/auth-cli.rs
+++ b/mountpoint-s3/tests/auth-cli.rs
@@ -1,0 +1,135 @@
+#![cfg(feature = "s3_tests")]
+
+mod common;
+
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use std::{fs, process::Command}; // Run programs
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sdk_s3::config::Credentials;
+
+use crate::common::s3::{get_test_bucket_and_prefix, get_test_region};
+
+/// This test puts valid credentials into the environment and configure invalid credentials in an AWS Profile.
+/// It verifies that Mountpoint fails due to using those credentials and ignoring the credentials in the environment.
+#[tokio::test]
+async fn check_profile_env_prefers_static_env_creds() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+    let profile_name = "test-profile";
+
+    let (bucket, prefix) = get_test_bucket_and_prefix("check_profile_env_prefers_static_env_creds");
+    let region = get_test_region();
+
+    let config_file_name = dir.join("config");
+    let mut config_file = fs::File::create(&config_file_name).unwrap();
+    cmd.env("AWS_CONFIG_FILE", &config_file_name);
+
+    // Configure invalid credentials. We intend to check Mountpoint uses these despite setting AWS_PROFILE.
+    {
+        let credentials = aws_sdk_s3::config::Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            None,
+            None,
+            "invalid_creds",
+        );
+        cmd.env("AWS_ACCESS_KEY_ID", credentials.access_key_id());
+        cmd.env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            cmd.env("AWS_SESSION_TOKEN", token);
+        }
+    }
+
+    // Configure invalid credentials in an AWS Profile.
+    {
+        let credentials = get_sdk_default_chain_creds().await;
+        write_credentials_to_named_profile(&mut config_file, profile_name, credentials).await;
+        cmd.env("AWS_PROFILE", profile_name);
+    }
+
+    cmd.env("AWS_REGION", region);
+    cmd.arg(&bucket);
+    cmd.arg(dir.path());
+    cmd.arg(format!("--prefix={prefix}"));
+    let error_message = "The AWS Access Key Id you provided does not exist in our records.";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+/// This test puts invalid credentials into the environment and configure valid credentials in an AWS Profile.
+/// It verifies that Mountpoint fails due to using those credentials and ignoring the credentials in the environment.
+#[tokio::test]
+async fn check_profile_flag_ignores_static_env_creds() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+    let profile_name = "test-profile";
+
+    let (bucket, prefix) = get_test_bucket_and_prefix("check_profile_flag_ignores_static_env_creds");
+    let region = get_test_region();
+
+    let config_file_name = dir.join("config");
+    let mut config_file = fs::File::create(&config_file_name).unwrap();
+    cmd.env("AWS_CONFIG_FILE", &config_file_name);
+
+    // Configure invalid credentials in an AWS Profile.
+    {
+        let credentials = aws_sdk_s3::config::Credentials::new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            None,
+            None,
+            "invalid_creds",
+        );
+        write_credentials_to_named_profile(&mut config_file, profile_name, credentials).await;
+    }
+
+    // Configure valid environment variables explicitly.
+    // We intend to check Mountpoint skips these when setting `--profile <PROFILE_NAME>`.
+    {
+        let credentials = get_sdk_default_chain_creds().await;
+        cmd.env("AWS_ACCESS_KEY_ID", credentials.access_key_id());
+        cmd.env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            cmd.env("AWS_SESSION_TOKEN", token);
+        }
+    }
+
+    cmd.env("AWS_REGION", region);
+    cmd.arg(&bucket);
+    cmd.arg(dir.path());
+    cmd.arg(format!("--prefix={prefix}"));
+    cmd.arg(format!("--profile={profile_name}"));
+    let error_message = "The AWS Access Key Id you provided does not exist in our records.";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}
+
+/// Takes something writable (such as an open file) and writes a new entry for the given name and SDK credentials.
+async fn write_credentials_to_named_profile<B: std::io::Write>(
+    mut config_buffer: B,
+    profile_name: &str,
+    credentials: aws_sdk_s3::config::Credentials,
+) {
+    writeln!(config_buffer, "[profile {profile_name}]").unwrap();
+    let access_key_id = credentials.access_key_id();
+    writeln!(config_buffer, "aws_access_key_id = {access_key_id}").unwrap();
+    let secret_access_key = credentials.secret_access_key();
+    writeln!(config_buffer, "aws_secret_access_key = {secret_access_key}",).unwrap();
+    if let Some(session_token) = credentials.session_token() {
+        writeln!(config_buffer, "aws_session_token = {session_token}").unwrap();
+    }
+}
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available")
+}

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -143,18 +143,6 @@ fn s3_uri_as_bucket_name() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn invalid_profile() -> Result<(), Box<dyn std::error::Error>> {
-    let dir = assert_fs::TempDir::new()?;
-    let mut cmd = Command::cargo_bin("mount-s3")?;
-
-    cmd.arg("test-bucket").arg(dir.path()).arg("--profile").arg("INVALID");
-    let error_message = "invalid AWS credentials";
-    cmd.assert().failure().stderr(predicate::str::contains(error_message));
-
-    Ok(())
-}
-
-#[test]
 fn validate_log_files_permissions() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let dir = assert_fs::TempDir::new()?;

--- a/mountpoint-s3/tests/common/creds.rs
+++ b/mountpoint-s3/tests/common/creds.rs
@@ -1,0 +1,103 @@
+//! Module providing methods for accessing different types of credentials for tests.
+//!
+//! Some methods are duplicated in `mountpoint-s3-client::tests::common::creds`.
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
+use aws_sdk_sts as sts;
+use aws_sdk_sts::config::Region;
+
+use super::s3::get_test_region;
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Provide some static credentials that are not valid.
+pub fn get_fake_creds() -> Credentials {
+    let credentials = Credentials::new(
+        "AKIAIOSFODNN7EXAMPLE",
+        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        None,
+        None,
+        "invalid_creds",
+    );
+
+    // They aren't valid, but just to be consistent let's mask them from CI.
+    mask_aws_creds_if_on_gha(&credentials);
+
+    credentials
+}
+
+/// Takes the provided IAM Policy and assumes the configured subsession role,
+/// applying the given policy to scope down the permissions available.
+///
+/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+/// The permissions are the intersection of the identity-based policy of the principal creating the session
+/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+/// this method can only reduce the scope of permissions.
+///
+/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+///
+/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -> Credentials {
+    let sts_client = get_test_sdk_sts_client().await;
+    let assume_role_response = sts_client
+        .assume_role()
+        .role_arn(get_subsession_iam_role())
+        .role_session_name("mountpoint-s3-client_tests")
+        .policy(policy)
+        .send()
+        .await
+        .expect("assume_role with valid ARN and policy should succeed");
+    let credentials = assume_role_response
+        .credentials()
+        .expect("credentials should be present if assume_role succeeded")
+        .to_owned();
+    // Reassemble into an AWS-service-agnostic credentials type. Without this, we'll get type errors.
+    let credentials = Credentials::new(
+        credentials.access_key_id().unwrap(),
+        credentials.secret_access_key().unwrap(),
+        credentials.session_token().map(|s| s.to_owned()),
+        None,
+        "scoped_down_sts_creds",
+    );
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
+async fn get_test_sdk_sts_client() -> sts::Client {
+    let config = aws_config::from_env()
+        .region(Region::new(get_test_region()))
+        .load()
+        .await;
+    sts::Client::new(&config)
+}

--- a/mountpoint-s3/tests/common/creds.rs
+++ b/mountpoint-s3/tests/common/creds.rs
@@ -2,24 +2,10 @@
 //!
 //! Some methods are duplicated in `mountpoint-s3-client::tests::common::creds`.
 
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
-use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::Credentials;
-use aws_sdk_sts as sts;
-use aws_sdk_sts::config::Region;
 
-use super::s3::get_test_region;
-
-/// Grab a set of SDK [Credentials] from the default credential provider chain.
-pub async fn get_sdk_default_chain_creds() -> Credentials {
-    let sdk_provider = DefaultCredentialsChain::builder().build().await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+#[cfg(feature = "s3_tests")]
+use crate::common::s3::get_test_region;
 
 /// Provide some static credentials that are not valid.
 pub fn get_fake_creds() -> Credentials {
@@ -37,6 +23,36 @@ pub fn get_fake_creds() -> Credentials {
     credentials
 }
 
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+#[cfg(feature = "s3_tests")]
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
 /// Takes the provided IAM Policy and assumes the configured subsession role,
 /// applying the given policy to scope down the permissions available.
 ///
@@ -48,8 +64,16 @@ pub fn get_fake_creds() -> Credentials {
 /// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
 ///
 /// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+#[cfg(feature = "s3_tests")]
 pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -> Credentials {
-    let sts_client = get_test_sdk_sts_client().await;
+    use aws_sdk_sts as sts;
+
+    let config = aws_config::from_env()
+        .region(sts::config::Region::new(get_test_region()))
+        .load()
+        .await;
+    let sts_client = sts::Client::new(&config);
+
     let assume_role_response = sts_client
         .assume_role()
         .role_arn(get_subsession_iam_role())
@@ -74,30 +98,8 @@ pub async fn get_scoped_down_credentials<Policy: Into<String>>(policy: Policy) -
     credentials
 }
 
-/// Detect if running on GitHub Actions (GHA) and if so,
-/// emit masking string to avoid credentials accidentally being printed.
-fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
-    if std::env::var_os("GITHUB_ACTIONS").is_some() {
-        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
-        // If we think we're in GitHub Actions environment, register each in stdout.
-        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
-        println!("::add-mask::{}", credentials.access_key_id());
-        println!("::add-mask::{}", credentials.secret_access_key());
-        if let Some(token) = credentials.session_token() {
-            println!("::add-mask::{}", token);
-        }
-    }
-}
-
 /// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+#[cfg(feature = "s3_tests")]
 fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
-async fn get_test_sdk_sts_client() -> sts::Client {
-    let config = aws_config::from_env()
-        .region(Region::new(get_test_region()))
-        .load()
-        .await;
-    sts::Client::new(&config)
 }

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -2,9 +2,9 @@
 //! Allow for unused items since this is included independently in each module.
 #![allow(dead_code)]
 
+pub mod creds;
 #[cfg(feature = "fuse_tests")]
 pub mod fuse;
-
 #[cfg(feature = "s3_tests")]
 pub mod s3;
 

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,5 +1,5 @@
+use aws_sdk_s3::config::Region;
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts::config::Region;
 use futures::Future;
 use rand::RngCore;
 use rand_chacha::rand_core::OsRng;


### PR DESCRIPTION
## Description of change

_A previous PR was open for this change but was very stale: #415._

This change means that a profile can be specified that does not configure any credentials, but may configure other things. **Mountpoint does not read any configuration from an AWS Profile other than credentials today** but may do in the future.

Before this change, the entire credential chain was replaced with one that would supply profile credentials or error - no fallback. This was not in line with AWS CLI or SDKs.

This should fix #389 since the default chain also allows credential process credentials to be used.

## Does this change impact existing behavior?

Yes, it fixes the behavior of the `--profile <AWS_PROFILE>` flag to be in line with `AWS_PROFILE` environment variable, as well as `--profile <AWS_PROFILE>` flag of the AWS CLI.

It also fixes bug #389.

**Note:** It does not validate that the AWS profile exists, like the AWS CLI does. If the profile does not exist, the parameter will be ignored. Mountpoint already behaves this way today when using the `AWS_PROFILE` environment variable. Mountpoint previously reporting an error was a side effect of replacing the default chain with a profile provider.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).