### PR TITLE
Support backpressure for GetObject request

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -117,6 +117,8 @@ fn main() {
                 bucket: BUCKET.to_owned(),
                 part_size: args.part_size,
                 unordered_list_seed: None,
+                enable_back_pressure: false,
+                initial_read_window_size: 0,
             };
             let client = ThroughputMockClient::new(config, args.throughput_target_gbps);
             let client = Arc::new(client);

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -117,8 +117,7 @@ fn main() {
                 bucket: BUCKET.to_owned(),
                 part_size: args.part_size,
                 unordered_list_seed: None,
-                enable_back_pressure: false,
-                initial_read_window_size: 0,
+                ..Default::default()
             };
             let client = ThroughputMockClient::new(config, args.throughput_target_gbps);
             let client = Arc::new(client);

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -376,8 +376,7 @@ mod tests {
             bucket: bucket.to_string(),
             part_size: 128,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let body = vec![0u8; 50];

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -52,7 +52,7 @@ pub mod imds_crt_client;
 pub mod instance_info;
 #[doc(hidden)]
 pub mod mock_client;
-mod object_client;
+pub mod object_client;
 mod s3_crt_client;
 #[doc(hidden)]
 pub mod user_agent;

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -52,7 +52,7 @@ pub mod imds_crt_client;
 pub mod instance_info;
 #[doc(hidden)]
 pub mod mock_client;
-pub mod object_client;
+mod object_client;
 mod s3_crt_client;
 #[doc(hidden)]
 pub mod user_agent;
@@ -71,9 +71,9 @@ pub mod config {
 pub mod types {
     pub use super::object_client::{
         Checksum, ChecksumAlgorithm, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts,
-        GetObjectAttributesResult, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult,
-        ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectTrailingChecksums, RestoreStatus,
-        UploadReview, UploadReviewPart,
+        GetObjectAttributesResult, GetObjectRequest, HeadObjectResult, ListObjectsResult, ObjectAttribute,
+        ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectTrailingChecksums,
+        RestoreStatus, UploadReview, UploadReviewPart,
     };
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -24,9 +24,9 @@ use tracing::trace;
 use crate::checksums::crc32c_to_base64;
 use crate::object_client::{
     Checksum, ChecksumAlgorithm, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError,
-    GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, HeadObjectError, HeadObjectResult,
-    ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult,
-    ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
+    GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
+    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
+    ObjectClientResult, ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
     PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
 };
 
@@ -62,6 +62,10 @@ pub struct MockClientConfig {
     pub part_size: usize,
     /// A seed to randomize the order of ListObjectsV2 results, or None to use ordered list
     pub unordered_list_seed: Option<u64>,
+    /// A flag to enable backpressure read
+    pub enable_back_pressure: bool,
+    /// Initial backpressure read window size, ignored if enable_back_pressure is false
+    pub initial_read_window_size: usize,
 }
 
 /// A mock implementation of an object client that we can manually add objects to, and then query
@@ -465,14 +469,16 @@ impl std::fmt::Debug for MockObject {
 }
 
 #[derive(Debug)]
-pub struct GetObjectResult {
+pub struct MockGetObjectRequest {
     object: MockObject,
     next_offset: u64,
     length: usize,
     part_size: usize,
+    enable_back_pressure: bool,
+    current_window_size: usize,
 }
 
-impl GetObjectResult {
+impl MockGetObjectRequest {
     /// Helpful test utility to just collect the entire object into memory. Will panic if the object
     /// parts are streamed out of order.
     pub async fn collect(mut self) -> ObjectClientResult<Box<[u8]>, GetObjectError, MockClientError> {
@@ -487,7 +493,15 @@ impl GetObjectResult {
     }
 }
 
-impl Stream for GetObjectResult {
+impl GetObjectRequest for MockGetObjectRequest {
+    type ClientError = MockClientError;
+
+    fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
+        self.current_window_size += len;
+    }
+}
+
+impl Stream for MockGetObjectRequest {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, MockClientError>;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -495,12 +509,21 @@ impl Stream for GetObjectResult {
             return Poll::Ready(None);
         }
 
-        let next_part_size = self.part_size.min(self.length);
-        let next_part = self.object.read(self.next_offset, next_part_size);
+        let mut next_read_size = self.part_size.min(self.length);
+
+        // Simulate backpressure mechanism
+        if self.enable_back_pressure {
+            if self.current_window_size == 0 {
+                return Poll::Pending;
+            }
+            next_read_size = self.current_window_size.min(next_read_size);
+            self.current_window_size -= next_read_size;
+        }
+        let next_part = self.object.read(self.next_offset, next_read_size);
 
         let result = (self.next_offset, next_part);
-        self.next_offset += next_part_size as u64;
-        self.length -= next_part_size;
+        self.next_offset += next_read_size as u64;
+        self.length -= next_read_size;
         Poll::Ready(Some(Ok(result)))
     }
 }
@@ -520,7 +543,7 @@ fn mock_client_error<T, E>(s: impl Into<Cow<'static, str>>) -> ObjectClientResul
 
 #[cfg_attr(not(docs_rs), async_trait)]
 impl ObjectClient for MockClient {
-    type GetObjectResult = GetObjectResult;
+    type GetObjectRequest = MockGetObjectRequest;
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
@@ -551,7 +574,7 @@ impl ObjectClient for MockClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
         trace!(bucket, key, ?range, ?if_match, "GetObject");
         self.inc_op_count(Operation::GetObject);
 
@@ -577,11 +600,13 @@ impl ObjectClient for MockClient {
                 (0, object.len())
             };
 
-            Ok(GetObjectResult {
+            Ok(MockGetObjectRequest {
                 object: object.clone(),
                 next_offset,
                 length,
                 part_size: self.config.part_size,
+                enable_back_pressure: self.config.enable_back_pressure,
+                current_window_size: self.config.initial_read_window_size,
             })
         } else {
             Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey))
@@ -872,7 +897,12 @@ enum MockObjectParts {
 
 #[cfg(test)]
 mod tests {
-    use futures::StreamExt;
+    use std::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread,
+    };
+
+    use futures::{pin_mut, StreamExt};
     use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
     use test_case::test_case;
@@ -886,6 +916,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut body = vec![0u8; size];
@@ -917,6 +949,55 @@ mod tests {
         test_get_object("key1", 10, Some(0..10)).await;
     }
 
+    async fn test_get_object_backpressure(
+        key: &str,
+        size: usize,
+        range: Option<Range<u64>>,
+        backpressure_read_window_size: usize,
+    ) {
+        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
+
+        let client = MockClient::new(MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024,
+            unordered_list_seed: None,
+            enable_back_pressure: true,
+            initial_read_window_size: backpressure_read_window_size,
+        });
+
+        let mut body = vec![0u8; size];
+        rng.fill_bytes(&mut body);
+        client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
+
+        let get_request = client
+            .get_object("test_bucket", key, range.clone(), None)
+            .await
+            .expect("should not fail");
+        pin_mut!(get_request);
+
+        let mut accum = vec![];
+        let mut next_offset = range.as_ref().map(|r| r.start).unwrap_or(0);
+        while let Some(r) = get_request.next().await {
+            let (offset, body) = r.expect("get_object body part failed");
+            assert_eq!(offset, next_offset, "wrong body part offset");
+            next_offset += body.len() as u64;
+            accum.extend_from_slice(&body[..]);
+            get_request
+                .as_mut()
+                .increment_read_window(backpressure_read_window_size);
+        }
+        let expected_range = range.unwrap_or(0..size as u64);
+        let expected_range = expected_range.start as usize..expected_range.end as usize;
+        assert_eq!(&accum[..], &body[expected_range], "body does not match");
+    }
+
+    #[tokio::test]
+    async fn get_object_backpressure() {
+        test_get_object_backpressure("key1", 2000, None, 256).await;
+        test_get_object_backpressure("key1", 9000, Some(50..2000), 512).await;
+        test_get_object_backpressure("key1", 10, Some(0..10), 256).await;
+    }
+
     #[allow(clippy::reversed_empty_ranges)]
     #[tokio::test]
     async fn get_object_errors() {
@@ -926,6 +1007,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut body = vec![0u8; 2000];
@@ -976,12 +1059,63 @@ mod tests {
         );
     }
 
+    // Verify that the request is blocked when we don't increment read window size
+    #[tokio::test]
+    async fn verify_backpressure_get_object() {
+        let key = "key1";
+        let size = 1000;
+        let range = 50..1000;
+        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
+
+        let client = MockClient::new(MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024,
+            unordered_list_seed: None,
+            enable_back_pressure: true,
+            initial_read_window_size: 256,
+        });
+
+        let mut body = vec![0u8; size];
+        rng.fill_bytes(&mut body);
+        client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
+
+        let mut get_request = client
+            .get_object("test_bucket", key, Some(range.clone()), None)
+            .await
+            .expect("should not fail");
+
+        let mut accum = vec![];
+        let mut next_offset = range.start;
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            futures::executor::block_on(async move {
+                while let Some(r) = get_request.next().await {
+                    let (offset, body) = r.unwrap();
+                    assert_eq!(offset, next_offset, "wrong body part offset");
+                    next_offset += body.len() as u64;
+                    accum.extend_from_slice(&body[..]);
+                }
+                let expected_range = range;
+                let expected_range = expected_range.start as usize..expected_range.end as usize;
+                assert_eq!(&accum[..], &body[expected_range], "body does not match");
+                sender.send(accum).unwrap();
+            })
+        });
+        match receiver.recv_timeout(Duration::from_millis(100)) {
+            Ok(_) => panic!("request should have been blocked"),
+            Err(e) => assert_eq!(e, RecvTimeoutError::Timeout),
+        }
+    }
+
     #[tokio::test]
     async fn list_object_dirs() {
         let client = MockClient::new(MockClientConfig {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut keys = vec![];
@@ -1070,6 +1204,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut keys = vec![];
@@ -1117,6 +1253,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1190,6 +1328,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1257,6 +1397,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         for i in 0..20 {
@@ -1323,6 +1465,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let mut put_request = client
@@ -1378,6 +1522,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let key = "key1";
@@ -1407,6 +1553,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let head_counter_1 = client.new_counter(Operation::HeadObject);
@@ -1443,6 +1591,8 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: PART_SIZE,
             unordered_list_seed: None,
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         });
 
         let key = "key1";

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -916,8 +916,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let mut body = vec![0u8; size];
@@ -1007,8 +1006,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let mut body = vec![0u8; 2000];
@@ -1114,8 +1112,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let mut keys = vec![];
@@ -1204,8 +1201,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let mut keys = vec![];
@@ -1253,8 +1249,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         for i in 0..20 {
@@ -1328,8 +1323,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         for i in 0..20 {
@@ -1397,8 +1391,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: Some(1234),
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         for i in 0..20 {
@@ -1465,8 +1458,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let mut put_request = client
@@ -1522,8 +1514,7 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let key = "key1";
@@ -1553,8 +1544,7 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let head_counter_1 = client.new_counter(Operation::HeadObject);
@@ -1591,8 +1581,7 @@ mod tests {
             bucket: bucket.to_owned(),
             part_size: PART_SIZE,
             unordered_list_seed: None,
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         });
 
         let key = "key1";

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -187,8 +187,7 @@ mod tests {
                     part_size: 8 * 1024 * 1024,
                     bucket: "test_bucket".to_owned(),
                     unordered_list_seed: None,
-                    enable_back_pressure: false,
-                    initial_read_window_size: 0,
+                    ..Default::default()
                 };
                 let client = ThroughputMockClient::new(config, rate_gbps);
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -3,19 +3,21 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use async_io::block_on;
 use async_trait::async_trait;
-use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
+use futures::Stream;
 use pin_project::pin_project;
 
 use crate::mock_client::leaky_bucket::LeakyBucket;
 use crate::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, MockPutObjectRequest};
 use crate::object_client::{
     DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
-    GetObjectError, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
-    ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams,
+    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
+    ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams,
 };
 use crate::types::ETag;
+
+use super::MockGetObjectRequest;
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
 /// performance without the jitter or service latency of targeting a real service. Note that while
@@ -57,23 +59,41 @@ impl ThroughputMockClient {
 }
 
 #[pin_project]
-pub struct GetObjectResult {
+pub struct ThroughputGetObjectRequest {
     #[pin]
-    inner: BoxStream<'static, ObjectClientResult<GetBodyPart, GetObjectError, MockClientError>>,
+    request: MockGetObjectRequest,
+    rate_limiter: LeakyBucket,
 }
 
-impl Stream for GetObjectResult {
+impl GetObjectRequest for ThroughputGetObjectRequest {
+    type ClientError = MockClientError;
+
+    fn increment_read_window(self: Pin<&mut Self>, len: usize) {
+        let this = self.project();
+        this.request.increment_read_window(len);
+    }
+}
+
+impl Stream for ThroughputGetObjectRequest {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, MockClientError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        this.inner.poll_next(cx)
+        this.request.poll_next(cx).map(|next| {
+            next.map(|item| {
+                item.map(|body_part| {
+                    // Acquire enough tokens for the number of bytes we want to deliver
+                    block_on(this.rate_limiter.acquire(body_part.1.len() as u32));
+                    body_part
+                })
+            })
+        })
     }
 }
 
 #[async_trait]
 impl ObjectClient for ThroughputMockClient {
-    type GetObjectResult = GetObjectResult;
+    type GetObjectRequest = ThroughputGetObjectRequest;
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
@@ -95,19 +115,10 @@ impl ObjectClient for ThroughputMockClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
-        let inner = self.inner.get_object(bucket, key, range, if_match).await?;
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
+        let request = self.inner.get_object(bucket, key, range, if_match).await?;
         let rate_limiter = self.rate_limiter.clone();
-        let stream = inner.then(move |p| {
-            let rate_limiter = rate_limiter.clone();
-            async move {
-                let p = p?;
-                // Acquire enough tokens for the number of bytes we want to deliver
-                rate_limiter.acquire(p.1.len() as u32).await;
-                Ok(p)
-            }
-        });
-        Ok(GetObjectResult { inner: stream.boxed() })
+        Ok(ThroughputGetObjectRequest { request, rate_limiter })
     }
 
     async fn list_objects(
@@ -176,6 +187,8 @@ mod tests {
                     part_size: 8 * 1024 * 1024,
                     bucket: "test_bucket".to_owned(),
                     unordered_list_seed: None,
+                    enable_back_pressure: false,
+                    initial_read_window_size: 0,
                 };
                 let client = ThroughputMockClient::new(config, rate_gbps);
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -346,7 +346,20 @@ pub trait GetObjectRequest:
 {
     type ClientError: std::error::Error + Send + Sync + 'static;
 
-    /// Increase current read window for backpressure read.
+    /// Increment the flow-control window, so that response data continues downloading.
+    ///
+    /// If the client was created with `enable_read_backpressure` set true,
+    /// each meta request has a flow-control window that shrinks as response
+    /// body data is downloaded (headers do not affect the size of the window).
+    /// The client's `initial_read_window` determines the starting size of each meta request's window.
+    /// If a meta request's flow-control window reaches 0, no further data will be downloaded.
+    /// If the `initial_read_window` is 0, the request will not start until the window is incremented.
+    /// Maintain a larger window to keep up a high download throughput,
+    /// parts cannot download in parallel unless the window is large enough to hold multiple parts.
+    /// Maintain a smaller window to limit the amount of data buffered in memory.
+    ///
+    /// If `enable_read_backpressure` is false this call will have no effect,
+    /// no backpressure is being applied and data is being downloaded as fast as possible.
     fn increment_read_window(self: Pin<&mut Self>, len: usize);
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use futures::Stream;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::time::SystemTime;
 use std::{
@@ -71,7 +72,7 @@ impl FromStr for ETag {
 #[cfg_attr(not(docs_rs), async_trait)]
 #[auto_impl(Arc)]
 pub trait ObjectClient {
-    type GetObjectResult: Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send;
+    type GetObjectRequest: GetObjectRequest<ClientError = Self::ClientError>;
     type PutObjectRequest: PutObjectRequest<ClientError = Self::ClientError>;
     type ClientError: std::error::Error + Send + Sync + 'static;
 
@@ -96,7 +97,7 @@ pub trait ObjectClient {
         key: &str,
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError>;
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError>;
 
     /// List the objects in a bucket under a given prefix
     async fn list_objects(
@@ -333,6 +334,21 @@ pub type UploadReviewPart = mountpoint_s3_crt::s3::client::UploadReviewPart;
 
 /// A checksum algorithm used by the object client for integrity checks on uploads and downloads.
 pub type ChecksumAlgorithm = mountpoint_s3_crt::s3::client::ChecksumAlgorithm;
+
+/// A streaming response to a GetObject request.
+///
+/// This struct implements [`futures::Stream`], which you can use to read the body of the object.
+/// Each item of the stream is a part of the object body together with the part's offset within the
+/// object.
+#[cfg_attr(not(docs_rs), async_trait)]
+pub trait GetObjectRequest:
+    Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send
+{
+    type ClientError: std::error::Error + Send + Sync + 'static;
+
+    /// Increase current read window for backpressure read.
+    fn increment_read_window(self: Pin<&mut Self>, len: usize);
+}
 
 /// A streaming put request which allows callers to asynchronously write the body of the request.
 ///

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -90,19 +90,24 @@ pub struct S3ClientConfig {
     request_payer: Option<String>,
     bucket_owner: Option<String>,
     max_attempts: Option<NonZeroUsize>,
+    read_backpressure: bool,
+    initial_read_window: usize,
 }
 
 impl Default for S3ClientConfig {
     fn default() -> Self {
+        const DEFAULT_PART_SIZE: usize = 8 * 1024 * 1024;
         Self {
             auth_config: Default::default(),
             throughput_target_gbps: 10.0,
-            part_size: 8 * 1024 * 1024,
+            part_size: DEFAULT_PART_SIZE,
             endpoint_config: EndpointConfig::new("us-east-1"),
             user_agent: None,
             request_payer: None,
             bucket_owner: None,
             max_attempts: None,
+            read_backpressure: false,
+            initial_read_window: DEFAULT_PART_SIZE,
         }
     }
 }
@@ -166,6 +171,20 @@ impl S3ClientConfig {
     #[must_use = "S3ClientConfig follows a builder pattern"]
     pub fn max_attempts(mut self, max_attempts: NonZeroUsize) -> Self {
         self.max_attempts = Some(max_attempts);
+        self
+    }
+
+    /// Set the flag for backpressure read
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn read_backpressure(mut self, read_backpressure: bool) -> Self {
+        self.read_backpressure = read_backpressure;
+        self
+    }
+
+    /// Set a value for initial backpressure read window size
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn initial_read_window(mut self, initial_read_window: usize) -> Self {
+        self.initial_read_window = initial_read_window;
         self
     }
 }
@@ -320,6 +339,8 @@ impl S3CrtClientInner {
         };
 
         client_config.express_support(true);
+        client_config.read_backpressure(config.read_backpressure);
+        client_config.initial_read_window(config.initial_read_window);
         client_config.signing_config(signing_config);
 
         client_config
@@ -1027,7 +1048,7 @@ fn emit_throughput_metric(bytes: u64, duration: Duration, op: &'static str) {
 
 #[cfg_attr(not(docs_rs), async_trait)]
 impl ObjectClient for S3CrtClient {
-    type GetObjectResult = S3GetObjectRequest;
+    type GetObjectRequest = S3GetObjectRequest;
     type PutObjectRequest = S3PutObjectRequest;
     type ClientError = S3RequestError;
 
@@ -1054,7 +1075,7 @@ impl ObjectClient for S3CrtClient {
         if_match: Option<ETag>,
         // TODO: If more arguments are added to get object, make a request struct having those arguments
         // along with bucket and key.
-    ) -> ObjectClientResult<Self::GetObjectResult, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
         self.get_object(bucket, key, range, if_match)
     }
 

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -15,6 +15,8 @@ use pin_project::pin_project;
 use crate::object_client::{ETag, GetBodyPart, GetObjectError, ObjectClientError, ObjectClientResult};
 use crate::s3_crt_client::{S3CrtClient, S3HttpRequest, S3RequestError};
 
+use super::GetObjectRequest;
+
 impl S3CrtClient {
     /// Create and begin a new GetObject request. The returned [GetObjectRequest] is a [Stream] of
     /// body parts of the object, which will be delivered in order.
@@ -111,6 +113,14 @@ pub struct S3GetObjectRequest {
     #[pin]
     finish_receiver: UnboundedReceiver<Result<GetBodyPart, Error>>,
     finished: bool,
+}
+
+impl GetObjectRequest for S3GetObjectRequest {
+    type ClientError = S3RequestError;
+
+    fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
+        self.request.meta_request.increment_read_window(len as u64);
+    }
 }
 
 impl Stream for S3GetObjectRequest {

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -565,7 +565,7 @@ impl MetaRequest {
 
     /// Increment the flow-control windows size.
     pub fn increment_read_window(&mut self, bytes: u64) {
-        // SAFETY: `self.inner` is a valid `aws_s3_meta_request`.
+        // SAFETY: `self.inner` is a valid `aws_s3_meta_request` since we hold a ref count to it.
         unsafe { aws_s3_meta_request_increment_read_window(self.inner.as_ptr(), bytes) };
     }
 }

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -102,6 +102,18 @@ impl ClientConfig {
         self
     }
 
+    /// Enable backpressure read
+    pub fn read_backpressure(&mut self, read_backpressure: bool) -> &mut Self {
+        self.inner.enable_read_backpressure = read_backpressure;
+        self
+    }
+
+    /// Initial read window size for backpressure read feature
+    pub fn initial_read_window(&mut self, initial_read_window: usize) -> &mut Self {
+        self.inner.initial_read_window = initial_read_window;
+        self
+    }
+
     /// Size in bytes of parts the files will be downloaded or uploaded in.
     ///
     /// The AWS CRT client may adjust this value per-request where possible
@@ -549,6 +561,12 @@ impl MetaRequest {
     /// will fail with an AWS_ERROR_INVALID_STATE error.
     pub fn write<'r, 's>(&'r mut self, slice: &'s [u8], eof: bool) -> MetaRequestWrite<'r, 's> {
         MetaRequestWrite::new(self, slice, eof)
+    }
+
+    /// Increment the flow-control windows size.
+    pub fn increment_read_window(&mut self, bytes: u64) {
+        // SAFETY: `self.inner` is a valid `aws_s3_meta_request`.
+        unsafe { aws_s3_meta_request_increment_read_window(self.inner.as_ptr(), bytes) };
     }
 }
 

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -39,6 +39,8 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
         bucket: args.bucket_name.clone(),
         part_size: args.part_size as usize,
         unordered_list_seed: None,
+        enable_back_pressure: false,
+        initial_read_window_size: 0,
     };
     let client = ThroughputMockClient::new(config, max_throughput_gbps);
 

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -39,8 +39,7 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
         bucket: args.bucket_name.clone(),
         part_size: args.part_size as usize,
         unordered_list_seed: None,
-        enable_back_pressure: false,
-        initial_read_window_size: 0,
+        ..Default::default()
     };
     let client = ThroughputMockClient::new(config, max_throughput_gbps);
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -2300,8 +2300,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024 * 1024,
             unordered_list_seed: (!ordered).then_some(123456),
-            enable_back_pressure: false,
-            initial_read_window_size: 0,
+            ..Default::default()
         };
         let client = Arc::new(MockClient::new(client_config));
 

--- a/mountpoint-s3/src/inode.rs
+++ b/mountpoint-s3/src/inode.rs
@@ -2300,6 +2300,8 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024 * 1024,
             unordered_list_seed: (!ordered).then_some(123456),
+            enable_back_pressure: false,
+            initial_read_window_size: 0,
         };
         let client = Arc::new(MockClient::new(client_config));
 


### PR DESCRIPTION
## Description of change

The CRT has flow-control window feature in the read path (https://github.com/awslabs/aws-c-s3/pull/213) to let users control how fast they want to download data. This change exposes the backpressure read mechanism in the `get_object` interface.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
