### PR TITLE
Release new mountpoint-s3-client crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-io",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.6.3 (February 12, 2023)
 
 ### Breaking changes
 
@@ -7,6 +7,7 @@
 ### Other changes
 
 * Introduced a new `ThroughputMockClient` that simulates a target network throughput from an in-memory mock S3 client. This client requires the `mock` feature flag. ([#723](https://github.com/awslabs/mountpoint-s3/pull/723)) 
+*  Updated some of the dependencies that aim to clean up our dependency closure. It includes the update of built dependency which fixes a vulnerability in libgit2-sys. ([#731] (https://github.com/awslabs/mountpoint-s3/pull/731))
 
 ## v0.6.2 (January 18, 2024)
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.6.3 (February 12, 2023)
+## v0.7.0 (February 12, 2023)
 
 ### Breaking changes
 
@@ -7,7 +7,7 @@
 ### Other changes
 
 * Introduced a new `ThroughputMockClient` that simulates a target network throughput from an in-memory mock S3 client. This client requires the `mock` feature flag. ([#723](https://github.com/awslabs/mountpoint-s3/pull/723)) 
-*  Updated some of the dependencies that aim to clean up our dependency closure. It includes the update of built dependency which fixes a vulnerability in libgit2-sys. ([#731] (https://github.com/awslabs/mountpoint-s3/pull/731))
+* Updated some of the dependencies that aim to clean up our dependency closure. It includes the update of built dependency which fixes a vulnerability in libgit2-sys. ([#731](https://github.com/awslabs/mountpoint-s3/pull/731))
 
 ## v0.6.2 (January 18, 2024)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.6.2" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.6.3" }
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.0" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.6.3" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.7.0" }
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.0" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }


### PR DESCRIPTION
## Description of change
Release mountpoint-s3 client crate version v0.7.0 .
Not releasing mountpoint-s3-crt-sys and mountpoint-s3-crt crate as they do not have the `built` dependency and there has been no major changes in those crates.

<!-- Please describe your contribution here. What and why? -->

## Does this change impact existing behavior?
No.

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
