### PR TITLE
Use separate IAM role for the bench CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
+        role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+        aws-region: ${{ vars.S3_BENCH_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v4
@@ -79,8 +79,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
+        role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+        aws-region: ${{ vars.S3_BENCH_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v4
@@ -125,8 +125,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
+        role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+        aws-region: ${{ vars.S3_BENCH_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
+        role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+        aws-region: ${{ vars.S3_BENCH_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v4
@@ -80,8 +80,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
-        aws-region: ${{ vars.S3_REGION }}
+        role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+        aws-region: ${{ vars.S3_BENCH_REGION }}
         role-duration-seconds: 21600
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description of change

Followup on https://github.com/awslabs/mountpoint-s3/pull/881, we also want to use different IAM role for running the benchmark.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
