### PR TITLE
reutilise reference across validate_mountpoint function

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -961,8 +961,8 @@ fn validate_mount_point(path: impl AsRef<Path>) -> anyhow::Result<()> {
             }
         };
 
-        if mounts.0.iter().any(|mount| mount.mount_point == path.as_ref()) {
-            return Err(anyhow!("mount point {} is already mounted", path.as_ref().display()));
+        if mounts.0.iter().any(|mount| mount.mount_point == mount_point) {
+            return Err(anyhow!("mount point {} is already mounted", mount_point.display()));
         }
     }
 


### PR DESCRIPTION
## Description of change

path.as_ref() was being called multiple times unnecessarily

Relevant issues: N/A
## Does this change impact existing behavior?

No breaking change

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
