### PR TITLE
Enable negative cache when using `--cache`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ env:
   S3_OLAP_ARN: ${{ vars.S3_OLAP_ARN }}
   S3_MRAP_ARN: ${{ vars.S3_MRAP_ARN }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,sse_kms,negative_cache
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,sse_kms
 
 permissions:
   id-token: write

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -91,10 +91,14 @@ To force an up-to-date view of a file, use the `O_DIRECT` flag when opening the 
 When this option is provided, Mountpoint will check S3 to ensure the object exists and return the latest object content.
 Unlike other file systems, Mountpoint does not support setting the `O_DIRECT` flag via `fcntl` after the file has been opened.
 
-Caching does not affect the behavior of writing new files.
-New files that are being written to remain unavailable for reading until the file is closed, consistent with behavior without caching.
-After the new file is closed, it is possible to open it for reading.
-Parts of the file that are read from S3 will then be cached and available for subsequent repeated reads.
+When caching is enabled, Mountpoint can also remember queries for missing keys. Once you try to
+access a file that does not exist on S3, subsequent attempts (within the configured TTL) may still
+not detect it, even if it was independently added to S3.
+
+Caching does not affect the behavior of writing to files. Files that are being written to remain
+unavailable for reading until the file is closed, consistent with behavior without caching.
+After the file is closed, it is possible to open it for reading. Parts of the file that are read
+from S3 will then be cached and available for subsequent repeated reads.
 
 ## Durability
 

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -91,9 +91,9 @@ To force an up-to-date view of a file, use the `O_DIRECT` flag when opening the 
 When this option is provided, Mountpoint will check S3 to ensure the object exists and return the latest object content.
 Unlike other file systems, Mountpoint does not support setting the `O_DIRECT` flag via `fcntl` after the file has been opened.
 
-When caching is enabled, Mountpoint can also remember queries for missing keys. Once you try to
+When caching is enabled, Mountpoint also remembers when objects do *not* exist. Once you try to
 access a file that does not exist on S3, subsequent attempts (within the configured TTL) may still
-not detect it, even if it was independently added to S3.
+fail, even if it was later added to S3.
 
 Caching does not affect the behavior of writing to files. Files that are being written to remain
 unavailable for reading until the file is closed, consistent with behavior without caching.

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -658,7 +658,7 @@ impl SuperblockInner {
                 }
             };
 
-            if cfg!(feature = "negative_cache") && superblock.negative_cache.contains(parent.ino(), name) {
+            if superblock.negative_cache.contains(parent.ino(), name) {
                 return Some(Err(InodeError::FileDoesNotExist(name.to_owned(), parent.err())));
             }
 
@@ -822,7 +822,7 @@ impl SuperblockInner {
             return Err(InodeError::NotADirectory(parent.err()));
         }
 
-        if cfg!(feature = "negative_cache") && self.config.cache_config.serve_lookup_from_cache {
+        if self.config.cache_config.serve_lookup_from_cache {
             match &remote {
                 // Remove negative cache entry.
                 Some(_) => self.negative_cache.remove(parent_ino, name),
@@ -1880,7 +1880,7 @@ mod tests {
 
         for entry in entries {
             let lookup = superblock.lookup(&client, FUSE_ROOT_INODE, entry.as_ref()).await;
-            if cached && cfg!(feature = "negative_cache") {
+            if cached {
                 lookup.expect_err("negative entry should still be valid in the cache, so the new key should not have been looked up in S3");
             } else {
                 lookup.expect("new object should have been looked up in S3");

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -170,7 +170,6 @@ async fn test_read_dir_nested(prefix: &str) {
     fs.releasedir(dir_ino, dir_handle, 0).await.unwrap();
 }
 
-#[cfg(feature = "negative_cache")]
 #[tokio::test]
 async fn test_lookup_negative_cached() {
     let fs_config = S3FilesystemConfig {

--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -235,14 +235,12 @@ where
     assert!(m.file_type().is_file());
 }
 
-#[cfg(feature = "negative_cache")]
 #[cfg(feature = "s3_tests")]
 #[test]
 fn lookup_with_negative_cache_s3() {
     lookup_with_negative_cache(fuse::s3_session::new);
 }
 
-#[cfg(feature = "negative_cache")]
 #[test]
 fn lookup_with_negative_cache_mock() {
     lookup_with_negative_cache(fuse::mock_session::new);


### PR DESCRIPTION
## Description of change

Enable the negative cache introduced in #696, when using `--cache`. (previously under a feature flag)

## Does this change impact existing behavior?

Yes, when Mountpoint is configured with the `--cache` option, repeated lookups for non-existing entries will not trigger S3 requests for the configured TTL.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
