### PR TITLE
Add a warning about duplicate files in SEMANTICS.md

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -45,6 +45,9 @@ Not all S3 object keys correspond to valid file names, and these objects will no
 
 then mounting your bucket with Mountpoint will show only the `blue` directory, containing the file `image.jpg`. The `blue` object will not be accessible. See the [detailed semantics](#mapping-s3-object-keys-to-files-and-directories) below for more information about invalid object keys.
 
+> [!IMPORTANT]
+> Please note, that there is a known [issue](https://github.com/awslabs/mountpoint-s3/issues/725) with `readdir` operation (used to list files in a directory), which results in duplicate files in the response. Duplicate files may occur for any type of a bucket if it contains keys which should be hidden according to the semantics described above. E.g. for bucket with keys `blue` and `blue/image.jpg` two files with the name `blue` may be shown, and none of those may be a directory file.
+
 ### Modifying directories
 
 Mountpoint allows creating new directories with commands like `mkdir`. Creating a new directory is a local operation and no changes are made to your S3 bucket. A new directory will only be visible to other clients once a file has been written and uploaded inside it. If you restart Mountpoint or your instance before writing any files into the new directory, it will not be preserved.


### PR DESCRIPTION
## Description of change

Update documentation to warn about a case when `readdir` does not follow our semantics.

Note that for Express buckets the problem is already in [TROUBLESHOOTING.md](https://github.com/awslabs/mountpoint-s3/blob/main/doc/TROUBLESHOOTING.md#listing-a-directory-containing-files-and-directories-of-the-same-name), but for Standard buckets its not mentioned anywhere.

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
