### PR TITLE
Set default binary in mountpoint-s3 crate manifest

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.4.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+default-run = "mount-s3"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -94,7 +94,7 @@ read_benchmark () {
 
     # mount file system
     set +e
-    cargo run --bin mount-s3 --quiet --release -- \
+    cargo run --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --debug \
       --allow-delete \
@@ -139,7 +139,7 @@ write_benchmark () {
     # mount file system
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
     set +e
-    cargo run --bin mount-s3 --quiet --release -- \
+    cargo run --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --debug \
       --allow-delete \

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -50,7 +50,7 @@ do
     echo "Running ${job_name}"
 
     # mount file system
-    cargo run --bin mount-s3 --release ${S3_BUCKET_NAME} ${mount_dir} \
+    cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
         --debug \
         --allow-delete \
         --log-directory=$log_dir \
@@ -123,7 +123,7 @@ for job_file in "${jobs_dir}"/*.fio; do
   echo "Running ${job_name}"
 
   # mount file system
-  cargo run --bin mount-s3 --release ${S3_BUCKET_NAME} ${mount_dir} \
+  cargo run --release ${S3_BUCKET_NAME} ${mount_dir} \
     --debug \
     --allow-delete \
     --log-directory=$log_dir \


### PR DESCRIPTION
## Description of change

We added a binary that uses a mock client. Let's set a default so we're not required to specify `--bin mount-s3` for `cargo run`. https://doc.rust-lang.org/cargo/reference/manifest.html#the-default-run-field

I also revert a change to the benchmarking which is no longer required.

Relevant issues: #739

## Does this change impact existing behavior?

No changes to releases.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
