### PR TITLE
Run the binary mount-s3 for benchamrks

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -94,7 +94,7 @@ read_benchmark () {
 
     # mount file system
     set +e
-    cargo run --quiet --release -- \
+    cargo run --bin mount-s3 --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --debug \
       --allow-delete \
@@ -139,7 +139,7 @@ write_benchmark () {
     # mount file system
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
     set +e
-    cargo run --quiet --release -- \
+    cargo run --bin mount-s3 --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --debug \
       --allow-delete \

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -50,7 +50,7 @@ do
     echo "Running ${job_name}"
 
     # mount file system
-    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+    cargo run --bin mount-s3 --release ${S3_BUCKET_NAME} ${mount_dir} \
         --debug \
         --allow-delete \
         --log-directory=$log_dir \
@@ -123,7 +123,7 @@ for job_file in "${jobs_dir}"/*.fio; do
   echo "Running ${job_name}"
 
   # mount file system
-  cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
+  cargo run --bin mount-s3 --release ${S3_BUCKET_NAME} ${mount_dir} \
     --debug \
     --allow-delete \
     --log-directory=$log_dir \


### PR DESCRIPTION
## Description of change
With the latest change #730 , we have 2 binaries `mock-mount-s3` and `mount-s3`. So, we need to specify the binary, we want to run with `cargo run`. 

<!-- Please describe your contribution here. What and why? -->
For benchmarks, we want to run it on S3 client, so updated the `cargo run` command. 

Relevant issues: <!-- Please add issue numbers. -->
NA
## Does this change impact existing behavior?
No. Benchmark is failing without this change : https://github.com/awslabs/mountpoint-s3/actions/runs/7819293126/job/21331433229
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
