### PR TITLE
Add support for --sse, --sse-kms-key-id flags under a feature flag

### DIFF
--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -14,7 +14,7 @@ pub mod prefix;
 mod sync;
 mod upload;
 
-pub use fs::{S3Filesystem, S3FilesystemConfig};
+pub use fs::{S3Filesystem, S3FilesystemConfig, ServerSideEncryption};
 
 /// Enable tracing and CRT logging when running unit tests.
 #[cfg(test)]

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use tracing::error;
 
 use crate::checksums::combine_checksums;
+use crate::fs::ServerSideEncryption;
 
 type PutRequestError<Client> = ObjectClientError<PutObjectError, <Client as ObjectClient>::ClientError>;
 
@@ -25,12 +26,21 @@ pub struct Uploader<Client> {
 struct UploaderInner<Client> {
     client: Arc<Client>,
     storage_class: Option<String>,
+    server_side_encryption: ServerSideEncryption,
 }
 
 impl<Client: ObjectClient> Uploader<Client> {
     /// Create a new [Uploader] that will make requests to the given client.
-    pub fn new(client: Arc<Client>, storage_class: Option<String>) -> Self {
-        let inner = UploaderInner { client, storage_class };
+    pub fn new(
+        client: Arc<Client>,
+        storage_class: Option<String>,
+        server_side_encryption: ServerSideEncryption,
+    ) -> Self {
+        let inner = UploaderInner {
+            client,
+            storage_class,
+            server_side_encryption,
+        };
         Self { inner: Arc::new(inner) }
     }
 
@@ -79,6 +89,8 @@ impl<Client: ObjectClient> UploadRequest<Client> {
         if let Some(storage_class) = &inner.storage_class {
             params = params.storage_class(storage_class.clone());
         }
+        params = params.server_side_encryption(inner.server_side_encryption.sse_type());
+        params = params.ssekms_key_id(inner.server_side_encryption.key_id());
 
         let request = inner.client.put_object(bucket, key, &params).await?;
         let maximum_upload_size = inner.client.part_size().map(|ps| ps * MAX_S3_MULTIPART_UPLOAD_PARTS);
@@ -204,7 +216,7 @@ mod tests {
             part_size: 32,
             ..Default::default()
         }));
-        let uploader = Uploader::new(client.clone(), None);
+        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default());
         let request = uploader.put(bucket, key).await.unwrap();
 
         assert!(!client.contains_key(key));
@@ -228,7 +240,11 @@ mod tests {
             part_size: 32,
             ..Default::default()
         }));
-        let uploader = Uploader::new(client.clone(), Some(storage_class.to_owned()));
+        let uploader = Uploader::new(
+            client.clone(),
+            Some(storage_class.to_owned()),
+            ServerSideEncryption::default(),
+        );
 
         let mut request = uploader.put(bucket, key).await.unwrap();
 
@@ -277,7 +293,7 @@ mod tests {
             put_failures,
         ));
 
-        let uploader = Uploader::new(failure_client.clone(), None);
+        let uploader = Uploader::new(failure_client.clone(), None, ServerSideEncryption::default());
 
         // First request fails on first write.
         {
@@ -318,7 +334,7 @@ mod tests {
             part_size: PART_SIZE,
             ..Default::default()
         }));
-        let uploader = Uploader::new(client.clone(), None);
+        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default());
         let mut request = uploader.put(bucket, key).await.unwrap();
 
         let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -564,7 +564,7 @@ fn get_mount_from_source_and_mountpoint(source: &str, mount_point: &str) -> Opti
     let stdout_reader = BufReader::new(stdout);
     let stdout_lines = stdout_reader.lines();
 
-    for line in stdout_lines.flatten() {
+    for line in stdout_lines.map_while(Result::ok) {
         let str: Vec<&str> = line.split_whitespace().collect();
         let source_rec = str[0];
         let mount_point_rec = str[2];

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -4,10 +4,14 @@
 use assert_cmd::prelude::*;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_config::BehaviorVersion;
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+use aws_sdk_s3::primitives::ByteStream;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_sts::config::Region;
 use std::fs;
 use std::io::{BufRead, BufReader};
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Child, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
@@ -16,6 +20,8 @@ use test_case::test_case;
 
 use crate::common::fuse::read_dir_to_entry_names;
 use crate::common::s3::{create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region};
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+use crate::common::s3::{get_scoped_down_credentials, get_test_kms_key_id, get_test_sdk_client};
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::s3::{get_subsession_iam_role, tokio_block_on};
 
@@ -386,6 +392,133 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+fn mount_with_sse(
+    bucket: &str,
+    mount_point: &Path,
+    prefix: &str,
+    key_id: &str,
+    credentials: Option<aws_sdk_s3::config::Credentials>,
+) -> Child {
+    let region = get_test_region();
+    let mut cmd = Command::cargo_bin("mount-s3").expect("can not locate mount-s3 binary");
+    cmd.stdout(Stdio::piped())
+        .arg(bucket)
+        .arg(mount_point)
+        .arg(format!("--region={region}"))
+        .arg(format!("--prefix={prefix}"))
+        .arg("--sse=aws:kms:dsse")
+        .arg(format!("--sse-kms-key-id={key_id}"))
+        .arg("--auto-unmount")
+        .arg("--foreground");
+    if let Some(credentials) = credentials {
+        cmd.env("AWS_ACCESS_KEY_ID", credentials.access_key_id())
+            .env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            cmd.env("AWS_SESSION_TOKEN", token);
+        }
+    }
+    let child = cmd.spawn().expect("unable to spawn child");
+    wait_for_mount("mountpoint-s3", mount_point.to_str().unwrap());
+    child
+}
+
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+fn erroneous_write_sse(mount_point: &Path) {
+    let mut f = fs::File::create(mount_point.join("file.txt")).expect("should be able to open file for writing");
+    let data = vec![0xaa; 32];
+    let write_result = f.write_all(&data);
+    write_result.expect_err("should not be able to write to the file without proper sse");
+}
+
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+#[test]
+fn write_with_inexistent_key_sse() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("write_with_inexistent_key_sse");
+    let key_id = "SOME_INVALID_KEY";
+    let mount_point = assert_fs::TempDir::new().expect("can not create a mount dir");
+    let child = mount_with_sse(&bucket, mount_point.path(), &prefix, key_id, None);
+    erroneous_write_sse(mount_point.path());
+
+    let expected_log_line =
+        regex::Regex::new(r"^.*WARN.*KMS.NotFoundException.*Invalid keyId \\'SOME_INVALID_KEY\\'.*$").unwrap();
+    unmount_and_check_log(child, mount_point.path(), &expected_log_line);
+}
+
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+#[test]
+fn write_with_no_permissions_for_a_key_sse() {
+    let policy_with_no_kms_perms = r#"{"Statement": [
+        {"Effect": "Allow", "Action": ["s3:*"], "Resource": "*"}
+    ]}"#;
+    let credentials = tokio_block_on(get_scoped_down_credentials(policy_with_no_kms_perms));
+
+    let (bucket, prefix) = get_test_bucket_and_prefix("write_with_no_permissions_for_a_key_sse");
+    let key_id = get_test_kms_key_id();
+    let mount_point = assert_fs::TempDir::new().expect("can not create a mount dir");
+    let child = mount_with_sse(&bucket, mount_point.path(), &prefix, &key_id, Some(credentials));
+    erroneous_write_sse(mount_point.path());
+
+    let log_line_pattern = format!("^.*WARN.*User: [^ ]* is not authorized to perform: kms:GenerateDataKey on resource: {key_id} because no session policy allows the kms:GenerateDataKey action.*$");
+    let expected_log_line = regex::Regex::new(&log_line_pattern).unwrap();
+    unmount_and_check_log(child, mount_point.path(), &expected_log_line);
+}
+
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+#[test]
+fn read_with_no_permissions_for_a_key_sse() {
+    let policy_with_no_kms_perms = r#"{"Statement": [
+        {"Effect": "Allow", "Action": ["s3:*"], "Resource": "*"}
+    ]}"#;
+    let credentials = tokio_block_on(get_scoped_down_credentials(policy_with_no_kms_perms));
+
+    let (bucket, prefix) = get_test_bucket_and_prefix("read_with_no_permissions_for_a_key_sse");
+    let key_id = get_test_kms_key_id();
+    let mount_point = assert_fs::TempDir::new().expect("can not create a mount dir");
+
+    let encrypted_object = "encrypted_with_kms";
+    let unencrypted_object = "unencrypted_with_s3_keys";
+    {
+        // create files
+        let test_client = tokio_block_on(get_test_sdk_client(get_test_region().as_str()));
+        let data = vec![0xaa; 32];
+        let mut request = test_client
+            .put_object()
+            .bucket(&bucket)
+            .key(format!("{prefix}{encrypted_object}"))
+            .body(ByteStream::from(data.clone()));
+        request =
+            request.set_server_side_encryption(Some(aws_sdk_s3::types::ServerSideEncryption::from("aws:kms:dsse")));
+        request = request.set_ssekms_key_id(Some(key_id.clone()));
+        tokio_block_on(request.send()).expect("should be able to upload object to S3 via SDK client");
+        let request = test_client
+            .put_object()
+            .bucket(&bucket)
+            .key(format!("{prefix}{unencrypted_object}"))
+            .body(ByteStream::from(data));
+        tokio_block_on(request.send()).expect("should be able to upload object to S3 via SDK client");
+    }
+
+    let child = mount_with_sse(&bucket, mount_point.path(), &prefix, &key_id, Some(credentials));
+    {
+        // attempting to read files using Mountpoint, this scoped block also limits file lifetimes
+        let encrypted_object = mount_point.join(encrypted_object);
+        let mut data = Vec::new();
+        let mut f = fs::File::open(encrypted_object).expect("can not open file for read");
+        let read_result = f.read_to_end(&mut data);
+        read_result.expect_err("should not be able to read a kms-encrypted file without kms permissions");
+
+        let unencrypted_object = mount_point.join(unencrypted_object);
+        let mut f = fs::File::open(unencrypted_object).expect("can not open file for read");
+        let read_result = f.read_to_end(&mut data);
+        read_result.expect("should be able to read a default-encrypted file after the first read failure");
+    }
+
+    let log_line_pattern = format!("^.*WARN.*{encrypted_object}.*read failed: get request failed: get object request failed: Client error: Forbidden: User: .* is not authorized to perform: kms:Decrypt on resource: {key_id} because no session policy allows the kms:Decrypt action.*$");
+    let expected_log_line = regex::Regex::new(&log_line_pattern).unwrap();
+    unmount_and_check_log(child, mount_point.path(), &expected_log_line);
+}
+
 fn test_read_files(bucket: &str, prefix: &str, region: &str, mount_point: &PathBuf) {
     // create objects for test
     create_objects(bucket, prefix, region, "file1.txt", b"hello world");
@@ -490,4 +623,25 @@ fn unmount(mount_point: &Path) {
     }
 
     panic!("failed to unmount");
+}
+
+#[cfg(all(feature = "sse_kms", not(feature = "s3express_tests")))]
+fn unmount_and_check_log(mut process: Child, mount_path: &Path, expected_log_line: &regex::Regex) {
+    unmount(mount_path);
+    let mut stdout = process
+        .stdout
+        .take()
+        .expect("stdout shouldn't be consumed at this point");
+    wait_for_exit(process);
+    let mut buf = Vec::new();
+    stdout
+        .read_to_end(&mut buf)
+        .expect("failed to read mountpoint log from pipe");
+    let log = String::from_utf8(buf).expect("mountpoint log is not a valid UTF-8");
+    for line in log.lines() {
+        if expected_log_line.is_match(line) {
+            return;
+        }
+    }
+    panic!("can not find a matching line in log: [{log}]");
 }


### PR DESCRIPTION
## Description of change

1. Pass `--sse`, `--sse-kms-key-id` to the S3CrtClient (changes are added under a compile-time feature flag); 
3. Add happy test to `fuse_tests/write_test.rs` that uses IAM session policies;
4. Add error tests to `fuse_tests/fork_test.rs` that check error logs.

*Thinking of adding the checksumming logic in a separate PR.*

Relevant issues: **not linking an issue to avoid accidental closing**

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
