### PR TITLE
Allow building on 32-bit platforms

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -78,6 +78,7 @@ macro_rules! event {
         }
     }
 }
+
 /// Configurations for the CRT-based S3 client
 #[derive(Debug, Clone)]
 pub struct S3ClientConfig {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::ffi::{OsStr, OsString};
 use std::future::Future;
 use std::num::NonZeroUsize;
@@ -77,7 +78,6 @@ macro_rules! event {
         }
     }
 }
-
 /// Configurations for the CRT-based S3 client
 #[derive(Debug, Clone)]
 pub struct S3ClientConfig {
@@ -311,10 +311,13 @@ impl S3CrtClientInner {
 
         client_config.throughput_target_gbps(config.throughput_target_gbps);
 
-        if !(5 * 1024 * 1024..=5 * 1024 * 1024 * 1024).contains(&config.part_size) {
-            return Err(NewClientError::InvalidConfiguration(
-                "part size must be at between 5MiB and 5GiB".into(),
-            ));
+        // max_part_size is 5GB or less depending on the platform (4GB on 32-bit)
+        let max_part_size = cmp::min(5_u64 * 1024 * 1024 * 1024, usize::MAX as u64) as usize;
+        if !(5 * 1024 * 1024..=max_part_size).contains(&config.part_size) {
+            return Err(NewClientError::InvalidConfiguration(format!(
+                "part size must be at between 5MiB and {}GiB",
+                max_part_size / 1024 / 1024 / 1024
+            )));
         }
         client_config.part_size(config.part_size);
 
@@ -1089,14 +1092,36 @@ mod tests {
     use test_case::test_case;
 
     /// Test explicit validation in [Client::new]
-    #[test_case(4 * 1024 * 1024; "less than 5MiB")]
-    #[test_case(6 * 1024 * 1024 * 1024; "greater than 5GiB")]
     fn client_new_fails_with_invalid_part_size(part_size: usize) {
         let config = S3ClientConfig {
             part_size,
             ..Default::default()
         };
-        S3CrtClient::new(config).expect_err("creating a new client should fail");
+        let e = S3CrtClient::new(config).expect_err("creating a new client should fail");
+        let message = if cfg!(target_pointer_width = "64") {
+            "invalid configuration: part size must be at between 5MiB and 5GiB".to_string()
+        } else {
+            format!(
+                "invalid configuration: part size must be at between 5MiB and {}GiB",
+                usize::MAX / 1024 / 1024 / 1024
+            )
+        };
+        assert_eq!(e.to_string(), message);
+    }
+
+    /// On 32-bit platform we limit part size with usize:MAX,
+    /// it is impossible to provide a greater value
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn client_new_fails_with_greater_part_size() {
+        let part_size = 6 * 1024 * 1024 * 1024; // greater than 5GiB
+        client_new_fails_with_invalid_part_size(part_size);
+    }
+
+    #[test]
+    fn client_new_fails_with_smaller_part_size() {
+        let part_size = 4 * 1024 * 1024; // less than 5MiB
+        client_new_fails_with_invalid_part_size(part_size);
     }
 
     /// Test if the prefix is added correctly to the User-Agent header

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -160,7 +160,7 @@ pub struct CliArgs {
         long,
         help = "Part size for multi-part GET and PUT",
         default_value = "8388608",
-        value_parser = value_parser!(u64).range(1..),
+        value_parser = value_parser!(u64).range(1..usize::MAX as u64),
         help_heading = CLIENT_OPTIONS_HEADER
     )]
     pub part_size: u64,

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -115,7 +115,10 @@ impl<Client: ObjectClient> UploadRequest<Client> {
         params = params.ssekms_key_id(key_id);
 
         let request = inner.client.put_object(bucket, key, &params).await?;
-        let maximum_upload_size = inner.client.part_size().map(|ps| ps * MAX_S3_MULTIPART_UPLOAD_PARTS);
+        let maximum_upload_size = inner
+            .client
+            .part_size()
+            .map(|ps| ps.saturating_mul(MAX_S3_MULTIPART_UPLOAD_PARTS));
 
         Ok(Self {
             bucket: bucket.to_owned(),


### PR DESCRIPTION
## Description of change

Enforcing a limit on `S3ClientConfig::part_size` to be `4GiB` on a 32-bit platform (this is the maximum value which fits in `usize` on a 32-bit platform). `4GiB` is the maximum possible RAM size. Making `part_size` greater than the available RAM won't ever be efficient.

Relevant issues: none

## Does this change impact existing behavior?

No. On 32-bit platforms we don't pass compilation now. On 64-bit platforms behaviour stays exactly the same.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
