### PR TITLE
Fix issue preventing reads after flush on a file handle

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Other changes
+* Fix an issue where read file handles could be closed too early, leading to bad file descriptor errors on subsequent reads. As a consequence of this fix, opening an existing file to overwrite it **immediately** after closing a read file handle may occasionally fail with an "Operation not permitted" error. In such cases, Mountpoint logs will also report that the file is "not writable while being read". ([#751](https://github.com/awslabs/mountpoint-s3/pull/751))
+
 ## v1.4.0 (January 26, 2024)
 
 ### New features

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Other changes
 * Fix an issue where read file handles could be closed too early, leading to bad file descriptor errors on subsequent reads. As a consequence of this fix, opening an existing file to overwrite it **immediately** after closing a read file handle may occasionally fail with an "Operation not permitted" error. In such cases, Mountpoint logs will also report that the file is "not writable while being read". ([#751](https://github.com/awslabs/mountpoint-s3/pull/751))
+* File handles are no longer initialized lazily. Lazy initialization was introduced in version 1.4.0 but is reverted in this change. If upgrading from 1.4.0, you may see errors that were previously deferred until read/write now raised at open time. ([#751](https://github.com/awslabs/mountpoint-s3/pull/751))
 
 ## v1.4.0 (January 26, 2024)
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -69,14 +69,9 @@ where
     /// A state where the file handle is created but the type is not yet determined
     Created { lookup: LookedUp, flags: i32, pid: u32 },
     /// The file handle has been assigned as a read handle
-    Read {
-        request: Prefetcher::PrefetchResult<Client>,
-        pid: u32,
-    },
+    Read(Prefetcher::PrefetchResult<Client>),
     /// The file handle has been assigned as a write handle
     Write(UploadState<Client>),
-    /// The file handle is already closed, currently only used to tell that the read is finished
-    Closed,
 }
 
 impl<Client, Prefetcher> std::fmt::Debug for FileHandleState<Client, Prefetcher>
@@ -92,9 +87,8 @@ where
                 .field("flags", flags)
                 .field("pid", pid)
                 .finish(),
-            FileHandleState::Read { request: _, pid } => f.debug_struct("Read").field("pid", pid).finish(),
+            FileHandleState::Read(_) => f.debug_struct("Read").finish(),
             FileHandleState::Write(arg0) => f.debug_tuple("Write").field(arg0).finish(),
-            FileHandleState::Closed => f.debug_struct("Closed").finish(),
         }
     }
 }
@@ -147,7 +141,6 @@ where
     async fn new_read_handle(
         lookup: &LookedUp,
         flags: i32,
-        pid: u32,
         fs: &S3Filesystem<Client, Prefetcher>,
     ) -> Result<FileHandleState<Client, Prefetcher>, Error> {
         if flags & libc::O_WRONLY != 0 {
@@ -169,7 +162,7 @@ where
         let request = fs
             .prefetcher
             .prefetch(fs.client.clone(), &fs.bucket, &full_key, object_size, etag.clone());
-        let handle = FileHandleState::Read { request, pid };
+        let handle = FileHandleState::Read(request);
         metrics::increment_gauge!("fs.current_handles", 1.0, "type" => "read");
         Ok(handle)
     }
@@ -766,19 +759,18 @@ where
         logging::record_name(handle.inode.name());
         let mut state = handle.state.lock().await;
         let request = match &mut *state {
-            FileHandleState::Created { lookup, flags, pid, .. } => {
+            FileHandleState::Created { lookup, flags, .. } => {
                 metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
 
-                *state = FileHandleState::new_read_handle(lookup, *flags, *pid, self).await?;
-                if let FileHandleState::Read { request, .. } = &mut *state {
+                *state = FileHandleState::new_read_handle(lookup, *flags, self).await?;
+                if let FileHandleState::Read(request) = &mut *state {
                     request
                 } else {
                     unreachable!("handle type always be assigned above");
                 }
             }
-            FileHandleState::Read { request, .. } => request,
+            FileHandleState::Read(request) => request,
             FileHandleState::Write(_) => return Err(err!(libc::EBADF, "file handle is not open for reads")),
-            FileHandleState::Closed => return Err(err!(libc::EBADF, "file handle is already closed")),
         };
 
         match request.read(offset as u64, size as usize).await {
@@ -881,7 +873,6 @@ where
                 }
                 FileHandleState::Read { .. } => return Err(err!(libc::EBADF, "file handle is not open for writes")),
                 FileHandleState::Write(request) => request,
-                FileHandleState::Closed => return Err(err!(libc::EBADF, "file handle is already closed")),
             };
 
             request.write(offset, data, &handle.full_key).await?
@@ -1122,7 +1113,6 @@ where
             }
             FileHandleState::Read { .. } => return Ok(()),
             FileHandleState::Write(request) => request,
-            FileHandleState::Closed => return Ok(()),
         };
         self.complete_upload(request, &file_handle.full_key, false, None).await
     }
@@ -1141,10 +1131,6 @@ where
         //   process. In many cases, the child will then immediately close (flush) the duplicated
         //   file descriptors. We will not complete the upload if we can detect that the process
         //   invoking flush is different from the one that originally opened the file.
-        //
-        // The same for read path. We want to stop the prefetcher and decrease the reader count
-        // as soon as users close a file descriptor so that we don't block users from doing other
-        // operation like overwrite the file.
         let file_handle = {
             let file_handles = self.file_handles.read().await;
             match file_handles.get(&fh) {
@@ -1156,29 +1142,11 @@ where
         let mut state = file_handle.state.lock().await;
         match &mut *state {
             FileHandleState::Created { .. } => Ok(()),
-            FileHandleState::Read { pid: open_pid, .. } => {
-                if !are_from_same_process(*open_pid, pid) {
-                    trace!(
-                        file_handle.full_key,
-                        pid,
-                        open_pid,
-                        "not stopping prefetch because current pid differs from pid at open"
-                    );
-                    return Ok(());
-                }
-                // TODO make sure we cancel the inflight PrefetchingGetRequest. is just dropping enough?
-                file_handle.inode.finish_reading()?;
-
-                // Mark the file handle state as closed so we only update the reader count once
-                *state = FileHandleState::Closed;
-                metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "read");
-                Ok(())
-            }
+            FileHandleState::Read { .. } => Ok(()),
             FileHandleState::Write(request) => {
                 self.complete_upload(request, &file_handle.full_key, true, Some(pid))
                     .await
             }
-            FileHandleState::Closed => Ok(()),
         }
     }
 
@@ -1241,7 +1209,6 @@ where
                 return Ok(());
             }
             FileHandleState::Write(request) => request,
-            FileHandleState::Closed => return Ok(()),
         };
 
         let result = request.complete_if_in_progress(&file_handle.full_key).await;

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -702,11 +702,11 @@ where
             let is_truncate = flags & libc::O_TRUNC != 0;
             if !remote_file || (self.config.allow_overwrite && is_truncate) {
                 // If the file is new or opened in truncate mode, we know it must be a write handle.
-                trace!("fs:open choosing write handle for O_RDWR");
+                debug!("fs:open choosing write handle for O_RDWR");
                 FileHandleState::new_write_handle(&lookup, lookup.inode.ino(), flags, pid, self).await?
             } else {
                 // Otherwise, it must be a read handle.
-                trace!("fs:open choosing read handle for O_RDWR");
+                debug!("fs:open choosing read handle for O_RDWR");
                 FileHandleState::new_read_handle(&lookup, self).await?
             }
         } else if flags & libc::O_WRONLY != 0 {

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -66,8 +66,6 @@ where
     Client: ObjectClient + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
-    /// A state where the file handle is created but the type is not yet determined
-    Created { lookup: LookedUp, flags: i32, pid: u32 },
     /// The file handle has been assigned as a read handle
     Read(Prefetcher::PrefetchResult<Client>),
     /// The file handle has been assigned as a write handle
@@ -81,12 +79,6 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FileHandleState::Created { lookup, flags, pid } => f
-                .debug_struct("Created")
-                .field("lookup", lookup)
-                .field("flags", flags)
-                .field("pid", pid)
-                .finish(),
             FileHandleState::Read(_) => f.debug_struct("Read").finish(),
             FileHandleState::Write(arg0) => f.debug_tuple("Write").field(arg0).finish(),
         }
@@ -98,11 +90,6 @@ where
     Client: ObjectClient + Send + Sync,
     Prefetcher: Prefetch,
 {
-    async fn new(lookup: LookedUp, flags: i32, pid: u32) -> Self {
-        metrics::increment_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
-        FileHandleState::Created { lookup, flags, pid }
-    }
-
     async fn new_write_handle(
         lookup: &LookedUp,
         ino: InodeNo,
@@ -110,10 +97,6 @@ where
         pid: u32,
         fs: &S3Filesystem<Client, Prefetcher>,
     ) -> Result<FileHandleState<Client, Prefetcher>, Error> {
-        if flags & libc::O_ACCMODE == libc::O_RDONLY {
-            return Err(err!(libc::EBADF, "file handle is not open for writes"));
-        }
-
         let is_truncate = flags & libc::O_TRUNC != 0;
         let handle = fs
             .superblock
@@ -140,12 +123,8 @@ where
 
     async fn new_read_handle(
         lookup: &LookedUp,
-        flags: i32,
         fs: &S3Filesystem<Client, Prefetcher>,
     ) -> Result<FileHandleState<Client, Prefetcher>, Error> {
-        if flags & libc::O_WRONLY != 0 {
-            return Err(err!(libc::EBADF, "file handle is not open for reads",));
-        }
         if !lookup.stat.is_readable {
             return Err(err!(
                 libc::EACCES,
@@ -719,10 +698,29 @@ where
             return Err(err!(libc::EINVAL, "O_SYNC and O_DSYNC are not supported"));
         }
 
-        // All file handles will be lazy initialized on first read/write.
-        let state = FileHandleState::new(lookup, flags, pid).await.into();
+        let state = if flags & libc::O_RDWR != 0 {
+            let is_truncate = flags & libc::O_TRUNC != 0;
+            if !remote_file || (self.config.allow_overwrite && is_truncate) {
+                // If the file is new or opened in truncate mode, we know it must be a write handle.
+                trace!("fs:open choosing write handle for O_RDWR");
+                FileHandleState::new_write_handle(&lookup, lookup.inode.ino(), flags, pid, self).await?
+            } else {
+                // Otherwise, it must be a read handle.
+                trace!("fs:open choosing read handle for O_RDWR");
+                FileHandleState::new_read_handle(&lookup, self).await?
+            }
+        } else if flags & libc::O_WRONLY != 0 {
+            FileHandleState::new_write_handle(&lookup, lookup.inode.ino(), flags, pid, self).await?
+        } else {
+            FileHandleState::new_read_handle(&lookup, self).await?
+        };
+
         let fh = self.next_handle();
-        let handle = FileHandle { inode, full_key, state };
+        let handle = FileHandle {
+            inode,
+            full_key,
+            state: AsyncMutex::new(state),
+        };
         debug!(fh, ino, "new file handle created");
         self.file_handles.write().await.insert(fh, Arc::new(handle));
 
@@ -759,16 +757,6 @@ where
         logging::record_name(handle.inode.name());
         let mut state = handle.state.lock().await;
         let request = match &mut *state {
-            FileHandleState::Created { lookup, flags, .. } => {
-                metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
-
-                *state = FileHandleState::new_read_handle(lookup, *flags, self).await?;
-                if let FileHandleState::Read(request) = &mut *state {
-                    request
-                } else {
-                    unreachable!("handle type always be assigned above");
-                }
-            }
             FileHandleState::Read(request) => request,
             FileHandleState::Write(_) => return Err(err!(libc::EBADF, "file handle is not open for reads")),
         };
@@ -862,15 +850,6 @@ where
         let len = {
             let mut state = handle.state.lock().await;
             let request = match &mut *state {
-                FileHandleState::Created { lookup, flags, pid } => {
-                    *state = FileHandleState::new_write_handle(lookup, ino, *flags, *pid, self).await?;
-                    metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
-                    if let FileHandleState::Write(request) = &mut *state {
-                        request
-                    } else {
-                        unreachable!("handle type always be assigned above");
-                    }
-                }
                 FileHandleState::Read { .. } => return Err(err!(libc::EBADF, "file handle is not open for writes")),
                 FileHandleState::Write(request) => request,
             };
@@ -1088,29 +1067,6 @@ where
         logging::record_name(file_handle.inode.name());
         let mut state = file_handle.state.lock().await;
         let request = match &mut *state {
-            FileHandleState::Created { lookup, flags, pid } => {
-                // This happens when users call fsync without any read() or write() requests,
-                // since we don't know what type of handle it would be we need to consider what
-                // to do next for both cases.
-                // * if the file is new or opened in truncate mode, we know it must be a write
-                //   handle so we can start an upload and complete it immediately, result in an
-                //   empty file.
-                // * if the file already exists and it is not opened in truncate mode, we still
-                //   can't be sure of its type so we will do nothing and just return ok.
-                let is_new_file = !lookup.inode.is_remote()?;
-                let is_truncate = *flags & libc::O_TRUNC != 0;
-                if is_new_file || is_truncate {
-                    *state = FileHandleState::new_write_handle(lookup, lookup.inode.ino(), *flags, *pid, self).await?;
-                    metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
-                    if let FileHandleState::Write(request) = &mut *state {
-                        request
-                    } else {
-                        unreachable!("handle type always be assigned above");
-                    }
-                } else {
-                    return Ok(());
-                }
-            }
             FileHandleState::Read { .. } => return Ok(()),
             FileHandleState::Write(request) => request,
         };
@@ -1141,7 +1097,6 @@ where
         logging::record_name(file_handle.inode.name());
         let mut state = file_handle.state.lock().await;
         match &mut *state {
-            FileHandleState::Created { .. } => Ok(()),
             FileHandleState::Read { .. } => Ok(()),
             FileHandleState::Write(request) => {
                 self.complete_upload(request, &file_handle.full_key, true, Some(pid))
@@ -1178,30 +1133,7 @@ where
             }
         };
 
-        let mut state = file_handle.state.into_inner();
-        let request = match state {
-            FileHandleState::Created { lookup, flags, pid } => {
-                metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "unassigned");
-                // This happens when release is called before any read() or write(),
-                // since we don't know what type of handle it would be we need to consider
-                // what to do next for both cases.
-                // * if the file is new or opened in truncate mode, we know it must be a write
-                //   handle so we can start an upload from here.
-                // * if the file already exists and it is not opened in truncate mode, we still
-                //   can't be sure of its type so we will just drop it.
-                let is_new_file = !lookup.inode.is_remote()?;
-                let is_truncate = flags & libc::O_TRUNC != 0;
-                if is_new_file || is_truncate {
-                    state = FileHandleState::new_write_handle(&lookup, lookup.inode.ino(), flags, pid, self).await?;
-                    if let FileHandleState::Write(request) = state {
-                        request
-                    } else {
-                        unreachable!("handle type always be assigned above");
-                    }
-                } else {
-                    return Ok(());
-                }
-            }
+        let request = match file_handle.state.into_inner() {
             FileHandleState::Read { .. } => {
                 // TODO make sure we cancel the inflight PrefetchingGetRequest. is just dropping enough?
                 metrics::decrement_gauge!("fs.current_handles", 1.0, "type" => "read");

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -611,13 +611,8 @@ async fn test_sequential_write(write_size: usize) {
     let file_ino = dentry.attr.ino;
 
     // First let's check that we can't write it again
-    let fh = fs
-        .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
-        .await
-        .unwrap()
-        .fh;
     let result = fs
-        .write(file_ino, fh, offset, &[0xaa; 27], 0, 0, None)
+        .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
         .await
         .expect_err("file should not be overwritable")
         .to_errno();
@@ -700,22 +695,13 @@ async fn test_duplicate_write_fails() {
     assert_eq!(dentry.attr.size, 0);
     let file_ino = dentry.attr.ino;
 
-    let opened = fs
+    let _opened = fs
         .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
         .await
         .unwrap();
-    _ = fs
-        .write(file_ino, opened.fh, 0, &[0xaa; 27], 0, 0, None)
-        .await
-        .expect("first write should succeed");
 
-    let opened = fs
-        .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
-        .await
-        .expect("open should succeed");
-    // Should not be allowed to write the file a second time
     let err = fs
-        .write(file_ino, opened.fh, 0, &[0xaa; 27], 0, 0, None)
+        .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
         .await
         .expect_err("should not be able to write twice")
         .to_errno();
@@ -1248,20 +1234,12 @@ async fn test_flexible_retrieval_objects() {
         let getattr = fs.getattr(entry.ino).await.unwrap();
         assert_eq!(flexible_retrieval, getattr.attr.perm == 0);
 
-        let open = fs
-            .open(entry.ino, libc::O_RDONLY, 0)
-            .await
-            .expect("open should succeed");
-        let read_result = fs.read(entry.ino, open.fh, 0, 4096, 0, None).await;
+        let open = fs.open(entry.ino, libc::O_RDONLY, 0).await;
         if flexible_retrieval {
-            let err = read_result.expect_err("can't read flexible retrieval objects");
+            let err = open.expect_err("can't open flexible retrieval objects");
             assert_eq!(err.to_errno(), libc::EACCES);
         } else {
-            assert_eq!(
-                &read_result.unwrap()[..],
-                b"hello world",
-                "instant retrieval files are readable"
-            );
+            let open = open.expect("instant retrieval files are readable");
             fs.release(entry.ino, open.fh, 0, None, true).await.unwrap();
         }
     }
@@ -1287,20 +1265,12 @@ async fn test_flexible_retrieval_objects() {
         let getattr = fs.getattr(lookup.attr.ino).await.unwrap();
         assert_eq!(flexible_retrieval, getattr.attr.perm == 0);
 
-        let open = fs
-            .open(lookup.attr.ino, libc::O_RDONLY, 0)
-            .await
-            .expect("open should succeed");
-        let read_result = fs.read(lookup.attr.ino, open.fh, 0, 4096, 0, None).await;
+        let open = fs.open(lookup.attr.ino, libc::O_RDONLY, 0).await;
         if flexible_retrieval {
-            let err = read_result.expect_err("can't read flexible retrieval objects");
+            let err = open.expect_err("can't open flexible retrieval objects");
             assert_eq!(err.to_errno(), libc::EACCES);
         } else {
-            assert_eq!(
-                &read_result.unwrap()[..],
-                b"hello world",
-                "instant retrieval files are readable"
-            );
+            let open = open.expect("instant retrieval files are readable");
             fs.release(lookup.attr.ino, open.fh, 0, None, true).await.unwrap();
         }
     }

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -277,6 +277,7 @@ where
     let mut contents = String::new();
     let err = write_fh.read_to_string(&mut contents).expect_err("read should fail");
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
+    write_fh.sync_all().unwrap();
     drop(write_fh);
 
     // We shouldn't be able to read from a file mid-write in O_RDWR

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -273,7 +273,7 @@ where
     assert_eq!(dir_entry_names, vec!["hello.txt"]);
 
     // Overwrite the test file and verify that we can't read from a file opened in O_WRONLY
-    let mut write_fh = File::options().write(true).open(&file_path).unwrap();
+    let mut write_fh = File::options().write(true).truncate(true).open(&file_path).unwrap();
     let mut contents = String::new();
     let err = write_fh.read_to_string(&mut contents).expect_err("read should fail");
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
@@ -293,8 +293,7 @@ where
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
 
     // Read should also fail from different file handle
-    let mut read_fh = open_for_read(&file_path, true).unwrap();
-    let err = read_fh.read_to_string(&mut contents).expect_err("read should fail");
+    let err = open_for_read(&file_path, true).expect_err("read should fail");
     assert_eq!(err.raw_os_error(), Some(libc::EPERM));
 }
 

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -293,7 +293,8 @@ where
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
 
     // Read should also fail from different file handle
-    let err = open_for_read(&file_path, true).expect_err("read should fail");
+    let err =
+        open_for_read(&file_path, true).expect_err("opening for read should fail with pending write handles open");
     assert_eq!(err.raw_os_error(), Some(libc::EPERM));
 }
 


### PR DESCRIPTION
## Description of change

Fix a regression introduced in https://github.com/awslabs/mountpoint-s3/commit/0030b0a527638a76b29fe387cfa6ae22b0ad1c92 where closing (`flush`) a file descriptor would prevent subsequent reads on the corresponding file handle. The issue was caused by `flush` setting the internal state of the file handle to `Closed` and decrementing the number of readers for the inode, which is used to disallow overwrites when there are open read file handles.

This PR includes 2 main changes:
* it removes the `Closed` state and reverts `flush` to a no op for read file handles. The number of readers for an inode is decremented only on `release`.
* it makes `open` eagerly discriminate between READ and WRITE, rather than on first read or write (or flush or release). This reverts the opposite change in #487 and allows to report error conditions on `open` when appropriate rather than on subsequent operations.

Relevant issues:  #749

## Does this change impact existing behavior?

Because `release` is async, there is a race condition when trying to overwrite a file immediately after closing a read file handle on it, which results in the overwrite to occasionally fail on open.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
