### PR TITLE
Unmount at end of fork tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -347,7 +347,7 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()
         .expect("unable to spawn child");
 
-    let exit_status = wait_for_exit(&mut child);
+    let exit_status = wait_for_exit(child);
 
     // verify mount status and mount entry
     assert!(!exit_status.success());
@@ -367,7 +367,7 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()
         .expect("unable to spawn child");
 
-    let exit_status = wait_for_exit(&mut child);
+    let exit_status = wait_for_exit(child);
 
     // verify mount status and mount entry
     assert!(exit_status.success());


### PR DESCRIPTION
## Description of change

`Command::spawn` returns a `Child`, but dropping a `Child` doesn't
shut down the process, so we leak all these mounts every time the fork
tests run. That's annoying when you run them a lot, so this change adds
unmount calls to all the tests that should succeed.

I also took this chance to clean up the test code a little by factoring
out the "wait in a loop" logic.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
