### PR TITLE
Add workflow_dispatch trigger for integration tests

### DIFF
--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -7,6 +7,12 @@ on:
     types: [ "checks_requested" ]
   schedule:
     - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git reference or commit hash to run the workflow against."
+        required: false
+        type: string
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Description of change

We want to be able to run integration tests on demand, even against arbitrary commits.

Note, only maintainers will be able to invoke workflows so its safe to use without the GitHub environment gate.

Relevant issues: N/A

## Does this change impact existing behavior?

No change, GitHub workflows only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
