### PR TITLE
Add request ID to meta request failures and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
+ "mountpoint-s3-crt-sys",
  "once_cell",
  "percent-encoding",
  "pin-project",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -9,6 +9,7 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.5.3" }
 
 async-trait = "0.1.57"
 auto_impl = "1.1.2"

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -15,12 +15,21 @@ use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use std::ops::Range;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::{EnvFilter, Layer};
+
+pub mod tracing_test;
 
 /// Enable tracing and CRT logging when running unit tests.
 #[ctor::ctor]
 fn init_tracing_subscriber() {
     let _ = RustLogAdapter::try_init();
-    let _ = tracing_subscriber::fmt::try_init();
+
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
+        .with(self::tracing_test::TracingTestLayer::get());
+    let _ = subscriber.try_init();
 }
 
 pub enum AccessPointType {

--- a/mountpoint-s3-client/tests/common/tracing_test.rs
+++ b/mountpoint-s3-client/tests/common/tracing_test.rs
@@ -1,0 +1,84 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use once_cell::sync::Lazy;
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::field::VisitOutput;
+use tracing_subscriber::fmt::format::{DefaultVisitor, Writer};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+static TRACING_TEST_LAYER: Lazy<TracingTestLayer> = Lazy::new(TracingTestLayer::new);
+
+/// This is a singleton [tracing::Layer] that can be used to write tests for log events.
+///
+/// Use it like this:
+/// ```rust
+/// let _guard = TracingTestLayer::enable();
+/// // ... do work that emits tracing events ...
+/// drop(_guard);
+/// let events = TracingTestLayer::take_events();
+/// // events is a list of all events emitted
+/// ```
+///
+/// THIS IS NOT THREAD SAFE! tracing doesn't give us a good way to separate threads, as tracing
+/// subscribers are global state. You almost certainly want to use [rusty_fork] to write tests using
+/// this layer.
+#[derive(Debug, Default, Clone)]
+pub struct TracingTestLayer {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    events: Mutex<Vec<(Level, String)>>,
+    enabled: AtomicBool,
+}
+
+impl TracingTestLayer {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                events: Mutex::new(Vec::new()),
+                enabled: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Get a handle to the singleton layer
+    pub fn get() -> Self {
+        TRACING_TEST_LAYER.clone()
+    }
+
+    /// Start collecting tracing events, and stop collecting them when the returned guard drops.
+    #[must_use = "returns a guard that disables tracing when dropped"]
+    pub fn enable() -> TracingTestLayerEnableGuard {
+        TRACING_TEST_LAYER.inner.enabled.store(true, Ordering::SeqCst);
+        TracingTestLayerEnableGuard {}
+    }
+
+    /// Take all the collected events
+    pub fn take_events() -> Vec<(Level, String)> {
+        TRACING_TEST_LAYER.inner.events.lock().unwrap().drain(..).collect()
+    }
+}
+
+impl<S: Subscriber> Layer<S> for TracingTestLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if self.inner.enabled.load(Ordering::SeqCst) {
+            let mut msg = String::new();
+            let writer = Writer::new(&mut msg);
+            let visitor = DefaultVisitor::new(writer, true);
+            visitor.visit(event).unwrap();
+            self.inner.events.lock().unwrap().push((*event.metadata().level(), msg));
+        }
+    }
+}
+
+pub struct TracingTestLayerEnableGuard;
+
+impl Drop for TracingTestLayerEnableGuard {
+    fn drop(&mut self) {
+        TRACING_TEST_LAYER.inner.enabled.store(false, Ordering::SeqCst);
+    }
+}

--- a/mountpoint-s3-client/tests/metrics.rs
+++ b/mountpoint-s3-client/tests/metrics.rs
@@ -1,0 +1,281 @@
+#![cfg(feature = "s3_tests")]
+
+//! Tests for metrics emitted by the client.
+//!
+//! Metrics tests are a bit annoying because metrics are emitted by different threads, and so the
+//! [metrics] crate's thread-local recorders can't be used for testing. So our tests instead need to
+//! fork (with [rusty_fork] so they can install a global recorder without interfering with each
+//! other.
+
+pub mod common;
+
+use std::collections::HashMap;
+use std::option::Option::None;
+use std::sync::{Arc, Mutex};
+
+use aws_sdk_s3::primitives::ByteStream;
+use common::*;
+use futures::TryStreamExt;
+use metrics::{
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+};
+use mountpoint_s3_client::error::ObjectClientError;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
+use regex::Regex;
+use rusty_fork::rusty_fork_test;
+use tracing::Level;
+
+use crate::tracing_test::TracingTestLayer;
+
+/// A test metrics recorder that just remembers the current values of gauges and counters, and all
+/// inserted values for histograms.
+#[derive(Debug, Default, Clone)]
+struct TestRecorder {
+    metrics: Arc<Mutex<Metrics>>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Metrics {
+    metrics: HashMap<Key, Arc<Metric>>,
+}
+
+impl Metrics {
+    /// Retrieve a metric with the given name, and optionally matching the given label key and value
+    fn get(&self, name: &str, label_key: Option<&str>, label_value: Option<&str>) -> Option<(&Key, &Metric)> {
+        assert!(
+            label_key.is_none() || label_value.is_some(),
+            "can only filter values with keys"
+        );
+        self.metrics
+            .iter()
+            .find(move |(key, _)| {
+                let label_matches = key.labels().any(|label| {
+                    let key_matches = label_key.map(|k| label.key() == k).unwrap_or(true);
+                    let value_matches = label_value.map(|v| label.value() == v).unwrap_or(true);
+                    key_matches && value_matches
+                }) || label_key.is_none();
+                key.name() == name && label_matches
+            })
+            .map(|(key, metric)| (key, metric.as_ref()))
+    }
+}
+
+impl Recorder for TestRecorder {
+    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        let mut metrics = self.metrics.lock().unwrap();
+        let metric = metrics
+            .metrics
+            .entry(key.clone())
+            .or_insert(Arc::new(Metric::Counter(Default::default())));
+        Counter::from_arc(metric.clone())
+    }
+
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        let mut metrics = self.metrics.lock().unwrap();
+        let metric = metrics
+            .metrics
+            .entry(key.clone())
+            .or_insert(Arc::new(Metric::Gauge(Default::default())));
+        Gauge::from_arc(metric.clone())
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        let mut metrics = self.metrics.lock().unwrap();
+        let metric = metrics
+            .metrics
+            .entry(key.clone())
+            .or_insert(Arc::new(Metric::Histogram(Default::default())));
+        Histogram::from_arc(metric.clone())
+    }
+}
+
+#[derive(Debug)]
+enum Metric {
+    Histogram(Mutex<Vec<f64>>),
+    Counter(Mutex<u64>),
+    Gauge(Mutex<f64>),
+}
+
+impl CounterFn for Metric {
+    fn increment(&self, value: u64) {
+        let Metric::Counter(counter) = self else {
+            panic!("expected counter");
+        };
+        *counter.lock().unwrap() += value;
+    }
+
+    fn absolute(&self, value: u64) {
+        let Metric::Counter(counter) = self else {
+            panic!("expected counter");
+        };
+        *counter.lock().unwrap() = value;
+    }
+}
+
+impl GaugeFn for Metric {
+    fn increment(&self, value: f64) {
+        let Metric::Gauge(gauge) = self else {
+            panic!("expected gauge");
+        };
+        *gauge.lock().unwrap() += value;
+    }
+
+    fn decrement(&self, value: f64) {
+        let Metric::Gauge(gauge) = self else {
+            panic!("expected gauge");
+        };
+        *gauge.lock().unwrap() -= value;
+    }
+
+    fn set(&self, value: f64) {
+        let Metric::Gauge(gauge) = self else {
+            panic!("expected gauge");
+        };
+        *gauge.lock().unwrap() = value;
+    }
+}
+
+impl HistogramFn for Metric {
+    fn record(&self, value: f64) {
+        let Metric::Histogram(histogram) = self else {
+            panic!("expected histogram");
+        };
+        histogram.lock().unwrap().push(value);
+    }
+}
+
+/// Test basic metrics emitted by get_object
+async fn test_get_object_metrics() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_metrics");
+
+    let key = format!("{prefix}/test");
+    let body = vec![0x42; 100];
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let recorder = TestRecorder::default();
+    metrics::set_global_recorder(recorder.clone()).unwrap();
+
+    let client: S3CrtClient = get_test_client();
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    let result = result
+        .map_ok(|(_offset, bytes)| bytes.len())
+        .try_fold(0, |a, b| async move { Ok(a + b) })
+        .await
+        .expect("get_object should succeed");
+    assert_eq!(result, body.len());
+
+    let metrics = recorder.metrics.lock().unwrap().clone();
+
+    // Host count metric is emitted for a host that ends in amazonaws.com
+    let (key, host_count) = metrics
+        .get("s3.client.host_count", None, None)
+        .expect("host count metric should exist");
+    let host = key
+        .labels()
+        .find(|l| l.key() == "host")
+        .expect("host label should exist");
+    // TODO: this assertion won't work in other partitions
+    assert!(host.value().ends_with(".amazonaws.com"));
+    let Metric::Gauge(host_count) = host_count else {
+        panic!("expected gauge for host count metric");
+    };
+    assert!(*host_count.lock().unwrap() > 0.0);
+
+    // Latency metrics should exist for get_object
+    let (_, ttfb) = metrics
+        .get("s3.requests.first_byte_latency_us", Some("op"), Some("get_object"))
+        .expect("first byte latency should exist");
+    let Metric::Histogram(ttfb) = ttfb else {
+        panic!("expected histogram for first byte latency");
+    };
+    assert!(ttfb.lock().unwrap().len() > 0);
+    let (_, total) = metrics
+        .get("s3.requests.total_latency_us", Some("op"), Some("get_object"))
+        .expect("total latency should exist");
+    let Metric::Histogram(total) = total else {
+        panic!("expected histogram for total latency");
+    };
+    assert!(total.lock().unwrap().len() > 0);
+}
+
+rusty_fork_test! {
+    #[test]
+    fn get_object_metrics() {
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_get_object_metrics());
+    }
+}
+
+/// Test metrics and log messages for a head object that gets a 403 error
+async fn test_head_object_403() {
+    let bucket = get_test_bucket_without_permissions();
+
+    let recorder = TestRecorder::default();
+    metrics::set_global_recorder(recorder.clone()).unwrap();
+    let _guard = TracingTestLayer::enable();
+
+    let client: S3CrtClient = get_test_client();
+    let err = client
+        .head_object(&bucket, "some-key")
+        .await
+        .expect_err("head to no-permissions bucket should fail");
+    assert!(matches!(
+        err,
+        ObjectClientError::ClientError(S3RequestError::Forbidden(_))
+    ));
+
+    drop(_guard);
+    let metrics = recorder.metrics.lock().unwrap().clone();
+
+    // WARN-level message with the failure and the request ID is emitted
+    let events = TracingTestLayer::take_events();
+    // Rather than hard-coding a request ID format, just look for anything that seems long enough
+    // and doesn't contain `<` (which we use for "unknown")
+    let request_id = Regex::new(r"request_id=[^\s<]{10}").unwrap();
+    events
+        .iter()
+        .find(|(level, message)| {
+            // Higher levels are higher verbosity, so ERROR is the lowest level
+            *level <= Level::WARN && message.contains("meta request failed") && request_id.is_match(message)
+        })
+        .expect("request ID message not found");
+
+    // Failures metric is incremented
+    let (status_code_key, failures) = metrics
+        .get("s3.meta_requests.failures", Some("op"), Some("head_object"))
+        .expect("failures metric should exist");
+    let status_code_label = status_code_key
+        .labels()
+        .find(|l| l.key() == "status")
+        .expect("status code should exist");
+    assert_eq!(status_code_label.value(), "403");
+    let Metric::Counter(failures) = failures else {
+        panic!("expected counter for failures metric");
+    };
+    assert!(*failures.lock().unwrap() > 0);
+}
+
+rusty_fork_test! {
+    #[test]
+    fn head_object_403() {
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_head_object_403());
+    }
+}


### PR DESCRIPTION
## Description of change

A side effect of https://github.com/awslabs/mountpoint-s3/pull/669 was that there's now no way to get request IDs for failed requests at the default logging settings, as only DEBUG-level messages include the request IDs. This change adds request IDs to the meta request failure message when available, so that these WARN-level messages still include request IDs.

I also added some new infrastructure to test metrics and log messages. For metrics, we build a new `metrics::Recorder` that collects all the metrics and can then be searched to find them. For log messages, we build a `tracing_subscriber::Layer` that collects all tracing events emitted while enabled. In both cases, the new objects aren't thread safe, as both `Recorder`s and `Layer`s are global state. So these tests need to continue to use `rusty_fork` to split into a new process per test.

Relevant issues: followup to #781.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
