### PR TITLE
Add link to CSI driver logging docs from Mountpoint logging docs

### DIFF
--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -8,6 +8,10 @@ On other systems, syslog entries are likely written to a file such as `/var/log/
 
 When running `mount-s3` in foreground mode (the `-f, --foreground` command-line argument), Mountpoint will emit logs to stdout in addition to syslog or any configured log directory (see below).
 
+> [!NOTE]
+> If you are using [Mountpoint for Amazon S3 CSI Driver](https://github.com/awslabs/mountpoint-s3-csi-driver/), logs will be written to the syslog on the underlying node.
+> Follow [Mountpoint CSI Driver's LOGGING.md guide](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/LOGGING.md) to learn about how to get logs for both Mountpoint and the driver itself.
+
 ## Logging to a file
 
 You can direct logs to a file instead of syslog by providing a destination directory using the `-l, --log-directory` command-line argument with `mount-s3`.


### PR DESCRIPTION
## Description of change

We added a new logging document in the CSI Driver project in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/206, which helps support locating the logs on the underlying host. This isn't visible from the Mountpoint repository including troubleshooting guides, so let's link it from MP's logging documentation.

Relevant issues: https://github.com/awslabs/mountpoint-s3-csi-driver/pull/206

## Does this change impact existing behavior?

No, documentation change only. All anchor tags intact.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
