### PR TITLE
Replace callback in FS read with simple Result instead

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1,5 +1,6 @@
 //! FUSE file system types and operations, not tied to the _fuser_ library bindings.
 
+use bytes::Bytes;
 use nix::unistd::{getgid, getuid};
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -642,7 +643,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)] // We don't get to choose this interface
-    pub async fn read<R: ReadReplier>(
+    pub async fn read(
         &self,
         ino: InodeNo,
         fh: u64,
@@ -650,8 +651,7 @@ where
         size: u32,
         _flags: i32,
         _lock: Option<u64>,
-        reply: R,
-    ) -> R::Replied {
+    ) -> Result<Bytes, Error> {
         trace!(
             "fs:read with ino {:?} fh {:?} offset {:?} size {:?}",
             ino,
@@ -664,13 +664,13 @@ where
             let file_handles = self.file_handles.read().await;
             match file_handles.get(&fh) {
                 Some(handle) => handle.clone(),
-                None => return reply.error(err!(libc::EBADF, "invalid file handle")),
+                None => return Err(err!(libc::EBADF, "invalid file handle")),
             }
         };
         logging::record_name(handle.inode.name());
         let file_etag: ETag;
         let mut request = match &handle.typ {
-            FileHandleType::Write { .. } => return reply.error(err!(libc::EBADF, "file handle is not open for reads")),
+            FileHandleType::Write { .. } => return Err(err!(libc::EBADF, "file handle is not open for reads")),
             FileHandleType::Read { request, etag } => {
                 file_etag = etag.clone();
                 request.lock().await
@@ -688,18 +688,17 @@ where
         }
 
         match request.as_mut().unwrap().read(offset as u64, size as usize).await {
-            Ok(checksummed_bytes) => match checksummed_bytes.into_bytes() {
-                Ok(bytes) => reply.data(&bytes),
-                Err(e) => reply.error(err!(libc::EIO, source:e, "integrity error")),
-            },
+            Ok(checksummed_bytes) => checksummed_bytes
+                .into_bytes()
+                .map_err(|e| err!(libc::EIO, source:e, "integrity error")),
             Err(PrefetchReadError::GetRequestFailed(ObjectClientError::ServiceError(
                 GetObjectError::PreconditionFailed,
-            ))) => reply.error(err!(libc::ESTALE, "object was mutated remotely")),
-            Err(PrefetchReadError::Integrity(e)) => reply.error(err!(libc::EIO, source:e, "integrity error")),
+            ))) => Err(err!(libc::ESTALE, "object was mutated remotely")),
+            Err(PrefetchReadError::Integrity(e)) => Err(err!(libc::EIO, source:e, "integrity error")),
             Err(e @ PrefetchReadError::GetRequestFailed(_))
             | Err(e @ PrefetchReadError::GetRequestTerminatedUnexpectedly)
             | Err(e @ PrefetchReadError::GetRequestReturnedWrongOffset { .. }) => {
-                reply.error(err!(libc::EIO, source:e, "get request failed"))
+                Err(err!(libc::EIO, source:e, "get request failed"))
             }
         }
     }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -478,19 +478,6 @@ pub struct DirectoryEntry {
     lookup: LookedUp,
 }
 
-/// Reply to a `read` call. This is funky because we want the reply to happen with only a borrow of
-/// the bytes. But that borrow probably comes from some lock in this module or below, and we don't
-/// want to have to shoehorn that lifetime into the layer above us. So instead we have this trait
-/// that forces the `read` method to invoke exactly one of the reply methods. The idea is that the
-/// [Replied] type should be private and unconstructable by this module.
-pub trait ReadReplier {
-    type Replied;
-    /// Reply with a data payload
-    fn data(self, data: &[u8]) -> Self::Replied;
-    /// Reply with an error
-    fn error(self, error: Error) -> Self::Replied;
-}
-
 impl<Client, Prefetcher> S3Filesystem<Client, Prefetcher>
 where
     Client: ObjectClient + Send + Sync + 'static,

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -10,7 +10,7 @@ pub mod s3;
 
 use fuser::{FileAttr, FileType};
 use futures::executor::ThreadPool;
-use mountpoint_s3::fs::{self, DirectoryEntry, DirectoryReplier, ReadReplier, ToErrno};
+use mountpoint_s3::fs::{DirectoryEntry, DirectoryReplier};
 use mountpoint_s3::prefetch::{default_prefetch, DefaultPrefetcher};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
@@ -88,20 +88,6 @@ impl DirectoryReply {
 
     pub fn clear(&mut self) {
         self.entries.clear();
-    }
-}
-
-pub struct ReadReply<'a>(pub &'a mut Result<Box<[u8]>, libc::c_int>);
-
-impl<'a> ReadReplier for ReadReply<'a> {
-    type Replied = ();
-
-    fn data(self, data: &[u8]) -> Self::Replied {
-        *self.0 = Ok(data.into());
-    }
-
-    fn error(self, error: fs::Error) -> Self::Replied {
-        *self.0 = Err(error.to_errno());
     }
 }
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use fuser::FileType;
 use futures::future::{BoxFuture, FutureExt};
-use mountpoint_s3::fs::{self, CacheConfig, InodeNo, ReadReplier, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{CacheConfig, InodeNo, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::mock_client::{MockClient, MockObject};
@@ -676,20 +676,6 @@ impl Harness {
     }
 
     async fn compare_file<'a>(&'a self, fs_file: InodeNo, ref_file: &'a MockObject) {
-        struct ReadVerifier(Box<[u8]>);
-
-        impl ReadReplier for ReadVerifier {
-            type Replied = ();
-
-            fn data(self, data: &[u8]) -> Self::Replied {
-                assert_eq!(&self.0[..], data, "read bytes don't match");
-            }
-
-            fn error(self, error: fs::Error) -> Self::Replied {
-                panic!("read failed: {error}");
-            }
-        }
-
         let fh = match self.fs.open(fs_file, 0x8000, 0).await {
             Ok(ret) => ret.fh,
             Err(e) => panic!("failed to open {fs_file}: {e:?}"),
@@ -701,10 +687,12 @@ impl Harness {
             let num_bytes = MAX_READ_SIZE.min(file_size - offset);
             let ref_bytes = ref_file.read(offset as u64, num_bytes);
             assert_eq!(ref_bytes.len(), num_bytes);
-            let read_verifier = ReadVerifier(ref_bytes);
-            self.fs
-                .read(fs_file, fh, offset as i64, num_bytes as u32, 0, None, read_verifier)
-                .await;
+            let bytes_from_read = self
+                .fs
+                .read(fs_file, fh, offset as i64, num_bytes as u32, 0, None)
+                .await
+                .expect("read should succeed");
+            assert_eq!(&ref_bytes[..], &bytes_from_read, "read bytes did not match");
             offset += num_bytes;
         }
     }


### PR DESCRIPTION
## Description of change

This chance simplifies `fs::read` by returning a result rather than invoking a callback to `fuse::read`.

We're making this change primarily due to the risk of a race condition introduced. Before this change, we reply directly to the FUSE driver via a callback (`ReadReplier`) before exiting the FS module code. The risk here is that we've already replied to the driver before we drop things like the file handle guard. Albeit small, this is a race condition and we intend to remove it to avoid any risk from it.

This race condition is suspected to be the root cause for this issue where FUSE release fails unable to unwrap the file handle reference: https://github.com/awslabs/mountpoint-s3/issues/670. I haven't yet reproduced that issue but the code before this change did not appear correct.

I also reviewed other usages of file handles to ensure that they are dropped at the appropriate time: `open`, `write`, `fsync`, `flush`, and `release` all look OK and should drop the reference before returning the response to the FUSE driver. Note, we may have a similar behavior in the directory handles which I'll review separately.

When triggered, this race condition could have a large impact since the file handle holds a reference to prefetched data and this would never be freed as file handles are put back in the file handle table when `release` fails.

Relevant issues:
- #670

## Does this change impact existing behavior?

Fixes possible bug where `read` completes early / asynchronously.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
