### PR TITLE
Cancel S3 requests when dropped 

### DIFF
--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -194,6 +194,7 @@ async fn test_get_object_cancel(read: bool) {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
-    // Explicitly cancel the request.
+    // Explicitly cancel the request. We don't have a good way to test that any inflight requests
+    // were actually cancelled, but we can at least check that the drop doesn't panic/deadlock.
     drop(request);
 }

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -748,6 +748,11 @@ impl MetaRequestResult {
         self.crt_error.is_err()
     }
 
+    /// Return whether this request was canceled according to its error code.
+    pub fn is_canceled(&self) -> bool {
+        self.crt_error.raw_error() == mountpoint_s3_crt_sys::aws_s3_errors::AWS_ERROR_S3_CANCELED as i32
+    }
+
     /// Convert the CRT's meta request result struct into a safe, owned result.
     /// SAFETY: This copies from the raw pointer inside of the request result, so only call on
     /// results given to us from the CRT.
@@ -1027,6 +1032,11 @@ impl RequestMetrics {
                 .ok()?;
         };
         Some(Duration::from_nanos(receive_start.saturating_sub(send_end)))
+    }
+
+    /// Return whether the request was canceled according to its error code
+    pub fn is_canceled(&self) -> bool {
+        self.error().raw_error() == mountpoint_s3_crt_sys::aws_s3_errors::AWS_ERROR_S3_CANCELED as i32
     }
 }
 


### PR DESCRIPTION
## Description of change

Today we don't cancel S3 requests when dropped. For our prefetcher that
means we keep streaming (up to) 2GB of data that will never be used.
This change cancels in-flight requests when dropped, so that the CRT
will stop streaming them. Some bytes might still be in flight or
delivered, which is fine. Canceling requests is a no-op if they've
already completed.

The tricky case for this change is PutObject. Our current implementation
of `PutObjectRequest::write` blocks until the bytes it provides are
consumed by the client. But sometimes the client might stop reading from
the stream because the request has failed. That case happens to work
today because we don't retain a reference to the meta request ourselves,
and so the failed request's destructors run immediately after the
failure, which unblocks the writer and returns it an error. But now we do
hold onto a reference, and the destructors can't run until the last
reference is released, so the writer is never unblocked. To fix this, we
make the `write` and `complete` methods of the `PutObjectRequest` poll
_both_ the write stream and the request itself in parallel. If the request
completes, this gives us a chance to bail out of the write rather than
blocking forever.

Relevant issues: fixes #510.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
