### PR TITLE
Add benchmarks for S3 express one zone bucket

### DIFF
--- a/.github/workflows/bench_main.yml
+++ b/.github/workflows/bench_main.yml
@@ -14,3 +14,8 @@ jobs:
     uses: ./.github/workflows/bench.yml
     with:
       ref: ${{ github.event.after }}
+  s3express-integration:
+    name: Benchmarks (s3express)
+    uses: ./.github/workflows/bench_s3express.yml
+    with:
+      ref: ${{ github.event.after }}

--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -17,3 +17,10 @@ jobs:
     with:
       environment: PR benchmarks
       ref: ${{ github.event.pull_request.head.sha }}
+  s3express-integration:
+    name: Benchmarks (s3express)
+    uses: ./.github/workflows/bench_s3express.yml
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
+    with:
+      environment: PR benchmarks
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -1,0 +1,163 @@
+name: Benchmark (s3-express one zone)
+
+# We use environments to require approval to run benchmarks on PRs, but not on pushes to `main`
+# (which have been approved already since PRs are required for `main`).
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+      ref:
+        required: true
+        type: string
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  S3_BUCKET_NAME: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME }}
+  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
+  S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
+  S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
+  S3_REGION: ${{ vars.S3_REGION }}
+
+jobs:
+  bench:
+    name: Benchmark (Throughput)
+    runs-on: [self-hosted, linux, x64, high-performance]
+
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+        role-duration-seconds: 21600
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --release
+    - name: Run Benchmark
+      run: mountpoint-s3/scripts/fs_bench.sh
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR benchmarks'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
+    - name: Check benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'customBiggerIsBetter'
+        output-file-path: results/output.json
+        benchmark-data-dir-path: dev/s3-express/bench
+        alert-threshold: "200%"
+        fail-on-alert: true
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Store the results and deploy GitHub pages automatically if the results are from main branch
+        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        comment-on-alert: true
+        max-items-in-chart: 20
+  
+  latency-bench:
+    name: Benchmark (Latency)
+    runs-on: [self-hosted, linux, x64, high-performance]
+
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Restore Cargo cache
+      id: restore-cargo-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --release
+    - name: Run Benchmark
+      run: mountpoint-s3/scripts/fs_latency_bench.sh
+    - name: Save Cargo cache
+      uses: actions/cache/save@v3
+      if: inputs.environment != 'PR benchmarks'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
+    - name: Check benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'customSmallerIsBetter'
+        output-file-path: results/output.json
+        benchmark-data-dir-path: dev/s3-express/latency_bench
+        alert-threshold: "200%"
+        fail-on-alert: true
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Store the results and deploy GitHub pages automatically if the results are from main branch
+        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        comment-on-alert: true
+        max-items-in-chart: 20

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -276,6 +276,7 @@ You can instead manually configure the maximum size of the cache with the `--max
 
 We recommend using local storage, such as Amazon EC2 instance storage or an Amazon EBS volume, as the target of the Mountpoint cache.
 When caching to EBS, you can use your instance's root EBS volume, or create and attach a new volume just for caching.
+There are several factors that can affect the performance of EBS volumes. See the [EBS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) for more details about EBS volume types and their performance characteristics. 
 If you create a new EBS volume or use EC2 instance storage, you will first need to [create a file system](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-instance-store-volumes.html#making-instance-stores-available-on-your-instances) on that storage and mount it at a path such as `/mnt/mp-cache`.
 The user running Mountpoint needs write access to the mounted file system,
 and we recommend setting the permissions on the file system to not allow reads by any other users (e.g., `chmod 0700 /mnt/mp-cache`).

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -99,7 +99,8 @@ read_benchmark () {
       --debug \
       --allow-delete \
       --log-directory=${log_dir} \
-      --prefix=${S3_BUCKET_TEST_PREFIX}
+      --prefix=${S3_BUCKET_TEST_PREFIX} \
+      --part-size=16777216
     mount_status=$?
     set -e
     if [ $mount_status -ne 0 ]; then

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -36,10 +36,13 @@ mkdir -p ${results_dir}
 
 # start readdir benchmarking
 dir_size=100
+jobs_dir=mountpoint-s3/scripts/fio/create
+
 while [ $dir_size -le 100000 ]
 do
     sum=0
     job_name="readdir_${dir_size}"
+    job_file="${jobs_dir}/create_files_${dir_size}.fio"
     mount_dir=$(mktemp -d /tmp/mount-s3-XXXXXXXXXXXX)
     target_dir="${mount_dir}/bench_dir_${dir_size}"
     startdelay=30
@@ -61,10 +64,12 @@ do
         exit 1
     fi
 
-    # verify that the target directory exists before running the benchmark
-    if [ ! -d "${target_dir}" ]; then
-      echo "Target directory ${target_dir} does not exist."
-      exit 1
+    # create the target directory if it does not exist before running the benchmark
+    mkdir -p ${target_dir}
+    # create the files in target directory if they do not exist
+    file_count=$(ls $target_dir | wc -l)
+    if [ $file_count -ne $dir_size ]; then
+      fio --thread --directory=${target_dir} ${job_file}
     fi
 
     sleep $startdelay


### PR DESCRIPTION
## Description of change
Added a separate workflow for s3 express one bucket benchmark and running that workflow on separate job. We have got successful result on wf-changes/s3-express-benchmark: https://github.com/awslabs/mountpoint-s3/actions/runs/8007392433
Pages for s3 express benchmark: [Throughput](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/), [Latency](https://awslabs.github.io/mountpoint-s3/dev/s3-express/latency_bench/)

<!-- Please describe your contribution here. What and why? -->
Also added the step of creation objects required for benchmarking within the scripts, so that if it required to setup benchmarking again for some other case, we dont need tohe manual setup.

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
