### PR TITLE
Adding benchmarks that use caching

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
-        tool: 'customSmallerIsBetter'
+        tool: 'customBiggerIsBetter'
         output-file-path: results/output.json
         benchmark-data-dir-path: dev/cache_bench
         alert-threshold: "200%"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -160,3 +160,51 @@ jobs:
         auto-push: ${{ inputs.environment && 'false' || 'true' }}
         comment-on-alert: true
         max-items-in-chart: 20
+
+  cache-bench:
+    name: Benchmark (Cache)
+    runs-on: [self-hosted, linux, x64, high-performance]
+
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --release
+    - name: Run Benchmark
+      run: mountpoint-s3/scripts/fs_cache_bench.sh
+    - name: Check benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'customSmallerIsBetter'
+        output-file-path: results/output.json
+        benchmark-data-dir-path: dev/cache_bench
+        alert-threshold: "200%"
+        fail-on-alert: true
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Store the results and deploy GitHub pages automatically if the results are from main branch
+        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        comment-on-alert: true
+        max-items-in-chart: 20

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+numjobs=4
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct.fio
@@ -1,0 +1,15 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_direct_io]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct_small.fio
@@ -1,0 +1,15 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_direct_io_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_small.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+numjobs=4
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_direct_io]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct_small.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_direct_io_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_small.fio
@@ -5,7 +5,7 @@ runtime=30s
 time_based
 group_reporting
 
-[sequential_read_small_file]
+[cache_sequential_read_small_file]
 size=5m
 rw=read
 ioengine=sync

--- a/mountpoint-s3/scripts/fio/read_cache/seq_read_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/seq_read_small.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[sequential_read_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+startdelay=30s

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -37,7 +37,7 @@ cd ${project_dir}
 results_dir=results
 runtime_seconds=30
 startdelay_seconds=30
-iterations=1
+iterations=10
 
 rm -rf ${results_dir}
 mkdir -p ${results_dir}

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -117,11 +117,12 @@ cache_benchmark () {
 
     # cleanup mount directory and log directory
     cleanup() {
-      # unmount file system
-      sudo umount ${mount_dir} 2> /dev/null
-      rm -rf ${mount_dir}
-      rm -rf ${cache_dir} # umount should clean this, but just in case
-      rm -rf ${log_dir}
+      echo "cache_benchmark:cleanup"
+      # unmount file system only if it is mounted
+      ! mountpoint -q ${mount_dir} || sudo umount ${mount_dir}
+      sudo rm -rf ${mount_dir}
+      sudo rm -rf ${cache_dir} # umount should clean this, but just in case
+      sudo rm -rf ${log_dir}
     }
 
     # trap cleanup on exit
@@ -163,7 +164,7 @@ cache_benchmark () {
     # run the benchmark
     run_fio_job $job_file $bench_file $mount_dir $log_dir
 
-
+    cleanup
   done
 }
 
@@ -185,10 +186,11 @@ read_benchmark () {
 
     # cleanup mount directory and log directory
     cleanup() {
-      # unmount file system
-      sudo umount ${mount_dir} 2> /dev/null
-      rm -rf ${mount_dir}
-      rm -rf ${log_dir}
+      echo "read_benchmark:cleanup"
+      # unmount file system only if it is mounted
+      ! mountpoint -q ${mount_dir} || sudo umount ${mount_dir}
+      sudo rm -rf ${mount_dir}
+      sudo rm -rf ${log_dir}
     }
 
     # trap cleanup on exit
@@ -222,6 +224,8 @@ read_benchmark () {
     # run the benchmark
     run_fio_job $job_file $bench_file $mount_dir $log_dir
 
+    cleanup
+
   done
 }
 
@@ -242,10 +246,11 @@ write_benchmark () {
 
     # cleanup mount directory and log directory
     cleanup() {
-      # unmount file system
-      sudo umount ${mount_dir} 2> /dev/null
-      rm -rf ${mount_dir}
-      rm -rf ${log_dir}
+      echo "write_benchmark:cleanup"
+      # unmount file system only if it is mounted
+      ! mountpoint -q ${mount_dir} || sudo umount ${mount_dir}
+      sudo rm -rf ${mount_dir}
+      sudo rm -rf ${log_dir}
     }
 
     # trap cleanup on exit
@@ -275,6 +280,8 @@ write_benchmark () {
 
     # run the benchmark
     run_fio_job $job_file $bench_file $mount_dir $log_dir
+
+    cleanup
 
   done
 }

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -121,7 +121,6 @@ cache_benchmark () {
       # unmount file system only if it is mounted
       ! mountpoint -q ${mount_dir} || sudo umount ${mount_dir}
       sudo rm -rf ${mount_dir}
-      sudo rm -rf ${cache_dir} # umount should clean this, but just in case
       sudo rm -rf ${log_dir}
     }
 


### PR DESCRIPTION
## Description of change

This change is adding benchmarks that use mountpoint caching. The fio jobs were copied from the `read` benchmarks and renamed accordingly. I ran some of the tests locally by using the _filter_ functionality. We might not need all of these tests for the cache benchmarks but defaulted to have the same as the read ones and change later if needed.

```bash
# filter to only run this test for both for normal reads and cached ones
export JOB_NAME_FILTER=seq_read_small

./mountpoint-s3/scripts/fs_cache_bench.sh
Will only run fio jobs which match seq_read_small
Skipping job mountpoint-s3/scripts/fio/read/rand_read_4t_direct.fio because it does not match seq_read_small
Skipping job mountpoint-s3/scripts/fio/read/rand_read_4t_direct_small.fio because it does not match seq_read_small
...

# list the mount and caching directories (sample)
ls -d1 /tmp/fio*

/tmp/fio-ZaNYWdZaBK3W
/tmp/fio-ZaNYWdZaBK3W-cache-O8X4T2w4UDnx

# benchmark results for this run
[
  {
    "name": "cache_sequential_read_small_file",
    "value": 1184.8017578125,
    "unit": "MiB/s"
  },
  {
    "name": "sequential_read_small_file",
    "value": 16.4091796875,
    "unit": "MiB/s"
  }
]
```

There is opportunity of doing some refactor between the different bench scripts but I'm prioritizing getting this out first and do refactor later if needed.

## Does this change impact existing behavior?

The only impact should be to our CI benchmarks that now will run additional tests that use caching (in a separate job).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
