### PR TITLE
Update and prune some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,16 +1694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libc-stdhandle"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dac2473dc28934c5e0b82250dab231c9d3b94160d91fe9ff483323b05797551"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libgit2-sys"
 version = "0.16.1+1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,7 +1933,6 @@ dependencies = [
  "futures",
  "lazy_static",
  "libc",
- "libc-stdhandle",
  "md-5",
  "metrics",
  "mountpoint-s3-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -109,7 +110,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.0.4",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -117,14 +118,14 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.0.13"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
+checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
 dependencies = [
  "anstyle",
  "doc-comment",
  "globwalk",
- "predicates 3.0.4",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "tempfile",
@@ -132,13 +133,15 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
+ "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -147,26 +150,17 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.28",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -175,7 +169,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener 4.0.3",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -186,21 +180,20 @@ version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
 [[package]]
 name = "auto_impl"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -218,7 +211,7 @@ dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-sdk-sso",
- "aws-sdk-sts 0.30.0",
+ "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-client",
  "aws-smithy-http",
@@ -296,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e30370b61599168d38190ad272bb91842cd81870a6ca035c05dd5726d22832c"
+checksum = "a531d010f9f556bf65eb3bcd8d24f1937600ab6940fede4d454cd9b1f031fb34"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -347,30 +340,6 @@ dependencies = [
  "http",
  "regex",
  "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e21aa1a5b0853969a1ef96ccfaa8ff5d57c761549786a4d5f86c1902b2586a"
-dependencies = [
- "aws-credential-types",
- "aws-http",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "http",
- "regex",
  "tracing",
 ]
 
@@ -685,8 +654,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -754,11 +723,10 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99c4cdc7b2c2364182331055623bdf45254fcb679fea565c40c3c11c101889a"
+checksum = "38d17f4d6e4dc36d1a02fbedc2753a096848e7c1b0772f7654eab8e2c927dd53"
 dependencies = [
- "cargo-lock",
  "git2",
 ]
 
@@ -791,18 +759,6 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
-]
-
-[[package]]
-name = "cargo-lock"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
-dependencies = [
- "semver",
- "serde",
- "toml",
- "url",
 ]
 
 [[package]]
@@ -903,8 +859,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -953,9 +909,9 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
- "unicode-xid 0.2.4",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1013,7 +969,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -1034,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1057,7 +1013,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset",
 ]
 
 [[package]]
@@ -1081,12 +1037,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
 dependencies = [
- "quote 1.0.33",
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1095,7 +1051,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
- "nix 0.27.1",
+ "nix",
  "windows-sys 0.48.0",
 ]
 
@@ -1190,12 +1146,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -1211,7 +1161,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.3",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1283,7 +1233,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.27.1",
+ "nix",
  "page_size",
  "pkg-config",
  "serde",
@@ -1357,8 +1307,8 @@ version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -1440,11 +1390,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1472,11 +1422,11 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "ignore",
  "walkdir",
 ]
@@ -1551,11 +1501,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1686,24 +1636,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.28",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -1718,15 +1657,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1769,9 +1699,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libc-stdhandle"
@@ -1785,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.2+1.6.4"
+version = "0.16.1+1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
 dependencies = [
  "cc",
  "libc",
@@ -1828,12 +1758,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1890,15 +1814,6 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -1908,24 +1823,24 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
  "ahash",
  "metrics-macros",
- "portable-atomic 0.3.20",
+ "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-macros"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1962,11 +1877,11 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "async-channel",
- "async-lock 2.8.0",
+ "async-lock",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "aws-sdk-sts 0.29.0",
+ "aws-sdk-sts",
  "base16ct",
  "bincode",
  "built",
@@ -1989,8 +1904,8 @@ dependencies = [
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
- "nix 0.26.4",
- "predicates 2.1.5",
+ "nix",
+ "predicates",
  "procfs",
  "proptest",
  "proptest-derive",
@@ -2011,7 +1926,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
  "walkdir",
 ]
@@ -2022,13 +1937,13 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-io",
- "async-lock 2.8.0",
+ "async-lock",
  "async-trait",
  "auto_impl",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
- "aws-sdk-sts 0.29.0",
+ "aws-sdk-sts",
  "aws-smithy-runtime-api",
  "base64ct",
  "built",
@@ -2098,19 +2013,6 @@ dependencies = [
  "rustflags",
  "smallstr",
  "which",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -2300,8 +2202,8 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -2370,18 +2272,9 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix",
  "tracing",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.6.0",
 ]
 
 [[package]]
@@ -2404,28 +2297,16 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.11.0",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -2451,8 +2332,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -2463,18 +2344,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -2488,15 +2360,25 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.4.1",
  "hex",
  "lazy_static",
- "rustix 0.36.17",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.4.1",
+ "hex",
 ]
 
 [[package]]
@@ -2521,13 +2403,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2538,20 +2420,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.70",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -2739,28 +2612,14 @@ checksum = "e74f1ec0cda1aea3a3a6c0df066cd67acac62e24064532b871e8eafb0ec6c126"
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -2899,9 +2758,6 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -2918,8 +2774,8 @@ version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -2931,15 +2787,6 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
-dependencies = [
  "serde",
 ]
 
@@ -2963,8 +2810,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -3109,23 +2956,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3135,8 +2971,8 @@ version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3168,7 +3004,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix 0.38.28",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3204,8 +3040,8 @@ checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3224,8 +3060,8 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -3317,8 +3153,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -3355,40 +3191,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -3437,8 +3239,8 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 
@@ -3450,17 +3252,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3489,7 +3280,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3530,12 +3321,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -3661,8 +3446,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
@@ -3673,7 +3458,7 @@ version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3683,8 +3468,8 @@ version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -3708,14 +3493,15 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
 dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.28",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3760,15 +3546,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3783,21 +3560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3832,12 +3594,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3847,12 +3603,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3868,12 +3618,6 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -3883,12 +3627,6 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3904,12 +3642,6 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -3919,12 +3651,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3940,12 +3666,6 @@ checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -3955,15 +3675,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "winnow"
-version = "0.5.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wyz"
@@ -4011,8 +3722,8 @@ version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
- "proc-macro2 1.0.70",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.41",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,16 +1208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,7 +1883,6 @@ dependencies = [
  "ctrlc",
  "dashmap",
  "filetime",
- "fs2",
  "fuser",
  "futures",
  "hdrhistogram",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -25,12 +25,12 @@ percent-encoding = "2.2.0"
 pin-project = "1.0.12"
 platform-info = "2.0.2"
 regex = "1.7.1"
+serde_json = "1.0.104"
 static_assertions = "1.1.0"
 thiserror = "1.0.34"
 time = { version = "0.3.17", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log"] }
 xmltree = "0.10.3"
-serde_json = "1.0.104"
 
 # Dependencies for the mock client only
 async-io = { version = "2.3.1", optional = true }
@@ -63,15 +63,15 @@ mountpoint-s3-client = { path = ".", features = ["mock"] }
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }
 
-[lib]
-doctest = false
-
 [features]
 mock = ["dep:async-io", "dep:async-lock", "dep:rand", "dep:rand_chacha"]
-# Test features
+# Features for choosing tests
 s3_tests = []
 fips_tests = []
 s3express_tests = []
+
+[lib]
+doctest = false
 
 # Make async trait docs not-ugly on docs.rs (https://github.com/dtolnay/async-trait/issues/213)
 [package.metadata.docs.rs]

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -14,11 +14,9 @@ async-trait = "0.1.57"
 auto_impl = "1.1.2"
 base64ct = { version = "1.6.0", features = ["std"] }
 const_format = "0.2.30"
-futures = { version = "0.3.24", features = ["thread-pool"] }
+futures = "0.3.24"
 lazy_static = "1.4.0"
 libc = "0.2.126"
-libc-stdhandle = "0.1.0"
-md-5 = "0.10.5"
 metrics = "0.21.1"
 once_cell = "1.16.0"
 percent-encoding = "2.2.0"
@@ -35,6 +33,7 @@ xmltree = "0.10.3"
 # Dependencies for the mock client only
 async-io = { version = "2.3.1", optional = true }
 async-lock = { version = "3.3.0", optional = true }
+md-5 = { version = "0.10.5", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
@@ -64,7 +63,7 @@ mountpoint-s3-client = { path = ".", features = ["mock"] }
 built = { version = "0.7.1", features = ["git2"] }
 
 [features]
-mock = ["dep:async-io", "dep:async-lock", "dep:rand", "dep:rand_chacha"]
+mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand", "dep:rand_chacha"]
 # Features for choosing tests
 s3_tests = []
 fips_tests = []

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -11,7 +11,7 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.0" }
 
 async-trait = "0.1.57"
-auto_impl = "1.0.1"
+auto_impl = "1.1.2"
 base64ct = { version = "1.6.0", features = ["std"] }
 const_format = "0.2.30"
 futures = { version = "0.3.24", features = ["thread-pool"] }
@@ -19,7 +19,7 @@ lazy_static = "1.4.0"
 libc = "0.2.126"
 libc-stdhandle = "0.1.0"
 md-5 = "0.10.5"
-metrics = "0.20.1"
+metrics = "0.21.1"
 once_cell = "1.16.0"
 percent-encoding = "2.2.0"
 pin-project = "1.0.12"
@@ -34,7 +34,7 @@ serde_json = "1.0.104"
 
 # Dependencies for the mock client only
 async-io = { version = "2.3.1", optional = true }
-async-lock = { version = "2.6.0", optional = true }
+async-lock = { version = "3.3.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
@@ -42,13 +42,13 @@ rand_chacha = { version = "0.3.1", optional = true }
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 aws-config = "0.56.0"
 aws-credential-types = "0.56.0"
-aws-sdk-s3 = "0.29.0"
-aws-sdk-sts = "0.29.0"
+aws-sdk-s3 = "0.30.0"
+aws-sdk-sts = "0.30.0"
 aws-smithy-runtime-api = "0.56.1"
 bytes = "1.2.1"
 clap = { version = "4.1.9", features = ["derive"] }
-ctor = "0.1.23"
-proptest = "1.0.0"
+ctor = "0.2.6"
+proptest = "1.4.0"
 rusty-fork = "0.3.0"
 tempfile = "3.5.0"
 test-case = "2.2.2"
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
 mountpoint-s3-client = { path = ".", features = ["mock"] }
 
 [build-dependencies]
-built = { version = "0.6.0", features = ["git2"] }
+built = { version = "0.7.1", features = ["git2"] }
 
 [lib]
 doctest = false

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -11,8 +11,6 @@ use std::{
 use thiserror::Error;
 use time::OffsetDateTime;
 
-use md5::{Digest, Md5};
-
 /// A single element of a [`get_object`](ObjectClient::get_object) response stream is a pair of
 /// offset within the object and the bytes starting at that offset.
 pub type GetBodyPart = (u64, Box<[u8]>);
@@ -42,8 +40,11 @@ impl ETag {
 
     /// Creating unique etag from bytes
     #[doc(hidden)]
+    #[cfg(feature = "mock")]
     pub fn from_object_bytes(data: &[u8]) -> Self {
-        let mut hasher = Md5::new();
+        use md5::Digest as _;
+
+        let mut hasher = md5::Md5::new();
         hasher.update(data);
 
         let hash = hasher.finalize();

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -42,7 +42,7 @@ bindgen = { version = "0.66.1", default-features = false, features = ["runtime"]
 cc = "1.0.73"
 cmake = "0.1.48"
 rustflags = "0.1.1"
-which = "4.3.0"
+which = "6.0.0"
 
 [dependencies]
 libc = "0.2.126"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazo
 [dependencies]
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.5.3" }
 
-async-channel = "1.8.0"
+async-channel = "2.1.1"
 futures = "0.3.24"
 libc = "0.2.132"
 log = "0.4.17"
@@ -20,7 +20,7 @@ thiserror = "1.0.35"
 
 [dev-dependencies]
 criterion = "0.5.1"
-ctor = "0.1.23"
+ctor = "0.2.6"
 futures-timer = "3.0.2"
 rand = { version = "0.8.5", features = ["small_rng"] }
 tempfile = "3.4.0"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -14,33 +14,33 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "2.1.1"
 async-lock = "3.3.0"
 async-trait = "0.1.57"
+bincode = "1.3.3"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
+const_format = "0.2.30"
 crc32c = "0.6.3"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dashmap = "5.5.0"
+fs2 = "0.4.3"
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
+hex = "0.4.3"
 lazy_static = "1.4.0"
 libc = "0.2.126"
+linked-hash-map = "0.5.6"
 metrics = "0.21.1"
+nix = { version = "0.27.1", features = ["user"] }
 regex = "1.7.1"
+serde = { version = "1.0.190", features = ["derive"] }
+serde_json = "1.0.95"
+sha2 = "0.10.6"
 supports-color = "2.0.0"
 syslog = "6.1.0"
 thiserror = "1.0.34"
+time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log", "attributes"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
-nix = { version = "0.27.1", features = ["user"] }
-time = { version = "0.3.17", features = ["macros", "formatting"] }
-const_format = "0.2.30"
-serde_json = "1.0.95"
-serde = { version = "1.0.190", features = ["derive"] }
-bincode = "1.3.3"
-sha2 = "0.10.6"
-hex = "0.4.3"
-linked-hash-map = "0.5.6"
-fs2 = "0.4.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }
@@ -61,6 +61,7 @@ proptest = "1.4.0"
 proptest-derive = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+rusty-fork = "0.3.0"
 serial_test = "2.0.0"
 sha2 = "0.10.6"
 shuttle = { version = "0.5.0" }
@@ -68,19 +69,19 @@ tempfile = "3.4.0"
 test-case = "2.2.2"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
 walkdir = "2.3.3"
-rusty-fork = "0.3.0"
+
+[build-dependencies]
+built = { version = "0.7.1", features = ["git2"] }
 
 [features]
-# Test features
+# Unreleased feature flags
+sse_kms = []
+# Features for choosing tests
 fips_tests = []
 fuse_tests = []
 s3_tests = []
 s3express_tests = []
 shuttle = []
-sse_kms = []
-
-[build-dependencies]
-built = { version = "0.7.1", features = ["git2"] }
 
 [[bin]]
 name = "mount-s3"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -11,8 +11,8 @@ mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.6.2" }
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.0" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
-async-channel = "1.8.0"
-async-lock = "2.6.0"
+async-channel = "2.1.1"
+async-lock = "3.3.0"
 async-trait = "0.1.57"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
@@ -23,15 +23,15 @@ futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
 lazy_static = "1.4.0"
 libc = "0.2.126"
-metrics = "0.20.1"
+metrics = "0.21.1"
 regex = "1.7.1"
 supports-color = "2.0.0"
 syslog = "6.1.0"
 thiserror = "1.0.34"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "log", "attributes"] }
-tracing-log = "0.1.3"
+tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
-nix = "0.26.2"
+nix = { version = "0.27.1", features = ["user"] }
 time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
 serde_json = "1.0.95"
@@ -43,22 +43,22 @@ linked-hash-map = "0.5.6"
 fs2 = "0.4.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procfs = { version = "0.15.1", default-features = false }
+procfs = { version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
 
 assert_cmd = "2.0.6"
-assert_fs = "1.0.9"
+assert_fs = "1.1.1"
 aws-config = "0.56.0"
-aws-sdk-s3 = "0.29.0"
-aws-sdk-sts = "0.29.0"
+aws-sdk-s3 = "0.30.0"
+aws-sdk-sts = "0.30.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
-ctor = "0.1.23"
+ctor = "0.2.6"
 filetime = "0.2.21"
-predicates = "2.1.2"
-proptest = "1.0.0"
-proptest-derive = "0.3.0"
+predicates = "3.1.0"
+proptest = "1.4.0"
+proptest-derive = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serial_test = "2.0.0"
@@ -80,7 +80,7 @@ shuttle = []
 sse_kms = []
 
 [build-dependencies]
-built = { version = "0.6.0", features = ["git2"] }
+built = { version = "0.7.1", features = ["git2"] }
 
 [[bin]]
 name = "mount-s3"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -37,9 +37,9 @@ supports-color = "2.0.0"
 syslog = "6.1.0"
 thiserror = "1.0.34"
 time = { version = "0.3.17", features = ["macros", "formatting"] }
-tracing = { version = "0.1.35", default-features = false, features = ["std", "log", "attributes"] }
+tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }
@@ -55,6 +55,7 @@ aws-sdk-sts = "0.30.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
 ctor = "0.2.6"
 filetime = "0.2.21"
+futures = { version = "*", features = ["thread-pool"] }
 predicates = "3.1.0"
 proptest = "1.4.0"
 proptest-derive = "0.4.0"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -21,7 +21,6 @@ const_format = "0.2.30"
 crc32c = "0.6.3"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dashmap = "5.5.0"
-fs2 = "0.4.3"
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
 hex = "0.4.3"

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -873,7 +873,7 @@ fn validate_mount_point(path: impl AsRef<Path>) -> anyhow::Result<()> {
             }
         };
 
-        if mounts.iter().any(|mount| mount.mount_point == path.as_ref()) {
+        if mounts.0.iter().any(|mount| mount.mount_point == path.as_ref()) {
             return Err(anyhow!("mount point {} is already mounted", path.as_ref().display()));
         }
     }

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -302,9 +302,9 @@ impl DiskDataCache {
             CacheLimit::Unbounded => false,
             CacheLimit::TotalSize { max_size } => size > max_size,
             CacheLimit::AvailableSpace { min_ratio } => {
-                let stats = match fs2::statvfs(&self.cache_directory) {
-                    Ok(stats) if stats.total_space() == 0 => {
-                        warn!("unable to determine available space");
+                let stats = match nix::sys::statvfs::statvfs(&self.cache_directory) {
+                    Ok(stats) if stats.blocks() == 0 => {
+                        warn!("unable to determine available space (0 blocks reported)");
                         return false;
                     }
                     Ok(stats) => stats,
@@ -313,7 +313,7 @@ impl DiskDataCache {
                         return false;
                     }
                 };
-                (stats.available_space() as f64) < min_ratio * (stats.total_space() as f64)
+                (stats.blocks_free() as f64) < min_ratio * (stats.blocks() as f64)
             }
         }
     }


### PR DESCRIPTION
## Description of change

This is a collection of four commits (probably best read individually) that aim to clean up our dependency closure a bit:
1. Take just enough version updates to remove several duplicate crates from our closure
2. Remove some crates and features from the release closure that were only being used in test code
3. Remove the dependency on `fs2`, which is old and unmaintained and has an equivalent function in `nix` anyway
4. Sorted the dependencies in Cargo.toml because I'm a pedant

The `fs2` change is slightly subtle as `nix`'s interface is different (it doesn't return space in bytes but space in blocks). But since we only care about the ratio, we don't need to do anything fancy.

I reviewed the changelogs for all the version updates. The only interesting one was `metrics`, which has had a big API refactor in 0.22, so I only updated to 0.21 for now. We can follow up on that later.

I also didn't update to the GA versions of the Rust SDK as that's quite a large change. I have a separate commit for that that I'll PR later.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
