### PR TITLE
Logging errors in a structured format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1040,20 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "ciborium"
@@ -2098,6 +2127,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2516,7 @@ dependencies = [
  "bincode",
  "built",
  "bytes",
+ "chrono",
  "clap",
  "const_format",
  "crc32c",
@@ -4084,6 +4137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,12 +4156,16 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "1.0.34"
 time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json", "time"] }
 async-stream = "0.3.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -66,6 +66,8 @@ proptest = "1.4.0"
 proptest-derive = "0.4.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+serde = { version = "1.0.190", features = ["derive"] }
+serde_json = "1.0.95"
 serial_test = "2.0.0"
 sha2 = "0.10.6"
 shuttle = { version = "0.7.0" }
@@ -74,6 +76,7 @@ test-case = "2.2.2"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
 walkdir = "2.3.3"
 httpmock = "0.7.0"
+chrono = "0.4.38"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2"] }

--- a/mountpoint-s3/src/fs/error_metadata.rs
+++ b/mountpoint-s3/src/fs/error_metadata.rs
@@ -22,4 +22,5 @@ pub struct ErrorMetadata {
 /// NOTE: the event log API is not stable and is subject to breaking changes
 pub const MOUNTPOINT_ERROR_CLIENT: &str = "error.client";
 pub const MOUNTPOINT_ERROR_LOOKUP_NONEXISTENT: &str = "error.fs.lookup_nonexistent";
+pub const MOUNTPOINT_ERROR_UNSUPPORTED: &str = "error.fs.unsupported_operation";
 pub const MOUNTPOINT_ERROR_INTERNAL: &str = "error.internal";

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -9,6 +9,7 @@ use time::OffsetDateTime;
 use tracing::{field, instrument, Instrument};
 
 use crate::fs::{DirectoryEntry, DirectoryReplier, InodeNo, S3Filesystem, S3FilesystemConfig, ToErrno};
+use crate::logging::event_log::{log_fuse_error_event, log_unsupported_event};
 use crate::prefetch::Prefetch;
 use crate::prefix::Prefix;
 #[cfg(target_os = "macos")]
@@ -37,27 +38,29 @@ macro_rules! event {
 /// Handle an error in a FUSE handler. This logs the appropriate error message and then calls
 /// `reply` on the given replier with the error's corresponding errno.
 macro_rules! fuse_error {
-    ($name:literal, $reply:expr, $err:expr) => {{
+    ($name:literal, $reply:expr, $err:expr, $request_id:expr) => {{
         let err = $err;
         event!(err.level, "{} failed: {:#}", $name, err);
         ::metrics::counter!("fuse.op_failures", "op" => $name).increment(1);
+        log_fuse_error_event(&err, $name, $request_id);
         $reply.error(err.to_errno());
     }};
 }
 
 /// Generic handler for unimplemented FUSE operations
 macro_rules! fuse_unsupported {
-    ($name:literal, $reply:expr, $err:expr, $level:expr) => {{
+    ($name:literal, $reply:expr, $err:expr, $level:expr, $request_id:expr) => {{
         event!($level, "{} failed: operation not supported by Mountpoint", $name);
         ::metrics::counter!("fuse.op_failures", "op" => $name).increment(1);
         ::metrics::counter!("fuse.op_unimplemented","op" => $name).increment(1);
+        log_unsupported_event($err, $name, $request_id);
         $reply.error($err);
     }};
-    ($name:literal, $reply:expr) => {
-        fuse_unsupported!($name, $reply, libc::ENOSYS, tracing::Level::WARN)
+    ($name:literal, $reply:expr, $request_id:expr) => {
+        fuse_unsupported!($name, $reply, libc::ENOSYS, tracing::Level::WARN, $request_id)
     };
-    ($name:literal, $reply:expr, $err:expr) => {
-        fuse_unsupported!($name, $reply, $err, tracing::Level::WARN)
+    ($name:literal, $reply:expr, $err:expr, $request_id:expr) => {
+        fuse_unsupported!($name, $reply, $err, tracing::Level::WARN, $request_id)
     };
 }
 
@@ -99,19 +102,19 @@ where
         block_on(self.fs.init(config).in_current_span())
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent, name=?name))]
-    fn lookup(&self, _req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEntry) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=?name))]
+    fn lookup(&self, req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEntry) {
         match block_on(self.fs.lookup(parent, name).in_current_span()) {
             Ok(entry) => reply.entry(&entry.ttl, &entry.attr, entry.generation),
-            Err(e) => fuse_error!("lookup", reply, e),
+            Err(e) => fuse_error!("lookup", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=field::Empty))]
-    fn getattr(&self, _req: &Request<'_>, ino: InodeNo, reply: ReplyAttr) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty))]
+    fn getattr(&self, req: &Request<'_>, ino: InodeNo, reply: ReplyAttr) {
         match block_on(self.fs.getattr(ino).in_current_span()) {
             Ok(attr) => reply.attr(&attr.ttl, &attr.attr),
-            Err(e) => fuse_error!("getattr", reply, e),
+            Err(e) => fuse_error!("getattr", reply, e, req.unique()),
         }
     }
 
@@ -124,14 +127,14 @@ where
     fn open(&self, req: &Request<'_>, ino: InodeNo, flags: i32, reply: ReplyOpen) {
         match block_on(self.fs.open(ino, flags, req.pid()).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
-            Err(e) => fuse_error!("open", reply, e),
+            Err(e) => fuse_error!("open", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, size=size, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, size=size, name=field::Empty))]
     fn read(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: InodeNo,
         fh: u64,
         offset: i64,
@@ -147,23 +150,23 @@ where
                 bytes_sent = data.len();
                 reply.data(&data);
             }
-            Err(err) => fuse_error!("read", reply, err),
+            Err(err) => fuse_error!("read", reply, err, req.unique()),
         }
 
         metrics::counter!("fuse.total_bytes", "type" => "read").increment(bytes_sent as u64);
         metrics::histogram!("fuse.io_size", "type" => "read").record(bytes_sent as f64);
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent, name=field::Empty))]
-    fn opendir(&self, _req: &Request<'_>, parent: InodeNo, flags: i32, reply: ReplyOpen) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=field::Empty))]
+    fn opendir(&self, req: &Request<'_>, parent: InodeNo, flags: i32, reply: ReplyOpen) {
         match block_on(self.fs.opendir(parent, flags).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
-            Err(e) => fuse_error!("opendir", reply, e),
+            Err(e) => fuse_error!("opendir", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent, fh=fh, offset=offset))]
-    fn readdir(&self, _req: &Request<'_>, parent: InodeNo, fh: u64, offset: i64, mut reply: fuser::ReplyDirectory) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset))]
+    fn readdir(&self, req: &Request<'_>, parent: InodeNo, fh: u64, offset: i64, mut reply: fuser::ReplyDirectory) {
         struct ReplyDirectory<'a> {
             inner: &'a mut fuser::ReplyDirectory,
             count: &'a mut usize,
@@ -190,14 +193,14 @@ where
                 reply.ok();
                 metrics::counter!("fuse.readdir.entries").increment(count as u64);
             }
-            Err(e) => fuse_error!("readdir", reply, e),
+            Err(e) => fuse_error!("readdir", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=parent, fh=fh, offset=offset))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset))]
     fn readdirplus(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: InodeNo,
         fh: u64,
         offset: i64,
@@ -236,15 +239,15 @@ where
                 reply.ok();
                 metrics::counter!("fuse.readdirplus.entries").increment(count as u64);
             }
-            Err(e) => fuse_error!("readdirplus", reply, e),
+            Err(e) => fuse_error!("readdirplus", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync, name=field::Empty))]
-    fn fsync(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, datasync=datasync, name=field::Empty))]
+    fn fsync(&self, req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
         match block_on(self.fs.fsync(ino, fh, datasync).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("fsync", reply, e),
+            Err(e) => fuse_error!("fsync", reply, e, req.unique()),
         }
     }
 
@@ -252,14 +255,14 @@ where
     fn flush(&self, req: &Request<'_>, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
         match block_on(self.fs.flush(ino, fh, lock_owner, req.pid()).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("flush", reply, e),
+            Err(e) => fuse_error!("flush", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, name=field::Empty))]
     fn release(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: InodeNo,
         fh: u64,
         flags: i32,
@@ -269,22 +272,22 @@ where
     ) {
         match block_on(self.fs.release(ino, fh, flags, lock_owner, flush).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("release", reply, e),
+            Err(e) => fuse_error!("release", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh))]
-    fn releasedir(&self, _req: &Request<'_>, ino: u64, fh: u64, flags: i32, reply: ReplyEmpty) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh))]
+    fn releasedir(&self, req: &Request<'_>, ino: u64, fh: u64, flags: i32, reply: ReplyEmpty) {
         match block_on(self.fs.releasedir(ino, fh, flags).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("releasedir", reply, e),
+            Err(e) => fuse_error!("releasedir", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
     fn mknod(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: InodeNo,
         name: &OsStr,
         mode: u32,
@@ -297,25 +300,25 @@ where
 
         match block_on(self.fs.mknod(parent, name, mode, umask, rdev).in_current_span()) {
             Ok(entry) => reply.entry(&entry.ttl, &entry.attr, entry.generation),
-            Err(e) => fuse_error!("mknod", reply, e),
+            Err(e) => fuse_error!("mknod", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
-    fn mkdir(&self, _req: &Request<'_>, parent: u64, name: &OsStr, mode: u32, umask: u32, reply: ReplyEntry) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    fn mkdir(&self, req: &Request<'_>, parent: u64, name: &OsStr, mode: u32, umask: u32, reply: ReplyEntry) {
         // mode_t is u32 on Linux but u16 on macOS, so cast it here
         let mode = mode as libc::mode_t;
 
         match block_on(self.fs.mkdir(parent, name, mode, umask).in_current_span()) {
             Ok(entry) => reply.entry(&entry.ttl, &entry.attr, entry.generation),
-            Err(e) => fuse_error!("mkdir", reply, e),
+            Err(e) => fuse_error!("mkdir", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=_req.pid(), name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=req.pid(), name=field::Empty))]
     fn write(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: InodeNo,
         fh: u64,
         offset: i64,
@@ -335,30 +338,30 @@ where
                 metrics::counter!("fuse.total_bytes", "type" => "write").increment(bytes_written as u64);
                 metrics::histogram!("fuse.io_size", "type" => "write").record(bytes_written as f64);
             }
-            Err(e) => fuse_error!("write", reply, e),
+            Err(e) => fuse_error!("write", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
-    fn rmdir(&self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    fn rmdir(&self, req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
         match block_on(self.fs.rmdir(parent, name).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("rmdir", reply, e),
+            Err(e) => fuse_error!("rmdir", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
-    fn unlink(&self, _req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    fn unlink(&self, req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
         match block_on(self.fs.unlink(parent, name).in_current_span()) {
             Ok(()) => reply.ok(),
-            Err(e) => fuse_error!("unlink", reply, e),
+            Err(e) => fuse_error!("unlink", reply, e, req.unique()),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty))]
     fn setattr(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: u64,
         _mode: Option<u32>,
         _uid: Option<u32>,
@@ -384,27 +387,27 @@ where
         });
         match block_on(self.fs.setattr(ino, atime, mtime, size, flags).in_current_span()) {
             Ok(attr) => reply.attr(&attr.ttl, &attr.attr),
-            Err(e) => fuse_error!("setattr", reply, e),
+            Err(e) => fuse_error!("setattr", reply, e, req.unique()),
         }
     }
 
     // Everything below here is stubs for unsupported functions so we log them correctly
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn readlink(&self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
-        fuse_unsupported!("readlink", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino))]
+    fn readlink(&self, req: &Request<'_>, ino: u64, reply: ReplyData) {
+        fuse_unsupported!("readlink", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name, link=?link))]
-    fn symlink(&self, _req: &Request<'_>, parent: u64, name: &OsStr, link: &Path, reply: ReplyEntry) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, link=?link))]
+    fn symlink(&self, req: &Request<'_>, parent: u64, name: &OsStr, link: &Path, reply: ReplyEntry) {
         // Userspace expects EPERM for link/symlink if unsupported
-        fuse_unsupported!("symlink", reply, libc::EPERM);
+        fuse_unsupported!("symlink", reply, libc::EPERM, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
     fn rename(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         name: &OsStr,
         newparent: u64,
@@ -412,24 +415,24 @@ where
         _flags: u32,
         reply: ReplyEmpty,
     ) {
-        fuse_unsupported!("rename", reply);
+        fuse_unsupported!("rename", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, newparent=newparent, newname=?newname))]
-    fn link(&self, _req: &Request<'_>, ino: u64, newparent: u64, newname: &OsStr, reply: ReplyEntry) {
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, newparent=newparent, newname=?newname))]
+    fn link(&self, req: &Request<'_>, ino: u64, newparent: u64, newname: &OsStr, reply: ReplyEntry) {
         // Userspace expects EPERM for link/symlink if unsupported
-        fuse_unsupported!("link", reply, libc::EPERM);
+        fuse_unsupported!("link", reply, libc::EPERM, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync))]
-    fn fsyncdir(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
-        fuse_unsupported!("fsyncdir", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, datasync=datasync))]
+    fn fsyncdir(&self, req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+        fuse_unsupported!("fsyncdir", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=?name))]
     fn setxattr(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: u64,
         name: &OsStr,
         _value: &[u8],
@@ -437,33 +440,33 @@ where
         _position: u32,
         reply: ReplyEmpty,
     ) {
-        fuse_unsupported!("setxattr", reply);
+        fuse_unsupported!("setxattr", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
-    fn getxattr(&self, _req: &Request<'_>, ino: u64, name: &OsStr, _size: u32, reply: ReplyXattr) {
-        fuse_unsupported!("getxattr", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=?name))]
+    fn getxattr(&self, req: &Request<'_>, ino: u64, name: &OsStr, _size: u32, reply: ReplyXattr) {
+        fuse_unsupported!("getxattr", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn listxattr(&self, _req: &Request<'_>, ino: u64, _size: u32, reply: ReplyXattr) {
-        fuse_unsupported!("listxattr", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino))]
+    fn listxattr(&self, req: &Request<'_>, ino: u64, _size: u32, reply: ReplyXattr) {
+        fuse_unsupported!("listxattr", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
-    fn removexattr(&self, _req: &Request<'_>, ino: u64, name: &OsStr, reply: ReplyEmpty) {
-        fuse_unsupported!("removexattr", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=?name))]
+    fn removexattr(&self, req: &Request<'_>, ino: u64, name: &OsStr, reply: ReplyEmpty) {
+        fuse_unsupported!("removexattr", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, mask=mask))]
-    fn access(&self, _req: &Request<'_>, ino: u64, mask: i32, reply: ReplyEmpty) {
-        fuse_unsupported!("access", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, mask=mask))]
+    fn access(&self, req: &Request<'_>, ino: u64, mask: i32, reply: ReplyEmpty) {
+        fuse_unsupported!("access", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
     fn create(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         name: &OsStr,
         _mode: u32,
@@ -471,13 +474,13 @@ where
         _flags: i32,
         reply: ReplyCreate,
     ) {
-        fuse_unsupported!("create", reply, libc::ENOSYS, tracing::Level::DEBUG);
+        fuse_unsupported!("create", reply, libc::ENOSYS, tracing::Level::DEBUG, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, pid=pid))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, pid=pid))]
     fn getlk(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: u64,
         fh: u64,
         _lock_owner: u64,
@@ -487,13 +490,13 @@ where
         pid: u32,
         reply: ReplyLock,
     ) {
-        fuse_unsupported!("getlk", reply);
+        fuse_unsupported!("getlk", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, pid=pid))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, pid=pid))]
     fn setlk(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: u64,
         fh: u64,
         _lock_owner: u64,
@@ -504,18 +507,18 @@ where
         _sleep: bool,
         reply: ReplyEmpty,
     ) {
-        fuse_unsupported!("setlk", reply);
+        fuse_unsupported!("setlk", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn bmap(&self, _req: &Request<'_>, ino: u64, _blocksize: u32, _idx: u64, reply: ReplyBmap) {
-        fuse_unsupported!("bmap", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino))]
+    fn bmap(&self, req: &Request<'_>, ino: u64, _blocksize: u32, _idx: u64, reply: ReplyBmap) {
+        fuse_unsupported!("bmap", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, cmd=cmd))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, cmd=cmd))]
     fn ioctl(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino: u64,
         fh: u64,
         _flags: u32,
@@ -524,32 +527,23 @@ where
         _out_size: u32,
         reply: ReplyIoctl,
     ) {
-        fuse_unsupported!("ioctl", reply);
+        fuse_unsupported!("ioctl", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=length))]
-    fn fallocate(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
-        length: i64,
-        _mode: i32,
-        reply: ReplyEmpty,
-    ) {
-        fuse_unsupported!("fallocate", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, length=length))]
+    fn fallocate(&self, req: &Request<'_>, ino: u64, fh: u64, offset: i64, length: i64, _mode: i32, reply: ReplyEmpty) {
+        fuse_unsupported!("fallocate", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, whence=whence))]
-    fn lseek(&self, _req: &Request<'_>, ino: u64, fh: u64, offset: i64, whence: i32, reply: ReplyLseek) {
-        fuse_unsupported!("lseek", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, whence=whence))]
+    fn lseek(&self, req: &Request<'_>, ino: u64, fh: u64, offset: i64, whence: i32, reply: ReplyLseek) {
+        fuse_unsupported!("lseek", reply, req.unique());
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino_in=ino_in, fh_in=fh_in, offset_in=offset_in, ino_out=ino_out, fh_out=fh_out, offset_out=offset_out, len=len))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino_in=ino_in, fh_in=fh_in, offset_in=offset_in, ino_out=ino_out, fh_out=fh_out, offset_out=offset_out, len=len))]
     fn copy_file_range(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         ino_in: u64,
         fh_in: u64,
         offset_in: i64,
@@ -560,20 +554,20 @@ where
         _flags: u32,
         reply: ReplyWrite,
     ) {
-        fuse_unsupported!("copy_file_range", reply);
+        fuse_unsupported!("copy_file_range", reply, req.unique());
     }
 
     #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), name=?name))]
-    fn setvolname(&self, _req: &Request<'_>, name: &OsStr, reply: ReplyEmpty) {
-        fuse_unsupported!("setvolname", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), name=?name))]
+    fn setvolname(&self, req: &Request<'_>, name: &OsStr, reply: ReplyEmpty) {
+        fuse_unsupported!("setvolname", reply, req.unique());
     }
 
     #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
     fn exchange(
         &self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         name: &OsStr,
         newparent: u64,
@@ -581,12 +575,12 @@ where
         _options: u64,
         reply: ReplyEmpty,
     ) {
-        fuse_unsupported!("exchange", reply);
+        fuse_unsupported!("exchange", reply, req.unique());
     }
 
     #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn getxtimes(&self, _req: &Request<'_>, ino: u64, reply: ReplyXTimes) {
-        fuse_unsupported!("getxtimes", reply);
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino))]
+    fn getxtimes(&self, req: &Request<'_>, ino: u64, reply: ReplyXTimes) {
+        fuse_unsupported!("getxtimes", reply, req.unique());
     }
 }

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -1,9 +1,9 @@
 use std::backtrace::Backtrace;
-use std::fs::{DirBuilder, OpenOptions};
+use std::fs::{DirBuilder, File, OpenOptions};
 use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::prelude::OpenOptionsExt;
 use std::panic::{self, PanicInfo};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::thread;
 
 use crate::metrics::metrics_tracing_span_layer;
@@ -18,6 +18,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, Registry};
 
+pub mod event_log;
 mod syslog;
 use self::syslog::SyslogLayer;
 
@@ -31,6 +32,8 @@ pub struct LoggingConfig {
     /// The default filter directive (in the sense of [tracing_subscriber::filter::EnvFilter]) to
     /// use for logs. Will be overridden by the `MOUNTPOINT_LOG` environment variable if set.
     pub default_filter: String,
+    /// A directory to create event log files in. If unspecified, event log is not produced.
+    pub event_log_directory: Option<PathBuf>,
 }
 
 /// Set up all our logging infrastructure.
@@ -76,6 +79,23 @@ fn install_panic_hook() {
     }))
 }
 
+fn create_log_file(dir_path: &Path, file_name_format: &[FormatItem<'static>]) -> anyhow::Result<File> {
+    let filename = OffsetDateTime::now_utc()
+        .format(file_name_format)
+        .context("couldn't format log file name")?;
+
+    // log directories and files created by Mountpoint should not be accessible by other users
+    let mut dir_builder = DirBuilder::new();
+    dir_builder.recursive(true).mode(0o750);
+    let mut file_options = OpenOptions::new();
+    file_options.mode(0o640).append(true).create(true);
+
+    dir_builder.create(dir_path).context("failed to create log folder")?;
+    file_options
+        .open(dir_path.join(filename))
+        .context("failed to create log file")
+}
+
 fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
     /// Create the logging config from the MOUNTPOINT_LOG environment variable or the default config
     /// if that variable is unset. We do this in a function because [EnvFilter] isn't [Clone] and we
@@ -95,25 +115,33 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
     let file_layer = if let Some(path) = &config.log_directory {
         const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
             macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
-        let filename = OffsetDateTime::now_utc()
-            .format(LOG_FILE_NAME_FORMAT)
-            .context("couldn't format log file name")?;
 
-        // log directories and files created by Mountpoint should not be accessible by other users
-        let mut dir_builder = DirBuilder::new();
-        dir_builder.recursive(true).mode(0o750);
-        let mut file_options = OpenOptions::new();
-        file_options.mode(0o640).append(true).create(true);
-
-        dir_builder.create(path).context("failed to create log folder")?;
-        let file = file_options
-            .open(path.join(filename))
-            .context("failed to create log file")?;
-
+        let file = create_log_file(path, LOG_FILE_NAME_FORMAT)?;
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
             .with_writer(file)
             .with_filter(env_filter);
+        Some(file_layer)
+    } else {
+        None
+    };
+
+    let event_log_layer = if let Some(path) = &config.event_log_directory {
+        const EVENT_LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
+            macros::format_description!("mountpoint-s3-event-log-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
+
+        let file = create_log_file(path, EVENT_LOG_FILE_NAME_FORMAT)?;
+        // keeps only the logs containing the `error_code` field, emitted from a `event_log` module
+        let event_log_filter = EnvFilter::new("mountpoint_s3::logging::event_log[{error_code}]");
+        let file_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_ansi(false)
+            .with_writer(file)
+            .with_filter(event_log_filter);
         Some(file_layer)
     } else {
         None
@@ -142,6 +170,7 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
         .with(syslog_layer)
         .with(console_layer)
         .with(file_layer)
+        .with(event_log_layer)
         .with(metrics_tracing_span_layer());
 
     registry.init();

--- a/mountpoint-s3/src/logging/event_log.rs
+++ b/mountpoint-s3/src/logging/event_log.rs
@@ -1,0 +1,61 @@
+/// Methods for logging events in a structured format to a file, utilizing `tracing`'s logging facade.
+/// Logging backend is configured to emit json-formatted logs for this module separately.
+///
+/// The output format is `\n`-separated `json`'s, where each `json` describes a single event. Currently,
+/// only errors occurring on fuse operations are logged as events. For each failed fuse operation an event
+/// will be present in the log. On contrary, errors occurring before the mount won't be logged.
+///
+/// Fields `error_code`, `s3_error_http_status` and `s3_error_code` may be used to detect specific
+/// failure conditions, for instance, errors caused by throttling or a lack of permissions. Fields
+/// `s3_object_key` and `s3_error_message` may be used to provide further diagnostics to the user.
+///
+/// Note that most of the fields are optional and may not be present in the event. Only `operation`,
+/// `error_code`, `timestamp` amd `version` will be present in all events. The field `error_code`
+/// is assigned to errors by Mountpoint itself and may be used for a rough classification of those.
+/// See [`mountpoint-s3::fs::error_metadata`] for the list of possible values.
+///
+/// As an example, the following rule may be used to detect permission errors:
+/// `s3_error_http_status == 403 || (s3_error_http_status == 400 && s3_error_code in {"AccessDenied"})`
+///
+/// And the following rule for throttling errors:
+/// `s3_error_http_status == 503`
+///
+/// Note that running Mountpoint with `MOUNTPOINT_LOG=off` turns off the event log.
+use crate::fs::error_metadata::{MOUNTPOINT_ERROR_INTERNAL, MOUNTPOINT_ERROR_UNSUPPORTED};
+use crate::fs::Error;
+use tracing::event;
+
+/// Logs a failed fuse operation. The field `error_code` is set to `MOUNTPOINT_ERROR_INTERNAL` if it
+/// is missing in the input `fs::Error`.
+pub fn log_fuse_error_event(error: &Error, fuse_operation: &str, fuse_request_id: u64) {
+    let error_code = match &error.meta().error_code {
+        Some(error_code) => error_code,
+        None => MOUNTPOINT_ERROR_INTERNAL,
+    };
+    event!(
+        ::tracing::Level::TRACE,
+        operation = fuse_operation,
+        fuse_request_id = fuse_request_id,
+        error_code = error_code,
+        errno = error.errno,
+        internal_message = format!("{:#}", error),
+        s3_object_key = error.meta().s3_object_key,
+        s3_bucket_name = error.meta().s3_bucket_name,
+        s3_error_http_status = error.meta().client_error_meta.http_code,
+        s3_error_code = error.meta().client_error_meta.error_code,
+        s3_error_message = error.meta().client_error_meta.error_message,
+        version = "1",
+    );
+}
+
+/// Logs a failed unsupported fuse operation.
+pub fn log_unsupported_event(errno: i32, fuse_operation: &str, fuse_request_id: u64) {
+    event!(
+        ::tracing::Level::TRACE,
+        operation = fuse_operation,
+        fuse_request_id = fuse_request_id,
+        error_code = MOUNTPOINT_ERROR_UNSUPPORTED,
+        errno = errno,
+        version = "1",
+    );
+}

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -10,6 +10,8 @@ pub mod fuse;
 #[cfg(feature = "s3_tests")]
 pub mod s3;
 
+pub mod mount;
+
 use aws_credential_types::Credentials;
 use fuser::{FileAttr, FileType};
 use futures::executor::ThreadPool;

--- a/mountpoint-s3/tests/common/mount.rs
+++ b/mountpoint-s3/tests/common/mount.rs
@@ -1,0 +1,110 @@
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+use std::process::Command;
+use std::process::{Child, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
+
+pub fn wait_for_mount(source: &str, mount_point: &str) {
+    let st = Instant::now();
+
+    loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for mount timeout")
+        }
+        if mount_exists(source, mount_point) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub fn wait_for_exit(mut child: Child) -> ExitStatus {
+    let st = Instant::now();
+
+    loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("wait for result timeout")
+        }
+        match child.try_wait().expect("unable to wait for result") {
+            Some(result) => break result,
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+}
+
+pub fn mount_exists(source: &str, mount_point: &str) -> bool {
+    get_mount_from_source_and_mountpoint(source, mount_point).is_some()
+}
+
+pub fn unmount(mount_point: &Path) {
+    fn run_fusermount(bin: &str, mount_point: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut child = Command::new(bin).arg("-u").arg(mount_point).spawn()?;
+        let result = child.wait()?;
+        Ok(result.success())
+    }
+
+    // Loop a bit to give any slow/async FUSE requests time to finish
+    for i in 1..4 {
+        // Try both FUSE 2 and FUSE 3 versions, since we don't know where we're running
+        for bin in ["fusermount", "fusermount3"] {
+            if matches!(run_fusermount(bin, mount_point), Ok(true)) {
+                return;
+            }
+        }
+        std::thread::sleep(i * Duration::from_secs(1));
+    }
+
+    panic!("failed to unmount");
+}
+
+pub fn unmount_and_check_log(mut process: Child, mount_path: &Path, expected_log_line: &regex::Regex) {
+    unmount(mount_path);
+    let mut stdout = process
+        .stdout
+        .take()
+        .expect("stdout shouldn't be consumed at this point");
+    wait_for_exit(process);
+    let mut buf = Vec::new();
+    stdout
+        .read_to_end(&mut buf)
+        .expect("failed to read mountpoint log from pipe");
+    let log = String::from_utf8(buf).expect("mountpoint log is not a valid UTF-8");
+    for line in log.lines() {
+        if expected_log_line.is_match(line) {
+            return;
+        }
+    }
+    panic!("can not find a matching line in log: [{log}]");
+}
+
+/// Read all mount records in the system and return the line that matches given arguments.
+/// # Arguments
+///
+/// * `source` - name of the file system.
+/// * `mount_point` - path to the mount point.
+pub fn get_mount_from_source_and_mountpoint(source: &str, mount_point: &str) -> Option<String> {
+    // macOS wrap its temp directory under /private but it's not visible to users
+    #[cfg(target_os = "macos")]
+    let mount_point = format!("/private{}", mount_point);
+
+    let mut cmd = Command::new("mount");
+    #[cfg(target_os = "linux")]
+    cmd.arg("-l");
+    let mut cmd = cmd.stdout(Stdio::piped()).spawn().expect("Unable to spawn mount tool");
+
+    let stdout = cmd.stdout.as_mut().unwrap();
+    let stdout_reader = BufReader::new(stdout);
+    let stdout_lines = stdout_reader.lines();
+
+    for line in stdout_lines.map_while(Result::ok) {
+        let str: Vec<&str> = line.split_whitespace().collect();
+        let source_rec = str[0];
+        let mount_point_rec = str[2];
+        if source_rec == source && mount_point_rec == mount_point {
+            return Some(line);
+        }
+    }
+    None
+}

--- a/mountpoint-s3/tests/fuse_tests/event_log_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/event_log_test.rs
@@ -1,0 +1,303 @@
+use crate::common::fuse::read_dir_to_entry_names;
+use crate::common::mount::{mount_exists, unmount, wait_for_exit};
+use crate::common::s3::{create_objects, get_test_bucket_and_prefix, get_test_region};
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::s3::deny_single_object_access_policy;
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::creds::get_scoped_down_credentials;
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::tokio_block_on;
+use assert_cmd::prelude::*;
+use assert_fs::TempDir;
+use aws_sdk_sts::config::Credentials;
+use chrono::DateTime;
+#[cfg(not(feature = "s3express_tests"))]
+use mountpoint_s3::fs::error_metadata::MOUNTPOINT_ERROR_CLIENT;
+use mountpoint_s3::fs::error_metadata::{MOUNTPOINT_ERROR_INTERNAL, MOUNTPOINT_ERROR_UNSUPPORTED};
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::fs::{symlink, MetadataExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(serde::Deserialize, Debug, Default, Clone)]
+struct Event {
+    operation: String,
+    fuse_request_id: Option<u64>,
+    error_code: String,
+    errno: Option<u32>,
+    internal_message: Option<String>,
+    s3_object_key: Option<String>,
+    s3_bucket_name: Option<String>,
+    s3_error_http_status: Option<u32>,
+    timestamp: String,
+    version: String,
+}
+
+#[cfg(not(feature = "s3express_tests"))]
+#[test]
+fn event_log_forbidden_on_open_attempt() {
+    let test_name = "forbidden_event_on_open_attempt";
+    let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
+    let region = get_test_region();
+
+    let forbidden_object_name = "forbidden_object";
+    let allowed_object_name = "allowed_object";
+    create_objects(&bucket, &prefix, &region, forbidden_object_name, &[0; 1024]);
+    create_objects(&bucket, &prefix, &region, allowed_object_name, &[0; 1024]);
+
+    // mount a bucket
+    let forbidden_object_key = format!("{prefix}{forbidden_object_name}");
+    let credentials = tokio_block_on(get_scoped_down_credentials(&deny_single_object_access_policy(
+        &bucket,
+        &forbidden_object_key,
+    )));
+    let (mount_point, log_directory) = mount_with_event_log(
+        Some(credentials),
+        &region,
+        &bucket,
+        &prefix,
+        /* application_log= */ false,
+    );
+
+    // try to open files corresponding to an allowed and a forbidden object
+    File::open(mount_point.path().join(allowed_object_name)).expect("must open allowed object");
+    for _ in 0..2 {
+        File::open(mount_point.path().join(forbidden_object_name)).expect_err("must fail to open forbidden object");
+    }
+
+    // check the event log
+    unmount(mount_point.path());
+    let events: Vec<_> = read_events(log_directory.path())
+        .into_iter()
+        .filter(|event| event.error_code != MOUNTPOINT_ERROR_UNSUPPORTED)
+        .collect();
+    let forbidden_event = Event {
+        operation: "lookup".to_owned(),
+        error_code: MOUNTPOINT_ERROR_CLIENT.to_owned(),
+        errno: Some(5),
+        s3_object_key: Some(forbidden_object_key),
+        s3_bucket_name: Some(bucket),
+        s3_error_http_status: Some(403),
+        version: "1".to_owned(),
+        internal_message: Some("^.*Forbidden.*$".to_owned()),
+        fuse_request_id: Some(0),
+        ..Default::default()
+    };
+    let expected_events = vec![forbidden_event.clone(), forbidden_event];
+    assert_events_match(&events, &expected_events);
+}
+
+#[test]
+fn event_log_unsupported_on_symlink_attempt() {
+    let test_name = "unsupported_event_on_symlink_attempt";
+    let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
+    let region = get_test_region();
+
+    create_objects(&bucket, &prefix, &region, test_name, &[0; 1024]);
+
+    // mount a bucket
+    let (mount_point, log_directory) =
+        mount_with_event_log(None, &region, &bucket, &prefix, /* application_log= */ false);
+
+    // try to create a symlink
+    symlink(mount_point.path().join(test_name), mount_point.path().join("symlink"))
+        .expect_err("symlink is unsupported");
+
+    // check the event log
+    unmount(mount_point.path());
+    let events: Vec<_> = read_events(log_directory.path())
+        .into_iter()
+        .filter(|event| event.error_code == MOUNTPOINT_ERROR_UNSUPPORTED && event.operation == "symlink")
+        .collect();
+    let expected_events = vec![Event {
+        operation: "symlink".to_owned(),
+        error_code: MOUNTPOINT_ERROR_UNSUPPORTED.to_owned(),
+        errno: Some(1),
+        version: "1".to_owned(),
+        fuse_request_id: Some(0),
+        ..Default::default()
+    }];
+    assert_events_match(&events, &expected_events);
+}
+
+#[test]
+fn event_log_internal_error_on_read_mutated_attempt() {
+    let test_name = "event_log_internal_error_on_read_mutated_attempt";
+    let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
+    let region = get_test_region();
+
+    let content_16mb = vec![0_u8; 16 * 1024 * 1024];
+    create_objects(&bucket, &prefix, &region, test_name, &content_16mb);
+    drop(content_16mb);
+
+    // mount a bucket
+    let (mount_point, log_directory) =
+        mount_with_event_log(None, &region, &bucket, &prefix, /* application_log= */ false);
+
+    // try to read from a stale file handle
+    let mut f = File::open(mount_point.path().join(test_name)).unwrap();
+    let mut buf = vec![0_u8; 1024];
+    let _ = f.read(&mut buf).unwrap();
+    // replace the original object
+    let content_16mb = vec![1_u8; 16 * 1024 * 1024];
+    create_objects(&bucket, &prefix, &region, test_name, &content_16mb);
+    drop(content_16mb);
+    let mut str = Default::default();
+    f.read_to_string(&mut str)
+        .expect_err("must not read from a mutated object");
+    drop(f);
+
+    // check the event log
+    unmount(mount_point.path());
+    let events: Vec<_> = read_events(log_directory.path())
+        .into_iter()
+        .filter(|event| event.error_code != MOUNTPOINT_ERROR_UNSUPPORTED && event.operation == "read")
+        .collect();
+    let expected_event = Event {
+        operation: "read".to_owned(),
+        error_code: MOUNTPOINT_ERROR_INTERNAL.to_owned(),
+        errno: Some(116),
+        version: "1".to_owned(),
+        internal_message: Some("^object was mutated remotely$".to_owned()),
+        fuse_request_id: Some(0),
+        ..Default::default()
+    };
+    // the exact number of events is not known (there are multiple reads involved), but all of them must be internal errors
+    let expected_events = vec![expected_event.clone(); events.len()];
+    assert_events_match(&events, &expected_events);
+}
+
+#[test]
+fn event_log_with_application_log() {
+    let test_name = "event_log_with_application_log";
+    let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
+    let region = get_test_region();
+
+    create_objects(&bucket, &prefix, &region, test_name, &[0; 1024]);
+
+    // mount a bucket
+    let (mount_point, log_directory) =
+        mount_with_event_log(None, &region, &bucket, &prefix, /* application_log= */ true);
+
+    // try to create a symlink
+    symlink(mount_point.path().join(test_name), mount_point.path().join("symlink"))
+        .expect_err("symlink is unsupported");
+    unmount(mount_point.path());
+
+    // check both logs contain something
+    let events = read_events(log_directory.path());
+    assert!(!events.is_empty(), "empty events");
+
+    let application_log_path = locate_log(log_directory.path(), "^mountpoint-s3-[0-9]{4}.*$");
+    let application_log_stat = std::fs::metadata(application_log_path).expect("");
+    assert!(application_log_stat.size() > 0, "empty application log");
+}
+
+fn mount_with_event_log(
+    credentials: Option<Credentials>,
+    region: &str,
+    bucket: &str,
+    prefix: &str,
+    application_log: bool,
+) -> (TempDir, TempDir) {
+    let mount_point = assert_fs::TempDir::new().expect("can not create a mount dir");
+    let log_directory = assert_fs::TempDir::new().expect("can not create a log dir");
+    let mut cmd = Command::cargo_bin("mount-s3").expect("mount-s3 binary must exist");
+    if let Some(credentials) = credentials {
+        cmd.env("AWS_ACCESS_KEY_ID", credentials.access_key_id())
+            .env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            cmd.env("AWS_SESSION_TOKEN", token);
+        }
+    }
+    if application_log {
+        cmd.arg(format!("--log-directory={}", log_directory.path().display()));
+    }
+    let child = cmd
+        .arg(bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .arg(format!("--region={region}"))
+        .arg(format!("--event-log-directory={}", log_directory.path().display()))
+        .spawn()
+        .expect("unable to spawn child");
+
+    // verify mount status and mount entry
+    let exit_status = wait_for_exit(child);
+    assert!(exit_status.success());
+    assert!(mount_exists("mountpoint-s3", mount_point.path().to_str().unwrap()));
+
+    (mount_point, log_directory)
+}
+
+fn locate_log(log_dir: &Path, f_name_pattern: &str) -> PathBuf {
+    let f_name_regex = regex::Regex::new(f_name_pattern).unwrap();
+    let read_dir_iter = std::fs::read_dir(log_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    let file_name = dir_entry_names
+        .iter()
+        .find(|name| f_name_regex.is_match(name))
+        .expect("event log must exist");
+    log_dir.join(file_name)
+}
+
+fn read_events(log_directory: &Path) -> Vec<Event> {
+    let event_log_path = locate_log(log_directory, "^mountpoint-s3-event-log.*$");
+    let event_log = std::fs::read_to_string(event_log_path).expect("event log must exist");
+    event_log
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).expect("must be able to parse an event"))
+        .collect()
+}
+
+fn assert_events_match(actual: &[Event], expected: &[Event]) {
+    assert_eq!(actual.len(), expected.len());
+    for i in 0..actual.len() {
+        assert_event_matches(&actual[i], &expected[i]);
+    }
+}
+
+fn assert_event_matches(actual: &Event, expected: &Event) {
+    let internal_message_pattern = expected
+        .internal_message
+        .as_ref()
+        .map(|internal_message_pattern| regex::Regex::new(internal_message_pattern).unwrap());
+
+    // the following fields should match the expected event
+    assert_eq!(actual.operation, expected.operation);
+    assert_eq!(actual.error_code, expected.error_code);
+    assert_eq!(actual.errno, expected.errno);
+    match &internal_message_pattern {
+        Some(internal_message_pattern) => assert!(
+            internal_message_pattern.is_match(
+                actual
+                    .internal_message
+                    .as_ref()
+                    .expect("internal_message must be non empty")
+            ),
+            "unexpected internal_message: {:?}",
+            actual.internal_message
+        ),
+        None => assert!(actual.internal_message.is_none()),
+    }
+    assert_eq!(actual.s3_object_key, expected.s3_object_key);
+    assert_eq!(actual.s3_bucket_name, expected.s3_bucket_name);
+    assert_eq!(actual.s3_error_http_status, expected.s3_error_http_status);
+    assert_eq!(actual.version, expected.version);
+
+    // the following fields should just make sense
+    match &expected.fuse_request_id {
+        Some(_) => assert!(actual.fuse_request_id.expect("fuse_request_id must be non empty") > 0),
+        None => assert!(actual.fuse_request_id.is_none()),
+    }
+    let parsed_time = DateTime::parse_from_rfc3339(&actual.timestamp);
+    assert!(
+        parsed_time.is_ok(),
+        "malformed time: {}, err: {:?}",
+        actual.timestamp,
+        parsed_time
+    );
+}

--- a/mountpoint-s3/tests/fuse_tests/event_log_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/event_log_test.rs
@@ -1,10 +1,10 @@
-use crate::common::fuse::read_dir_to_entry_names;
-use crate::common::mount::{mount_exists, unmount, wait_for_exit};
-use crate::common::s3::{create_objects, get_test_bucket_and_prefix, get_test_region};
-#[cfg(not(feature = "s3express_tests"))]
-use crate::common::s3::deny_single_object_access_policy;
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::creds::get_scoped_down_credentials;
+use crate::common::fuse::read_dir_to_entry_names;
+use crate::common::mount::{mount_exists, unmount, wait_for_exit};
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::s3::deny_single_object_access_policy;
+use crate::common::s3::{create_objects, get_test_bucket_and_prefix, get_test_region};
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::tokio_block_on;
 use assert_cmd::prelude::*;

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -1,4 +1,6 @@
 mod consistency_test;
+#[cfg(all(feature = "event_log", feature = "s3_tests"))]
+mod event_log_test;
 mod fork_test;
 mod lookup_test;
 mod mkdir_test;


### PR DESCRIPTION
## Description of change

Adds `--event-log-directory` CLI flag. If specified all of the logs originating from `mountpoint_s3::logging::event_log` will be written as `\n`-separated json's in this file. We do this logging in `fuse_error!` and `fuse_unsupported!` macros for failed fuse operations.  

Note that the application log will also contain an additional log line per failed fuse operation with TRACE level **even if the feature flag / cli option are not provided**.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/721

## Does this change impact existing behavior?

If compiled without `event_log` feature flag there should be no changes to existing behaviour.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
