### PR TITLE
Add fio job to benchmark read-skip-read pattern

### DIFF
--- a/mountpoint-s3/scripts/fio/read/seq_read_skip_17m.fio
+++ b/mountpoint-s3/scripts/fio/read/seq_read_skip_17m.fio
@@ -5,10 +5,9 @@ runtime=30s
 time_based
 group_reporting
 
-[seq_read_skip_read]
-size=2G
+[seq_read_skip_17m]
+size=100G
 rw=read:17m
 ioengine=sync
 fallocate=none
-#TODO:
-#startdelay=30s
+startdelay=30s

--- a/mountpoint-s3/scripts/fio/read/seq_read_skip_read.fio
+++ b/mountpoint-s3/scripts/fio/read/seq_read_skip_read.fio
@@ -1,0 +1,14 @@
+[global]
+name=fs_bench
+bs=256m
+runtime=30s
+time_based
+group_reporting
+
+[seq_read_skip_read]
+size=2G
+rw=read:17m
+ioengine=sync
+fallocate=none
+#TODO:
+#startdelay=30s

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -73,11 +73,11 @@ run_fio_job() {
   echo "done"
 
   # combine the results and find an average value
-  # TODO: requires testing
-  jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw | startswith("read"))
+  jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw == "read")
       then $job.read.bw / 1024
       elif ($job."job options".rw == "randread") then $job.read.bw / 1024
       elif ($job."job options".rw == "randwrite") then $job.write.bw / 1024
+      elif ($job."job options".rw | startswith("read")) then $job.read.bw / 1024
       else $job.write.bw / 1024 end)) | {name: .name, value: (.value / .len), unit: "MiB/s"}' ${results_dir}/${job_name}_iter*.json | tee ${results_dir}/${job_name}_parsed.json
 }
 

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -73,7 +73,8 @@ run_fio_job() {
   echo "done"
 
   # combine the results and find an average value
-  jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw == "read")
+  # TODO: requires testing
+  jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw | startswith("read"))
       then $job.read.bw / 1024
       elif ($job."job options".rw == "randread") then $job.read.bw / 1024
       elif ($job."job options".rw == "randwrite") then $job.write.bw / 1024


### PR DESCRIPTION
## Description of change

This is a supporting PR for the performance improvement: https://github.com/awslabs/mountpoint-s3/pull/797
Read-skip-read pattern is different to any of the benchmarked ones. Also it seems to be versatile enough to be tracked on our graphs.

Relevant issues: No

### Testing

Ran `mountpoint-s3/scripts/fs_bench.sh` (slightly patched) locally which produced a `results/output.json` file with:
```
[
  {
    "name": "sequential_read",
    "value": 8.0244140625,
    "unit": "MiB/s"
  },
  {
    "name": "seq_read_skip_17m",
    "value": 9.4453125,
    "unit": "MiB/s"
  }
]
```

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
