### PR TITLE
Tidy up ChecksummedBytes public methods

### DIFF
--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -197,7 +197,7 @@ impl DiskBlock {
         let data_checksum =
             self.header
                 .validate(cache_key.key(), cache_key.etag().as_str(), block_idx, block_offset)?;
-        let bytes = ChecksummedBytes::new(self.data.clone(), data_checksum);
+        let bytes = ChecksummedBytes::new_from_inner_data(self.data.clone(), data_checksum);
         Ok(bytes)
     }
 }
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn test_block_format_version_requires_update() {
         let cache_key = ObjectId::new("hello-world".to_string(), ETag::for_tests());
-        let data = ChecksummedBytes::from_bytes("Foo".into());
+        let data = ChecksummedBytes::new("Foo".into());
         let block = DiskBlock::new(cache_key, 100, 100 * 10, data).expect("should succeed as data checksum is valid");
         let expected_bytes: Vec<u8> = vec![
             100, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 116, 101, 115, 116, 95, 101,
@@ -631,9 +631,9 @@ mod tests {
 
     #[test]
     fn test_put_get() {
-        let data_1 = ChecksummedBytes::from_bytes("Foo".into());
-        let data_2 = ChecksummedBytes::from_bytes("Bar".into());
-        let data_3 = ChecksummedBytes::from_bytes("Baz".into());
+        let data_1 = ChecksummedBytes::new("Foo".into());
+        let data_2 = ChecksummedBytes::new("Bar".into());
+        let data_3 = ChecksummedBytes::new("Baz".into());
 
         let block_size = 8 * 1024 * 1024;
         let cache_directory = tempfile::tempdir().unwrap();
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_checksummed_bytes_slice() {
-        let data = ChecksummedBytes::from_bytes("0123456789".into());
+        let data = ChecksummedBytes::new("0123456789".into());
         let slice = data.slice(1..5);
 
         let cache_directory = tempfile::tempdir().unwrap();
@@ -748,7 +748,7 @@ mod tests {
             let mut body = vec![0u8; size];
             rng.fill(&mut body[..]);
 
-            ChecksummedBytes::from_bytes(body.into())
+            ChecksummedBytes::new(body.into())
         }
 
         fn is_block_in_cache(
@@ -845,7 +845,7 @@ mod tests {
 
     #[test]
     fn data_block_extract_checks() {
-        let data_1 = ChecksummedBytes::from_bytes("Foo".into());
+        let data_1 = ChecksummedBytes::new("Foo".into());
 
         let cache_key_1 = ObjectId::new("a".into(), ETag::for_tests());
         let cache_key_2 = ObjectId::new("b".into(), ETag::for_tests());

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -69,11 +69,11 @@ mod tests {
     #[test]
     fn test_put_get() {
         let data_1 = Bytes::from_static(b"Hello world");
-        let data_1 = ChecksummedBytes::from_bytes(data_1.clone());
+        let data_1 = ChecksummedBytes::new(data_1.clone());
         let data_2 = Bytes::from_static(b"Foo bar");
-        let data_2 = ChecksummedBytes::from_bytes(data_2.clone());
+        let data_2 = ChecksummedBytes::new(data_2.clone());
         let data_3 = Bytes::from_static(b"Baz");
-        let data_3 = ChecksummedBytes::from_bytes(data_3.clone());
+        let data_3 = ChecksummedBytes::new(data_3.clone());
 
         let block_size = 8 * 1024 * 1024;
         let cache = InMemoryDataCache::new(block_size);

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -107,7 +107,6 @@ mod tests {
     use bytes::Bytes;
     use futures::executor::block_on;
     use mountpoint_s3_client::types::ETag;
-    use mountpoint_s3_crt::checksums::crc32c;
     use proptest::proptest;
     use proptest_derive::Arbitrary;
     use thiserror::Error;
@@ -161,8 +160,7 @@ mod tests {
                     let offset = current_offset + current_length as u64;
                     let body: Box<[u8]> = (0u8..=255).cycle().skip(offset as u8 as usize).take(n).collect();
                     let bytes: Bytes = body.into();
-                    let checksum = crc32c::checksum(&bytes);
-                    let checksummed_bytes = ChecksummedBytes::new(bytes, checksum);
+                    let checksummed_bytes = ChecksummedBytes::new(bytes);
                     let part = Part::new(part_id.clone(), offset, checksummed_bytes);
                     part_queue_producer.push(Ok(part));
                     current_length += n;

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -4,7 +4,6 @@ use bytes::Bytes;
 use futures::task::SpawnExt;
 use futures::{pin_mut, task::Spawn, StreamExt};
 use mountpoint_s3_client::{types::ETag, ObjectClient};
-use mountpoint_s3_crt::checksums::crc32c;
 use tracing::{debug_span, error, trace, Instrument};
 
 use crate::checksums::ChecksummedBytes;
@@ -220,8 +219,7 @@ where
                                 let chunk = body.split_to(chunk_size);
                                 // S3 doesn't provide checksum for us if the request range is not aligned to
                                 // object part boundaries, so we're computing our own checksum here.
-                                let checksum = crc32c::checksum(&chunk);
-                                let checksum_bytes = ChecksummedBytes::new(chunk, checksum);
+                                let checksum_bytes = ChecksummedBytes::new(chunk);
                                 let part = Part::new(id.clone(), curr_offset, checksum_bytes);
                                 curr_offset += part.len() as u64;
                                 part_queue_producer.push(Ok(part));


### PR DESCRIPTION
## Description of change

Includes a few minor changes to `ChecksummedBytes` in preparation of adding metadata checksums:

* Simplify initialization methods: most callers can use `ChecksummedBytes::new(Bytes)` to create new instances, rather than calculating the checksum explicitly.
* Refactor `ChecksummedBytes::shrink_to_fit` to mutate self rather than returning a new instance. 
* Tidy up some of the existing `ChecksummedBytes` tests.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
