### PR TITLE
Save associated binary for core dump

### DIFF
--- a/.github/actions/scripts/save-coredump.sh
+++ b/.github/actions/scripts/save-coredump.sh
@@ -3,7 +3,7 @@
 bucket_name=$S3_BUCKET_NAME
 bucket_prefix=$S3_BUCKET_TEST_PREFIX
 coredump_path=/var/lib/systemd/coredump/
-coredump_pattern=core.mountpoint_s3*
+coredump_pattern=core.*
 
 # upload core dump files to S3
 aws s3 cp ${coredump_path} s3://${bucket_name}/${bucket_prefix}coredump/ --recursive --exclude "*" --include "${coredump_pattern}"

--- a/.github/actions/scripts/save-coredump.sh
+++ b/.github/actions/scripts/save-coredump.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+bucket_name=$S3_BUCKET_NAME
+bucket_prefix=$S3_BUCKET_TEST_PREFIX
+coredump_path=/var/lib/systemd/coredump/
+coredump_pattern=core.mountpoint_s3*
+
+# upload core dump files to S3
+aws s3 cp ${coredump_path} s3://${bucket_name}/${bucket_prefix}coredump/ --recursive --exclude "*" --include "${coredump_pattern}"
+
+# get all core dump records to find their associated binary files
+coredump_records=`coredumpctl --no-legend | awk '{print $5,$10}'`
+
+while IFS= read -r line; do
+    # get the pid to help matching it with the core dump
+    pid=`echo $line | awk '{print $1}'`
+    binary_path=`echo $line | awk '{print $2}'`
+    binary_name=$(basename $binary_path)
+    # upload each binary to S3
+    aws s3 cp ${binary_path} s3://${bucket_name}/${bucket_prefix}binary/${pid}_${binary_name}
+done <<< "$coredump_records"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,7 @@ jobs:
       run: cargo test --features $RUST_FEATURES
     - name: Save dump files
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
-      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"
+      run: ./.github/actions/scripts/save-coredump.sh
 
   s3express-test:
     name: S3 Express One Zone tests (${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
@@ -131,7 +131,7 @@ jobs:
       run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
     - name: Save dump files
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
-      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_EXPRESS_ONE_ZONE_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"
+      run: ./.github/actions/scripts/save-coredump.sh
 
   asan:
     name: Address sanitizer
@@ -171,4 +171,4 @@ jobs:
       run: make test-asan
     - name: Save dump files
       if: ${{ failure() }}
-      run: aws s3 cp /var/lib/systemd/coredump/ s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_BUCKET_TEST_PREFIX }}coredump/ --recursive --exclude "*" --include "core.mountpoint_s3*"
+      run: ./.github/actions/scripts/save-coredump.sh


### PR DESCRIPTION
## Description of change

To be able to analyze the core dump we also need the binary it was generated from. This adds a new script for uploading the binary associated with the core dump when tests are failing in the CI.

Tested here https://github.com/monthonk/mountpoint-s3/actions/runs/9318610444/job/25651288788#step:8:324, verified that the core dump and the binary are both uploaded to the test bucket.

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
