### PR TITLE
Avoid creating a new rule engine for every endpoint resolution

### DIFF
--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -55,6 +55,7 @@ pub struct EndpointConfig {
     use_dual_stack: bool,
     endpoint: Option<Uri>,
     addressing_style: AddressingStyle,
+    endpoint_rule_engine: RuleEngine,
 }
 
 impl EndpointConfig {
@@ -67,6 +68,7 @@ impl EndpointConfig {
             use_dual_stack: false,
             endpoint: None,
             addressing_style: AddressingStyle::Automatic,
+            endpoint_rule_engine: RuleEngine::new(&Default::default()).unwrap(),
         }
     }
 
@@ -146,7 +148,6 @@ impl EndpointConfig {
     pub fn resolve_for_bucket(&self, bucket: &str) -> Result<ResolvedEndpointInfo, EndpointError> {
         let allocator = Allocator::default();
         let mut endpoint_request_context: RequestContext = RequestContext::new(&allocator).unwrap();
-        let endpoint_rule_engine = RuleEngine::new(&allocator).unwrap();
 
         endpoint_request_context
             .add_string(&allocator, "Region", &self.region)
@@ -180,7 +181,8 @@ impl EndpointConfig {
                 .unwrap()
         };
 
-        let resolved_endpoint = endpoint_rule_engine
+        let resolved_endpoint = self
+            .endpoint_rule_engine
             .resolve(endpoint_request_context)
             .map_err(EndpointError::UnresolvedEndpoint)?;
 

--- a/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
+++ b/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
@@ -74,16 +74,6 @@ impl RuleEngine {
     }
 }
 
-impl Clone for RuleEngine {
-    fn clone(&self) -> Self {
-        // SAFETY: self.inner is a valid aws_endpoints_rule_engine and aws_endpoints_rule_engine_acquire
-        // increments the reference count for it (and always returns a copy of the input, which is non-null).
-        let inner = unsafe { NonNull::new_unchecked(aws_endpoints_rule_engine_acquire(self.inner.as_ptr())) };
-
-        Self { inner }
-    }
-}
-
 impl Drop for RuleEngine {
     fn drop(&mut self) {
         // SAFETY: `self.inner` is a valid `aws_endpoints_rule_engine`, and on Drop it's safe to decrement


### PR DESCRIPTION
## Description of change

Currently, we are creating a new rule engine for every bucket endpoint resolution. This operation is really expensive because we have to parse the JSON file for the rule engine and we're doing this whenever we create a new http request via [new_request_template](https://github.com/awslabs/mountpoint-s3/blob/268b672c81b3b8820af29051b599deaf04207b88/mountpoint-s3-client/src/s3_crt_client.rs#L345-L346).

With this change we will only create the rule engine once for an endpoint config which is reusable and it should improve performance for all http requests.

Flame graph of the latency before this change.

![full_app_flamegraph](https://github.com/awslabs/mountpoint-s3/assets/47974768/73d2deb5-ac35-41c8-86cf-7e0dddee14bd)

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
