### PR TITLE
Made the name of environment variables consistent through benchmarking doc

### DIFF
--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -32,14 +32,7 @@ You can use the following steps.
                 --fuse-version 2 \
                 --with-fio --with-libunwind
 
-2. Set environment variables related to the benchmark. There are four required environment variables you need to set in order to run the benchmark. These variables can be set to any name, but be consistent with it in subsequent steps.
-
-        export S3_BUCKET_NAME=bucket_name
-        export S3_BUCKET_TEST_PREFIX=benchmark/
-        export S3_BUCKET_BENCH_FILE=bench100GB.bin
-        export S3_BUCKET_SMALL_BENCH_FILE=bench5MB.bin
-
-3. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
+2. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
 
         MOUNT_DIR=path/to/mount
         mount-s3 DOC-EXAMPLE-BUCKET $MOUNT_DIR/ --prefix benchmark/ --part-size=16777216
@@ -51,6 +44,13 @@ You can use the following steps.
         fio --directory=$MOUNT_DIR/bench_dir_1000 create/create_files_1000.fio
         fio --directory=$MOUNT_DIR/bench_dir_10000 create/create_files_10000.fio
         fio --directory=$MOUNT_DIR/bench_dir_100000 create/create_files_100000.fio
+
+3. Set environment variables related to the benchmark. There are four required environment variables you need to set in order to run the benchmark. These variable names should be the same as the resource names used in the previous step.
+
+        export S3_BUCKET_NAME=DOC-EXAMPLE-BUCKET
+        export S3_BUCKET_TEST_PREFIX=benchmark/
+        export S3_BUCKET_BENCH_FILE=bench100GB.bin
+        export S3_BUCKET_SMALL_BENCH_FILE=bench5MB.bin
 
 4. Run the benchmark script for [throughput](../mountpoint-s3/scripts/fs_bench.sh) or [latency](../mountpoint-s3/scripts/fs_latency_bench.sh).
 

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -32,12 +32,12 @@ You can use the following steps.
                 --fuse-version 2 \
                 --with-fio --with-libunwind
 
-2. Set environment variables related to the benchmark. There are four required environment variables you need to set in order to run the benchmark.
+2. Set environment variables related to the benchmark. There are four required environment variables you need to set in order to run the benchmark. These variables can be set to any name, but be consistent with it in subsequent steps.
 
         export S3_BUCKET_NAME=bucket_name
-        export S3_BUCKET_TEST_PREFIX=prefix_path/
-        export S3_BUCKET_BENCH_FILE=bench_file_name
-        export S3_BUCKET_SMALL_BENCH_FILE=small_bench_file_name
+        export S3_BUCKET_TEST_PREFIX=benchmark/
+        export S3_BUCKET_BENCH_FILE=bench100GB.bin
+        export S3_BUCKET_SMALL_BENCH_FILE=bench5MB.bin
 
 3. Create the bench files manually in your S3 bucket. You can do that by mounting the bucket on your machine using Mountpoint. Then, running fio jobs against your mount directory to let fio create the files for you.
 


### PR DESCRIPTION
## Description of change
In our [Benchmarking doc](https://github.com/awslabs/mountpoint-s3/blob/main/doc/BENCHMARKING.md#running-the-benchmark), the names for environment variables `S3_BUCKET_NAME`, `S3_BUCKET_TEST_PREFIX`, `S3_BUCKET_BENCH_FILE` and `S3_BUCKET_SMALL_BENCH_FILE` across steps. This might create confusion for new user trying to run benchmark.

<!-- Please describe your contribution here. What and why? -->
Made the names consistent across the steps for environment variables in used in benchmarking.

Relevant issues: <!-- Please add issue numbers. -->
NA

## Does this change impact existing behavior?
No. Just documentation edits.

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
