### PR TITLE
Remove cargo cache from the Address Sanitizer tests in Github CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -202,17 +202,6 @@ jobs:
         toolchain: stable
         override: true
         components: rust-src
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-asan-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -222,14 +211,3 @@ jobs:
       run: make test-asan-working
     - name: Run tests
       run: make test-asan
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR integration tests'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Description of change
Our Github CI is failing due Address Sanitizer job is running out of device space: https://github.com/awslabs/mountpoint-s3/actions/runs/7832124518/job/21394015887?pr=742
So, I am removing the restore cache and save cache step to reduce disk space usage.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
NA

## Does this change impact existing behavior?
No. 

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
