### PR TITLE
Publish new crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-io",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bindgen",
  "cc",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.8.1 (April 10, 2024)
 
 ### Breaking changes
 
@@ -7,6 +7,10 @@
 ### Other changes
 
 * The maximum number of attempts for S3 requests can now be configured with the `S3ClientConfig::max_attempts` method or the `AWS_MAX_ATTEMPTS` environment variable. ([#830](https://github.com/awslabs/mountpoint-s3/pull/830))
+* Return server-side encryption headers in `PutObjectResult`. ([#745](https://github.com/awslabs/mountpoint-s3/pull/745))
+* Add support for AES256 server-side encryption (SSE-S3). ([#827](https://github.com/awslabs/mountpoint-s3/pull/827))
+* Expose memory consumption metrics for the CRT buffer pool (`s3.client.buffer_pool.*`). ([#820](https://github.com/awslabs/mountpoint-s3/pull/820))
+* Adopt new async write API for PutObject requests ([#832](https://github.com/awslabs/mountpoint-s3/pull/832))
 
 ## v0.8.0 (March 8, 2024)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.3" }
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.3" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.7.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.7.0" }
 
 async-trait = "0.1.57"
 auto_impl = "1.1.2"

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.2" }
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.2" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.3" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.3" }
 
 async-trait = "0.1.57"
 auto_impl = "1.1.2"

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.6.3 (April 10, 2024)
+## v0.7.0 (April 10, 2024)
 
 * Update to latest CRT dependencies
 

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.3 (April 10, 2024)
+
+* Update to latest CRT dependencies
+
 ## v0.6.2 (March 7, 2024)
 
 * Incremented version number to be in lockstep with the `mountpoint-s3-crt` crate.

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.6.3 (April 10, 2024)
+
+* Update to latest CRT dependencies
+* Adopt new async write API for PutObject requests ([#832](https://github.com/awslabs/mountpoint-s3/pull/832))
+
 ## v0.6.2 (March 7, 2024)
 
 * Update to latest CRT dependencies

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.6.3 (April 10, 2024)
+## v0.7.0 (April 10, 2024)
 
 * Update to latest CRT dependencies
 * Adopt new async write API for PutObject requests ([#832](https://github.com/awslabs/mountpoint-s3/pull/832))

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.3" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.7.0" }
 
 async-channel = "2.1.1"
 futures = "0.3.24"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.2" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.6.3" }
 
 async-channel = "2.1.1"
 futures = "0.3.24"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "mount-s3"
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.8.1" }
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.3" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.7.0" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "2.1.1"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,8 +8,8 @@ default-run = "mount-s3"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.8.0" }
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.2" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.8.1" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.6.3" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "2.1.1"


### PR DESCRIPTION
## Description of change

Include the latest CRT release and the following changes:

* The maximum number of attempts for S3 requests can now be configured with the `S3ClientConfig::max_attempts` method or the `AWS_MAX_ATTEMPTS` environment variable. ([#830](https://github.com/awslabs/mountpoint-s3/pull/830))
* Return server-side encryption headers in `PutObjectResult`. ([#745](https://github.com/awslabs/mountpoint-s3/pull/745))
* Add support for AES256 server-side encryption (SSE-S3). ([#827](https://github.com/awslabs/mountpoint-s3/pull/827))
* Expose memory consumption metrics for the CRT buffer pool (`s3.client.buffer_pool.*`). ([#820](https://github.com/awslabs/mountpoint-s3/pull/820))
* Adopt new async write API for PutObject requests ([#832](https://github.com/awslabs/mountpoint-s3/pull/832))

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
