### PR TITLE
Expose memory consumption metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1968,6 +1968,7 @@ dependencies = [
  "sha2",
  "shuttle",
  "supports-color",
+ "sysinfo",
  "syslog",
  "tempfile",
  "test-case",
@@ -2094,6 +2095,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3091,6 +3101,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "syslog"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,11 +3638,30 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
- "windows-core",
+ "windows-core 0.54.0",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
  "windows-targets 0.52.4",
 ]
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -23,7 +23,7 @@ use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 use mountpoint_s3_crt::io::host_resolver::{AddressKinds, HostResolver, HostResolverDefaultOptions};
 use mountpoint_s3_crt::io::retry_strategy::{ExponentialBackoffJitterMode, RetryStrategy, StandardRetryOptions};
 use mountpoint_s3_crt::s3::client::{
-    init_signing_config, BufferPoolUsageStats, ChecksumConfig, Client, ClientConfig, MetaRequest, MetaRequestOptions, MetaRequestResult,
+    init_signing_config, ChecksumConfig, Client, ClientConfig, MetaRequest, MetaRequestOptions, MetaRequestResult,
     MetaRequestType, RequestType,
 };
 
@@ -664,14 +664,14 @@ impl S3CrtClientInner {
 
         // Buffer pool metrics
         let buffer_pool_stats = s3_client.poll_buffer_pool_usage_stats();
-        metrics::gauge!("s3.buffer_pool.mem_limit").set(buffer_pool_stats.mem_limit as f64);
-        metrics::gauge!("s3.buffer_pool.primary_cutoff").set(buffer_pool_stats.primary_cutoff as f64);
-        metrics::gauge!("s3.buffer_pool.primary_used").set(buffer_pool_stats.primary_used as f64);
-        metrics::gauge!("s3.buffer_pool.primary_allocated").set(buffer_pool_stats.primary_allocated as f64);
-        metrics::gauge!("s3.buffer_pool.primary_reserved").set(buffer_pool_stats.primary_reserved as f64);
-        metrics::gauge!("s3.buffer_pool.primary_num_blocks").set(buffer_pool_stats.primary_num_blocks as f64);
-        metrics::gauge!("s3.buffer_pool.secondary_reserved").set(buffer_pool_stats.secondary_reserved as f64);
-        metrics::gauge!("s3.buffer_pool.secondary_used").set(buffer_pool_stats.secondary_used as f64);
+        metrics::gauge!("s3.client.buffer_pool.mem_limit").set(buffer_pool_stats.mem_limit as f64);
+        metrics::gauge!("s3.client.buffer_pool.primary_cutoff").set(buffer_pool_stats.primary_cutoff as f64);
+        metrics::gauge!("s3.client.buffer_pool.primary_used").set(buffer_pool_stats.primary_used as f64);
+        metrics::gauge!("s3.client.buffer_pool.primary_allocated").set(buffer_pool_stats.primary_allocated as f64);
+        metrics::gauge!("s3.client.buffer_pool.primary_reserved").set(buffer_pool_stats.primary_reserved as f64);
+        metrics::gauge!("s3.client.buffer_pool.primary_num_blocks").set(buffer_pool_stats.primary_num_blocks as f64);
+        metrics::gauge!("s3.client.buffer_pool.secondary_reserved").set(buffer_pool_stats.secondary_reserved as f64);
+        metrics::gauge!("s3.client.buffer_pool.secondary_used").set(buffer_pool_stats.secondary_used as f64);
     }
 
     fn next_request_counter(&self) -> u64 {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -23,7 +23,7 @@ use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 use mountpoint_s3_crt::io::host_resolver::{AddressKinds, HostResolver, HostResolverDefaultOptions};
 use mountpoint_s3_crt::io::retry_strategy::{ExponentialBackoffJitterMode, RetryStrategy, StandardRetryOptions};
 use mountpoint_s3_crt::s3::client::{
-    init_signing_config, ChecksumConfig, Client, ClientConfig, MetaRequest, MetaRequestOptions, MetaRequestResult,
+    init_signing_config, BufferPoolUsageStats, ChecksumConfig, Client, ClientConfig, MetaRequest, MetaRequestOptions, MetaRequestResult,
     MetaRequestType, RequestType,
 };
 
@@ -661,6 +661,17 @@ impl S3CrtClientInner {
             .set(metrics.num_requests_stream_queued_waiting as f64);
         metrics::gauge!("s3.client.num_requests_streaming_response")
             .set(metrics.num_requests_streaming_response as f64);
+
+        // Buffer pool metrics
+        let buffer_pool_stats = s3_client.poll_buffer_pool_usage_stats();
+        metrics::gauge!("s3.buffer_pool.mem_limit").set(buffer_pool_stats.mem_limit as f64);
+        metrics::gauge!("s3.buffer_pool.primary_cutoff").set(buffer_pool_stats.primary_cutoff as f64);
+        metrics::gauge!("s3.buffer_pool.primary_used").set(buffer_pool_stats.primary_used as f64);
+        metrics::gauge!("s3.buffer_pool.primary_allocated").set(buffer_pool_stats.primary_allocated as f64);
+        metrics::gauge!("s3.buffer_pool.primary_reserved").set(buffer_pool_stats.primary_reserved as f64);
+        metrics::gauge!("s3.buffer_pool.primary_num_blocks").set(buffer_pool_stats.primary_num_blocks as f64);
+        metrics::gauge!("s3.buffer_pool.secondary_reserved").set(buffer_pool_stats.secondary_reserved as f64);
+        metrics::gauge!("s3.buffer_pool.secondary_used").set(buffer_pool_stats.secondary_used as f64);
     }
 
     fn next_request_counter(&self) -> u64 {

--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -58,6 +58,7 @@ const CRT_HEADERS: &[&str] = &[
 const PRIVATE_CRT_HEADERS: &[&str] = &[
     // To access S3 client stats
     "aws-c-s3/include/aws/s3/private/s3_client_impl.h",
+    "aws-c-s3/include/aws/s3/private/s3_buffer_pool.h",
 ];
 
 /// Get the OS name we are compiling to

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -604,6 +604,35 @@ impl ClientMetrics {
     }
 }
 
+/// Stats
+#[derive(Debug)]
+pub struct BufferPoolUsageStats {
+    /// Effective Max memory limit. Memory limit value provided during construction minus
+    /// buffer reserved for overhead of the pool
+    pub mem_limit: u64,
+
+    /// Max size of buffer to be allocated from primary.
+    pub primary_cutoff: u64,
+
+    /// Used memory in primary storage.
+    pub primary_used: u64,
+
+    /// Overall memory allocated for blocks.
+    pub primary_allocated: u64,
+
+    /// Reserved memory for primary storage.
+    pub primary_reserved: u64,
+
+    /// Number of blocks allocated in primary.
+    pub primary_num_blocks: u64,
+
+    /// Secondary mem used. Accurate, maps directly to base allocator.
+    pub secondary_reserved: u64,
+
+    /// Secondary mem reserved. Accurate, maps directly to base allocator.
+    pub secondary_used: u64,    
+}
+
 impl Client {
     /// Create a new S3 [Client].
     pub fn new(allocator: &Allocator, config: ClientConfig) -> Result<Self, Error> {
@@ -694,6 +723,36 @@ impl Client {
                 num_requests_stream_queued_waiting,
                 num_requests_streaming_response,
             }
+        }
+    }
+
+    /// Poll [BufferPoolUsageStats] from underlying CRT client.
+    pub fn poll_buffer_pool_usage_stats(&self) -> BufferPoolUsageStats {
+        // SAFETY: The `aws_s3_client` in `self.inner` is guaranteed to be initialized and
+        // dereferencable as long as Client lives.
+        let inner_stats = unsafe {
+            let client = self.inner.as_ref();
+            aws_s3_buffer_pool_get_usage(client.buffer_pool)
+        };
+
+        let mem_limit = inner_stats.mem_limit as u64;
+        let primary_cutoff = inner_stats.primary_cutoff as u64;
+        let primary_used = inner_stats.primary_used as u64;
+        let primary_allocated = inner_stats.primary_allocated as u64;
+        let primary_reserved = inner_stats.primary_reserved as u64;
+        let primary_num_blocks = inner_stats.primary_num_blocks as u64;
+        let secondary_reserved = inner_stats.secondary_reserved as u64;
+        let secondary_used = inner_stats.secondary_used as u64;
+
+        BufferPoolUsageStats { 
+            mem_limit,
+            primary_cutoff,
+            primary_used,
+            primary_allocated,
+            primary_reserved,
+            primary_num_blocks,
+            secondary_reserved,
+            secondary_used,
         }
     }
 

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -604,7 +604,7 @@ impl ClientMetrics {
     }
 }
 
-/// Stats
+/// S3 buffer pool usage stats
 #[derive(Debug)]
 pub struct BufferPoolUsageStats {
     /// Effective Max memory limit. Memory limit value provided during construction minus
@@ -614,7 +614,8 @@ pub struct BufferPoolUsageStats {
     /// Max size of buffer to be allocated from primary.
     pub primary_cutoff: u64,
 
-    /// Used memory in primary storage.
+    /// Primary mem used, including memory used by blocks
+    /// that are waiting on all allocs to release before being put back in circulation.
     pub primary_used: u64,
 
     /// Overall memory allocated for blocks.
@@ -630,7 +631,7 @@ pub struct BufferPoolUsageStats {
     pub secondary_reserved: u64,
 
     /// Secondary mem reserved. Accurate, maps directly to base allocator.
-    pub secondary_used: u64,    
+    pub secondary_used: u64,
 }
 
 impl Client {
@@ -744,7 +745,7 @@ impl Client {
         let secondary_reserved = inner_stats.secondary_reserved as u64;
         let secondary_used = inner_stats.secondary_used as u64;
 
-        BufferPoolUsageStats { 
+        BufferPoolUsageStats {
             mem_limit,
             primary_cutoff,
             primary_used,

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -41,6 +41,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+sysinfo = "0.30.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -124,13 +124,9 @@ impl<E: std::error::Error> Drop for PartQueue<E> {
         // close the channel and drain remaining parts
         self.receiver.close();
         let mut queue_size = 0;
-        loop {
-            if let Ok(part) = self.receiver.try_recv() {
-                if let Ok(part) = part {
-                    queue_size += part.len();
-                }
-            } else {
-                break;
+        while let Ok(part) = self.receiver.try_recv() {
+            if let Ok(part) = part {
+                queue_size += part.len();
             }
         }
         let remaining = current_size + queue_size;

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -85,13 +85,12 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
         };
         debug_assert!(!part.is_empty(), "parts must not be empty");
 
-        if length >= part.len() {
-            Ok(part)
-        } else {
+        if length < part.len() {
             let tail = part.split_off(length);
             *current_part = Some(tail);
-            Ok(part)
         }
+        metrics::gauge!("prefetch.bytes_in_queue").decrement(part.len() as f64);
+        Ok(part)
     }
 
     pub fn bytes_received(&self) -> usize {
@@ -102,14 +101,40 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
 impl<E: std::error::Error + Send + Sync> PartQueueProducer<E> {
     /// Push a new [Part] onto the back of the queue
     pub fn push(&self, part: Result<Part, PrefetchReadError<E>>) {
-        if let Ok(ref part) = part {
-            self.bytes_sent.fetch_add(part.len(), Ordering::SeqCst);
-        }
+        let part_len = part.as_ref().map_or(0, |part| part.len());
+
         // Unbounded channel will never actually block
         let send_result = self.sender.send_blocking(part);
         if send_result.is_err() {
             trace!("closed channel");
+        } else {
+            self.bytes_sent.fetch_add(part_len, Ordering::SeqCst);
+            metrics::gauge!("prefetch.bytes_in_queue").increment(part_len as f64);
         }
+    }
+}
+
+impl<E: std::error::Error> Drop for PartQueue<E> {
+    fn drop(&mut self) {
+        let current_part = self.current_part.lock_blocking();
+        let current_size = match current_part.as_ref() {
+            Some(part) => part.len(),
+            None => 0,
+        };
+        // close the channel and drain remaining parts
+        self.receiver.close();
+        let mut queue_size = 0;
+        loop {
+            if let Ok(part) = self.receiver.try_recv() {
+                if let Ok(part) = part {
+                    queue_size += part.len();
+                }
+            } else {
+                break;
+            }
+        }
+        let remaining = current_size + queue_size;
+        metrics::gauge!("prefetch.bytes_in_queue").decrement(remaining as f64);
     }
 }
 


### PR DESCRIPTION
## Description of change

Collect and expose some memory consumption metrics for the prefetcher, CRT buffer pool, and total usage.

## Does this change impact existing behavior?

No, only metrics

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
