### PR TITLE
Adding support for rewinddir by restarting readdir if offset is zero.

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -203,7 +203,7 @@ the following behavior:
 
 ### Directory operations
 
-Basic read-only directory operations (`opendir`, `readdir`, `closedir`) are supported. However, seeking (`lseek`) on directory handles is not supported.
+Basic read-only directory operations (`opendir`, `readdir`, `closedir`, `rewinddir`) are supported. However, seeking (`lseek`) on directory handles is not supported.
 
 Sorting order of `readdir` results:
 * For general purpose buckets, `readdir` returns results in lexicographical order.

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -50,6 +50,10 @@ impl DirHandle {
     fn next_offset(&self) {
         self.offset.fetch_add(1, Ordering::SeqCst);
     }
+
+    fn rewind_offset(&self) {
+        self.offset.store(0, Ordering::SeqCst);
+    }
 }
 
 #[derive(Debug)]
@@ -995,7 +999,7 @@ where
         // special case where we need to rewind and restart the streaming
         if offset == 0 && dir_handle.offset() != 0 {
             // only do this if this is not the first call with offset 0
-            dir_handle.offset.store(0, Ordering::SeqCst);
+            dir_handle.rewind_offset();
             let new_handle = self.superblock.readdir(&self.client, parent, 1000).await?;
             *dir_handle.handle.lock().await = new_handle;
         }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1004,7 +1004,7 @@ where
         if offset == 0 && dir_handle.offset() != 0 {
             // only do this if this is not the first call with offset 0
             dir_handle.rewind_offset();
-            let new_handle = self.default_handle( parent).await?;
+            let new_handle = self.default_handle(parent).await?;
             *dir_handle.handle.lock().await = new_handle;
         }
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -939,10 +939,14 @@ where
         Ok(len)
     }
 
+    async fn default_handle(&self, parent: InodeNo) -> Result<ReaddirHandle, InodeError> {
+        self.superblock.readdir(&self.client, parent, 1000).await
+    }
+
     pub async fn opendir(&self, parent: InodeNo, _flags: i32) -> Result<Opened, Error> {
         trace!("fs:opendir with parent {:?} flags {:#b}", parent, _flags);
 
-        let inode_handle = self.superblock.readdir(&self.client, parent, 1000).await?;
+        let inode_handle = self.default_handle(parent).await?;
 
         let fh = self.next_handle();
         let handle = DirHandle {
@@ -1000,7 +1004,7 @@ where
         if offset == 0 && dir_handle.offset() != 0 {
             // only do this if this is not the first call with offset 0
             dir_handle.rewind_offset();
-            let new_handle = self.superblock.readdir(&self.client, parent, 1000).await?;
+            let new_handle = self.default_handle( parent).await?;
             *dir_handle.handle.lock().await = new_handle;
         }
 

--- a/mountpoint-s3/src/inode/readdir.rs
+++ b/mountpoint-s3/src/inode/readdir.rs
@@ -186,6 +186,11 @@ impl ReaddirHandle {
         self.inner.update_from_remote(self.dir_ino, entry.name(), remote_lookup)
     }
 
+    pub async fn rewind(&self) {
+        self.readded.lock().unwrap().take();
+        self.iter.lock().await.rewind();
+    }
+
     #[cfg(test)]
     pub(super) async fn collect<OC: ObjectClient>(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
         let mut result = vec![];
@@ -290,6 +295,13 @@ impl ReaddirIter {
         Self::Unordered(unordered::ReaddirIter::new(bucket, full_path, page_size, local_entries))
     }
 
+    fn rewind(&mut self) {
+        match self {
+            Self::Ordered(iter) => iter.rewind(),
+            Self::Unordered(iter) => iter.rewind()
+        }
+    }
+
     async fn next(&mut self, client: &impl ObjectClient) -> Result<Option<ReaddirEntry>, InodeError> {
         match self {
             Self::Ordered(iter) => iter.next(client).await,
@@ -391,6 +403,11 @@ impl RemoteIter {
 
         Ok(self.entries.pop_front())
     }
+
+    fn rewind(&mut self) {
+        self.state = RemoteIterState::InProgress(None);
+        self.entries.clear();
+    }
 }
 
 /// Iterator implementation for S3 implementations that provide lexicographically ordered LIST.
@@ -423,6 +440,14 @@ mod ordered {
                 next_local: None,
                 last_entry: None,
             }
+        }
+
+        pub fn rewind(&mut self) {
+            self.next_remote = None;
+            self.next_local = None;
+            self.last_entry = None;
+            self.remote.rewind();
+            self.local.rewind();
         }
 
         /// Return the next [ReaddirEntry] for the directory stream. If the stream is finished, returns
@@ -491,6 +516,10 @@ mod ordered {
         fn next(&mut self) -> Option<ReaddirEntry> {
             self.entries.pop_front()
         }
+
+        fn rewind(&mut self) {
+            self.entries.clear();
+        }
     }
 }
 
@@ -548,6 +577,12 @@ mod unordered {
             }
 
             Ok(self.local_iter.pop_front())
+        }
+
+        pub fn rewind(&mut self) {
+            self.remote.rewind();
+            self.local.clear();
+            self.local_iter.clear();
         }
     }
 }

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -1,6 +1,5 @@
 //! Manually implemented tests executing the FUSE protocol against [S3Filesystem]
 
-use assert_cmd::assert;
 use fuser::FileType;
 use libc::S_IFREG;
 use mountpoint_s3::fs::{CacheConfig, S3Personality, ToErrno, FUSE_ROOT_INODE};
@@ -1404,10 +1403,10 @@ async fn test_readdir_rewind_with_new_files(s3_fs_config: S3FilesystemConfig) {
 
     // Let's add a new local file
     let file_name = "newfile.bin";
-    new_local_file(&fs, &file_name).await;
+    new_local_file(&fs, file_name).await;
 
     // Let's add a new remote file
-    client.add_object(&format!("foo10"), b"foo".into());
+    client.add_object("foo10", b"foo".into());
 
     // Requesting same offset (non zero) works fine by returning last response
     let _ = ls(&fs, dir_handle, 0, 5).await;
@@ -1441,7 +1440,7 @@ async fn test_readdir_rewind_with_local_files_only() {
 
     // Let's add a new local file
     let file_name = "newfile.bin";
-    new_local_file(&fs, &file_name).await;
+    new_local_file(&fs, file_name).await;
 
     // Requesting same offset (non zero) works fine by returning last response
     let _ = ls(&fs, dir_handle, 0, 5).await;

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -2,7 +2,7 @@
 
 use fuser::FileType;
 use libc::S_IFREG;
-use mountpoint_s3::fs::{CacheConfig, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{CacheConfig, S3Personality, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::failure_client::countdown_failure_client;
@@ -21,7 +21,7 @@ use std::time::{Duration, SystemTime};
 use test_case::test_case;
 
 mod common;
-use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply};
+use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply, TestS3Filesystem};
 
 #[test_case(""; "unprefixed")]
 #[test_case("test_prefix/"; "prefixed")]
@@ -1276,7 +1276,7 @@ async fn test_flexible_retrieval_objects() {
 }
 
 #[tokio::test]
-async fn test_readdir_rewind() {
+async fn test_readdir_rewind_ordered() {
     let (client, fs) = make_test_filesystem("test_readdir_rewind", &Default::default(), Default::default());
 
     for i in 0..10 {
@@ -1304,45 +1304,34 @@ async fn test_readdir_rewind() {
         .expect_err("out of order");
 
     // Requesting the same buffer size should work fine
-    let mut new_reply = DirectoryReply::new(5);
-    let _ = fs
-        .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut new_reply)
-        .await
-        .unwrap();
-    let new_entries = new_reply
-        .entries
-        .iter()
-        .map(|e| (e.ino, e.name.clone()))
-        .collect::<Vec<_>>();
+    let new_entries = ls(&fs, dir_handle, 0, 5).await;
     assert_eq!(entries, new_entries);
 
     // Requesting a smaller buffer works fine and returns a prefix
-    let mut new_reply = DirectoryReply::new(3);
-    let _ = fs
-        .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut new_reply)
-        .await
-        .unwrap();
-    let new_entries = new_reply
-        .entries
-        .iter()
-        .map(|e| (e.ino, e.name.clone()))
-        .collect::<Vec<_>>();
+    let new_entries = ls(&fs, dir_handle, 0, 3).await;
     assert_eq!(&entries[..3], new_entries);
 
-    // Requesting a larger buffer works fine, but only partially fills (which is allowed)
-    let mut new_reply = DirectoryReply::new(10);
-    let _ = fs
-        .readdirplus(FUSE_ROOT_INODE, dir_handle, 0, &mut new_reply)
-        .await
-        .unwrap();
-    let new_entries = new_reply
-        .entries
-        .iter()
-        .map(|e| (e.ino, e.name.clone()))
-        .collect::<Vec<_>>();
-    assert_eq!(entries, new_entries);
+    // Requesting same offset (non zero) works fine by returning last response
+    let _ = ls(&fs, dir_handle, 0, 5).await;
+    let new_entries = ls(&fs, dir_handle, 5, 5).await;
+    let new_entries_repeat = ls(&fs, dir_handle, 5, 5).await;
+    assert_eq!(new_entries, new_entries_repeat);
+
+    // Request all entries
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 12); // 10 files + 2 dirs (. and ..) = 12 entries
+
+    // Request more entries but there is no more
+    let new_entries = ls(&fs, dir_handle, 12, 20).await;
+    assert_eq!(new_entries.len(), 0);
+
+    // Request everything from zero one more time
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 12); // 10 files + 2 dirs (. and ..) = 12 entries
 
     // And we can resume the stream from the end of the first request
+    // but let's rewind first
+    let _ = ls(&fs, dir_handle, 0, 5).await;
     let mut next_page = DirectoryReply::new(0);
     let _ = fs
         .readdirplus(
@@ -1353,6 +1342,7 @@ async fn test_readdir_rewind() {
         )
         .await
         .unwrap();
+
     assert_eq!(next_page.entries.len(), 7); // 10 directory entries + . + .. = 12, minus the 5 we already saw
     assert_eq!(next_page.entries.front().unwrap().name, "foo3");
 
@@ -1364,4 +1354,109 @@ async fn test_readdir_rewind() {
             fs.forget(entry.ino, 2).await;
         }
     }
+}
+
+#[tokio::test]
+async fn test_readdir_rewind_unordered() {
+    let config = S3FilesystemConfig {
+        s3_personality: S3Personality::ExpressOneZone,
+        ..Default::default()
+    };
+    let (client, fs) = make_test_filesystem("test_readdir_rewind", &Default::default(), config);
+
+    for i in 0..10 {
+        client.add_object(&format!("foo{i}"), b"foo".into());
+    }
+
+    let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
+
+    // Requesting same offset (non zero) works fine by returning last response
+    let _ = ls(&fs, dir_handle, 0, 5).await;
+    let new_entries = ls(&fs, dir_handle, 5, 5).await;
+    let new_entries_repeat = ls(&fs, dir_handle, 5, 5).await;
+    assert_eq!(new_entries, new_entries_repeat);
+
+    // Request all entries
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 12); // 10 files + 2 dirs (. and ..) = 12 entries
+
+    // Request more entries but there is no more
+    let new_entries = ls(&fs, dir_handle, 12, 20).await;
+    assert_eq!(new_entries.len(), 0);
+
+    // Request everything from zero one more time
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 12); // 10 files + 2 dirs (. and ..) = 12 entries
+}
+
+#[test_case(Default::default())]
+#[test_case(S3FilesystemConfig {s3_personality: S3Personality::ExpressOneZone, ..Default::default()})]
+#[tokio::test]
+async fn test_readdir_rewind_with_new_files(s3_fs_config: S3FilesystemConfig) {
+    let (client, fs) = make_test_filesystem("test_readdir_rewind", &Default::default(), s3_fs_config);
+
+    for i in 0..10 {
+        client.add_object(&format!("foo{i}"), b"foo".into());
+    }
+
+    let dir_handle = fs.opendir(FUSE_ROOT_INODE, 0).await.unwrap().fh;
+
+    // Let's add a new local file
+    let mode = libc::S_IFREG | libc::S_IRWXU; // regular file + 0700 permissions
+    let dentry = fs
+        .mknod(FUSE_ROOT_INODE, "newfile.bin".as_ref(), mode, 0, 0)
+        .await
+        .unwrap();
+    assert_eq!(dentry.attr.size, 0);
+    let file_ino = dentry.attr.ino;
+
+    let fh = fs
+        .open(file_ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
+        .await
+        .unwrap()
+        .fh;
+
+    let slice = &[0xaa; 27];
+    let written = fs.write(file_ino, fh, 0, slice, 0, 0, None).await.unwrap();
+    assert_eq!(written as usize, slice.len());
+    fs.fsync(file_ino, fh, true).await.unwrap();
+
+    // Let's add a new remote file
+    client.add_object(&format!("foo10"), b"foo".into());
+
+    // Requesting same offset (non zero) works fine by returning last response
+    let _ = ls(&fs, dir_handle, 0, 5).await;
+    let new_entries = ls(&fs, dir_handle, 5, 5).await;
+    let new_entries_repeat = ls(&fs, dir_handle, 5, 5).await;
+    assert_eq!(new_entries, new_entries_repeat);
+
+    // Request all entries
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 14); // 10 original remote files + 1 new local file + 1 new remote file + 2 dirs (. and ..) = 13 entries
+
+    // Request more entries but there is no more
+    let new_entries = ls(&fs, dir_handle, 14, 20).await;
+    assert_eq!(new_entries.len(), 0);
+
+    // Request everything from zero one more time
+    let new_entries = ls(&fs, dir_handle, 0, 20).await;
+    assert_eq!(new_entries.len(), 14); // 10 original remote files + 1 new local file + 1 new remote file + 2 dirs (. and ..) = 13 entries
+}
+
+async fn ls(
+    fs: &TestS3Filesystem<Arc<MockClient>>,
+    dir_handle: u64,
+    offset: i64,
+    max_entries: usize,
+) -> Vec<(u64, OsString)> {
+    let mut reply = DirectoryReply::new(max_entries);
+    let _ = fs
+        .readdirplus(FUSE_ROOT_INODE, dir_handle, offset, &mut reply)
+        .await
+        .unwrap();
+    reply
+        .entries
+        .iter()
+        .map(|e| (e.ino, e.name.clone()))
+        .collect::<Vec<_>>()
 }


### PR DESCRIPTION
## Description of change

If we get a `readdir` call with offset 0, we restart the directory stream. In https://github.com/awslabs/mountpoint-s3/pull/581, we added support for consecutive calls with same offset by storing the last response. However, we're not using that feature when offset is 0 because we want any files that were added or removed between the `opendir` and the `rewinddir` to reflect in subsequent calls to `readdir`.

If all the use cases for which https://github.com/awslabs/mountpoint-s3/pull/581 was added are for offset 0, we could remove it. However, since https://github.com/awslabs/mountpoint-s3/pull/581 allows repeated offsets other than 0, it could break code that is relying on this behavior.

It is worth calling out that we cannot distinguish from a `rewinddir` or `seekdir`. We know that `rewinddir` will always call with offset 0, while `seekdir` could be with any offset. Regardless, `seekdir` is still not supported.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/819

## Does this change impact existing behavior?

The behavior of `readdir` is changing: now, calling it with an offset of 0 will restart the directory stream, ensuring that new or removed files are accurately reflected. Previously, it was possible to miss new files or still observe removed files if `readdir` returned the last response due to consecutive calls with the same offset.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
