### PR TITLE
Add hourly integration test run

### DIFF
--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main", "wf-changes/**" ]
   merge_group:
     types: [ "checks_requested" ]
+  schedule:
+    - cron: "0 * * * *"
 
 permissions:
   id-token: write
@@ -15,4 +17,4 @@ jobs:
     name: Integration
     uses: ./.github/workflows/integration.yml
     with:
-      ref: ${{ github.event.after }}
+      ref: ${{ github.sha }}


### PR DESCRIPTION
## Description of change

We saw an intermittent test issue. We'd like to have more visibility into this issue by reviewing regular test runs that don't depend on code change activity. By using a regular test run (currently hourly, we may reduce that later), we can see if there is an uptick in test failures and hopefully identify a time the change was introduced based on the pattern.

We use the schedule trigger: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

We change to the broader `github.sha` which should be set to a reasonable value for each event. For pushes, that's the new commit (or the default branch if the ref is deleted - irrelevant for `main`), the commit to be pushed to `main` for `merge_group`, or the default branch's latest SHA (`main`).

Relevant issues: N/A

## Does this change impact existing behavior?

Changes test workflows only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
