### PR TITLE
Remove license clarification for zerocopy

### DIFF
--- a/package/attribution.toml
+++ b/package/attribution.toml
@@ -20,15 +20,3 @@ ignore-dev-dependencies = true
 no-clearly-defined = true
 
 workarounds = ["ring"]
-
-[zerocopy.clarify]
-license = "BSD-2-Clause"
-[[zerocopy.clarify.files]]
-path = "LICENSE"
-checksum = "83c1763356e822adde0a2cae748d938a73fdc263849ccff6b27776dff213bd32"
-
-[zerocopy-derive.clarify]
-license = "BSD-2-Clause"
-[[zerocopy-derive.clarify.files]]
-path = "LICENSE"
-checksum = "83c1763356e822adde0a2cae748d938a73fdc263849ccff6b27776dff213bd32"


### PR DESCRIPTION
This isn't needed after https://github.com/google/zerocopy/pull/542.

Fixes #786.