### PR TITLE
Raise filter for metrics tracing spans to WARN

### DIFF
--- a/mountpoint-s3-crt-sys/src/logging_shim.rs
+++ b/mountpoint-s3-crt-sys/src/logging_shim.rs
@@ -1,5 +1,5 @@
-//! A small shim that the `aws-crt-s3` crate uses to connect to a logging implementation. The CRT's
-//! logging implementation uses varargs, but Rust hasn't stablized those, so we need a small C
+//! A small shim that the `mountpoint-s3-crt` crate uses to connect to a logging implementation. The
+//! CRT's logging implementation uses varargs, but Rust hasn't stablized those, so we need a small C
 //! trampoline to translate varargs to Rust strings.
 
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
This change avoids unnecessary invocations of the CRT log handlers, which are fairly expensive (up to 5% of our CPU usage in benchmarks) and therefore worth avoiding, but it's a bit of a journey to explain why and how.

The `MetricsTracingSpanLayer` is how we get end-to-end latencies for FUSE operations. It tracks the spans created by the `fuse` module and emits latency metrics at the end of them. To do this, it filters for those spans, and that filter specifies both a target name and a maximum level, which is currently DEBUG. This tracing layer gets added to the registry we construct in `init_tracing_subscriber` at mount time.

Because this filter asks for DEBUG-level spans, the overall tracing subscriber sets its maximum level to DEBUG, even though (in our default configuration) we only emit logs at WARN and below. This maximum level is how `tracing` and `log` can cheaply check whether to skip constructing a log event -- they check if the log event's level is higher than the maximum level. So setting the maximum level to DEBUG makes this cheap filtering less effective, and some log messages will be constructed but not emitted (because they'll fail the actual, more expensive check) as a result.

One place that uses this cheap filtering is our CRT log adapter. The CRT logging macros call `get_log_level` to find out what the maximum log level currently being emitted is, and skip calling the actual log method if they're trying to emit a log message at a higher level than that. Our implementation of `get_log_level` checks the maximum level set by the tracing subscriber (via `log::max_level()`, which is set by `tracing-log`).

The net result is that the CRT logging macros end up calling their actual log methods more often than they need to, because even though we set CRT logging to off by default, the `log::max_level()` is set to DEBUG because of the logic above. And because of some Rust/C FFI weirdness, these methods are somewhat expensive: they need to construct the entire log message before they can filter to decide if the message should actually be emitted (this is what the the
`aws_crt_s3_rs_logging_shim_log_fn_trampoline` method does). In benchmarks, this log construction can show up in profiles as up to 5% of our CPU cycles even though none of these log messages will actually be emitted.

To fix this, we can change the maximum level of the `MetricsTracingSpanLayer`'s filter to WARN. The spans it's interested in have been at warning severity for quite a while, so this doesn't change anything about our actual logging. But it does mean that the tracing subscriber can now set its maximum level to WARN instead of DEBUG, which makes the cheap filtering effective for the CRT log handlers, avoiding constructing every DEBUG-or-below log message only to throw it away.

As a simple test, we can use perf to count how often the CRT log handler is invoked:

    $ sudo perf probe -x target/release/mount-s3 -a aws_crt_s3_rs_logging_shim_log_fn

Before this change:

    $ sudo perf stat -e probe_mount:aws_crt_s3_rs_logging_shim_log_fn -- target/release/mount-s3 bornholt-test-bucket ~/mnt -f
    2024-02-12T20:05:56.471429Z  WARN list_objects{id=0 bucket="bornholt-test-bucket" continued=false delimiter="" max_keys="0" prefix=""}: mountpoint_s3_client::s3_crt_client: meta request failed duration=33.846617ms error=ClientError(Forbidden("Access Denied"))
    Error: Failed to create S3 client

    Caused by:
        0: initial ListObjectsV2 failed for bucket bornholt-test-bucket in region us-west-2
        1: Client error
        2: Forbidden: Access Denied

    Performance counter stats for 'target/release/mount-s3 bornholt-test-bucket /home/bornholt/mnt -f':

                592      probe_mount:aws_crt_s3_rs_logging_shim_log_fn

After this change:

    $ sudo perf stat -e probe_mount:aws_crt_s3_rs_logging_shim_log_fn -- target/release/mount-s3 bornholt-test-bucket ~/mnt -f
    2024-02-12T20:01:17.588700Z  WARN list_objects{id=0 bucket="bornholt-test-bucket" continued=false delimiter="" max_keys="0" prefix=""}: mountpoint_s3_client::s3_crt_client: meta request failed duration=41.092086ms error=ClientError(Forbidden("Access Denied"))
    Error: Failed to create S3 client

    Caused by:
        0: initial ListObjectsV2 failed for bucket bornholt-test-bucket in region us-west-2
        1: Client error
        2: Forbidden: Access Denied

    Performance counter stats for 'target/release/mount-s3 bornholt-test-bucket /home/bornholt/mnt -f':

                    8      probe_mount:aws_crt_s3_rs_logging_shim_log_fn

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
