### PR TITLE
Resolve clippy warnings introduced in Rust 1.75.0

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -711,14 +711,14 @@ impl SuperblockInner {
 
                     let found_directory = if result
                         .common_prefixes
-                        .get(0)
+                        .first()
                         .map(|prefix| prefix.starts_with(&full_path_suffixed))
                         .unwrap_or(false)
                     {
                         true
                     } else if result
                         .objects
-                        .get(0)
+                        .first()
                         .map(|object| object.key.starts_with(&full_path_suffixed))
                         .unwrap_or(false)
                     {

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -141,7 +141,11 @@ impl Reference {
     pub fn new(remote_keys: Vec<(String, MockObject)>) -> Self {
         let local_files = vec![];
         let local_directories = vec![];
-        let materialized = build_reference(remote_keys.iter().map(|(k, o)| (k, o)));
+        let remote_key_iter = remote_keys.iter().map(|(k, o): &(String, MockObject)| {
+            let tuple_of_refs: (&String, &MockObject) = (k, o);
+            tuple_of_refs
+        });
+        let materialized = build_reference(remote_key_iter);
         Self {
             remote_keys: remote_keys.into_iter().collect(),
             local_files,

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -141,11 +141,7 @@ impl Reference {
     pub fn new(remote_keys: Vec<(String, MockObject)>) -> Self {
         let local_files = vec![];
         let local_directories = vec![];
-        let remote_key_iter = remote_keys.iter().map(|(k, o): &(String, MockObject)| {
-            let tuple_of_refs: (&String, &MockObject) = (k, o);
-            tuple_of_refs
-        });
-        let materialized = build_reference(remote_key_iter);
+        let materialized = build_reference(remote_keys.iter().map(|(k, o): &(_, _)| (k, o)));
         Self {
             remote_keys: remote_keys.into_iter().collect(),
             local_files,


### PR DESCRIPTION
## Description of change

Making changes based on new clippy rules.
Changes are seen for the following update:

    stable-x86_64-apple-darwin updated - rustc 1.75.0 (82e1608df 2023-12-21) (from rustc 1.74.1 (a28077b28 2023-12-04))

For the mapping of `&(String, MockObject)` to `(&String, &MockObject)`, I decided to make the conversion explicit rather than adding an ignore. This is also reported as a false positive to Clippy, but the fix has not been released yet: https://github.com/rust-lang/rust-clippy/issues/11764

Relevant issues: N/A

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
