### PR TITLE
Save dump files to S3 when tests are failing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,6 +81,9 @@ jobs:
       run: cargo test --features $RUST_FEATURES --no-run
     - name: Run tests
       run: cargo test --features $RUST_FEATURES
+    - name: Save dump files
+      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"
 
   s3express-test:
     name: S3 Express One Zone tests (${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
@@ -126,6 +129,9 @@ jobs:
       run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests' --no-run
     - name: Run tests
       run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
+    - name: Save dump files
+      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_EXPRESS_ONE_ZONE_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"
 
   asan:
     name: Address sanitizer
@@ -163,3 +169,6 @@ jobs:
       run: make test-asan-working
     - name: Run tests
       run: make test-asan
+    - name: Save dump files
+      if: ${{ failure() }}
+      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"


### PR DESCRIPTION
## Description of change

We saw an intermittent test issue with segmentation fault. We want to get more information about this issue and the core dump files should help us understand it better. This will make our CI jobs save core dump files to the test bucket for further investigation.

Tested in my fork repo: https://github.com/monthonk/mountpoint-s3/actions/runs/9302773522/job/25603659858#step:8:35

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
