### PR TITLE
Update libgit2-sys from 0.16.1 to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,9 +1771,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Description of change

Cargo deny fails as `libgit2-sys 0.16.1` contains [a volnurability](https://github.com/awslabs/mountpoint-s3/actions/runs/7870551514/job/21471967025?pr=745#step:5:2383), updating it to the recommended version.

Package `libgit2-sys` is a transitive dependency from `built` package: [Cargo.lock](https://github.com/awslabs/mountpoint-s3/blob/0b980a0fc8c50e75b2a3ef45ba56a8766a51528a/Cargo.lock#L1943).
## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
