### PR TITLE
Include test files in cargo

### DIFF
--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust FFI bindings to the AWS Common Runtime for Mountpoint for Amazon S3."
 exclude = [
     # Exclude large files/directories not required to build the CRT (e.g. tests, docs)
-    "crt/*/tests/**",
+    "crt/*/tests",
     "!crt/aws-lc/tests/compiler_features_tests",
     "!crt/s2n-tls/tests/features",
     "crt/**/docs",


### PR DESCRIPTION
## Description of change

Cargo publish was failing without these files. 

verified that it works after this change by running `cargo publish --dry-run -p mountpoint-s3-crt-sys` . Crate size is 9.9MB

## Does this change impact existing behavior?

no

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
