### PR TITLE
Workflow updates for AL2023

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -143,7 +143,7 @@ jobs:
       run: cargo build --release
     - name: Run Benchmark
       env:
-        S3_MOUNT_LOCAL_STORAGE: ${{ vars.MOUNT_LOCAL_STORAGE || 'yes' }}
+        S3_MOUNT_LOCAL_STORAGE: yes
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,10 +47,7 @@ jobs:
         libunwind: true
         fio: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
@@ -95,10 +92,7 @@ jobs:
         libunwind: true
         fio: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
@@ -144,10 +138,7 @@ jobs:
         libunwind: true
         fio: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --release
     - name: Run Benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true
@@ -99,13 +99,13 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true
@@ -170,13 +170,13 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,32 +51,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_bench.sh
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR benchmarks'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -121,32 +99,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_latency_bench.sh
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR benchmarks'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,9 @@ on:
     inputs:
       environment:
         type: string
+      publish:
+        type: boolean
+        default: false
       ref:
         required: true
         type: string
@@ -62,7 +65,7 @@ jobs:
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Store the results and deploy GitHub pages automatically if the results are from main branch
-        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
   
@@ -108,7 +111,7 @@ jobs:
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Store the results and deploy GitHub pages automatically if the results are from main branch
-        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
 
@@ -156,6 +159,6 @@ jobs:
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Store the results and deploy GitHub pages automatically if the results are from main branch
-        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20

--- a/.github/workflows/bench_main.yml
+++ b/.github/workflows/bench_main.yml
@@ -14,8 +14,10 @@ jobs:
     uses: ./.github/workflows/bench.yml
     with:
       ref: ${{ github.event.after }}
+      publish: ${{ github.event.ref == 'refs/heads/main' }}
   s3express-integration:
     name: Benchmarks (s3express)
     uses: ./.github/workflows/bench_s3express.yml
     with:
       ref: ${{ github.event.after }}
+      publish: ${{ github.event.ref == 'refs/heads/main' }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -7,6 +7,9 @@ on:
     inputs:
       environment:
         type: string
+      publish:
+        type: boolean
+        default: false
       ref:
         required: true
         type: string
@@ -63,7 +66,7 @@ jobs:
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Store the results and deploy GitHub pages automatically if the results are from main branch
-        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
   
@@ -109,6 +112,6 @@ jobs:
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Store the results and deploy GitHub pages automatically if the results are from main branch
-        auto-push: ${{ inputs.environment && 'false' || 'true' }}
+        auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -51,32 +51,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_bench.sh
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR benchmarks'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -122,32 +100,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_latency_bench.sh
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR benchmarks'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true
@@ -100,13 +100,13 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -47,10 +47,7 @@ jobs:
         libunwind: true
         fio: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
@@ -96,10 +93,7 @@ jobs:
         libunwind: true
         fio: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --release
     - name: Run Benchmark

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -24,10 +24,7 @@ jobs:
         with:
           submodules: true
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Package ${{ matrix.crate }} crate
         # `--no-verify` avoids building using crates.io dependencies, which for local packages may not be updated yet
         run: cargo package -p ${{ matrix.crate }} --no-verify

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up stable Rust

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,12 +61,12 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true
@@ -131,12 +131,12 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true
@@ -187,12 +187,12 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
         aws-region: ${{ vars.S3_REGION }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         submodules: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -129,11 +129,11 @@ jobs:
 
   asan:
     name: Address sanitizer
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, arm64]
 
     environment: ${{ inputs.environment }}
 
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
     - name: Configure AWS credentials

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,10 +72,7 @@ jobs:
         submodules: true
         persist-credentials: false
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -120,10 +117,7 @@ jobs:
         submodules: true
         persist-credentials: false
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -153,10 +147,8 @@ jobs:
         ref: ${{ inputs.ref }}
         submodules: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rust-src
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,17 +76,6 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-fuse${{ matrix.fuseVersion }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -95,17 +84,6 @@ jobs:
       run: cargo test --features $RUST_FEATURES --no-run
     - name: Run tests
       run: cargo test --features $RUST_FEATURES
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR integration tests'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
 
   s3express-test:
     name: S3 Express One Zone tests (${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
@@ -146,17 +124,6 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-fuse${{ matrix.fuseVersion }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -165,17 +132,6 @@ jobs:
       run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests' --no-run
     - name: Run tests
       run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR integration tests'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
 
   asan:
     name: Address sanitizer
@@ -202,17 +158,6 @@ jobs:
         toolchain: stable
         override: true
         components: rust-src
-    - name: Restore Cargo cache
-      id: restore-cargo-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ github.job }}-integration-asan-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -222,14 +167,3 @@ jobs:
       run: make test-asan-working
     - name: Run tests
       run: make test-asan
-    - name: Save Cargo cache
-      uses: actions/cache/save@v3
-      if: inputs.environment != 'PR integration tests'
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install operating system dependencies
@@ -31,7 +31,7 @@ jobs:
         with:
           fuseVersion: 2
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           tags: mountpoint-builder
           context: ./package
@@ -42,7 +42,7 @@ jobs:
       - name: Check release binary
         run: mkdir ./pkg-out && tar -xzf ./out/mount-s3*.tar.gz -C ./pkg-out && ./pkg-out/bin/mount-s3 --version
       - name: Upload unofficial packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.runner.name }}
           path:  ./out/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   create-github-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: taiki-e/create-gh-release-action@v1
       with:
         title: "mountpoint-s3 v$version"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,7 @@ jobs:
       with:
         fuseVersion: ${{ matrix.fuseVersion }}
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Cargo cache
       uses: actions/cache@v3
       with:
@@ -68,10 +65,7 @@ jobs:
       run: |
         brew install --cask macfuse
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Cargo cache
       uses: actions/cache@v3
       with:
@@ -101,10 +95,7 @@ jobs:
       with:
         fuseVersion: 2
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Cargo cache
       uses: actions/cache@v3
       with:
@@ -132,10 +123,7 @@ jobs:
       with:
         fuseVersion: 2
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Cargo cache
       uses: actions/cache@v3
       with:
@@ -159,10 +147,7 @@ jobs:
       with:
         submodules: true
     - name: Set up stable Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Install operating system dependencies
       uses: ./.github/actions/install-dependencies
       with:
@@ -188,10 +173,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt
       - name: Check format
         run: make fmt-check
@@ -210,10 +193,8 @@ jobs:
         with:
           fuseVersion: 2
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: clippy
       - name: Cargo cache
         uses: actions/cache@v3
@@ -238,10 +219,9 @@ jobs:
         with:
           submodules: true
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
+          components: rust-docs
       - name: Cargo cache
         uses: actions/cache@v3
         with:
@@ -263,9 +243,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install operating system dependencies
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install operating system dependencies
@@ -124,7 +124,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install operating system dependencies
@@ -155,7 +155,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up stable Rust
@@ -186,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up stable Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -202,7 +202,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install operating system dependencies
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up stable Rust
@@ -261,7 +261,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up stable Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-asan-working:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
 	RUSTFLAGS="-Zsanitizer=address" \
 	RUSTC_BOOTSTRAP=1 \
-	cargo test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- --ignored test_asan_working 2>&1 \
+	cargo test -Z build-std --target `rustc -vV | grep 'host:' | cut -f2 -d' '` --features $(RUST_FEATURES) $$packages -- --ignored test_asan_working 2>&1 \
 	| tee /dev/stderr \
 	| grep "heap-use-after-free" \
 	  && echo "ASan is working" || (echo "ASan did not find the use-after-free; something's wrong"; exit 1)
@@ -39,7 +39,7 @@ test-asan:
 	LSAN_OPTIONS=suppressions="$$(pwd)/lsan-suppressions.txt" \
 	RUSTFLAGS="-Zsanitizer=address" \
 	RUSTC_BOOTSTRAP=1 \
-	cargo test -Z build-std --target x86_64-unknown-linux-gnu --features $(RUST_FEATURES) $$packages -- \
+	cargo test -Z build-std --target `rustc -vV | grep 'host:' | cut -f2 -d' '` --features $(RUST_FEATURES) $$packages -- \
 	--skip reftest_ \
 	--skip proptest_ \
 	--skip fork_test \


### PR DESCRIPTION
## Description of change

Now that our CI runners are on AL2023 we can make some updates we've been putting off for a while. These are six separate commits to make the review easier.

1. Update workflow versions to the latest ones (#512, #521, #522, #681).
2. Remove Cargo caching — we have too many build variants in CI at this point, and the cache is limited to 10GB per repo, so in practice it never/rarely hits before evicting random variants.
3. Replace the deprecated [actions-rs/toolchain](https://github.com/actions-rs/toolchain) with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) for installing Rust.
4. Fix a small syntax thing (undefined variable) in the cache workflow
5. Run ASan on self-hosted ARM runners instead of GitHub-hosted ones. ASan is the long pole in our current CI performance, and these runners should significantly speed it up.
6. Don't publish benchmark results from branches other than main (they're currently being published on any commit to `wf-changes/*`).

Relevant issues: fixes #708.

## Does this change impact existing behavior?

No, this only affects CI.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
