### PR TITLE
Bump version of shlex to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle"


### PR DESCRIPTION
## Description of change

Update version of `shlex` dependency to 1.3.0 with `cargo update -p shlex`

There is a security vulnerability in it, which blocks our CI:
- https://github.com/awslabs/mountpoint-s3/actions/runs/7609365814/job/20720447197?pr=693
- https://rustsec.org/advisories/RUSTSEC-2024-0006
 
Relevant issues: None

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
