### PR TITLE
Add AES256 SSE type

### DIFF
--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -404,6 +404,7 @@ async fn check_sse(
         .expect("head object should succeed");
     let (expected_sse, expected_sdk_sse) = match expected_sse {
         None => (Some("AES256"), aws_sdk_s3::types::ServerSideEncryption::Aes256),
+        Some("AES256") => (Some("AES256"), aws_sdk_s3::types::ServerSideEncryption::Aes256),
         Some("aws:kms") => (Some("aws:kms"), aws_sdk_s3::types::ServerSideEncryption::AwsKms),
         Some("aws:kms:dsse") => (
             Some("aws:kms:dsse"),
@@ -450,6 +451,7 @@ async fn check_sse(
 #[test_case(Some("aws:kms:dsse"), Some(get_test_kms_key_id()))]
 #[test_case(Some("aws:kms:dsse"), None)]
 #[test_case(None, None)]
+#[test_case(Some("AES256"), None)]
 #[tokio::test]
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -389,10 +389,6 @@ where
     Runtime: Spawn + Send + Sync + 'static,
 {
     let args = CliArgs::parse();
-    #[cfg(feature = "sse_kms")]
-    {
-        validate_sse_args(&args.sse, &args.sse_kms_key_id)?;
-    }
     let successful_mount_msg = format!(
         "{} is mounted at {}",
         args.bucket_description(),
@@ -610,6 +606,10 @@ where
     tracing::debug!("{:?}", args);
 
     validate_mount_point(&args.mount_point)?;
+    #[cfg(feature = "sse_kms")]
+    {
+        validate_sse_args(&args.sse, &args.sse_kms_key_id)?;
+    }
 
     let (client, runtime, s3_personality) = client_builder(&args)?;
 

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -268,3 +268,18 @@ fn sse_args_non_empty() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(feature = "sse_kms")]
+#[test]
+fn sse_key_not_allowed_with_aes256() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = assert_fs::TempDir::new()?;
+    let mut cmd = Command::cargo_bin("mount-s3")?;
+    cmd.arg("test-bucket")
+        .arg(dir.path())
+        .arg("--sse=AES256")
+        .arg("--sse-kms-key-id=some_key");
+    let error_message = "--sse_kms_key_id can not be used with AES256 sse_type";
+    cmd.assert().failure().stderr(predicate::str::contains(error_message));
+
+    Ok(())
+}

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -278,7 +278,7 @@ fn sse_key_not_allowed_with_aes256() -> Result<(), Box<dyn std::error::Error>> {
         .arg(dir.path())
         .arg("--sse=AES256")
         .arg("--sse-kms-key-id=some_key");
-    let error_message = "--sse_kms_key_id can not be used with AES256 sse_type";
+    let error_message = "--sse-kms-key-id can not be used with --sse AES256";
     cmd.assert().failure().stderr(predicate::str::contains(error_message));
 
     Ok(())


### PR DESCRIPTION
## Description of change

Add support for SSE-S3 (`sse_type` flag still follows the convention of `aws s3 cp` and `aws s3api putobject`) 

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/807

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
