### PR TITLE
Increase default max retries and expose environment variable to override

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -168,6 +168,8 @@ If the bucket you are mounting is a [Requester Pays bucket](https://docs.aws.ama
 
 If you want to verify that the S3 bucket you are mounting is [owned by the expected AWS account](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html), use the `--expected-bucket-owner` command-line argument. For example, if you expect the bucket to be owned by the AWS account `111122223333`, specify the argument `--expected-bucket-owner 111122223333`. If the argument doesn't match the bucket owner's account ID, mounting will fail with an Access Denied error.
 
+There are certain situations where Mountpoint receives a response from Amazon S3 indicating that a retry is necessary. For example, if an application generates high request rates (typically sustained rates of over 5,000 requests per second to a small number of objects), Mountpoint might receive HTTP 503 slowdown responses from S3. Mountpoint automatically retries these requests up to a total of 10 attempts, using jittered exponential backoff between attempts. If these attempts are exhausted, Mountpoint will return an error to your application (usually `EIO`). If you need to modify the maximum number of attempts, set the `AWS_MAX_ATTEMPTS` environment variable.
+
 ## File system configuration
 
 Mountpoint automatically configures reasonable defaults for file system settings such as permissions and for performance. You can adjust these settings if you need finer control over how the Mountpoint file system behaves.

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -200,4 +200,6 @@ Amazon S3 automatically scales to high request rates.
 Your application can achieve at least 3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per partitioned Amazon S3 prefix.
 You can reduce the impact of throttling errors by distributing objects across multiple prefixes in your bucket.
 
-For more details on optimizing Amazon S3 performance and avoid throttling errors, see the [S3 best practices documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html).
+By default, Mountpoint retries throttled requests up to a total to 10 attempts. You can increase this default by setting the `AWS_MAX_ATTEMPTS` environment variable.
+
+For more details on optimizing Amazon S3 performance and avoiding throttling errors, see the [S3 best practices documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html).

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Breaking changes
+
+* No breaking changes.
+
+### Other changes
+
+* The maximum number of attempts for S3 requests can now be configured with the `S3ClientConfig::max_attempts` method or the `AWS_MAX_ATTEMPTS` environment variable. ([#830](https://github.com/awslabs/mountpoint-s3/pull/830))
+
 ## v0.8.0 (March 8, 2024)
 
 ### Breaking changes

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -261,7 +261,7 @@ impl S3CrtClientInner {
             let max_attempts = std::env::var("AWS_MAX_ATTEMPTS")
                 .ok()
                 .and_then(|s| s.parse::<usize>().ok())
-                .or(config.max_attempts.map(|m| m.get()))
+                .or_else(|| config.max_attempts.map(|m| m.get()))
                 .unwrap_or(3);
             // Max *attempts* includes the initial attempt, the CRT's max *retries* does not, so
             // decrement by one

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1,5 +1,6 @@
 use std::ffi::{OsStr, OsString};
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::ops::Range;
 use std::os::unix::prelude::OsStrExt;
@@ -88,6 +89,7 @@ pub struct S3ClientConfig {
     user_agent: Option<UserAgent>,
     request_payer: Option<String>,
     bucket_owner: Option<String>,
+    max_attempts: Option<NonZeroUsize>,
 }
 
 impl Default for S3ClientConfig {
@@ -100,6 +102,7 @@ impl Default for S3ClientConfig {
             user_agent: None,
             request_payer: None,
             bucket_owner: None,
+            max_attempts: None,
         }
     }
 }
@@ -155,6 +158,14 @@ impl S3ClientConfig {
     #[must_use = "S3ClientConfig follows a builder pattern"]
     pub fn bucket_owner(mut self, bucket_owner: &str) -> Self {
         self.bucket_owner = Some(bucket_owner.to_owned());
+        self
+    }
+
+    /// Set a maximum number of attempts for S3 requests. Will be overridden by the
+    /// `AWS_MAX_ATTEMPTS` environment variable if set.
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn max_attempts(mut self, max_attempts: NonZeroUsize) -> Self {
+        self.max_attempts = Some(max_attempts);
         self
     }
 }
@@ -245,12 +256,20 @@ impl S3CrtClientInner {
 
         let mut client_config = ClientConfig::new();
 
-        let mut retry_strategy_options = StandardRetryOptions::default(&mut event_loop_group);
-        // Match the SDK "legacy" retry strategies
-        retry_strategy_options.backoff_retry_options.max_retries = 3;
-        retry_strategy_options.backoff_retry_options.backoff_scale_factor = Duration::from_millis(500);
-        retry_strategy_options.backoff_retry_options.jitter_mode = ExponentialBackoffJitterMode::Full;
-        let retry_strategy = RetryStrategy::standard(&allocator, &retry_strategy_options).unwrap();
+        let retry_strategy = {
+            let mut retry_strategy_options = StandardRetryOptions::default(&mut event_loop_group);
+            let max_attempts = std::env::var("AWS_MAX_ATTEMPTS")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .or(config.max_attempts.map(|m| m.get()))
+                .unwrap_or(3);
+            // Max *attempts* includes the initial attempt, the CRT's max *retries* does not, so
+            // decrement by one
+            retry_strategy_options.backoff_retry_options.max_retries = max_attempts.saturating_sub(1);
+            retry_strategy_options.backoff_retry_options.backoff_scale_factor = Duration::from_millis(500);
+            retry_strategy_options.backoff_retry_options.jitter_mode = ExponentialBackoffJitterMode::Full;
+            RetryStrategy::standard(&allocator, &retry_strategy_options).unwrap()
+        };
 
         trace!("constructing client with auth config {:?}", config.auth_config);
         let credentials_provider = match config.auth_config {

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other changes
+
+* Mountpoint now retries S3 requests up to a total of 10 attempts (up from 4), which should make file operations more robust to transient failures or throttling. The maximum number of attempts can be overridden by setting the `AWS_MAX_ATTEMPTS` environment variable. ([#830](https://github.com/awslabs/mountpoint-s3/pull/830))
+
 ## v1.5.0 (March 7, 2024)
 
 ### New features


### PR DESCRIPTION
## Description of change

We were using the SDK's default retry configuration (actually, slightly wrong -- it's supposed to be 3 total attempts, but we configured 3 *retries*, so 4 attempts). This isn't a good default for file systems, as it works out to only retrying for about 2 seconds before giving up, and applications are rarely equipped to gracefully handle transient file IO errors.

This change increases the default to 10 total attempts, which takes about a minute on average. This is in the same ballpark as NFS's defaults (3 attempts, 60 seconds linear backoff), though still a little more aggressive. There's probably scope to go even further (20?), but this is a reasonable step for now.

To allow customers to further tweak this, the S3CrtClient (and therefore Mountpoint) now respects the `AWS_MAX_ATTEMPTS` environment variable, and its value overrides the defaults. This is only a partial solution, as SDKs are supposed to also respect the `max_attempts` config file setting, but we don't have any of the infrastructure for that today (similar issue as #389).

We don't really have any way to test retries at the moment. It would be neat to have a mock S3 server we could control to test them, like [the CRT does](https://github.com/awslabs/aws-c-s3/tree/main/tests/mock_s3_server). But that's for another day.

Relevant issues: fixes #829, closes #743.

## Does this change impact existing behavior?

Yes, Mountpoint now retries failing requests more, which can manifest as higher latency for file operations that previously would have failed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
