### PR TITLE
Update integration test schedule from hourly to daily at 06:45Z

### DIFF
--- a/.github/workflows/integration_main.yml
+++ b/.github/workflows/integration_main.yml
@@ -6,7 +6,7 @@ on:
   merge_group:
     types: [ "checks_requested" ]
   schedule:
-    - cron: "0 * * * *"
+    - cron: "45 6 * * *" # Daily at 06:45 UTC
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Description of change

We don't need to run the tests hourly, so dropping this down to daily. This should give us sufficient visibility into any transient test failures which may be introduced.

- Runs at 45 minutes past the hour to avoid the huge amount of scheduling that will typically arrive at 0 minutes past, where some queued workflows may be dropped.
- Run early morning UK time so the workflow run is sort of recent at the start of the working day (since most maintainers are UK-based) :)

Relevant issues:

- #892

## Does this change impact existing behavior?

CI change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
