### PR TITLE
Add additional logging around mount timeout failures

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -524,6 +524,10 @@ where
                 });
 
                 let timeout = Duration::from_secs(30);
+                tracing::debug!(
+                    "waiting up to {} seconds for child process to be ready",
+                    timeout.as_secs(),
+                );
                 let status = receiver.recv_timeout(timeout);
                 match status {
                     Ok('0') => {
@@ -535,6 +539,10 @@ where
                         return Err(anyhow!("Failed to create mount process"));
                     }
                     Err(_timeout_err) => {
+                        tracing::error!(
+                            "timeout after {} seconds waiting for message from child process",
+                            timeout.as_secs(),
+                        );
                         // kill child process before returning error.
                         if let Err(e) = nix::sys::signal::kill(child, Signal::SIGTERM) {
                             tracing::error!("Unable to kill hanging child process with SIGTERM: {:?}", e);


### PR DESCRIPTION
## Description of change

Timeout errors are only reported to stderr, and we don't get any timestamps. This makes it quite difficult to build a timeline of what occurred when while reviewing the logs.

For example, looking at this comment didn't reveal much about what happened at first glance: https://github.com/awslabs/mountpoint-s3/issues/906#issuecomment-2164707416

This change not only adds timeout end to the logs but also when we make decisions to start the timeout.

Relevant issues: N/A

## Does this change impact existing behavior?

No breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
