### PR TITLE
Add information about `--log-metrics` flag to logging documentation

### DIFF
--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -34,3 +34,20 @@ You can enable more verbose logging with the `--debug` command-line argument. We
 To enable more verbose logging for the AWS Common Runtime that Mountpoint uses to communicate with S3, use the `--debug-crt` command-line argument. These logs are very verbose, and should be combined with the `-l, --log-directory` and `--debug` arguments described above.
 
 For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LOG` environment variable, which overrides the verbosity options above. The `MOUNTPOINT_LOG` environment variable uses the [`tracing-subscriber` directive syntax](https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html), and can be used to control log verbosity on a per-subject basis. For example, setting `MOUNTPOINT_LOG` to `trace` enables all trace-level logs, while `trace,awscrt=warn` enables trace-level logs for all log subjects except `awscrt`, which has only warning-level logging enabled.
+
+## Metrics
+
+Mountpoint optionally collects metrics measuring various values across different components.
+For example, Mountpoint records the durations of FUSE operations and the number of S3 responses grouped by HTTP status code.
+
+To opt-in, use the `--log-metrics` command-line argument.
+Metrics will be collected by Mountpoint and flushed to the logs every five seconds.
+See below an example of what the emitted metrics may look like in the logs.
+
+    [INFO] mountpoint_s3::metrics: fuse.io_size[type=read]: n=4: min=3184 p10=3199 p50=16511 avg=26494.00 p90=70143 p99=70143 p99.9=70143 max=70143
+    [INFO] mountpoint_s3::metrics: fuse.op_latency_us[op=lookup]: n=8: min=22912 p10=23039 p50=65023 avg=62632.00 p90=95231 p99=95231 p99.9=95231 max=95231
+    [INFO] mountpoint_s3::metrics: fuse.op_latency_us[op=open]: n=3: min=24448 p10=24575 p50=64255 avg=54037.33 p90=73727 p99=73727 p99.9=73727 max=73727
+    [INFO] mountpoint_s3::metrics: fuse.total_bytes[type=read]: 105584 (n=4)
+
+We recommend using the metrics only for debugging at this time.
+Metrics are currently output in an unstructured format and are subject to change in future releases.


### PR DESCRIPTION
## Description of change

We don't mention `--log-metrics` anywhere in our documentation (other than `--help`). Let's fix that!

Relevant issues: N/A

## Does this change impact existing behavior?

No change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
