### PR TITLE
Remove crate check workflow for non -sys crates

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -16,8 +16,6 @@ jobs:
     strategy:
       matrix:
         crate:
-          - mountpoint-s3-client
-          - mountpoint-s3-crt
           - mountpoint-s3-crt-sys
 
     steps:


### PR DESCRIPTION
## Description of change

This workflow exists because we're worried about the 10MiB limit. The
    sys crate is the only one that's in any danger of hitting that limit
    because it's packaging a ton of C code, including an entire TLS
    implementation. This workflow is also broken (#700) when updating crate
    versions for multiple crates at the same time, which we really want to
    do.

Since we only care about the size of the sys crate, let's only check
    that one.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
