### PR TITLE
Remove fuse_tests from asan

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -133,6 +133,10 @@ jobs:
 
     environment: ${{ inputs.environment }}
 
+    env:
+      # We're using ASan to test our CRT bindings, so focus only on S3, not on FUSE
+      RUST_FEATURES: s3_tests,fips_tests
+
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Description of change

They frequently trigger a deadlock inside ASan's allocator. We're really using ASan to test the CRT bindings anyway, so the S3 tests are really what matter most. I don't love this change because future features won't get added automatically, but I'm more worried right now about unblocking a flaky CI.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
