### PR TITLE
Fix packaging workflow on AL2023

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,7 +196,7 @@ jobs:
       with:
         ref: ${{ inputs.ref }}
         submodules: true
-    - name: Install nightly Rust
+    - name: Set up stable Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           tags: mountpoint-builder
           context: ./package
+          # https://github.com/docker/buildx/issues/379
+          ulimit: nofile=100000
       - name: Package an unofficial release
         run: docker run --mount type=bind,source=$(pwd),target=/mountpoint mountpoint-builder
       - name: Check release binary


### PR DESCRIPTION
## Description of change

This is prep for moving the CI to AL2023. That OS sets a very high ulimit for open files, and that seems to interact badly with `yum` on Centos 7. The net result is that our packaging workflow takes hours to install OS dependencies. There's an issue: https://github.com/docker/buildx/issues/379. A workaround suggested there is to just lower the ulimit, which works in my testing.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
