### PR TITLE
Set CI parameters for sse-kms tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ env:
   S3_OLAP_ARN: ${{ vars.S3_OLAP_ARN }}
   S3_MRAP_ARN: ${{ vars.S3_MRAP_ARN }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,sse-kms
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,sse_kms
 
 permissions:
   id-token: write

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,8 @@ env:
   S3_OLAP_ALIAS: ${{ vars.S3_OLAP_ALIAS }}
   S3_OLAP_ARN: ${{ vars.S3_OLAP_ARN }}
   S3_MRAP_ARN: ${{ vars.S3_MRAP_ARN }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests
+  KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,sse-kms
 
 permissions:
   id-token: write

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "1.3.2"
+version = "1.3.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
@@ -75,6 +75,7 @@ fuse_tests = []
 s3_tests = []
 s3express_tests = []
 shuttle = []
+sse_kms = []
 
 [build-dependencies]
 built = { version = "0.6.0", features = ["git2"] }

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
## Description of change

As CI parameters are fetched from main repo, adding them as a separate PR. `KMS_TEST_KEY_ID` variable is already present in the repo's settings. 

Original PR: https://github.com/awslabs/mountpoint-s3/pull/693

Relevant issues: **not linking the issue to avoid accidental closing**

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
