### PR TITLE
Serialization benchmarks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49f6183038e081170ebbbadee6678966c7d54728938a3e7de7f4e780770318f"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,11 +1945,13 @@ dependencies = [
  "aws-sdk-sts",
  "base16ct",
  "bincode",
+ "bincode2",
  "built",
  "bytes",
  "clap",
  "const_format",
  "crc32c",
+ "criterion",
  "ctor",
  "ctrlc",
  "dashmap",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -16,6 +16,7 @@ async-channel = "2.1.1"
 async-lock = "3.3.0"
 async-trait = "0.1.57"
 bincode = "1.3.3"
+bincode2 = "2.0.1"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
 const_format = "0.2.30"
@@ -54,6 +55,7 @@ aws-config = "1.1.4"
 aws-sdk-s3 = "1.14.0"
 aws-sdk-sts = "1.12.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
+criterion = "0.5"
 ctor = "0.2.6"
 filetime = "0.2.21"
 futures = { version = "*", features = ["thread-pool"] }
@@ -92,3 +94,10 @@ path = "src/main.rs"
 name = "mock-mount-s3"
 path = "src/bin/mock-mount-s3.rs"
 required-features = ["mountpoint-s3-client/mock"]
+
+[[bench]]
+name = "cache_serialization"
+harness = false
+
+[profile.bench]
+debug = true

--- a/mountpoint-s3/benches/cache_serialization.rs
+++ b/mountpoint-s3/benches/cache_serialization.rs
@@ -1,0 +1,121 @@
+use std::{fs, io::Write, path::PathBuf, sync::Arc};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use mountpoint_s3::data_cache::{
+    Bincode2DiskBlockFileReader, Bincode2DiskBlockFileWriter, ChecksummedBytes, DataCache, DiskDataCache,
+    DiskDataCacheConfig, ObjectId,
+};
+use mountpoint_s3_client::types::ETag;
+use rand::Rng;
+const BLOCK_SIZE: u64 = 1024 * 1024;
+
+#[inline]
+fn read_cache_bincode() {
+    let config = DiskDataCacheConfig {
+        block_size: BLOCK_SIZE,
+        limit: mountpoint_s3::data_cache::CacheLimit::Unbounded,
+        ..Default::default()
+    };
+    let cache_directory = PathBuf::from("/tmp/mp-cache1/");
+    let cache = DiskDataCache::new(cache_directory, config);
+    let cache_key = ObjectId::new("a".into(), ETag::for_tests());
+    let _data = cache
+        .get_block(&cache_key, 0, 0)
+        .expect("is able to read")
+        .expect("data is there");
+}
+
+#[inline]
+fn read_cache_bincode2() {
+    let config = DiskDataCacheConfig {
+        block_size: BLOCK_SIZE,
+        limit: mountpoint_s3::data_cache::CacheLimit::Unbounded,
+        reader: Arc::new(Bincode2DiskBlockFileReader {}),
+        writer: Arc::new(Bincode2DiskBlockFileWriter {}),
+    };
+    let cache_directory = PathBuf::from("/tmp/mp-cache2/");
+    let cache = DiskDataCache::new(cache_directory, config);
+    let cache_key = ObjectId::new("a".into(), ETag::for_tests());
+    let _data = cache
+        .get_block(&cache_key, 0, 0)
+        .expect("is able to read")
+        .expect("data is there");
+}
+
+#[inline]
+fn read_file() {
+    let _read = fs::read("/tmp/mp-file/file").expect("is able to read file");
+}
+
+fn random_bytes(length: usize) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    let random_bytes: Vec<u8> = (0..length).map(|_| rng.gen()).collect();
+    random_bytes
+}
+
+fn write_file(data: &Vec<u8>) {
+    fs::create_dir("/tmp/mp-file").expect("is able to create temp dir");
+    let file_path = "/tmp/mp-file/file";
+    let mut file = fs::File::create(file_path).expect("is able to create file");
+    file.write_all(data.as_slice()).expect("is able to write file");
+}
+
+fn write_cache_bincode(data: &Vec<u8>) {
+    let config = DiskDataCacheConfig {
+        block_size: BLOCK_SIZE,
+        limit: mountpoint_s3::data_cache::CacheLimit::Unbounded,
+        ..Default::default()
+    };
+    fs::create_dir("/tmp/mp-cache1").expect("is able to create dir 1");
+    let cache_dir = PathBuf::from("/tmp/mp-cache1/");
+    let cache = DiskDataCache::new(cache_dir, config);
+    let cache_key = ObjectId::new("a".into(), ETag::for_tests());
+    let data = ChecksummedBytes::new(data.clone().into());
+    cache
+        .put_block(cache_key.clone(), 0, 0, data)
+        .expect("is able to write to cache");
+}
+
+fn write_cache_bincode2(data: &Vec<u8>) {
+    let config = DiskDataCacheConfig {
+        block_size: BLOCK_SIZE,
+        limit: mountpoint_s3::data_cache::CacheLimit::Unbounded,
+        reader: Arc::new(Bincode2DiskBlockFileReader {}),
+        writer: Arc::new(Bincode2DiskBlockFileWriter {}),
+    };
+    fs::create_dir("/tmp/mp-cache2").expect("is able to create dir 1");
+    let cache_dir = PathBuf::from("/tmp/mp-cache2/");
+    let cache = DiskDataCache::new(cache_dir, config);
+    let cache_key = ObjectId::new("a".into(), ETag::for_tests());
+    let data = ChecksummedBytes::new(data.clone().into());
+    cache
+        .put_block(cache_key.clone(), 0, 0, data)
+        .expect("is able to write to cache");
+}
+
+fn cleanup() {
+    let _ = fs::remove_dir_all("/tmp/mp-file");
+    let _ = fs::remove_dir_all("/tmp/mp-cache1");
+    let _ = fs::remove_dir_all("/tmp/mp-cache2");
+}
+
+fn setup() {
+    let data = random_bytes(BLOCK_SIZE.try_into().unwrap());
+    write_file(&data);
+    write_cache_bincode(&data);
+    write_cache_bincode2(&data);
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    setup();
+
+    c.bench_function("read_cache_bincode", |b| b.iter(|| read_cache_bincode()));
+    c.bench_function("read_cache_bincode2", |b| b.iter(|| read_cache_bincode2()));
+    c.bench_function("read_file", |b| b.iter(|| read_file()));
+
+    cleanup();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -668,7 +668,7 @@ where
                 filesystem_config,
                 fuse_config,
                 &bucket_description,
-            )?;
+             )?;
 
             fuse_session.run_on_close(Box::new(move || {
                 drop(managed_cache_dir);

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -6,16 +6,20 @@
 
 mod cache_directory;
 mod disk_data_cache;
+mod disk_data_cache_io;
 mod in_memory_data_cache;
 
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
-pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
+pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskBlock, DiskDataCache, DiskDataCacheConfig};
+pub use crate::data_cache::disk_data_cache_io::{
+    Bincode2DiskBlockFileReader, Bincode2DiskBlockFileWriter, BincodeDiskBlockFileReader, BincodeDiskBlockFileWriter,
+    DiskDataReader, DiskDataWriter,
+};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
-
-use crate::object::ObjectId;
+pub use crate::object::ObjectId;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;

--- a/mountpoint-s3/src/data_cache/disk_data_cache_io.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache_io.rs
@@ -1,0 +1,76 @@
+use crate::data_cache::disk_data_cache::DiskBlock;
+use crate::data_cache::DataCacheError;
+use std::fs;
+use std::io::Seek;
+use tracing::warn;
+
+pub trait DiskDataWriter: std::fmt::Debug {
+    fn write_to_file(&self, file: &fs::File, disk_block: &DiskBlock) -> Result<usize, DataCacheError>;
+}
+
+pub trait DiskDataReader: std::fmt::Debug {
+    fn read_from_file(&self, file: &fs::File) -> Result<DiskBlock, DataCacheError>;
+}
+
+#[derive(Debug)]
+pub struct BincodeDiskBlockFileWriter {}
+
+impl DiskDataWriter for BincodeDiskBlockFileWriter {
+    fn write_to_file(&self, mut file: &fs::File, disk_block: &DiskBlock) -> Result<usize, DataCacheError> {
+        let serialize_result = bincode::serialize_into(file, disk_block);
+        if let Err(err) = serialize_result {
+            return match *err {
+                bincode::ErrorKind::Io(io_err) => return Err(DataCacheError::from(io_err)),
+                _ => Err(DataCacheError::InvalidBlockContent),
+            };
+        };
+        Ok(file.stream_position()? as usize)
+    }
+}
+
+#[derive(Debug)]
+pub struct BincodeDiskBlockFileReader {}
+
+impl DiskDataReader for BincodeDiskBlockFileReader {
+    fn read_from_file(&self, file: &fs::File) -> Result<DiskBlock, DataCacheError> {
+        let block: DiskBlock = match bincode::deserialize_from(file) {
+            Ok(block) => block,
+            Err(e) => {
+                warn!("block could not be deserialized: {:?}", e);
+                return Err(DataCacheError::InvalidBlockContent);
+            }
+        };
+        Ok(block)
+    }
+}
+#[derive(Debug)]
+pub struct Bincode2DiskBlockFileWriter {}
+
+impl DiskDataWriter for Bincode2DiskBlockFileWriter {
+    fn write_to_file(&self, mut file: &fs::File, disk_block: &DiskBlock) -> Result<usize, DataCacheError> {
+        let serialize_result = bincode2::serialize_into(file, disk_block);
+        if let Err(err) = serialize_result {
+            return match *err {
+                bincode2::ErrorKind::Io(io_err) => return Err(DataCacheError::from(io_err)),
+                _ => Err(DataCacheError::InvalidBlockContent),
+            };
+        };
+        Ok(file.stream_position()? as usize)
+    }
+}
+
+#[derive(Debug)]
+pub struct Bincode2DiskBlockFileReader {}
+
+impl DiskDataReader for Bincode2DiskBlockFileReader {
+    fn read_from_file(&self, file: &fs::File) -> Result<DiskBlock, DataCacheError> {
+        let block: DiskBlock = match bincode2::deserialize_from(file) {
+            Ok(block) => block,
+            Err(e) => {
+                warn!("block could not be deserialized: {:?}", e);
+                return Err(DataCacheError::InvalidBlockContent);
+            }
+        };
+        Ok(block)
+    }
+}


### PR DESCRIPTION
## Description of change

1. Using Criterion benchmarks, I want to show how we see a performance gain (~33% faster) by switching from `bincode` to `bincode2` when reading the cached blocks from disk.
2. I want to get feedback on changes made to `DiskDataCache` to abstract out the serialization library. For example, am I doing the right abstraction? Am I using the trait boundaries in the right way? So, mostly on the Rust-side of things.

### Benchmarks results
In summary, using `bincode2` gets a better performance than `bincode` and closer to the base line of reading the contents of a file to memory (`read_file` in the graphs). From flamegraphs, we noticed that `bincode` was zeroing the vectors in its `fill_buffer` [implementation](https://github.com/bincode-org/bincode/blob/v1.3.3/src/de/read.rs#L143-L149). `bincode2` has a separate [implementation](https://github.com/pravega/bincode2/blob/171ea73400c98e82c3315b91154bde61243b1530/src/de/read.rs#L138-L165) which is more efficient.

#### Reading a file (base line)

<img width="977" alt="Screenshot 2024-03-10 at 10 19 56 AM" src="https://github.com/awslabs/mountpoint-s3/assets/341088/fa98772c-c732-460f-a57a-b494a8ba38eb">

#### Reading cache through bincode

<img width="967" alt="Screenshot 2024-03-10 at 10 20 10 AM" src="https://github.com/awslabs/mountpoint-s3/assets/341088/d645bcb0-102c-42d6-9e96-9b8bacb72273">


#### Reading cache through bincode2

<img width="957" alt="Screenshot 2024-03-10 at 10 20 23 AM" src="https://github.com/awslabs/mountpoint-s3/assets/341088/a437cb7e-5c5a-4163-8b99-eeae677edd5b">


Relevant issues: N/A

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
