### PR TITLE
Add metrics for number of inodes

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -607,39 +607,39 @@ impl S3CrtClientInner {
 
     fn poll_client_metrics(s3_client: &Client) {
         let metrics = s3_client.poll_client_metrics();
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_requests_being_processed",
-            metrics.num_requests_tracked_requests as u64
+            metrics.num_requests_tracked_requests as f64
         );
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_requests_being_prepared",
-            metrics.num_requests_being_prepared as u64
+            metrics.num_requests_being_prepared as f64
         );
-        metrics::absolute_counter!("s3.client.request_queue_size", metrics.request_queue_size as u64);
-        metrics::absolute_counter!(
+        metrics::gauge!("s3.client.request_queue_size", metrics.request_queue_size as f64);
+        metrics::gauge!(
             "s3.client.num_auto_default_network_io",
-            metrics.num_auto_default_network_io as u64
+            metrics.num_auto_default_network_io as f64
         );
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_auto_ranged_get_network_io",
-            metrics.num_auto_ranged_get_network_io as u64
+            metrics.num_auto_ranged_get_network_io as f64
         );
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_auto_ranged_put_network_io",
-            metrics.num_auto_ranged_put_network_io as u64
+            metrics.num_auto_ranged_put_network_io as f64
         );
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_auto_ranged_copy_network_io",
-            metrics.num_auto_ranged_copy_network_io as u64
+            metrics.num_auto_ranged_copy_network_io as f64
         );
-        metrics::absolute_counter!("s3.client.num_total_network_io", metrics.num_total_network_io() as u64);
-        metrics::absolute_counter!(
+        metrics::gauge!("s3.client.num_total_network_io", metrics.num_total_network_io() as f64);
+        metrics::gauge!(
             "s3.client.num_requests_stream_queued_waiting",
-            metrics.num_requests_stream_queued_waiting as u64
+            metrics.num_requests_stream_queued_waiting as f64
         );
-        metrics::absolute_counter!(
+        metrics::gauge!(
             "s3.client.num_requests_streaming_response",
-            metrics.num_requests_streaming_response as u64
+            metrics.num_requests_streaming_response as f64
         );
     }
 

--- a/mountpoint-s3/src/metrics.rs
+++ b/mountpoint-s3/src/metrics.rs
@@ -239,7 +239,7 @@ mod tests {
                         }
                         Metric::Gauge(inner) => {
                             assert_eq!(key.name(), TEST_GAUGE);
-                            let value = inner.load();
+                            let value = inner.load_if_changed();
                             let label = key.labels().next().unwrap();
                             if label == &Label::new("type", "processing") {
                                 assert_eq!(value, Some(2.0));
@@ -271,13 +271,12 @@ mod tests {
                 let metric = entry.value_mut();
                 match metric {
                     Metric::Counter(inner) => assert!(inner.load_and_reset().is_none()),
-                    // Gauges don't reset on their own
-                    Metric::Gauge(inner) => assert!(inner.load().is_some()),
+                    Metric::Gauge(inner) => assert!(inner.load_if_changed().is_none()),
                     Metric::Histogram(inner) => assert!(inner.run_and_reset(|_| panic!("unreachable")).is_none()),
                 }
             }
 
-            // Set the gauges to zero and check they're no longer emitted
+            // Set the gauges to zero and check they emit their change only once
             metrics::gauge!(TEST_GAUGE, 0.0, "type" => "processing");
             metrics::gauge!(TEST_GAUGE, 0.0, "type" => "in_queue");
             for mut entry in sink.metrics.iter_mut() {
@@ -285,7 +284,9 @@ mod tests {
                 let Metric::Gauge(inner) = metric else {
                     continue;
                 };
-                assert!(inner.load().is_none());
+                // We want to emit once to reflect that it's changed to 0, and then not emit again
+                assert!(inner.load_if_changed().is_some());
+                assert!(inner.load_if_changed().is_none());
             }
         }
     }

--- a/mountpoint-s3/src/metrics/data.rs
+++ b/mountpoint-s3/src/metrics/data.rs
@@ -1,6 +1,4 @@
-use std::sync::atomic::AtomicBool;
-
-use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use crate::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use crate::sync::{Arc, Mutex};
 
 /// A single metric


### PR DESCRIPTION
## Description of change

We track the total number of inodes as well as tracking them by kind. I did this by updating how we use gauges to work better for our current metrics stack, so that we don't just emit the same value every 5 seconds forever.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
