### PR TITLE
Initialize the CRT eagerly in tests

### DIFF
--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -32,6 +32,12 @@ fn init_tracing_subscriber() {
     let _ = subscriber.try_init();
 }
 
+#[ctor::ctor]
+fn init_crt() {
+    mountpoint_s3_crt::io::io_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+    mountpoint_s3_crt::s3::s3_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+}
+
 pub enum AccessPointType {
     SingleRegion,
     ObjectLambda,

--- a/mountpoint-s3-crt/src/io.rs
+++ b/mountpoint-s3-crt/src/io.rs
@@ -15,7 +15,7 @@ pub mod retry_strategy;
 static IO_LIBRARY_INIT: Once = Once::new();
 
 /// Set up the aws-c-io library using the given allocator.
-fn io_library_init(allocator: &Allocator) {
+pub fn io_library_init(allocator: &Allocator) {
     IO_LIBRARY_INIT.call_once(|| {
         // Safety: the CRT ensures this call happens only once.
         unsafe {

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -138,6 +138,12 @@ mod test {
         tracing_subscriber::fmt::init();
     }
 
+    #[ctor::ctor]
+    fn init_crt() {
+        crate::io::io_library_init(&crate::common::allocator::Allocator::default());
+        crate::s3::s3_library_init(&crate::common::allocator::Allocator::default());
+    }
+
     /// Validate that ASan is working across both Rust and the CRT by intentionally provoking a
     /// use-after-free that crosses the boundary: the allocation is created and freed by Rust, but
     /// accessed by the CRT. Ignored by default, and run only by ASan in CI.

--- a/mountpoint-s3-crt/src/s3.rs
+++ b/mountpoint-s3-crt/src/s3.rs
@@ -12,7 +12,7 @@ pub mod endpoint_resolver;
 static S3_LIBRARY_INIT: Once = Once::new();
 
 /// Set up the aws-c-io library using the given allocator.
-fn s3_library_init(allocator: &Allocator) {
+pub fn s3_library_init(allocator: &Allocator) {
     S3_LIBRARY_INIT.call_once(|| {
         // Safety: the CRT ensures this call happens only once.
         unsafe {

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -24,3 +24,10 @@ fn init_tracing_subscriber() {
     let _ = mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter::try_init();
     let _ = tracing_subscriber::fmt::try_init();
 }
+
+#[cfg(test)]
+#[ctor::ctor]
+fn init_crt() {
+    mountpoint_s3_crt::io::io_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+    mountpoint_s3_crt::s3::s3_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+}

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -107,3 +107,9 @@ fn init_tracing_subscriber() {
     let _ = RustLogAdapter::try_init();
     let _ = tracing_subscriber::fmt::try_init();
 }
+
+#[ctor::ctor]
+fn init_crt() {
+    mountpoint_s3_crt::io::io_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+    mountpoint_s3_crt::s3::s3_library_init(&mountpoint_s3_crt::common::allocator::Allocator::default());
+}


### PR DESCRIPTION
## Description of change

We think the lazy initialization might be the cause of some of our issues, because it happens on an ephemeral thread. Let's try initializing it at load time.

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
