### PR TITLE
PoC to buffer write requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ name = "mountpoint-s3-client"
 version = "0.8.1"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-trait",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -11,6 +11,7 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.7.0" }
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.7.0" }
 
+async-channel = "2.1.1"
 async-trait = "0.1.57"
 auto_impl = "1.1.2"
 base64ct = { version = "1.6.0", features = ["std"] }


### PR DESCRIPTION
Buffer write requests into part-size buffers before sending them to the CRT client. 

**Draft**: it will need some tidy up and fixing test failures (cancellation/error reporting).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
