### PR TITLE
 Add option to disable trailing checksums for uploads

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased changes
+
+### Breaking changes
+
+* The `trailing_checksums` field of `PutObjectParams` is now an enum, with a new `ReviewOnly` option that allows disabling sending additional checksum headers to S3 while still computing them for use by `UploadReview` callbacks. ([#849](https://github.com/awslabs/mountpoint-s3/pull/849))
+
+### Other changes
+
+* No other changes.
+
 ## v0.8.1 (April 10, 2024)
 
 ### Breaking changes

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -73,7 +73,8 @@ pub mod types {
     pub use super::object_client::{
         Checksum, ChecksumAlgorithm, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts,
         GetObjectAttributesResult, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult,
-        ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, RestoreStatus, UploadReview, UploadReviewPart,
+        ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectTrailingChecksums, RestoreStatus,
+        UploadReview, UploadReviewPart,
     };
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -705,7 +705,7 @@ impl ObjectClient for MockClient {
                             Some(MockObjectParts::Parts(parts)) => Some(GetObjectAttributesParts {
                                 is_truncated: Some(false),
                                 max_parts: Some(10000),
-                                next_part_number_marker: None,
+                                next_part_number_marker: Some(parts.len()),
                                 part_number_marker: Some(0),
                                 parts: Some(
                                     parts
@@ -861,6 +861,9 @@ struct MockObjectPartAttributes {
     checksum: Option<String>,
 }
 
+/// Some S3 implementations only report per-part data from GetObjectAttributes if parts were
+/// uploaded with additional checksums. This enum is how we remember whether additional checksums
+/// were used; if not, the only thing we report is the number of parts.
 #[derive(Debug, Clone)]
 enum MockObjectParts {
     Count(usize),

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -320,7 +320,7 @@ pub enum PutObjectTrailingChecksums {
     Enabled,
     /// Checksums are computed, passed to upload review, but not sent to S3
     ReviewOnly,
-    /// Checksums are not computed
+    /// Checksums are not computed on the client side
     #[default]
     Disabled,
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -272,7 +272,7 @@ pub enum GetObjectAttributesError {
 #[non_exhaustive]
 pub struct PutObjectParams {
     /// Enable Crc32c trailing checksums.
-    pub trailing_checksums: bool,
+    pub trailing_checksums: PutObjectTrailingChecksums,
     /// Storage class to be used when creating new S3 object
     pub storage_class: Option<String>,
     /// The server-side encryption algorithm to be used for this object in Amazon S3 (for example, AES256, aws:kms, aws:kms:dsse)
@@ -289,7 +289,7 @@ impl PutObjectParams {
     }
 
     /// Set Crc32c trailing checksums.
-    pub fn trailing_checksums(mut self, value: bool) -> Self {
+    pub fn trailing_checksums(mut self, value: PutObjectTrailingChecksums) -> Self {
         self.trailing_checksums = value;
         self
     }
@@ -311,6 +311,18 @@ impl PutObjectParams {
         self.ssekms_key_id = value;
         self
     }
+}
+
+/// How CRC32c checksums are used for parts of a multi-part PutObject request
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PutObjectTrailingChecksums {
+    /// Checksums are computed, passed to upload review, and also sent to S3
+    Enabled,
+    /// Checksums are computed, passed to upload review, but not sent to S3
+    ReviewOnly,
+    /// Checksums are not computed
+    #[default]
+    Disabled,
 }
 
 /// Info for the caller to review before an upload completes.

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -335,10 +335,9 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
             assert_eq!(checksum, encoded);
         }
     } else {
-        // For S3 Express, crc32 is used by default. For S3 Standard, no checksums are used by
-        // default and the list of parts is empty in GetObjectAttributes. So allow either case --
-        // the important thing is that crc32c checksums aren't present because we disabled those by
-        // disabling our upload checksums.
+        // For S3 Standard, the list of parts is only present if checksums were used, but for S3
+        // Express One Zone the list of parts is always present. The important thing is just that
+        // the *checksums* aren't present, because we disabled those.
         for part in parts {
             assert!(
                 part.checksum_crc32_c().is_none(),

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update to latest CRT dependencies
+
 ## v0.7.0 (April 10, 2024)
 
 * Update to latest CRT dependencies

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Update to latest CRT dependencies
+* Allow omitting additional checksums from PutObject requests while still computing them for upload reviews ([#849](https://github.com/awslabs/mountpoint-s3/pull/849))
+
 ## v0.7.0 (April 10, 2024)
 
 * Update to latest CRT dependencies

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1276,6 +1276,17 @@ impl ChecksumConfig {
         }
     }
 
+    /// Create a [ChecksumConfig] enabling Crc32 trailing checksums only for upload review.
+    pub fn upload_review_crc32c() -> Self {
+        Self {
+            inner: aws_s3_checksum_config {
+                location: aws_s3_checksum_location::AWS_SCL_NONE,
+                checksum_algorithm: aws_s3_checksum_algorithm::AWS_SCA_CRC32C,
+                ..Default::default()
+            },
+        }
+    }
+
     /// Get out the inner pointer to the checksum config
     pub(crate) fn to_inner_ptr(&self) -> *const aws_s3_checksum_config {
         &self.inner

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1276,7 +1276,7 @@ impl ChecksumConfig {
         }
     }
 
-    /// Create a [ChecksumConfig] enabling Crc32 trailing checksums only for upload review.
+    /// Create a [ChecksumConfig] enabling Crc32c trailing checksums only for upload review.
     pub fn upload_review_crc32c() -> Self {
         Self {
             inner: aws_s3_checksum_config {

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Breaking changes
+* No breaking changes.
+
+### Other changes
+* The checksum algorithm to use for uploads to S3 can now be chosen with the `--upload-checksums <ALGORITHM>` command-line argument. The only supported values in this release are `crc32c` (the default, and the existing behavior) and `off`, which disables including checksums in uploads. The `off` value allows uploads to S3 implementations that do not support [additional checksums](https://aws.amazon.com/blogs/aws/new-additional-checksum-algorithms-for-amazon-s3/). This option defaults to `off` when the bucket name is an S3 on Outposts bucket access point (either an ARN or a bucket alias). ([#849](https://github.com/awslabs/mountpoint-s3/pull/849)).
+
 ## v1.6.0 (April 11, 2024)
 
 ### New features
@@ -9,7 +15,6 @@
 * No breaking changes.
 
 ### Other changes
-
 * Mountpoint now retries S3 requests up to a total of 10 attempts (up from 4), which should make file operations more robust to transient failures or throttling. The maximum number of attempts can be overridden by setting the `AWS_MAX_ATTEMPTS` environment variable. ([#830](https://github.com/awslabs/mountpoint-s3/pull/830))
 * Fix an issue where Mountpoint could become unresponsive after opening too many files in write mode. ([#832](https://github.com/awslabs/mountpoint-s3/pull/832))
 * Add support for `rewinddir` by restarting `readdir` if offset is zero. ([#825](https://github.com/awslabs/mountpoint-s3/pull/825))

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -11,8 +11,8 @@
 //! This binary is intended only for use in testing and development of Mountpoint.
 
 use futures::executor::ThreadPool;
-use mountpoint_s3::cli::{CliArgs, S3PersonalityArg};
-use mountpoint_s3::fs::S3Personality;
+use mountpoint_s3::cli::CliArgs;
+use mountpoint_s3::s3::S3Personality;
 use mountpoint_s3_client::mock_client::throughput_client::ThroughputMockClient;
 use mountpoint_s3_client::mock_client::{MockClientConfig, MockObject};
 use mountpoint_s3_client::types::ETag;
@@ -44,8 +44,8 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
 
     let runtime = ThreadPool::builder().name_prefix("runtime").create()?;
 
-    let s3_personality = if let Some(S3PersonalityArg(personality)) = args.bucket_type {
-        personality
+    let s3_personality = if let Some(bucket_type) = &args.bucket_type {
+        bucket_type.to_personality()
     } else {
         S3Personality::Standard
     };

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -634,6 +634,8 @@ where
     let (client, runtime, s3_personality) = client_builder(&args)?;
 
     let bucket_description = args.bucket_description();
+    tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");
+
     let fuse_config = args.fuse_session_config();
 
     let mut filesystem_config = S3FilesystemConfig::default();

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -286,6 +286,13 @@ pub struct CliArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new(),
     )]
     pub sse_kms_key_id: Option<String>,
+
+    #[clap(
+        long,
+        help = "Disable S3 additional checksums for object uploads",
+        help_heading = BUCKET_OPTIONS_HEADER,
+    )]
+    pub disable_upload_checksums: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -633,9 +640,8 @@ where
     filesystem_config.allow_delete = args.allow_delete;
     filesystem_config.allow_overwrite = args.allow_overwrite;
     filesystem_config.s3_personality = s3_personality;
-    {
-        filesystem_config.server_side_encryption = ServerSideEncryption::new(args.sse, args.sse_kms_key_id);
-    }
+    filesystem_config.use_upload_checksums = !args.disable_upload_checksums;
+    filesystem_config.server_side_encryption = ServerSideEncryption::new(args.sse, args.sse_kms_key_id);
 
     let prefetcher_config = Default::default();
 

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -21,6 +21,7 @@ use crate::inode::{Inode, InodeError, InodeKind, LookedUp, ReaddirHandle, Superb
 use crate::logging;
 use crate::prefetch::{Prefetch, PrefetchReadError, PrefetchResult};
 use crate::prefix::Prefix;
+use crate::s3::S3Personality;
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use crate::sync::{Arc, AsyncMutex, AsyncRwLock};
 use crate::upload::{UploadRequest, Uploader};
@@ -377,30 +378,9 @@ impl Default for S3FilesystemConfig {
             allow_delete: false,
             allow_overwrite: false,
             storage_class: None,
-            s3_personality: S3Personality::Standard,
+            s3_personality: S3Personality::default(),
             server_side_encryption: Default::default(),
             use_upload_checksums: true,
-        }
-    }
-}
-
-/// The type of S3 we're talking to. S3 Standard and S3 Express One Zone have slightly different
-/// semantics around ListObjects (ordered versus unordered) that this enum captures.
-///
-/// This enum intentionally doesn't implement PartialEq/Eq. You shouldn't test it directly. Instead,
-/// use its methods like `is_list_ordered` to check the actual behavior you're looking for.
-#[derive(Debug, Clone, Copy, Default)]
-pub enum S3Personality {
-    #[default]
-    Standard,
-    ExpressOneZone,
-}
-
-impl S3Personality {
-    pub fn is_list_ordered(self) -> bool {
-        match self {
-            Self::Standard => true,
-            Self::ExpressOneZone => false,
         }
     }
 }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -358,6 +358,8 @@ pub struct S3FilesystemConfig {
     pub s3_personality: S3Personality,
     /// Server side encryption configuration to be used when creating new S3 object
     pub server_side_encryption: ServerSideEncryption,
+    /// Use additional checksums for uploads
+    pub use_upload_checksums: bool,
 }
 
 impl Default for S3FilesystemConfig {
@@ -377,6 +379,7 @@ impl Default for S3FilesystemConfig {
             storage_class: None,
             s3_personality: S3Personality::Standard,
             server_side_encryption: Default::default(),
+            use_upload_checksums: true,
         }
     }
 }
@@ -548,6 +551,7 @@ where
             client.clone(),
             config.storage_class.to_owned(),
             config.server_side_encryption.clone(),
+            config.use_upload_checksums,
         );
 
         Self {

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -39,9 +39,10 @@ use thiserror::Error;
 use time::OffsetDateTime;
 use tracing::{debug, error, trace, warn};
 
-use crate::fs::{CacheConfig, S3Personality};
+use crate::fs::CacheConfig;
 use crate::logging;
 use crate::prefix::Prefix;
+use crate::s3::S3Personality;
 use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::RwLockReadGuard;
 use crate::sync::RwLockWriteGuard;

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -11,6 +11,7 @@ pub mod metrics;
 mod object;
 pub mod prefetch;
 pub mod prefix;
+pub mod s3;
 mod sync;
 mod upload;
 

--- a/mountpoint-s3/src/s3.rs
+++ b/mountpoint-s3/src/s3.rs
@@ -1,0 +1,32 @@
+//! Personalities of different S3 implementations. We use this to auto-configure some sensible
+//! defaults that differ between implementations.
+
+/// The type of S3 we're talking to.
+///
+/// This enum intentionally doesn't implement PartialEq/Eq. You shouldn't test it directly. Instead,
+/// use its methods like `is_list_ordered` to check the actual behavior you're looking for.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum S3Personality {
+    #[default]
+    Standard,
+    ExpressOneZone,
+    Outposts,
+}
+
+impl S3Personality {
+    pub fn is_list_ordered(&self) -> bool {
+        match self {
+            S3Personality::Standard => true,
+            S3Personality::ExpressOneZone => false,
+            S3Personality::Outposts => true,
+        }
+    }
+
+    pub fn supports_additional_checksums(&self) -> bool {
+        match self {
+            S3Personality::Standard => true,
+            S3Personality::ExpressOneZone => true,
+            S3Personality::Outposts => false,
+        }
+    }
+}

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -206,13 +206,13 @@ fn verify_checksums(review: UploadReview, expected_size: u64, expected_checksum:
         uploaded_size += part.size;
 
         let Some(checksum) = &part.checksum else {
-            error!(part_number = i, "missing part checksum");
+            error!(part_number = i + 1, "missing part checksum");
             return false;
         };
         let checksum = match crc32c_from_base64(checksum) {
             Ok(checksum) => checksum,
             Err(error) => {
-                error!(part_number = i, ?error, "error decoding part checksum");
+                error!(part_number = i + 1, ?error, "error decoding part checksum");
                 return false;
             }
         };

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -277,7 +277,7 @@ pub mod s3_session {
     use aws_sdk_s3::Client;
     use mountpoint_s3::prefetch::{caching_prefetch, default_prefetch};
     use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
-    use mountpoint_s3_client::types::Checksum;
+    use mountpoint_s3_client::types::{Checksum, PutObjectTrailingChecksums};
     use mountpoint_s3_client::S3CrtClient;
 
     use crate::common::s3::{get_test_bucket_and_prefix, get_test_region, get_test_sdk_client, tokio_block_on};
@@ -377,7 +377,7 @@ pub mod s3_session {
             if let Some(storage_class) = params.storage_class {
                 request = request.set_storage_class(Some(storage_class.as_str().into()));
             }
-            if params.trailing_checksums {
+            if params.trailing_checksums == PutObjectTrailingChecksums::Enabled {
                 request = request.set_checksum_algorithm(Some(ChecksumAlgorithm::Crc32C));
             }
             Ok(tokio_block_on(request.send()).map(|_| ())?)

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -16,6 +16,8 @@ use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProvi
 use mountpoint_s3_crt::common::allocator::Allocator;
 use tempfile::TempDir;
 
+use crate::common::tokio_block_on;
+
 pub trait TestClient: Send {
     fn put_object(&mut self, key: &str, value: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
         self.put_object_params(key, value, PutObjectParams::default())
@@ -109,8 +111,6 @@ where
 }
 
 pub mod mock_session {
-    use crate::common::s3::tokio_block_on;
-
     use super::*;
 
     use futures::executor::ThreadPool;
@@ -280,7 +280,7 @@ pub mod s3_session {
     use mountpoint_s3_client::types::{Checksum, PutObjectTrailingChecksums};
     use mountpoint_s3_client::S3CrtClient;
 
-    use crate::common::s3::{get_test_bucket_and_prefix, get_test_region, get_test_sdk_client, tokio_block_on};
+    use crate::common::s3::{get_test_bucket_and_prefix, get_test_region, get_test_sdk_client};
 
     /// Create a FUSE mount backed by a real S3 client
     pub fn new(test_name: &str, test_config: TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox) {

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -18,6 +18,7 @@ use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
 use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use std::collections::VecDeque;
+use std::future::Future;
 use std::sync::Arc;
 
 pub type TestS3Filesystem<Client> = S3Filesystem<Client, DefaultPrefetcher<ThreadPool>>;
@@ -89,6 +90,15 @@ impl DirectoryReply {
     pub fn clear(&mut self) {
         self.entries.clear();
     }
+}
+
+pub fn tokio_block_on<F: Future>(future: F) -> F::Output {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(future)
 }
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,9 +1,10 @@
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_sts::config::Credentials;
-use futures::Future;
 use rand::RngCore;
 use rand_chacha::rand_core::OsRng;
+
+use crate::common::tokio_block_on;
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
     let bucket = if cfg!(feature = "s3express_tests") {
@@ -100,15 +101,6 @@ pub fn create_objects(bucket: &str, prefix: &str, region: &str, key: &str, value
             .send(),
     )
     .unwrap();
-}
-
-pub fn tokio_block_on<F: Future>(future: F) -> F::Output {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .enable_time()
-        .build()
-        .unwrap();
-    runtime.block_on(future)
 }
 
 /// Detect if running on GitHub Actions (GHA) and if so,

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -2,8 +2,9 @@
 
 use fuser::FileType;
 use libc::S_IFREG;
-use mountpoint_s3::fs::{CacheConfig, S3Personality, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{CacheConfig, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
+use mountpoint_s3::s3::S3Personality;
 use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::failure_client::countdown_failure_client;
 use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, Operation};

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -327,7 +327,7 @@ fn mount_disable_checksums(disable_checksums: bool) -> Result<(), Box<dyn std::e
         .arg("--auto-unmount")
         .arg(format!("--region={region}"));
     if disable_checksums {
-        cmd.arg("--disable-upload-checksums");
+        cmd.arg("--upload-checksums=off");
     }
     let child = cmd.spawn().expect("unable to spawn child");
 

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -21,10 +21,10 @@ use test_case::test_case;
 use crate::common::fuse::read_dir_to_entry_names;
 use crate::common::s3::{
     create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region, get_test_sdk_client,
-    tokio_block_on,
 };
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::s3::{get_scoped_down_credentials, get_subsession_iam_role, get_test_kms_key_id};
+use crate::common::tokio_block_on;
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -1107,3 +1107,79 @@ fn concurrent_open_for_write_test(max_files: usize) {
         assert!(test_client.contains_key(&file_name).unwrap(), "object must exist in S3");
     }
 }
+
+fn write_checksums_test<F>(creator_fn: F, use_upload_checksums: bool)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    const OBJECT_SIZE: usize = 20 * 1024 * 1024;
+    const PART_SIZE: usize = 8 * 1024 * 1024;
+    const KEY: &str = "dir/new.txt";
+
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            use_upload_checksums,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let (mount_point, _session, mut test_client) = creator_fn("write_checksums_test", config);
+
+    // Make sure there's an existing directory
+    test_client.put_object("dir/hello.txt", b"hello world").unwrap();
+
+    let path = mount_point.path().join(KEY);
+
+    let mut f = open_for_write(path, false, true).unwrap();
+    let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
+    let mut body = vec![0u8; OBJECT_SIZE];
+    rng.fill(&mut body[..]);
+
+    let mut current_size = 0;
+    for part in body.chunks(1024 * 1024) {
+        f.write_all(part).unwrap();
+        current_size += part.len() as u64;
+        assert_eq!(f.metadata().unwrap().len(), current_size);
+    }
+
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Now it's fsync'ed and closed, it should be present in S3
+    let parts = test_client.get_object_parts(KEY).unwrap();
+    if use_upload_checksums {
+        let parts = parts.expect("parts should be non-empty");
+        assert_eq!(parts.len(), (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE);
+        for part in parts {
+            let checksum = part.checksum.expect("checksum should be present");
+            let _crc32c = checksum.checksum_crc32c.expect("crc32c is used for trailing checksums");
+        }
+    } else {
+        // For S3 Express, crc32 is used by default, otherwise no checksums are used by default. So
+        // allow either case -- the important thing is that crc32c (which we use for trailing
+        // checksums) isn't present because we disabled it.
+        if let Some(parts) = parts {
+            assert_eq!(parts.len(), (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE);
+            for part in parts {
+                let checksum = part.checksum.expect("checksum should be present");
+                assert!(
+                    checksum.checksum_crc32c.is_none(),
+                    "crc32c is not default for trailing checksums"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(true; "enabled")]
+#[test_case(false; "disabled")]
+fn write_checksums_test_s3(use_upload_checksums: bool) {
+    write_checksums_test(fuse::s3_session::new, use_upload_checksums);
+}
+
+#[test_case(true; "enabled")]
+#[test_case(false; "disabled")]
+fn write_checksums_test_mock(use_upload_checksums: bool) {
+    write_checksums_test(fuse::mock_session::new, use_upload_checksums);
+}

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -1157,10 +1157,9 @@ where
             let _crc32c = checksum.checksum_crc32c.expect("crc32c is used for trailing checksums");
         }
     } else {
-        // For S3 Express, crc32 is used by default. For S3 Standard, no checksums are used by
-        // default and the list of parts is empty in GetObjectAttributes. So allow either case --
-        // the important thing is that crc32c checksums aren't present because we disabled those by
-        // disabling our upload checksums.
+        // For S3 Standard, the list of parts is only present if checksums were used, but for S3
+        // Express One Zone the list of parts is always present. The important thing is just that
+        // the *checksums* aren't present, because we disabled those.
         if let Some(parts) = parts {
             assert_eq!(parts.len(), (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE);
             for part in parts {

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -17,7 +17,7 @@ use mountpoint_s3::ServerSideEncryption;
 
 use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
-use crate::common::s3::{get_scoped_down_credentials, get_test_kms_key_id, tokio_block_on};
+use crate::common::s3::{get_scoped_down_credentials, get_test_kms_key_id};
 
 fn open_for_write(path: impl AsRef<Path>, append: bool, write_only: bool) -> std::io::Result<File> {
     let mut options = File::options();
@@ -1045,6 +1045,8 @@ const SSE_S3_POLICY: &str = r#"{"Statement": [
 #[test_case(SSE_S3_POLICY, ServerSideEncryption::new(Some("aws:kms".to_owned()), None), true)]
 #[test_case(SSE_S3_POLICY, ServerSideEncryption::new(Some("AES256".to_owned()), None), false)]
 fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_fail: bool) {
+    use crate::common::tokio_block_on;
+
     let policy = policy
         .to_string()
         .replace("__SSE_KEY_ARN__", get_test_kms_key_id().as_str());


### PR DESCRIPTION
## Description of change

Some S3 implementations (notably S3 on Outposts) don't support the S3 additional checksums feature, which causes uploads to fail. This change adds a new command-line flag to disable additional checksums for uploads. We also automatically disable additional checksums when we detect (via endpoint resolution) that the target is an Outposts bucket.

Even when trailing checksums are disabled, we still validate the checksums of parts right before committing an upload.
This change adopts a new CRT ability to decouple upload review checksums from the actual S3 headers (https://github.com/awslabs/aws-c-s3/pull/421), so that we can still validate upload checksums locally without sending them to S3.

We don't have (and likely won't have) Outposts in CI, but I've tested manually like this:
```
[ec2-user@ip-172-31-44-14 ~]$ ./mount-s3 arn:aws:s3-outposts:us-east-1:691736938728:outpost/op-0f129d3877cfede5e/accesspoint/bornholt-test-bucket-ap ~/mnt
bucket arn:aws:s3-outposts:us-east-1:691736938728:outpost/op-0f129d3877cfede5e/accesspoint/bornholt-test-bucket-ap is mounted at /home/ec2-user/mnt
[ec2-user@ip-172-31-44-14 ~]$ echo "hello world!" > ~/mnt/test.txt
[ec2-user@ip-172-31-44-14 ~]$ cat ~/mnt/test.txt
hello world!
[ec2-user@ip-172-31-44-14 ~]$ aws s3api get-object --bucket arn:aws:s3-outposts:us-east-1:691736938728:outpost/op-0f129d3877cfede5e/accesspoint/bornholt-test-bucket-ap --key test.txt outfile
{
    "AcceptRanges": "bytes",
    "LastModified": "2024-04-12T02:20:29+00:00",
    "ContentLength": 13,
    "ETag": "\"8e8732f3d5618766a7ddfea2a6594f7b-1\"",
    "ContentType": "text/plain",
    "Metadata": {},
    "StorageClass": "OUTPOSTS"
}
[ec2-user@ip-172-31-44-14 ~]$ cat outfile
hello world!
```
(Outpost access point aliases also work the same way)

Relevant issues: fixes #516.

## Does this change impact existing behavior?

Not by default.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
