### PR TITLE
Use stable Rust for address sanitizer

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -200,7 +200,7 @@ jobs:
     - name: Install nightly Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         override: true
         components: rust-src
     - name: Restore Cargo cache

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ test:
 test-asan-working:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
 	RUSTFLAGS="-Zsanitizer=address" \
-	cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- --ignored test_asan_working 2>&1 \
+	RUSTC_BOOTSTRAP=1 \
+	cargo test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- --ignored test_asan_working 2>&1 \
 	| tee /dev/stderr \
 	| grep "heap-use-after-free" \
 	  && echo "ASan is working" || (echo "ASan did not find the use-after-free; something's wrong"; exit 1)
@@ -37,7 +38,8 @@ test-asan:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
 	LSAN_OPTIONS=suppressions="$$(pwd)/lsan-suppressions.txt" \
 	RUSTFLAGS="-Zsanitizer=address" \
-	cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- \
+	RUSTC_BOOTSTRAP=1 \
+	cargo test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- \
 	--skip reftest_ \
 	--skip proptest_ \
 	--skip fork_test \


### PR DESCRIPTION
## Description of change

Nightly is broken today, which blocks our CI. This is the third or fourth time this has happened to us, so let's switch over to using the RUSTC_BOOTSTRAP hack to use nightly features on stable Rust. This is scoped only to the ASan makefile target, so it won't actually allow us to use nightly features in our code, just when running the sanitizers.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
