### PR TITLE
Expose max_backoff_secs in exponential backoff retry options, increase default retries

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -245,7 +245,8 @@ impl S3CrtClientInner {
 
         let mut retry_strategy_options = StandardRetryOptions::default(&mut event_loop_group);
         // Match the SDK "legacy" retry strategies
-        retry_strategy_options.backoff_retry_options.max_retries = 3;
+        retry_strategy_options.backoff_retry_options.max_retries = 16;
+        retry_strategy_options.backoff_retry_options.max_backoff_secs = 120;
         retry_strategy_options.backoff_retry_options.backoff_scale_factor = Duration::from_millis(500);
         retry_strategy_options.backoff_retry_options.jitter_mode = ExponentialBackoffJitterMode::Full;
         let retry_strategy = RetryStrategy::standard(&allocator, &retry_strategy_options).unwrap();

--- a/mountpoint-s3-crt/src/io/retry_strategy.rs
+++ b/mountpoint-s3-crt/src/io/retry_strategy.rs
@@ -80,6 +80,8 @@ pub struct ExponentialBackoffRetryOptions<'a> {
     pub max_retries: usize,
     /// Scaling factor to add for the backoff. Default is 25ms.
     pub backoff_scale_factor: Duration,
+    /// Max retry backoff in seconds. Default is 20 seconds
+    pub max_backoff_secs: u32,
     /// Jitter mode to use. Default is [ExponentialBackoffJitterMode::Full].
     pub jitter_mode: ExponentialBackoffJitterMode,
 }
@@ -92,6 +94,7 @@ impl<'a> ExponentialBackoffRetryOptions<'a> {
             // Defer to the CRT's defaults for everything else
             max_retries: 0,
             backoff_scale_factor: Duration::from_millis(0),
+            max_backoff_secs: 20,
             jitter_mode: ExponentialBackoffJitterMode::Full,
         }
     }
@@ -101,6 +104,7 @@ impl<'a> ExponentialBackoffRetryOptions<'a> {
             el_group: self.event_loop_group.inner.as_ptr(),
             max_retries: self.max_retries,
             backoff_scale_factor_ms: self.backoff_scale_factor.as_millis().min(u32::MAX as u128) as u32,
+            max_backoff_secs: self.max_backoff_secs,
             jitter_mode: self.jitter_mode.into(),
             ..Default::default()
         }


### PR DESCRIPTION
## Description of change

Using mount-s3 for distributed DDP training of ML models. I'm observing AWS_ERROR_S3_SLOW_DOWN throttling errors and system calls such as open failing.


## Does this change impact existing behavior?

Will increase the number of retries

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
