### PR TITLE
Fix version number tests

### DIFF
--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -3,8 +3,8 @@ use predicates::prelude::*; // Used for writing assertions
 use std::{fs, os::unix::prelude::PermissionsExt, process::Command}; // Run programs
 
 /// Regular expression for something that looks mostly like a SemVer version.
-/// Don't use this outside of this test - SemVer is both more restrictive and flexible.
-const VALID_VERSION_OUTPUT_PATTERN: &str = "^mount-s3 \\d+\\.\\d+\\.\\d+(?:-\\w+(?:\\.\\w+)*)*(?:\\+[\\w\\.]+)*\n$";
+/// See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+const VALID_VERSION_OUTPUT_PATTERN: &str = "^mount-s3 (0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\n$";
 
 #[test]
 fn mount_point_doesnt_exist() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Description of change

Use a regex recommended by semver.org to verify the cli version output. The change allows tests to pass even on dirty Git repos, where version includes the "-dirty" indicator introduced in #678).

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
