### PR TITLE
Makes mountpoint-s3-client support backpressure read

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -117,6 +117,8 @@ fn main() {
                 bucket: BUCKET.to_owned(),
                 part_size: args.part_size,
                 unordered_list_seed: None,
+                enable_back_pressure: false,
+                initial_read_window_size: 0,
             };
             let client = ThroughputMockClient::new(config, args.throughput_target_gbps);
             let client = Arc::new(client);

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -15,9 +15,9 @@ use pin_project::pin_project;
 
 use crate::object_client::{
     DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
-    GetObjectError, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
-    ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
-    UploadReview,
+    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
+    ObjectAttribute, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest,
+    PutObjectResult, UploadReview,
 };
 use crate::ObjectClient;
 
@@ -69,7 +69,7 @@ where
     State: Send + Sync + 'static,
     GetWrapperState: Send + Sync + 'static,
 {
-    type GetObjectResult = FailureGetResult<Client, GetWrapperState>;
+    type GetObjectRequest = FailureGetRequest<Client, GetWrapperState>;
     type PutObjectRequest = FailurePutObjectRequest<Client, GetWrapperState>;
     type ClientError = Client::ClientError;
 
@@ -92,7 +92,7 @@ where
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
         let wrapper = (self.get_object_cb)(
             &mut *self.state.lock().unwrap(),
             bucket,
@@ -100,11 +100,11 @@ where
             range.clone(),
             if_match.clone(),
         )?;
-        let get_result = self.client.get_object(bucket, key, range, if_match).await?;
-        Ok(FailureGetResult {
+        let request = self.client.get_object(bucket, key, range, if_match).await?;
+        Ok(FailureGetRequest {
             state: wrapper.state,
             result_fn: wrapper.result_fn,
-            get_result,
+            request,
         })
     }
 
@@ -170,20 +170,30 @@ where
 }
 
 #[pin_project]
-pub struct FailureGetResult<Client: ObjectClient, GetWrapperState> {
+pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
     state: GetWrapperState,
     result_fn: fn(&mut GetWrapperState) -> Result<(), Client::ClientError>,
     #[pin]
-    get_result: Client::GetObjectResult,
+    request: Client::GetObjectRequest,
 }
 
-impl<Client: ObjectClient, FailState> Stream for FailureGetResult<Client, FailState> {
+#[cfg_attr(not(docs_rs), async_trait)]
+impl<Client: ObjectClient, FailState: Send> GetObjectRequest for FailureGetRequest<Client, FailState> {
+    type ClientError = Client::ClientError;
+
+    async fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
+        let this = self.project();
+        this.request.increment_read_window(len).await;
+    }
+}
+
+impl<Client: ObjectClient, FailState> Stream for FailureGetRequest<Client, FailState> {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, Client::ClientError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         let this = self.project();
         (this.result_fn)(this.state)?;
-        this.get_result.poll_next(cx)
+        this.request.poll_next(cx)
     }
 }
 
@@ -367,6 +377,8 @@ mod tests {
             bucket: bucket.to_string(),
             part_size: 128,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let body = vec![0u8; 50];

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -52,7 +52,7 @@ pub mod imds_crt_client;
 pub mod instance_info;
 #[doc(hidden)]
 pub mod mock_client;
-mod object_client;
+pub mod object_client;
 mod s3_crt_client;
 #[doc(hidden)]
 pub mod user_agent;

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -24,9 +24,9 @@ use tracing::trace;
 use crate::checksums::crc32c_to_base64;
 use crate::object_client::{
     Checksum, ChecksumAlgorithm, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError,
-    GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, HeadObjectError, HeadObjectResult,
-    ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult,
-    ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
+    GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
+    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
+    ObjectClientResult, ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
     PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
 };
 
@@ -62,6 +62,10 @@ pub struct MockClientConfig {
     pub part_size: usize,
     /// A seed to randomize the order of ListObjectsV2 results, or None to use ordered list
     pub unordered_list_seed: Option<u64>,
+    /// A flag to enable backpressure read
+    pub enable_back_pressure: bool,
+    /// Initial backpressure read window size, ignored if enable_back_pressure is false
+    pub initial_read_window_size: usize,
 }
 
 /// A mock implementation of an object client that we can manually add objects to, and then query
@@ -465,14 +469,16 @@ impl std::fmt::Debug for MockObject {
 }
 
 #[derive(Debug)]
-pub struct GetObjectResult {
+pub struct MockGetObjectRequest {
     object: MockObject,
     next_offset: u64,
     length: usize,
     part_size: usize,
+    enable_back_pressure: bool,
+    current_window_size: usize,
 }
 
-impl GetObjectResult {
+impl MockGetObjectRequest {
     /// Helpful test utility to just collect the entire object into memory. Will panic if the object
     /// parts are streamed out of order.
     pub async fn collect(mut self) -> ObjectClientResult<Box<[u8]>, GetObjectError, MockClientError> {
@@ -487,7 +493,16 @@ impl GetObjectResult {
     }
 }
 
-impl Stream for GetObjectResult {
+#[cfg_attr(not(docs_rs), async_trait)]
+impl GetObjectRequest for MockGetObjectRequest {
+    type ClientError = MockClientError;
+
+    async fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
+        self.current_window_size += len;
+    }
+}
+
+impl Stream for MockGetObjectRequest {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, MockClientError>;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -495,12 +510,21 @@ impl Stream for GetObjectResult {
             return Poll::Ready(None);
         }
 
-        let next_part_size = self.part_size.min(self.length);
-        let next_part = self.object.read(self.next_offset, next_part_size);
+        let mut next_read_size = self.part_size.min(self.length);
+
+        // Simulate backpressure mechanism
+        if self.enable_back_pressure {
+            if self.current_window_size == 0 {
+                return Poll::Pending;
+            }
+            next_read_size = self.current_window_size.min(next_read_size);
+            self.current_window_size -= next_read_size;
+        }
+        let next_part = self.object.read(self.next_offset, next_read_size);
 
         let result = (self.next_offset, next_part);
-        self.next_offset += next_part_size as u64;
-        self.length -= next_part_size;
+        self.next_offset += next_read_size as u64;
+        self.length -= next_read_size;
         Poll::Ready(Some(Ok(result)))
     }
 }
@@ -520,7 +544,7 @@ fn mock_client_error<T, E>(s: impl Into<Cow<'static, str>>) -> ObjectClientResul
 
 #[cfg_attr(not(docs_rs), async_trait)]
 impl ObjectClient for MockClient {
-    type GetObjectResult = GetObjectResult;
+    type GetObjectRequest = MockGetObjectRequest;
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
@@ -551,7 +575,7 @@ impl ObjectClient for MockClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
         trace!(bucket, key, ?range, ?if_match, "GetObject");
         self.inc_op_count(Operation::GetObject);
 
@@ -577,11 +601,13 @@ impl ObjectClient for MockClient {
                 (0, object.len())
             };
 
-            Ok(GetObjectResult {
+            Ok(MockGetObjectRequest {
                 object: object.clone(),
                 next_offset,
                 length,
                 part_size: self.config.part_size,
+                enable_back_pressure: self.config.enable_back_pressure,
+                current_window_size: self.config.initial_read_window_size,
             })
         } else {
             Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey))
@@ -872,7 +898,12 @@ enum MockObjectParts {
 
 #[cfg(test)]
 mod tests {
-    use futures::StreamExt;
+    use std::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread,
+    };
+
+    use futures::{pin_mut, StreamExt};
     use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
     use test_case::test_case;
@@ -886,6 +917,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut body = vec![0u8; size];
@@ -917,6 +950,56 @@ mod tests {
         test_get_object("key1", 10, Some(0..10)).await;
     }
 
+    async fn test_get_object_backpressure(
+        key: &str,
+        size: usize,
+        range: Option<Range<u64>>,
+        backpressure_read_window_size: usize,
+    ) {
+        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
+
+        let client = MockClient::new(MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024,
+            unordered_list_seed: None,
+            enable_back_pressure: true,
+            initial_read_window_size: backpressure_read_window_size,
+        });
+
+        let mut body = vec![0u8; size];
+        rng.fill_bytes(&mut body);
+        client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
+
+        let get_request = client
+            .get_object("test_bucket", key, range.clone(), None)
+            .await
+            .expect("should not fail");
+        pin_mut!(get_request);
+
+        let mut accum = vec![];
+        let mut next_offset = range.as_ref().map(|r| r.start).unwrap_or(0);
+        while let Some(r) = get_request.next().await {
+            let (offset, body) = r.expect("get_object body part failed");
+            assert_eq!(offset, next_offset, "wrong body part offset");
+            next_offset += body.len() as u64;
+            accum.extend_from_slice(&body[..]);
+            get_request
+                .as_mut()
+                .increment_read_window(backpressure_read_window_size)
+                .await;
+        }
+        let expected_range = range.unwrap_or(0..size as u64);
+        let expected_range = expected_range.start as usize..expected_range.end as usize;
+        assert_eq!(&accum[..], &body[expected_range], "body does not match");
+    }
+
+    #[tokio::test]
+    async fn get_object_backpressure() {
+        test_get_object_backpressure("key1", 2000, None, 256).await;
+        test_get_object_backpressure("key1", 9000, Some(50..2000), 512).await;
+        test_get_object_backpressure("key1", 10, Some(0..10), 256).await;
+    }
+
     #[allow(clippy::reversed_empty_ranges)]
     #[tokio::test]
     async fn get_object_errors() {
@@ -926,6 +1009,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut body = vec![0u8; 2000];
@@ -976,12 +1061,63 @@ mod tests {
         );
     }
 
+    // Verify that the request is blocked when we don't increment read window size
+    #[tokio::test]
+    async fn verify_backpressure_get_object() {
+        let key = "key1";
+        let size = 1000;
+        let range = 50..1000;
+        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
+
+        let client = MockClient::new(MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024,
+            unordered_list_seed: None,
+            enable_back_pressure: true,
+            initial_read_window_size: 256,
+        });
+
+        let mut body = vec![0u8; size];
+        rng.fill_bytes(&mut body);
+        client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
+
+        let mut get_request = client
+            .get_object("test_bucket", key, Some(range.clone()), None)
+            .await
+            .expect("should not fail");
+
+        let mut accum = vec![];
+        let mut next_offset = range.start;
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            futures::executor::block_on(async move {
+                while let Some(r) = get_request.next().await {
+                    let (offset, body) = r.unwrap();
+                    assert_eq!(offset, next_offset, "wrong body part offset");
+                    next_offset += body.len() as u64;
+                    accum.extend_from_slice(&body[..]);
+                }
+                let expected_range = range;
+                let expected_range = expected_range.start as usize..expected_range.end as usize;
+                assert_eq!(&accum[..], &body[expected_range], "body does not match");
+                sender.send(accum).unwrap();
+            })
+        });
+        match receiver.recv_timeout(Duration::from_millis(100)) {
+            Ok(_) => panic!("request should have been blocked"),
+            Err(e) => assert_eq!(e, RecvTimeoutError::Timeout),
+        }
+    }
+
     #[tokio::test]
     async fn list_object_dirs() {
         let client = MockClient::new(MockClientConfig {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut keys = vec![];
@@ -1070,6 +1206,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut keys = vec![];
@@ -1117,6 +1255,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1190,6 +1330,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1257,6 +1399,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1323,6 +1467,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut put_request = client
@@ -1378,6 +1524,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let key = "key1";
@@ -1407,6 +1555,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let head_counter_1 = client.new_counter(Operation::HeadObject);
@@ -1443,6 +1593,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: PART_SIZE,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let key = "key1";

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -10,6 +10,7 @@ use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::object_client::GetObjectRequest;
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use rand::rngs::OsRng;
@@ -64,6 +65,17 @@ pub fn get_test_kms_key_id() -> String {
 pub fn get_test_client() -> S3CrtClient {
     let endpoint_config = EndpointConfig::new(&get_test_region());
     S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client")
+}
+
+pub fn get_test_backpressure_client(initial_read_window: usize) -> S3CrtClient {
+    let endpoint_config = EndpointConfig::new(&get_test_region());
+    S3CrtClient::new(
+        S3ClientConfig::new()
+            .endpoint_config(endpoint_config)
+            .read_backpressure(true)
+            .initial_read_window(initial_read_window),
+    )
+    .expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
@@ -181,6 +193,35 @@ pub async fn check_get_result<E: std::fmt::Debug>(
     assert_eq!(&accum[..], expected, "body does not match");
 }
 
+/// Check the result of a GET against expected bytes.
+pub async fn check_back_pressure_get_result(
+    read_window: usize,
+    result: impl GetObjectRequest,
+    range: Option<Range<u64>>,
+    expected: &[u8],
+) {
+    let mut accum_read_window = read_window;
+    let mut accum_len = 0;
+    let mut accum = vec![];
+    let mut next_offset = range.map(|r| r.start).unwrap_or(0);
+    pin_mut!(result);
+    while let Some(r) = result.next().await {
+        let (offset, body) = r.expect("get_object body part failed");
+        assert_eq!(offset, next_offset, "wrong body part offset");
+        next_offset += body.len() as u64;
+        accum.extend_from_slice(&body[..]);
+
+        accum_len += body.len();
+        // We run out of data to read if read window is smaller than accum length of data,
+        // so we keeping adding window size, otherwise the request will be blocked.
+        while accum_read_window <= accum_len {
+            result.as_mut().increment_read_window(read_window).await;
+            accum_read_window += read_window;
+        }
+    }
+    assert_eq!(&accum[..], expected, "body does not match");
+}
+
 /// Create a test suite that will execute a test that works over a generic [ObjectClient] against
 /// both the Rust CRT as well and the mock object client implementations.
 ///
@@ -205,6 +246,8 @@ macro_rules! object_client_test {
                     bucket: bucket.to_string(),
                     part_size: 1024,
                     unordered_list_seed: None,
+                    enable_back_pressure: false,
+                    initial_read_window_size: 0,
                 });
 
                 let key = format!("{prefix}hello");

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -102,6 +102,18 @@ impl ClientConfig {
         self
     }
 
+    /// Enable backpressure read
+    pub fn read_backpressure(&mut self, read_backpressure: bool) -> &mut Self {
+        self.inner.enable_read_backpressure = read_backpressure;
+        self
+    }
+
+    /// Initial read window size for backpressure read feature
+    pub fn initial_read_window(&mut self, initial_read_window: usize) -> &mut Self {
+        self.inner.initial_read_window = initial_read_window;
+        self
+    }
+
     /// Size in bytes of parts the files will be downloaded or uploaded in.
     ///
     /// The AWS CRT client may adjust this value per-request where possible
@@ -549,6 +561,12 @@ impl MetaRequest {
     /// will fail with an AWS_ERROR_INVALID_STATE error.
     pub fn write<'r, 's>(&'r mut self, slice: &'s [u8], eof: bool) -> MetaRequestWrite<'r, 's> {
         MetaRequestWrite::new(self, slice, eof)
+    }
+
+    /// Increment the flow-control windows size.
+    pub fn increment_read_window(&mut self, bytes: u64) {
+        // SAFETY: `self.inner` is a valid `aws_s3_meta_request`.
+        unsafe { aws_s3_meta_request_increment_read_window(self.inner.as_ptr(), bytes) };
     }
 }
 

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -39,6 +39,8 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
         bucket: args.bucket_name.clone(),
         part_size: args.part_size as usize,
         unordered_list_seed: None,
+        enable_back_pressure: false,
+        initial_read_window_size: 0,
     };
     let client = ThroughputMockClient::new(config, max_throughput_gbps);
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -2309,6 +2309,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024 * 1024,
             unordered_list_seed: (!ordered).then_some(123456),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         };
         let client = Arc::new(MockClient::new(client_config));
 


### PR DESCRIPTION
## Description of change

The CRT has flow-control window feature in the read path (https://github.com/awslabs/aws-c-s3/pull/213) to let users control how fast they want to download data. This change exposes the backpressure read mechanism in the `get_object` interface.

Putting this into a draft to get early feedback.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
