### PR TITLE
Improve coredump script for the tests workflow

### DIFF
--- a/.github/actions/scripts/save-coredump.sh
+++ b/.github/actions/scripts/save-coredump.sh
@@ -5,6 +5,9 @@ bucket_prefix=$S3_BUCKET_TEST_PREFIX
 coredump_path=/var/lib/systemd/coredump/
 coredump_pattern=core.*
 
+# list core dump records
+coredumpctl list
+
 # upload core dump files to S3
 aws s3 cp ${coredump_path} s3://${bucket_name}/${bucket_prefix}coredump/ --recursive --exclude "*" --include "${coredump_pattern}"
 

--- a/.github/actions/scripts/save-coredump.sh
+++ b/.github/actions/scripts/save-coredump.sh
@@ -2,23 +2,29 @@
 
 bucket_name=$S3_BUCKET_NAME
 bucket_prefix=$S3_BUCKET_TEST_PREFIX
-coredump_path=/var/lib/systemd/coredump/
-coredump_pattern=core.*
 
-# list core dump records
+# list coredump records
 coredumpctl list
 
-# upload core dump files to S3
-aws s3 cp ${coredump_path} s3://${bucket_name}/${bucket_prefix}coredump/ --recursive --exclude "*" --include "${coredump_pattern}"
-
-# get all core dump records to find their associated binary files
+# get all coredump records to find their associated binary files
 coredump_records=`coredumpctl --no-legend | awk '{print $5,$10}'`
 
+if [ -z "${coredump_records}" ]; then
+    # no coredump found so we can stop
+    exit 0
+fi
+
 while IFS= read -r line; do
-    # get the pid to help matching it with the core dump
+    # get the pid to help matching it with the coredump
     pid=`echo $line | awk '{print $1}'`
     binary_path=`echo $line | awk '{print $2}'`
     binary_name=$(basename $binary_path)
     # upload each binary to S3
     aws s3 cp ${binary_path} s3://${bucket_name}/${bucket_prefix}binary/${pid}_${binary_name}
+
+    coredump_filename=core_${pid}_${binary_name}
+    coredump_path=${HOME}/${coredump_filename}
+    coredumpctl dump ${pid} --output=${coredump_path}
+    # upload each coredump file to S3
+    aws s3 cp ${coredump_path} s3://${bucket_name}/${bucket_prefix}coredump/${coredump_filename}
 done <<< "$coredump_records"


### PR DESCRIPTION
## Description of change

Update the `save-coredump` script to also show coredump records and their status. We will also explicitly call `coredumpctl dump` to extract the specific dump file for each pid and upload it to S3.

## Does this change impact existing behavior?

No, only affects integration tests workflow.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
