### PR TITLE
Improve error logs for unsupported operations: File Overwrite, Random Write, Directory Shadowing, Unlink (without mount option)

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -365,7 +365,7 @@ pub enum RestoreStatus {
 ///
 /// See [Object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html) in the *Amazon S3
 /// API Reference* for more details.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectInfo {
     /// Key for this object.
     pub key: String,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1198,7 +1198,10 @@ where
 
     pub async fn unlink(&self, parent_ino: InodeNo, name: &OsStr) -> Result<(), Error> {
         if !self.config.allow_delete {
-            return Err(err!(libc::EPERM, "deletes are disabled"));
+            return Err(err!(
+                libc::EPERM,
+                "Deletes are disabled. Use '--allow-delete' mount option to enable it."
+            ));
         }
         Ok(self.superblock.unlink(&self.client, parent_ino, name).await?)
     }

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -120,6 +120,7 @@ impl ToErrno for InodeError {
             // Not obvious what InodeNotWritable, InodeAlreadyWriting, InodeNotReadableWhileWriting should be.
             // EINVAL or EROFS would also be reasonable -- but we'll treat them like sealed files.
             InodeError::InodeNotWritable(_) => libc::EPERM,
+            InodeError::InodeInvalidWriteStatus(_) => libc::EPERM,
             InodeError::InodeAlreadyWriting(_) => libc::EPERM,
             InodeError::InodeNotReadableWhileWriting(_) => libc::EPERM,
             InodeError::InodeNotWritableWhileReading(_) => libc::EPERM,

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1174,7 +1174,7 @@ impl WriteHandle {
 
                 Ok(())
             }
-            _ => Err(InodeError::InodeNotWritable(inode.err())),
+            _ => Err(InodeError::InodeInvalidWriteStatus(inode.err())),
         }
     }
 }
@@ -1555,6 +1555,8 @@ pub enum InodeError {
     FileAlreadyExists(InodeErrorInfo),
     #[error("inode {0} is not writable")]
     InodeNotWritable(InodeErrorInfo),
+    #[error("Invalid state of inode {0} to be written")]
+    InodeInvalidWriteStatus(InodeErrorInfo),
     #[error("inode {0} is already being written")]
     InodeAlreadyWriting(InodeErrorInfo),
     #[error("inode {0} is not readable while being written")]

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -1555,7 +1555,7 @@ pub enum InodeError {
     FileAlreadyExists(InodeErrorInfo),
     #[error("inode {0} is not writable")]
     InodeNotWritable(InodeErrorInfo),
-    #[error("Invalid state of inode {0} to be written")]
+    #[error("Invalid state of inode {0} to be written. Aborting the write.")]
     InodeInvalidWriteStatus(InodeErrorInfo),
     #[error("inode {0} is already being written")]
     InodeAlreadyWriting(InodeErrorInfo),

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -458,7 +458,7 @@ mod ordered {
                     (Some(entry), Some(last_entry)) => {
                         if last_entry.name() == entry.name() {
                             warn!(
-                                "{} is omitted because another {} exist with the same name.\n",
+                                "{} is omitted because another {} exist with the same name",
                                 entry.description(),
                                 last_entry.description(),
                             );

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -198,7 +198,7 @@ impl ReaddirHandle {
 
 /// A single entry in a readdir stream. Remote entries have not yet been converted to inodes -- that
 /// should be done lazily by the consumer of the entry.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum ReaddirEntry {
     RemotePrefix { name: String },
     RemoteObject { name: String, object_info: ObjectInfo },
@@ -406,7 +406,7 @@ mod ordered {
         local: LocalIter,
         next_remote: Option<ReaddirEntry>,
         next_local: Option<ReaddirEntry>,
-        last_name: Option<String>,
+        last_entry: Option<ReaddirEntry>,
     }
 
     impl ReaddirIter {
@@ -421,7 +421,7 @@ mod ordered {
                 local: LocalIter::new(local_entries),
                 next_remote: None,
                 next_local: None,
-                last_name: None,
+                last_entry: None,
             }
         }
 
@@ -456,13 +456,16 @@ mod ordered {
                 // Deduplicate the entry we want to return
                 match next {
                     Some(entry) => {
-                        if self.last_name.as_deref() == Some(entry.name()) {
+                        let last_name = self.last_entry.as_ref().map(|entry| entry.name());
+                        let last_description = self.last_entry.as_ref().map(|entry| entry.description());
+                        if last_name == Some(entry.name()) {
                             warn!(
-                                "{} is shadowed by another entry with the same name and will be unavailable",
+                                "{} is omitted because another {} exist with the same name.\n",
                                 entry.description(),
+                                last_description.expect("Last entry should have some value as already checked"),
                             );
                         } else {
-                            self.last_name = Some(entry.name().to_owned());
+                            self.last_entry = Some(entry.clone());
                             return Ok(Some(entry));
                         }
                     }

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -454,26 +454,24 @@ mod ordered {
                 };
 
                 // Deduplicate the entry we want to return
-                match next {
-                    Some(entry) => match &self.last_entry {
-                        Some(last_entry) => {
-                            if last_entry.name() == entry.name() {
-                                warn!(
-                                    "{} is omitted because another {} exist with the same name.\n",
-                                    entry.description(),
-                                    last_entry.description(),
-                                );
-                            } else {
-                                self.last_entry = Some(entry.clone());
-                                return Ok(Some(entry));
-                            }
-                        }
-                        None => {
+                match (next, &self.last_entry) {
+                    (Some(entry), Some(last_entry)) => {
+                        if last_entry.name() == entry.name() {
+                            warn!(
+                                "{} is omitted because another {} exist with the same name.\n",
+                                entry.description(),
+                                last_entry.description(),
+                            );
+                        } else {
                             self.last_entry = Some(entry.clone());
                             return Ok(Some(entry));
                         }
-                    },
-                    None => return Ok(None),
+                    }
+                    (Some(entry), None) => {
+                        self.last_entry = Some(entry.clone());
+                        return Ok(Some(entry));
+                    }
+                    _ => return Ok(None),
                 }
             }
         }

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -455,20 +455,24 @@ mod ordered {
 
                 // Deduplicate the entry we want to return
                 match next {
-                    Some(entry) => {
-                        let last_name = self.last_entry.as_ref().map(|entry| entry.name());
-                        let last_description = self.last_entry.as_ref().map(|entry| entry.description());
-                        if last_name == Some(entry.name()) {
-                            warn!(
-                                "{} is omitted because another {} exist with the same name.\n",
-                                entry.description(),
-                                last_description.expect("Last entry should have some value as already checked"),
-                            );
-                        } else {
+                    Some(entry) => match &self.last_entry {
+                        Some(last_entry) => {
+                            if last_entry.name() == entry.name() {
+                                warn!(
+                                    "{} is omitted because another {} exist with the same name.\n",
+                                    entry.description(),
+                                    last_entry.description(),
+                                );
+                            } else {
+                                self.last_entry = Some(entry.clone());
+                                return Ok(Some(entry));
+                            }
+                        }
+                        None => {
                             self.last_entry = Some(entry.clone());
                             return Ok(Some(entry));
                         }
-                    }
+                    },
                     None => return Ok(None),
                 }
             }

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -49,7 +49,7 @@ pub enum UploadWriteError<E: std::error::Error> {
     #[error("put request failed")]
     PutRequestFailed(#[from] E),
 
-    #[error("out of order write; expected offset {expected_offset:?} but got {write_offset:?}")]
+    #[error("out of order write is NOT supported by Mountpoint, aborting the upload; expected offset {expected_offset:?} but got {write_offset:?}")]
     OutOfOrderWrite { write_offset: u64, expected_offset: u64 },
 
     #[error("object exceeded maximum upload size of {maximum_size} bytes")]


### PR DESCRIPTION
## Description of change
Added clear message for the operations that are unsupported but did not had easy to understand logs. Added links to semantics for deletion and allowed filenames to be visible using Mountpoint. But, with links there is a risk that they can get broken once the content is moved somewhere else.
I will add another PR for troubleshooting page and down level the error noise to `debug!` in other Pull Requests.
<!-- Please describe your contribution here. What and why? -->
With this new change, following are error logs that we receive:
For directory shadowing of file with same name, `ls` give following output -
```
WARN readdir{req=5 ino=1 fh=2 offset=17}: mountpoint_s3::inode::readdir::ordered: file 'out' (full key "out") is omitted because another directory 'out' exist with the same name.
```
For file deletion without using --allow-delete flag, give following in logs -
```
WARN unlink{req=8 parent=1 name="ini.txt"}: mountpoint_s3::fuse: unlink failed: Deletes are disabled. Use '--allow-delete' mount option to enable it.
```
Out of Write gives -
```
WARN write{req=52 ino=49 fh=3 offset=512 length=512 name="new.txt"}: mountpoint_s3::fuse: write failed: upload error: out of order write NOT supported by Mountpoint, aborting the upload; expected offset 0 but got 512
```
UPDATE: Overwriting a file is now supported, so the error message is the one set in PR #487  -
```
WARN file overwrite is disabled by default, you need to remount with --allow-overwrite flag and open the file in truncate mode (O_TRUNC) to overwrite it
```
Also changed the logging in case of finish writing to update status of Inode, but the Inode WriteStatus is in Invalid state. Earlier it was `InodeNotWritable` which is same error for File Overwrite when its flag is not enabled. Also, it did not completely explained that WriteStatus of the Inode is not valid for writing.

Relevant issues: <!-- Please add issue numbers. -->
#533 

## Does this change impact existing behavior?
No. It only improves the error logging as mentioned above.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No, there is no breaking change.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
