### PR TITLE
Return error from `Uploader::put` on checksum mismatch

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -481,6 +481,12 @@ impl ServerSideEncryption {
         }
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn corrupt_data(&mut self, sse_type: Option<String>, sse_kms_key_id: Option<String>) {
+        self.sse_type = sse_type;
+        self.sse_kms_key_id = sse_kms_key_id;
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Description of change

This changes the way MP treats SSE settings checksum mismatch in case when it occurred **before** the start of the request. Previously MP paniced, the new behaviour is to return an error. 

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/534

## Does this change impact existing behavior?

No, SSE-KMS is behind a feature flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
