### PR TITLE
Adding benchmarks that use caching.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -161,3 +161,52 @@ jobs:
         auto-push: ${{ inputs.environment && 'false' || 'true' }}
         comment-on-alert: true
         max-items-in-chart: 20
+
+  cache-bench:
+    name: Benchmark (Cache)
+    runs-on: [self-hosted, linux, x64, nvme-high-performance]
+
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+        role-duration-seconds: 21600
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        libunwind: true
+        fio: true
+    - name: Set up stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --release
+    - name: Run Benchmark
+      run: mountpoint-s3/scripts/fs_cache_bench.sh
+    - name: Check benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        tool: 'customBiggerIsBetter'
+        output-file-path: results/output.json
+        benchmark-data-dir-path: dev/cache_bench
+        alert-threshold: "200%"
+        fail-on-alert: true
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Store the results and deploy GitHub pages automatically if the results are from main branch
+        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        comment-on-alert: true
+        max-items-in-chart: 20

--- a/.github/workflows/bench_main.yml
+++ b/.github/workflows/bench_main.yml
@@ -2,7 +2,7 @@ name: Benchmarks
 
 on:
   push:
-    branches: [ "main", "wf-changes/**"]
+    branches: [ "main", "wf-changes/**" ]
 
 permissions:
   id-token: write

--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   push:
-    branches: [ "main", "wf-changes/**"]
+    branches: [ "main", "wf-changes/**" ]
   merge_group:
     types: [ "checks_requested" ]
 

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read]
+size=100G
+rw=randread
+ioengine=sync
+fallocate=none

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_four_threads]
+size=100G
+rw=randread
+ioengine=sync
+fallocate=none
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_direct.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_four_threads_direct_io]
+size=100G
+rw=randread
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_direct_small.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_four_threads_direct_io_small_file]
+size=5m
+rw=randread
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_4t_small.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_four_threads_small_file]
+size=5m
+rw=randread
+ioengine=sync
+fallocate=none
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_direct.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_direct_io]
+size=100G
+rw=randread
+ioengine=sync
+fallocate=none
+direct=1

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_direct_small.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_direct_io_small_file]
+size=5m
+rw=randread
+ioengine=sync
+fallocate=none
+direct=1

--- a/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_rand_read_small.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_random_read_small_file]
+size=5m
+rw=randread
+ioengine=sync
+fallocate=none

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_direct_io]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_direct_small.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_direct_io_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+direct=1
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_4t_small.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_four_threads_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+numjobs=4

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_direct_io]
+size=100G
+rw=read
+ioengine=sync
+fallocate=none
+direct=1

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_direct_small.fio
@@ -1,0 +1,13 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_direct_io_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none
+direct=1

--- a/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_small.fio
+++ b/mountpoint-s3/scripts/fio/read_cache/cache_seq_read_small.fio
@@ -1,0 +1,12 @@
+[global]
+name=fs_cache_bench
+bs=256k
+runtime=30s
+time_based
+group_reporting
+
+[cache_sequential_read_small_file]
+size=5m
+rw=read
+ioengine=sync
+fallocate=none


### PR DESCRIPTION
## Description of change

_NOTE: This is a new PR replacing https://github.com/awslabs/mountpoint-s3/pull/761 because through this branch `wf-changes/caching-benchmarks` I was able to actually run the new job for caching: https://github.com/awslabs/mountpoint-s3/actions/runs/8031555207._

This change is adding benchmarks that use mountpoint caching with files up to 1 GB in size because the current workers have only 30 GB of disk. If we want to support bigger sizes, we'll likely need to make changes to provision new workers.

The fio jobs were copied from the `read` benchmarks and renamed accordingly. I ran some of the tests locally by using the _filter_ functionality. We might not need all of these tests for the cache benchmarks but defaulted to have the same as the read ones and change later if needed.

```bash
# filter to only run this test for both for normal reads and cached ones
export JOB_NAME_FILTER=seq_read_small

./mountpoint-s3/scripts/fs_cache_bench.sh
Will only run fio jobs which match seq_read_small
Skipping job mountpoint-s3/scripts/fio/read/rand_read_4t_direct.fio because it does not match seq_read_small
Skipping job mountpoint-s3/scripts/fio/read/rand_read_4t_direct_small.fio because it does not match seq_read_small
...

# list the mount and caching directories (sample)
ls -d1 /tmp/fio*

/tmp/fio-ZaNYWdZaBK3W
/tmp/fio-ZaNYWdZaBK3W-cache-O8X4T2w4UDnx

# benchmark results for this run
[
  {
    "name": "cache_sequential_read_small_file",
    "value": 1184.8017578125,
    "unit": "MiB/s"
  },
  {
    "name": "sequential_read_small_file",
    "value": 16.4091796875,
    "unit": "MiB/s"
  }
]
```

There is opportunity of doing some refactor between the different bench scripts but I'm prioritizing getting this out first and do refactor later if needed.

## Does this change impact existing behavior?

The only impact should be to our CI benchmarks that now will run additional tests that use caching (in a separate job).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).