### PR TITLE
Support various KMS Key identifiers in `--sse-kms-key-id`

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -490,7 +490,13 @@ impl ServerSideEncryption {
                 sse_type.map(str::to_string),
             ));
         }
-        if self.sse_kms_key_id.is_some() && self.sse_kms_key_id.as_deref() != sse_kms_key_id {
+
+        let key_is_ok = match (&self.sse_kms_key_id, &sse_kms_key_id) {
+            (Some(provided_key), Some(returned_key)) => returned_key.ends_with(provided_key),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        if !key_is_ok {
             return Err(SseCorruptedError::KeyMismatch(
                 self.sse_kms_key_id.as_ref().unwrap().clone(),
                 sse_kms_key_id.map(str::to_string),

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -54,6 +54,10 @@ pub async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {
     aws_sdk_s3::Client::new(&sdk_config)
 }
 
+pub fn get_test_kms_key_arn() -> String {
+    std::env::var("KMS_TEST_KEY_ARN").expect("Set KMS_TEST_KEY_ARN to run integration tests")
+}
+
 pub fn get_test_kms_key_id() -> String {
     std::env::var("KMS_TEST_KEY_ID").expect("Set KMS_TEST_KEY_ID to run integration tests")
 }


### PR DESCRIPTION
## Description of change

S3 always returns KMS Key **ARN** (e.g. `arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`) for a newly created object. This PR fixes the sse headers check to pass when KMS Key ID was provided (e.g. `1234abcd-12ab-34cd-56ef-1234567890ab`).

Other options: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/906

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
