### PR TITLE
Update h2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
Address vulnerability found by `cargo deny`:

```
    = ID: RUSTSEC-2024-0332
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0332
    = An attacker can send a flood of CONTINUATION frames, causing `h2` to process them indefinitely.
      This results in an increase in CPU usage.

      Tokio task budget helps prevent this from a complete denial-of-service, as the server can still
      respond to legitimate requests, albeit with increased latency.

      More details at "https://seanmonstar.com/blog/hyper-http2-continuation-flood/.

      Patches available for 0.4.x and 0.3.x versions.
    = Solution: Upgrade to ^0.3.26 OR >=0.4.4 (try `cargo update -p h2`)
    = h2 v0.3.24
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
