### PR TITLE
Add new cases of expected behaviours in troubleshooting doc

### DIFF
--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -169,15 +169,17 @@ In this case, try using `--force-path-style` CLI option when you are mounting th
 
 NOTE - Third party storage provider are not officially supported by Mountpoint for Amazon S3.
 
+For more details on how Mountpoint handles endpoint, please see our [configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#endpoints-and-aws-privatelink).
+
 ## Directory disappear after deleting all the files within it
 
 Amazon S3 does not support directories and objects are just grouped using prefix.
 Mountpoint automatically infers a directory structure for your bucket by treating the `/` separator after prefix in your object keys as a delimiter between directories.
 
-So, if all the files within a prefix is deleted, the prefix itself cease to exist.
+So, if all the files within a prefix are deleted, the prefix itself and the corresponding directory cease to exist.
 In this case, it is expected that mountpoint will not be able to show the directory for listing or other file system operation.
 
-Workaround to persist a directory could be creating a hidden empty file (for example, `.keep`).
+Workaround to persist a directory could be creating an empty file (for example, `.keep`). These files can be hidden as `ls` filters out files with prefix `.` without `-a` option.
 
 For more details on how Mountpoint maps S3 object keys to files and directories, see the [semantics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#mapping-s3-object-keys-to-files-and-directories).
 
@@ -206,11 +208,26 @@ head_object{id=21 bucket=plutodemo key=Input}: mountpoint_s3_client::s3_crt_clie
 meta request failed duration=11.087781ms error=ClientError(Forbidden("<no message>"))
 ```
 
-You might need to have a fresh mount of your bucket with valid credentials.
+You might need to have a fresh mount of your bucket with valid credentials or increase your credential session duration if that suits your use case.
 For more details to configure AWS credentials, see the [configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#aws-credentials).
 
 ## Throttling Errors
 
-When looking at the logs, these will appear as failed requests with `http_status=503` or `http_status=429` .
+When looking at the logs, these errors will appear as failed requests with `http_status=503` or `http_status=429` . For example:
+
+```
+[WARN] lookup{req=20094 ino=109 name="***"}:
+list_objects{id=16589 bucket=*** continued=false delimiter=/ max_keys=1 prefix=***}: mountpoint_s3_client::s3_crt_client:
+request failed request_type=Default http_status=503 range=None duration=426.995805ms ttfb=Some(7.681499ms) request_id=***
+
+[WARN] open{req=20158 ino=1706 pid=1759}:
+list_objects{id=16643 bucket=*** continued=false delimiter=/ max_keys=1 prefix=***}: mountpoint_s3_client::s3_crt_client:
+request failed request_type=Default http_status=503 range=None duration=314.021865ms ttfb=Some(8.180981ms) request_id=***
+```
+
 The 503 or 429 status codes means the request limits have been exceeded.
 Mountpoint itself does not do any throttling, so any throttling will be from S3 or possibly dependent services, like STS which is used to provide credentials.
+
+You can try to mitigate  throttling (503 Slow Down) by distributing objects across multiple prefixes if your use case allows it.
+Since, you can send 3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per prefix in an S3 bucket, increasing the prefix in the bucket would allow more requests to be processed by S3.
+Amazon S3 gradually scales up to handle requests for each of the prefixes separately.


### PR DESCRIPTION
## Description of change
Updated troubleshooting documentation with 4 new cases. It includes the expected behaviour in case of all file deletion, credential expiry while bucket is still mounted, throttling error and invalid hostname for storage provider not supporting virtual style.
NOTE: I am not adding the the cases of invalid credentials at the time of mounting as the error message in those cases are super clear and user don't need to go to logs to understand the issue.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->
#722 

## Does this change impact existing behavior?
No. It is just documentation change.

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
