### PR TITLE
Improve cancellation test for PutObject write

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -252,3 +252,10 @@ impl PutObjectRequest for S3PutObjectRequest {
         })
     }
 }
+
+impl S3PutObjectRequest {
+    /// The number of bytes written to this request so far.
+    pub fn bytes_written(&self) -> u64 {
+        self.total_bytes
+    }
+}

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -255,6 +255,7 @@ impl PutObjectRequest for S3PutObjectRequest {
 
 impl S3PutObjectRequest {
     /// The number of bytes written to this request so far.
+    // TODO: consider exposing on the `PutObjectRequest` trait.
     pub fn bytes_written(&self) -> u64 {
         self.total_bytes
     }


### PR DESCRIPTION
## Description of change

Remove reliance of timing when testing PutObject write cancellation. 

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
