### PR TITLE
Add assume role authorization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "aws-sdk-sts",
  "base16ct",

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -100,9 +100,9 @@ async fn test_static_provider() {
 /// test. So the [test_profile_provider] test below is forked into its own process, where it can set
 /// the environment variables it needs to point to an isolated CLI configuration file without
 /// affecting the rest of the real test runner.
-async fn test_profile_provider_async() {
+async fn test_profile_provider_static() {
     let sdk_client = get_test_sdk_client().await;
-    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider");
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider_static");
 
     let key = format!("{prefix}/hello");
     let body = b"hello world!";
@@ -187,12 +187,72 @@ async fn test_profile_provider_async() {
     let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
 }
 
+async fn test_profile_provider_assume_role() {
+    let sdk_client = get_test_sdk_client().await;
+    let subsession_role = get_subsession_iam_role();
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider_assume_role");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let profile_name = "mountpoint-profile";
+    let mut config_file = NamedTempFile::new().unwrap();
+    writeln!(config_file, "[profile {}]", profile_name).unwrap();
+
+    // Set up the environment variables to use this new config file. This is only OK to do because
+    // this test is run in a forked process, so won't affect any other concurrently running tests.
+    std::env::set_var("AWS_CONFIG_FILE", config_file.path().as_os_str());
+
+    // First, verify that we can use this profile for the client but the request should fail because
+    // we did not configure which arn to assume yet.
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(config).unwrap();
+
+    let mut request = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should be sent");
+
+    let _error = request.next().await.unwrap().expect_err("role arn is not set");
+
+    // Build a S3CrtClient that uses the right config, now the request should succeed.
+    writeln!(config_file, "role_arn = {}", subsession_role).unwrap();
+    writeln!(config_file, "source_profile = default").unwrap();
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(config).unwrap();
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
+}
+
 rusty_fork_test! {
     #[test]
     fn test_profile_provider() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-        runtime.block_on(test_profile_provider_async());
+        runtime.block_on(test_profile_provider_static());
+    }
+
+    #[test]
+    fn test_profile_provider_sts() {
+        // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        runtime.block_on(test_profile_provider_assume_role());
     }
 }
 

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -218,7 +218,6 @@ async fn test_profile_provider_assume_role_async() {
         .expect("static credentials should be available");
 
     writeln!(config_file, "[profile {}]", source_profile).unwrap();
-    writeln!(config_file, "region = {}", get_test_region()).unwrap();
     writeln!(config_file, "aws_access_key_id={}", credentials.access_key_id()).unwrap();
     writeln!(config_file, "aws_secret_access_key={}", credentials.secret_access_key()).unwrap();
     if let Some(session_token) = credentials.session_token() {

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -100,7 +100,7 @@ async fn test_static_provider() {
 /// test. So the [test_profile_provider] test below is forked into its own process, where it can set
 /// the environment variables it needs to point to an isolated CLI configuration file without
 /// affecting the rest of the real test runner.
-async fn test_profile_provider_static() {
+async fn test_profile_provider_static_async() {
     let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider_static");
 
@@ -187,7 +187,7 @@ async fn test_profile_provider_static() {
     let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
 }
 
-async fn test_profile_provider_assume_role() {
+async fn test_profile_provider_assume_role_async() {
     let sdk_client = get_test_sdk_client().await;
     let subsession_role = get_subsession_iam_role();
     let (bucket, prefix) = get_test_bucket_and_prefix("test_profile_provider_assume_role");
@@ -266,17 +266,17 @@ async fn test_profile_provider_assume_role() {
 
 rusty_fork_test! {
     #[test]
-    fn test_profile_provider() {
+    fn test_profile_provider_static() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-        runtime.block_on(test_profile_provider_static());
+        runtime.block_on(test_profile_provider_static_async());
     }
 
     #[test]
-    fn test_profile_provider_sts() {
+    fn test_profile_provider_assume_role() {
         // rusty_fork doesn't support async tests, so build an SDK-usable runtime manually
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-        runtime.block_on(test_profile_provider_assume_role());
+        runtime.block_on(test_profile_provider_assume_role_async());
     }
 }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "s3_tests")]
 
 use aws_config::BehaviorVersion;
-use aws_credential_types::Credentials;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::error::SdkError;
@@ -118,20 +117,6 @@ pub fn get_test_domain() -> String {
 
 pub fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
-pub fn get_credentials_from_env() -> Option<Credentials> {
-    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
-    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
-    let session_token = std::env::var("AWS_SESSION_TOKEN").ok();
-
-    Some(Credentials::new(
-        access_key_id,
-        secret_access_key,
-        session_token,
-        None,
-        "env",
-    ))
 }
 
 pub async fn get_test_sdk_client() -> s3::Client {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "s3_tests")]
 
 use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::error::SdkError;
@@ -117,6 +118,20 @@ pub fn get_test_domain() -> String {
 
 pub fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
+pub fn get_credentials_from_env() -> Option<Credentials> {
+    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
+    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+    let session_token = std::env::var("AWS_SESSION_TOKEN").ok();
+
+    Some(Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+        None,
+        "env",
+    ))
 }
 
 pub async fn get_test_sdk_client() -> s3::Client {

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -53,6 +53,7 @@ mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
 assert_cmd = "2.0.6"
 assert_fs = "1.1.1"
 aws-config = "1.2.0"
+aws-credential-types = "1.2.0"
 aws-sdk-s3 = "1.23.0"
 aws-sdk-sts = "1.20.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,7 +1,7 @@
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_sts::config::Credentials;
-use rand::{seq::IteratorRandom, RngCore};
+use rand::RngCore;
 use rand_chacha::rand_core::OsRng;
 
 use crate::common::tokio_block_on;
@@ -34,37 +34,12 @@ pub fn get_test_region() -> String {
     std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
 }
 
-// Get a random region other than what configured in S3_REGION
-pub fn get_random_non_test_region() -> String {
-    // All AWS regions that are enabled by default, we can get this list from APIs but that's probably overkill.
-    let regions = vec![
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-northeast-3",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ca-central-1",
-        "eu-central-1",
-        "eu-north-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "sa-east-1",
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-    ];
-
-    let test_region = get_test_region();
-    let mut rng = rand::thread_rng();
-    regions
-        .into_iter()
-        .filter(|region| *region != test_region)
-        .choose(&mut rng)
-        .unwrap()
-        .to_string()
+// Get a region other than what configured in S3_REGION
+pub fn get_non_test_region() -> String {
+    match get_test_region().as_str() {
+        "us-east-1" => String::from("us-west-2"),
+        _ => String::from("us-east-1"),
+    }
 }
 
 pub fn get_subsession_iam_role() -> String {

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -46,20 +46,6 @@ pub fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
 }
 
-pub fn get_credentials_from_env() -> Option<Credentials> {
-    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
-    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
-    let session_token = std::env::var("AWS_SESSION_TOKEN").ok();
-
-    Some(Credentials::new(
-        access_key_id,
-        secret_access_key,
-        session_token,
-        None,
-        "env",
-    ))
-}
-
 pub async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {
     let sdk_config = aws_config::defaults(BehaviorVersion::latest())
         .region(Region::new(region.to_owned()))

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -61,7 +61,7 @@ pub fn get_random_non_test_region() -> String {
     let mut rng = rand::thread_rng();
     regions
         .into_iter()
-        .filter(|region| region.to_string() != test_region)
+        .filter(|region| *region != test_region)
         .choose(&mut rng)
         .unwrap()
         .to_string()
@@ -69,6 +69,20 @@ pub fn get_random_non_test_region() -> String {
 
 pub fn get_subsession_iam_role() -> String {
     std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}
+
+pub fn get_credentials_from_env() -> Option<Credentials> {
+    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
+    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+    let session_token = std::env::var("AWS_SESSION_TOKEN").ok();
+
+    Some(Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+        None,
+        "env",
+    ))
 }
 
 pub async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,7 +1,7 @@
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_sts::config::Credentials;
-use rand::RngCore;
+use rand::{seq::IteratorRandom, RngCore};
 use rand_chacha::rand_core::OsRng;
 
 use crate::common::tokio_block_on;
@@ -32,6 +32,39 @@ pub fn get_test_bucket_forbidden() -> String {
 
 pub fn get_test_region() -> String {
     std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
+}
+
+// Get a random region other than what configured in S3_REGION
+pub fn get_random_non_test_region() -> String {
+    // All AWS regions that are enabled by default, we can get this list from APIs but that's probably overkill.
+    let regions = vec![
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    ];
+
+    let test_region = get_test_region();
+    let mut rng = rand::thread_rng();
+    regions
+        .into_iter()
+        .filter(|region| region.to_string() != test_region)
+        .choose(&mut rng)
+        .unwrap()
+        .to_string()
 }
 
 pub fn get_subsession_iam_role() -> String {

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -21,8 +21,8 @@ use test_case::test_case;
 
 use crate::common::fuse::read_dir_to_entry_names;
 use crate::common::s3::{
-    create_objects, get_credentials_from_env, get_random_non_test_region, get_subsession_iam_role,
-    get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region, get_test_sdk_client,
+    create_objects, get_credentials_from_env, get_non_test_region, get_subsession_iam_role, get_test_bucket_and_prefix,
+    get_test_bucket_forbidden, get_test_region, get_test_sdk_client,
 };
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::s3::{get_scoped_down_credentials, get_test_kms_key_id};
@@ -538,7 +538,7 @@ fn mount_with_assumed_role_in_other_region() -> Result<(), Box<dyn std::error::E
     let (bucket, prefix) = get_test_bucket_and_prefix("mount_with_assumed_role_in_other_region");
     let subsession_role = get_subsession_iam_role();
     let region = get_test_region();
-    let other_region = get_random_non_test_region();
+    let other_region = get_non_test_region();
     let mount_point = assert_fs::TempDir::new()?;
     let profile_name = "fork_test";
     let source_profile = "default";
@@ -611,6 +611,7 @@ fn mount_with_assumed_role_no_region() -> Result<(), Box<dyn std::error::Error>>
         .env_remove("AWS_ACCESS_KEY_ID")
         .env_remove("AWS_SECRET_ACCESS_KEY")
         .env_remove("AWS_SESSION_TOKEN")
+        .env("AWS_EC2_METADATA_DISABLED", "true")
         .env_remove("AWS_REGION")
         .env_remove("AWS_DEFAULT_REGION")
         .spawn()


### PR DESCRIPTION
## Description of change

Currently, we don't have any tests that verify mountpoint can assume a role configured in the CLI config file. This change adds some tests to cover them.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/861

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
