### PR TITLE
Fix the updated clippy error

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -432,7 +432,7 @@ fn get_mount_from_source_and_mountpoint(source: &str, mount_point: &str) -> Opti
     let stdout_reader = BufReader::new(stdout);
     let stdout_lines = stdout_reader.lines();
 
-    for line in stdout_lines.flatten() {
+    for line in stdout_lines.map_while(Result::ok) {
         let str: Vec<&str> = line.split_whitespace().collect();
         let source_rec = str[0];
         let mount_point_rec = str[2];


### PR DESCRIPTION
## Description of change
With the recent clippy update, our CI is failing: https://github.com/awslabs/mountpoint-s3/actions/runs/7831215650/job/21367024955. It is not allowing `flatten()` method as `std::io::Lines` may produce an infinite number of `Err` in case of a read error.
I have replaced it with `map_while(Result::ok)`. It maps the `Lines` to string until there is an error.
We may also use `flat_map()` if we want to ignore the read errors and not stop at the first error. I went with the clippy recommended option.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
N/A

## Does this change impact existing behavior?
No.
<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
