### PR TITLE
Small refactors of inode code

### DIFF
--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -297,13 +297,12 @@ impl Superblock {
         _client: &OC,
         ino: InodeNo,
         parent_ino: InodeNo,
-        pid: u32,
         allow_overwrite: bool,
         is_truncate: bool,
     ) -> WriteHandle {
         trace!(?ino, parent=?parent_ino, "write");
 
-        WriteHandle::new(self.inner.clone(), ino, parent_ino, pid, allow_overwrite, is_truncate)
+        WriteHandle::new(self.inner.clone(), ino, parent_ino, allow_overwrite, is_truncate)
     }
 
     /// Start a readdir stream for the given directory inode
@@ -1092,7 +1091,6 @@ pub struct WriteHandle {
     inner: Arc<SuperblockInner>,
     ino: InodeNo,
     parent_ino: InodeNo,
-    pid: u32,
     allow_overwrite: bool,
     is_truncate: bool,
 }
@@ -1103,7 +1101,6 @@ impl WriteHandle {
         inner: Arc<SuperblockInner>,
         ino: InodeNo,
         parent_ino: InodeNo,
-        pid: u32,
         allow_overwrite: bool,
         is_truncate: bool,
     ) -> Self {
@@ -1111,7 +1108,6 @@ impl WriteHandle {
             inner,
             ino,
             parent_ino,
-            pid,
             allow_overwrite,
             is_truncate,
         }
@@ -1151,11 +1147,6 @@ impl WriteHandle {
                 Ok(self)
             }
         }
-    }
-
-    /// The pid of the process which opened this handle.
-    pub fn pid(&self) -> u32 {
-        self.pid
     }
 
     /// Update status of the inode and of containing "local" directories.
@@ -2141,7 +2132,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, 0, false, false)
+                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
                 .await;
             expected_list.push(filename);
         }
@@ -2197,7 +2188,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, 0, false, false)
+                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
                 .await;
             expected_list.push(filename);
         }
@@ -2354,7 +2345,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, 0, false, false)
+                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
                 .await;
         }
 
@@ -2654,7 +2645,7 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), leaf_dir_ino, 0, false, false)
+            .write(&client, new_inode.inode.ino(), leaf_dir_ino, false, false)
             .await;
         let writehandle = writehandle.start_writing().expect("should be able to start writing");
 
@@ -2827,7 +2818,7 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, 0, false, false)
+            .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
             .await;
         let writehandle = writehandle.start_writing().expect("should be able to start writing");
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -291,18 +291,65 @@ impl Superblock {
         Ok(LookedUp { inode, stat })
     }
 
-    /// Create a new write handle to be used for state transition
+    /// Create a new handle for a file being written. The handle can be used to update the state of
+    /// the inflight write and commit it once finished.
     pub async fn write<OC: ObjectClient>(
         &self,
         _client: &OC,
         ino: InodeNo,
-        parent_ino: InodeNo,
         allow_overwrite: bool,
         is_truncate: bool,
-    ) -> WriteHandle {
-        trace!(?ino, parent=?parent_ino, "write");
+    ) -> Result<WriteHandle, InodeError> {
+        trace!(?ino, "write");
 
-        WriteHandle::new(self.inner.clone(), ino, parent_ino, allow_overwrite, is_truncate)
+        let inode = self.inner.get(ino)?;
+        let mut state = inode.get_mut_inode_state()?;
+        if state.reader_count > 0 {
+            return Err(InodeError::InodeNotWritableWhileReading(inode.err()));
+        }
+        match state.write_status {
+            WriteStatus::LocalUnopened => {
+                state.write_status = WriteStatus::LocalOpen;
+                state.stat.size = 0;
+            }
+            WriteStatus::LocalOpen => return Err(InodeError::InodeAlreadyWriting(inode.err())),
+            WriteStatus::Remote => {
+                if !allow_overwrite {
+                    tracing::warn!(
+                        "file overwrite is disabled by default, you need to remount with --allow-overwrite flag and open the file in truncate mode (O_TRUNC) to overwrite it"
+                    );
+                    return Err(InodeError::InodeNotWritable(inode.err()));
+                }
+
+                if !is_truncate {
+                    tracing::warn!(
+                        "modifying an existing file is only allowed when the file is opened in truncate mode (O_TRUNC)"
+                    );
+                    return Err(InodeError::InodeNotWritable(inode.err()));
+                }
+
+                state.write_status = WriteStatus::LocalOpen;
+                state.stat.size = 0;
+            }
+        }
+        drop(state);
+
+        Ok(WriteHandle::new(self.inner.clone(), inode))
+    }
+
+    /// Create a new handle for a file being read. The handle can be used to update the state of
+    /// the inflight read and commit it once finished.
+    pub async fn read<OC: ObjectClient>(&self, _client: &OC, ino: InodeNo) -> Result<ReadHandle, InodeError> {
+        trace!(?ino, "read");
+
+        let inode = self.inner.get(ino)?;
+        let mut state = inode.get_mut_inode_state()?;
+        if state.write_status != WriteStatus::Remote {
+            return Err(InodeError::InodeNotReadableWhileWriting(inode.err()));
+        }
+        state.reader_count += 1;
+        drop(state);
+        Ok(ReadHandle::new(inode))
     }
 
     /// Start a readdir stream for the given directory inode
@@ -1089,75 +1136,22 @@ impl LookedUp {
 #[derive(Debug, Clone)]
 pub struct WriteHandle {
     inner: Arc<SuperblockInner>,
-    ino: InodeNo,
-    parent_ino: InodeNo,
-    allow_overwrite: bool,
-    is_truncate: bool,
+    inode: Inode,
 }
 
 impl WriteHandle {
     /// Create a new write handle
-    fn new(
-        inner: Arc<SuperblockInner>,
-        ino: InodeNo,
-        parent_ino: InodeNo,
-        allow_overwrite: bool,
-        is_truncate: bool,
-    ) -> Self {
-        Self {
-            inner,
-            ino,
-            parent_ino,
-            allow_overwrite,
-            is_truncate,
-        }
-    }
-
-    /// Check the status on the inode and set it to writing state if it's writable
-    pub fn start_writing(self) -> Result<Self, InodeError> {
-        let inode = self.inner.get(self.ino)?;
-        let mut state = inode.get_mut_inode_state()?;
-        if state.reader_count > 0 {
-            return Err(InodeError::InodeNotWritableWhileReading(inode.err()));
-        }
-        match state.write_status {
-            WriteStatus::LocalUnopened => {
-                state.write_status = WriteStatus::LocalOpen;
-                state.stat.size = 0;
-                Ok(self)
-            }
-            WriteStatus::LocalOpen => Err(InodeError::InodeAlreadyWriting(inode.err())),
-            WriteStatus::Remote => {
-                if !self.allow_overwrite {
-                    tracing::warn!(
-                        "file overwrite is disabled by default, you need to remount with --allow-overwrite flag and open the file in truncate mode (O_TRUNC) to overwrite it"
-                    );
-                    return Err(InodeError::InodeNotWritable(inode.err()));
-                }
-
-                if !self.is_truncate {
-                    tracing::warn!(
-                        "modifying an existing file is only allowed when the file is opened in truncate mode (O_TRUNC)"
-                    );
-                    return Err(InodeError::InodeNotWritable(inode.err()));
-                }
-
-                state.write_status = WriteStatus::LocalOpen;
-                state.stat.size = 0;
-                Ok(self)
-            }
-        }
+    fn new(inner: Arc<SuperblockInner>, inode: Inode) -> Self {
+        Self { inner, inode }
     }
 
     /// Update status of the inode and of containing "local" directories.
-    pub fn finish_writing(self) -> Result<(), InodeError> {
-        let inode = self.inner.get(self.ino)?;
-
+    pub fn finish(self) -> Result<(), InodeError> {
         // Collect ancestor inodes that may need updating,
         // from parent to first remote ancestor.
         let ancestors = {
             let mut ancestors = Vec::new();
-            let mut ancestor_ino = self.parent_ino;
+            let mut ancestor_ino = self.inode.parent();
             let mut visited = HashSet::new();
             loop {
                 assert!(visited.insert(ancestor_ino), "cycle detected in inode ancestors");
@@ -1178,7 +1172,7 @@ impl WriteHandle {
             .map(|inode| inode.get_mut_inode_state())
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut state = inode.get_mut_inode_state()?;
+        let mut state = self.inode.get_mut_inode_state()?;
         match state.write_status {
             WriteStatus::LocalOpen => {
                 state.write_status = WriteStatus::Remote;
@@ -1188,7 +1182,8 @@ impl WriteHandle {
 
                 // Walk up the ancestors from parent to first remote ancestor to transition
                 // the inode and all "local" containing directories to "remote".
-                let children_inos = std::iter::once(self.ino).chain(ancestors.iter().map(|ancestor| ancestor.ino()));
+                let children_inos =
+                    std::iter::once(self.inode.ino()).chain(ancestors.iter().map(|ancestor| ancestor.ino()));
                 for (ancestor_state, child_ino) in ancestors_states.iter_mut().rev().zip(children_inos) {
                     match &mut ancestor_state.kind_data {
                         InodeKindData::File { .. } => unreachable!("we know the ancestor is a directory"),
@@ -1201,8 +1196,29 @@ impl WriteHandle {
 
                 Ok(())
             }
-            _ => Err(InodeError::InodeInvalidWriteStatus(inode.err())),
+            _ => Err(InodeError::InodeInvalidWriteStatus(self.inode.err())),
         }
+    }
+}
+
+/// Handle for a file being read
+#[derive(Debug)]
+pub struct ReadHandle {
+    inode: Inode,
+}
+
+impl ReadHandle {
+    /// Create a new read handle
+    fn new(inode: Inode) -> Self {
+        Self { inode }
+    }
+
+    /// Update status of the inode to reflect the read being finished
+    pub fn finish(self) -> Result<(), InodeError> {
+        // Decrease reader count for the inode
+        let mut state = self.inode.get_mut_inode_state()?;
+        state.reader_count -= 1;
+        Ok(())
     }
 }
 
@@ -1296,24 +1312,6 @@ impl Inode {
     pub fn inc_file_size(&self, len: usize) {
         let mut state = self.inner.sync.write().unwrap();
         state.stat.size += len;
-    }
-
-    pub fn start_reading(&self) -> Result<(), InodeError> {
-        let mut state = self.get_mut_inode_state()?;
-        match state.write_status {
-            WriteStatus::Remote => {
-                state.reader_count += 1;
-                Ok(())
-            }
-            _ => Err(InodeError::InodeNotReadableWhileWriting(self.err())),
-        }
-    }
-
-    pub fn finish_reading(&self) -> Result<(), InodeError> {
-        // Decrease reader count for the inode
-        let mut state = self.get_mut_inode_state()?;
-        state.reader_count -= 1;
-        Ok(())
     }
 
     /// return Inode State with read lock after checking whether the directory inode is deleted or not.
@@ -2132,8 +2130,9 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
-                .await;
+                .write(&client, new_inode.inode.ino(), false, false)
+                .await
+                .expect("should be able to start writing");
             expected_list.push(filename);
         }
 
@@ -2188,8 +2187,9 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
-                .await;
+                .write(&client, new_inode.inode.ino(), false, false)
+                .await
+                .expect("should be able to start writing");
             expected_list.push(filename);
         }
 
@@ -2345,8 +2345,9 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
-                .await;
+                .write(&client, new_inode.inode.ino(), false, false)
+                .await
+                .expect("should be able to start writing");
         }
 
         // Create some local directories
@@ -2645,13 +2646,13 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), leaf_dir_ino, false, false)
-            .await;
-        let writehandle = writehandle.start_writing().expect("should be able to start writing");
+            .write(&client, new_inode.inode.ino(), false, false)
+            .await
+            .expect("should be able to start writing");
 
         // Invoke [finish_writing], without actually adding the
         // object to the client
-        writehandle.finish_writing().unwrap();
+        writehandle.finish().unwrap();
 
         // All nested dirs disappear
         let dirname = nested_dirs.first().unwrap();
@@ -2818,9 +2819,9 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), FUSE_ROOT_INODE, false, false)
-            .await;
-        let writehandle = writehandle.start_writing().expect("should be able to start writing");
+            .write(&client, new_inode.inode.ino(), false, false)
+            .await
+            .expect("should be able to start writing");
 
         let atime = OffsetDateTime::UNIX_EPOCH + Duration::days(90);
         let mtime = OffsetDateTime::UNIX_EPOCH + Duration::days(60);
@@ -2843,7 +2844,7 @@ mod tests {
         assert_eq!(stat.mtime, mtime);
 
         // Invoke [finish_writing] to make the file remote
-        writehandle.finish_writing().unwrap();
+        writehandle.finish().unwrap();
 
         // Should get an error back when calling setattr
         let result = superblock


### PR DESCRIPTION
## Description of change

This is three commits, each a small refactoring to better separate `inode.rs` and `fs.rs`, which I did as part of a larger refactoring coming later:
1. Move the process ID out of `inode.rs` -- the WriteHandle was just storing the PID and never using it itself, since the check happens in `fs.rs`, so the PID can live on the `fs.rs` handle instead
2. Clean up the lifecycle of `inode.rs` WriteHandles by making them immediately call `start_writing`, and add a symmetric ReadHandle with the same lifecycle and purpose, in place of `start_reading` and `finish_reading`.
3. Move `inc_file_size` off the Inode and onto the WriteHandle since it only makes sense to use while writing.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
