### PR TITLE
Implement statfs with synthetic values

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.4.0"
 libc = "0.2.126"
 linked-hash-map = "0.5.6"
 metrics = "0.22.1"
-nix = { version = "0.27.1", features = ["user"] }
+nix = { version = "0.27.1", features = ["user", "fs"] }
 regex = "1.7.1"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.95"

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -9,5 +9,6 @@ mod readdir_test;
 mod rmdir_test;
 mod semantics_doc_test;
 mod setattr_test;
+mod statfs_test;
 mod unlink_test;
 mod write_test;

--- a/mountpoint-s3/tests/fuse_tests/statfs_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/statfs_test.rs
@@ -1,0 +1,35 @@
+use fuser::BackgroundSession;
+use nix::sys::statvfs::statvfs;
+use tempfile::TempDir;
+
+use crate::common::fuse::{self, TestClientBox, TestSessionConfig};
+
+fn statfs_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
+{
+    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+
+    // Make sure there's an existing directory
+    test_client.put_object("dir/hello.txt", b"hello world").unwrap();
+
+    let path = mount_point.path().join("dir");
+
+    let reply = statvfs(&path).unwrap();
+
+    assert_eq!(reply.files(), 0, "inodes/files should not be counted and returned");
+    assert_eq!(
+        reply.name_max(),
+        255,
+        "name_max should return 255, matching Fuser default",
+    );
+    assert!(
+        reply.blocks_available() > 0,
+        "blocks available should be non-zero, even though we can't provide a real number",
+    );
+}
+
+#[test]
+fn statfs_test_mock() {
+    statfs_test(fuse::mock_session::new, "statfs_test_mock");
+}


### PR DESCRIPTION
## Description of change

Draft prototype change for now. May not be merged.

Some applications do not work as expected when a file system reports available space as zero. Some applications may check for available space, and fail if that's a small number (like zero). I believe even `df -h` will not report the file system in the list by default for some reason - and this may fix it (TBC).

Next steps:
- Are these the right fields to change? What use cases are we solving?
- Confirm that we do actually want to implement `statfs` by default, diverging from the values provided by Fuser.
- Converge on an agreed value for these fields.
  - u64 max may have some unexpected consequences - we have no idea. Half of u64 is probably large enough.
  - u32 max is too small - that would only be a bit over 4TiB using default block size of 1024.
  - In 2021, AWS shared that there are over 100 trillion objects in Amazon S3. Maybe we could take inspiration from there. https://aws.amazon.com/blogs/aws/amazon-s3s-15th-birthday-it-is-still-day-1-after-5475-days-100-trillion-objects/
- Merge.

Relevant issues: #710

## Does this change impact existing behavior?

Mountpoint will now report a non-zero number of available blocks, free blocks, and free files. Before, it reported zero for all three values.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
