### PR TITLE
Use MaybeUninit when getting thread ID from CRT request metrics

### DIFF
--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1184,15 +1184,11 @@ impl RequestMetrics {
     /// Get the ID of the thread the request was made from
     pub fn thread_id(&self) -> Option<ThreadId> {
         let mut out: MaybeUninit<aws_thread_id_t> = MaybeUninit::uninit();
-        // SAFETY: `inner` is a valid aws_s3_request_metrics, `out` will be a valid pointer if no error was set
+        // SAFETY: `inner` is a valid aws_s3_request_metrics, `out` will point to initialized memory if no error was set
         let thread_id = unsafe {
             aws_s3_request_metrics_get_thread_id(self.inner.as_ptr(), out.as_mut_ptr())
                 .ok_or_last_error()
                 .ok()?;
-            assert!(
-                !out.as_ptr().is_null(),
-                "Thread ID should be available if call succeeded",
-            );
             out.assume_init()
         };
         Some(thread_id.into())

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -13,9 +13,11 @@ use crate::s3::s3_library_init;
 use crate::{aws_byte_cursor_as_slice, CrtError, ResultExt, ToAwsByteCursor};
 use futures::Future;
 use mountpoint_s3_crt_sys::*;
+
 use std::ffi::{OsStr, OsString};
 use std::fmt::Debug;
 use std::marker::PhantomPinned;
+use std::mem::MaybeUninit;
 use std::os::unix::prelude::OsStrExt;
 use std::pin::Pin;
 use std::ptr::NonNull;
@@ -1181,14 +1183,19 @@ impl RequestMetrics {
 
     /// Get the ID of the thread the request was made from
     pub fn thread_id(&self) -> Option<ThreadId> {
-        let mut out: aws_thread_id_t = 0;
-        // SAFETY: `inner` is a valid aws_s3_request_metrics
-        unsafe {
-            aws_s3_request_metrics_get_thread_id(self.inner.as_ptr(), &mut out)
+        let mut out: MaybeUninit<aws_thread_id_t> = MaybeUninit::uninit();
+        // SAFETY: `inner` is a valid aws_s3_request_metrics, `out` will be a valid pointer if no error was set
+        let thread_id = unsafe {
+            aws_s3_request_metrics_get_thread_id(self.inner.as_ptr(), out.as_mut_ptr())
                 .ok_or_last_error()
-                .ok()?
+                .ok()?;
+            assert!(
+                !out.as_ptr().is_null(),
+                "Thread ID should be available if call succeeded",
+            );
+            out.assume_init()
         };
-        Some(out.into())
+        Some(thread_id.into())
     }
 
     /// Get the stream ID of the request


### PR DESCRIPTION
## Description of change

Alpine Linux is not officially supported by Mountpoint, however I saw in https://github.com/awslabs/mountpoint-s3/issues/527#issuecomment-2171576001 that building currently fails for what appears to be a trivial reason - we do not use a more generic way of initializing a null pointer.

It would fail with this error:

```
388.8    Compiling mountpoint-s3-crt v0.7.0 (/mountpoint-s3/mountpoint-s3-crt)
389.1 warning: `mountpoint-s3-crt-sys` (lib) generated 2 warnings
389.3 error[E0308]: mismatched types
389.3     --> mountpoint-s3-crt/src/s3/client.rs:1184:40
389.3      |
389.3 1184 |         let mut out: aws_thread_id_t = 0;
389.3      |                      ---------------   ^ expected `*mut c_void`, found `usize`
389.3      |                      |
389.3      |                      expected due to this
389.3      |
389.3      = note: expected raw pointer `*mut c_void`
389.3                        found type `usize`
389.3 help: if you meant to create a null pointer, use `std::ptr::null_mut()`
389.3      |
389.3 1184 |         let mut out: aws_thread_id_t = std::ptr::null_mut();
389.3      |                                        ~~~~~~~~~~~~~~~~~~~~
389.3 
389.5 For more information about this error, try `rustc --explain E0308`.
389.5 error: could not compile `mountpoint-s3-crt` (lib) due to 1 previous error
```

This change updates the code to use [`std::mem::MaybeUninit<aws_thread_id_t>`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#out-pointers) rather than `0long` for the thread ID. The type of the thread ID can vary depending on where Mountpoint is built, and this will allow Mountpoint to compile where the thread ID is not type `long`.

Note, we do not appear to be following the advised practice for formatting the thread ID. _"For portability, aws_thread_id_t must not be printed directly."_. Since we only use try to print the thread ID for logging, I think this is OK for now. Really, we should be using [`aws_thread_id_t_to_string`](https://docs.rs/mountpoint-s3-crt-sys/latest/mountpoint_s3_crt_sys/fn.aws_thread_id_t_to_string.html) however using this relies on the C macro `AWS_THREAD_ID_T_REPR_BUFSZ` which is not made available today by our bindings.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/527#issuecomment-2171576001

### Testing

I've verified that this change compiles on Alpine 3.18. The change will go through standard integration tests as part of the pull request and merge.

For reference, I was using this Dockerfile:

```Dockerfile
FROM alpine:3.18

# Install build tools
RUN apk add gcc curl git zlib g++ cmake make pkgconfig fuse fuse-dev clang clang-dev

# Install rust
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
    source "$HOME/.cargo/env"

ENV RUSTFLAGS="-C target-feature=-crt-static"

# Build mountpoint-s3
RUN git clone \
        --recurse-submodules --shallow-submodules \
        https://github.com/awslabs/mountpoint-s3.git && \
    source "$HOME/.cargo/env" && \
    cd mountpoint-s3 && \
    cargo build --release

RUN echo "user_allow_other" >> /etc/fuse.conf

# Run in foreground mode so that the container can be detached without exiting Mountpoint
ENTRYPOINT [ "/mount-s3", "-f" ]

```

## Does this change impact existing behavior?

This does not change existing behavior. This allows Mountpoint to build on platforms where the thread ID type in the CRT is not `long`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
