### PR TITLE
Fix clippy error in version string logic

### DIFF
--- a/mountpoint-s3/src/build_info.rs
+++ b/mountpoint-s3/src/build_info.rs
@@ -12,25 +12,30 @@ pub const FULL_VERSION: &str = {
     if is_official_aws_release() {
         built::PKG_VERSION
     } else {
-        // A little hacky so we can pull out the hash as a const
-        const COMMIT_HASH_STR: &str = match built::GIT_COMMIT_HASH_SHORT {
-            Some(hash) => hash,
-            None => "",
-        };
-        const COMMIT_DIRTY_STR: &str = match built::GIT_DIRTY {
-            Some(true) => "-dirty",
-            _ => "",
-        };
-        const UNOFFICIAL_SUFFIX: &str = if COMMIT_HASH_STR.is_empty() {
-            "-unofficial"
-        } else {
-            const_format::concatcp!("-unofficial+", COMMIT_HASH_STR, COMMIT_DIRTY_STR)
-        };
-        const_format::concatcp!(built::PKG_VERSION, UNOFFICIAL_SUFFIX)
+        const_format::concatcp!(built::PKG_VERSION, "-unofficial", git_commit_suffix())
     }
 };
 
 /// Checks environment to see if this build is for an official Mountpoint for Amazon S3 release.
 const fn is_official_aws_release() -> bool {
     option_env!("MOUNTPOINT_S3_AWS_RELEASE").is_some()
+}
+
+/// Formats the current git commit hash and dirty state as a version suffix.
+/// Returns the empty string if building outside a git repository.
+const fn git_commit_suffix() -> &'static str {
+    if built::GIT_COMMIT_HASH_SHORT.is_none() {
+        return "";
+    }
+    // A little hacky so we can pull out the hash as a const
+    const COMMIT_HASH_STR: &str = match built::GIT_COMMIT_HASH_SHORT {
+        Some(hash) => hash,
+        // Evaluated at compile time, but never used
+        None => "unreachable",
+    };
+    const COMMIT_DIRTY_STR: &str = match built::GIT_DIRTY {
+        Some(true) => "-dirty",
+        _ => "",
+    };
+    const_format::concatcp!("+", COMMIT_HASH_STR, COMMIT_DIRTY_STR)
 }


### PR DESCRIPTION
Refactor the logic to format the version suffix into a const function. 

Workaround for new clippy error introduced in rustc 1.79.0:
```
error: this expression always evaluates to false
  --> mountpoint-s3/src/build_info.rs:24:44
   |
24 |         const UNOFFICIAL_SUFFIX: &str = if COMMIT_HASH_STR.is_empty() {
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#const_is_empty
   = note: `-D clippy::const-is-empty` implied by `-D clippy::all`
```

## Does this change impact existing behavior?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
