### PR TITLE
Add `s3.client.total_bytes` metric

### DIFF
--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -195,6 +195,7 @@ where
             match get_object_result.next().await {
                 Some(Ok((offset, body))) => {
                     trace!(offset, length = body.len(), "received GetObject part");
+                    metrics::counter!("s3.client.total_bytes", "type" => "read").increment(body.len() as u64);
 
                     let expected_offset = block_offset + buffer.len() as u64;
                     if offset != expected_offset {

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -207,6 +207,7 @@ where
                     match get_object_result.next().await {
                         Some(Ok((offset, body))) => {
                             trace!(offset, length = body.len(), "received GetObject part");
+                            metrics::counter!("s3.client.total_bytes", "type" => "read").increment(body.len() as u64);
                             // pre-split the body into multiple parts as suggested by preferred part size
                             // in order to avoid validating checksum on large parts at read.
                             let mut body: Bytes = body.into();


### PR DESCRIPTION
## Description of change

Add a `s3.client.total_bytes` metric counting total bytes received from CRT per 5 sec periods:
- It follows the same idea as the existing `fuse.total_bytes` and makes it possible to reason about how much data was downloaded vs how much was consumed;
- It differs from `s3.meta_requests.throughput_mibs`, which:
  - Is only emitted at the end of the request;
  - Is emitted **per-request** thus not providing data about total bandwidth.

Relevant issues: None

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
