### PR TITLE
Re-implement the prefetcher using backpressure mechanism

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -81,6 +81,10 @@ where
         self.client.write_part_size()
     }
 
+    fn initial_read_window_size(&self) -> Option<usize> {
+        self.client.initial_read_window_size()
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,
@@ -187,6 +191,11 @@ impl<Client: ObjectClient, FailState: Send> GetObjectRequest for FailureGetReque
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);
+    }
+
+    fn read_window_offset(self: Pin<&Self>) -> u64 {
+        let this = self.project_ref();
+        this.request.read_window_offset()
     }
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -64,7 +64,7 @@ pub struct MockClientConfig {
     /// A seed to randomize the order of ListObjectsV2 results, or None to use ordered list
     pub unordered_list_seed: Option<u64>,
     /// A flag to enable backpressure read
-    pub enable_back_pressure: bool,
+    pub enable_backpressure: bool,
     /// Initial backpressure read window size, ignored if enable_back_pressure is false
     pub initial_read_window_size: usize,
 }
@@ -475,8 +475,8 @@ pub struct MockGetObjectRequest {
     next_offset: u64,
     length: usize,
     part_size: usize,
-    enable_back_pressure: bool,
-    current_window_size: usize,
+    enable_backpressure: bool,
+    read_window_offset: u64,
 }
 
 impl MockGetObjectRequest {
@@ -498,7 +498,11 @@ impl GetObjectRequest for MockGetObjectRequest {
     type ClientError = MockClientError;
 
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
-        self.current_window_size += len;
+        self.read_window_offset += len as u64;
+    }
+
+    fn read_window_offset(self: Pin<&Self>) -> u64 {
+        self.read_window_offset
     }
 }
 
@@ -510,15 +514,13 @@ impl Stream for MockGetObjectRequest {
             return Poll::Ready(None);
         }
 
-        let mut next_read_size = self.part_size.min(self.length);
+        let next_read_size = self.part_size.min(self.length);
 
         // Simulate backpressure mechanism
-        if self.enable_back_pressure {
-            if self.current_window_size == 0 {
-                return Poll::Pending;
-            }
-            next_read_size = self.current_window_size.min(next_read_size);
-            self.current_window_size -= next_read_size;
+        if self.enable_backpressure && self.next_offset >= self.read_window_offset {
+            return Poll::Ready(Some(Err(ObjectClientError::ClientError(MockClientError(
+                "empty read window".into(),
+            )))));
         }
         let next_part = self.object.read(self.next_offset, next_read_size);
 
@@ -562,6 +564,14 @@ impl ObjectClient for MockClient {
         Some(self.config.part_size)
     }
 
+    fn initial_read_window_size(&self) -> Option<usize> {
+        if self.config.enable_backpressure {
+            Some(self.config.initial_read_window_size)
+        } else {
+            None
+        }
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,
@@ -586,7 +596,15 @@ impl ObjectClient for MockClient {
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
     ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
-        trace!(bucket, key, ?range, ?if_match, "GetObject");
+        trace!(
+            bucket,
+            key,
+            ?range,
+            ?if_match,
+            enable_back_pressure = self.config.enable_backpressure,
+            initial_read_window_size = self.config.initial_read_window_size,
+            "GetObject"
+        );
         self.inc_op_count(Operation::GetObject);
 
         if bucket != self.config.bucket {
@@ -616,8 +634,8 @@ impl ObjectClient for MockClient {
                 next_offset,
                 length,
                 part_size: self.config.part_size,
-                enable_back_pressure: self.config.enable_back_pressure,
-                current_window_size: self.config.initial_read_window_size,
+                enable_backpressure: self.config.enable_backpressure,
+                read_window_offset: next_offset + self.config.initial_read_window_size as u64,
             })
         } else {
             Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey))
@@ -908,17 +926,24 @@ enum MockObjectParts {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::mpsc::{self, RecvTimeoutError},
-        thread,
-    };
-
     use futures::{pin_mut, StreamExt};
     use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
     use test_case::test_case;
 
     use super::*;
+
+    macro_rules! assert_client_error {
+        ($e:expr, $err:expr) => {
+            let err = $e.expect_err("should fail");
+            match err {
+                ObjectClientError::ClientError(MockClientError(m)) => {
+                    assert_eq!(&*m, $err);
+                }
+                _ => assert!(false, "wrong error type"),
+            }
+        };
+    }
 
     async fn test_get_object(key: &str, size: usize, range: Option<Range<u64>>) {
         let mut rng = ChaChaRng::seed_from_u64(0x12345678);
@@ -971,7 +996,7 @@ mod tests {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: true,
+            enable_backpressure: true,
             initial_read_window_size: backpressure_read_window_size,
         });
 
@@ -992,9 +1017,12 @@ mod tests {
             assert_eq!(offset, next_offset, "wrong body part offset");
             next_offset += body.len() as u64;
             accum.extend_from_slice(&body[..]);
-            get_request
-                .as_mut()
-                .increment_read_window(backpressure_read_window_size);
+
+            while next_offset >= get_request.as_ref().read_window_offset() {
+                get_request
+                    .as_mut()
+                    .increment_read_window(backpressure_read_window_size);
+            }
         }
         let expected_range = range.unwrap_or(0..size as u64);
         let expected_range = expected_range.start as usize..expected_range.end as usize;
@@ -1023,18 +1051,6 @@ mod tests {
         let mut body = vec![0u8; 2000];
         rng.fill_bytes(&mut body);
         client.add_object("key1", body[..].into());
-
-        macro_rules! assert_client_error {
-            ($e:expr, $err:expr) => {
-                let err = $e.expect_err("should fail");
-                match err {
-                    ObjectClientError::ClientError(MockClientError(m)) => {
-                        assert_eq!(&*m, $err);
-                    }
-                    _ => assert!(false, "wrong error type"),
-                }
-            };
-        }
 
         assert!(matches!(
             client.get_object("wrong_bucket", "key1", None, None).await,
@@ -1068,53 +1084,45 @@ mod tests {
         );
     }
 
-    // Verify that the request is blocked when we don't increment read window size
+    // Verify that an error is returned when we don't increment read window size
     #[tokio::test]
     async fn verify_backpressure_get_object() {
         let key = "key1";
-        let size = 1000;
-        let range = 50..1000;
-        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
 
+        let mut rng = ChaChaRng::seed_from_u64(0x12345678);
         let client = MockClient::new(MockClientConfig {
             bucket: "test_bucket".to_string(),
             part_size: 1024,
             unordered_list_seed: None,
-            enable_back_pressure: true,
+            enable_backpressure: true,
             initial_read_window_size: 256,
         });
 
-        let mut body = vec![0u8; size];
-        rng.fill_bytes(&mut body);
-        client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
+        let part_size = client.read_part_size().unwrap();
+        let size = part_size * 2;
+        let range = 0..(part_size + 1) as u64;
+
+        let mut expected_body = vec![0u8; size];
+        rng.fill_bytes(&mut expected_body);
+        client.add_object(key, MockObject::from_bytes(&expected_body, ETag::for_tests()));
 
         let mut get_request = client
             .get_object("test_bucket", key, Some(range.clone()), None)
             .await
             .expect("should not fail");
 
-        let mut accum = vec![];
-        let mut next_offset = range.start;
+        // Verify that we can receive some data since the window size is more than 0
+        let first_part = get_request.next().await.expect("result should not be empty");
+        let (offset, body) = first_part.unwrap();
+        assert_eq!(offset, 0, "wrong body part offset");
 
-        let (sender, receiver) = mpsc::channel();
-        thread::spawn(move || {
-            futures::executor::block_on(async move {
-                while let Some(r) = get_request.next().await {
-                    let (offset, body) = r.unwrap();
-                    assert_eq!(offset, next_offset, "wrong body part offset");
-                    next_offset += body.len() as u64;
-                    accum.extend_from_slice(&body[..]);
-                }
-                let expected_range = range;
-                let expected_range = expected_range.start as usize..expected_range.end as usize;
-                assert_eq!(&accum[..], &body[expected_range], "body does not match");
-                sender.send(accum).unwrap();
-            })
-        });
-        match receiver.recv_timeout(Duration::from_millis(100)) {
-            Ok(_) => panic!("request should have been blocked"),
-            Err(e) => assert_eq!(e, RecvTimeoutError::Timeout),
-        }
+        // The CRT always return at least a part even if the window is smaller than that
+        let expected_range = range.start as usize..part_size;
+        assert_eq!(&body[..], &expected_body[expected_range]);
+
+        // This await should return an error because current window is not enough to get the next part
+        let next = get_request.next().await.expect("result should not be empty");
+        assert_client_error!(next, "empty read window");
     }
 
     #[tokio::test]

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -72,6 +72,11 @@ impl GetObjectRequest for ThroughputGetObjectRequest {
         let this = self.project();
         this.request.increment_read_window(len);
     }
+
+    fn read_window_offset(self: Pin<&Self>) -> u64 {
+        let this = self.project_ref();
+        this.request.read_window_offset()
+    }
 }
 
 impl Stream for ThroughputGetObjectRequest {
@@ -103,6 +108,10 @@ impl ObjectClient for ThroughputMockClient {
 
     fn write_part_size(&self) -> Option<usize> {
         self.inner.write_part_size()
+    }
+
+    fn initial_read_window_size(&self) -> Option<usize> {
+        self.inner.initial_read_window_size()
     }
 
     async fn delete_object(

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -85,6 +85,10 @@ pub trait ObjectClient {
     /// can be `None` if the client does not do multi-part operations.
     fn write_part_size(&self) -> Option<usize>;
 
+    /// Query the initial read window size this client uses for backpressure GetObject requests.
+    /// This can be `None` if backpressure is disabled.
+    fn initial_read_window_size(&self) -> Option<usize>;
+
     /// Delete a single object from the object store.
     ///
     /// DeleteObject will succeed even if the object within the bucket does not exist.
@@ -378,6 +382,10 @@ pub trait GetObjectRequest:
     /// If `enable_read_backpressure` is false this call will have no effect,
     /// no backpressure is being applied and data is being downloaded as fast as possible.
     fn increment_read_window(self: Pin<&mut Self>, len: usize);
+
+    /// Get the upper bound of the range for read window. `GetObjectRequest` can only return data up to
+    /// this offset *exclusively*.
+    fn read_window_offset(self: Pin<&Self>) -> u64;
 }
 
 /// A streaming put request which allows callers to asynchronously write the body of the request.

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -46,13 +46,16 @@ impl S3CrtClient {
                 .map_err(S3RequestError::construction_failure)?;
         }
 
-        if let Some(range) = range {
+        let next_offset = if let Some(range) = range {
             // Range HTTP header is bounded below *inclusive*
             let range_value = format!("bytes={}-{}", range.start, range.end.saturating_sub(1));
             message
                 .set_header(&Header::new("Range", range_value))
                 .map_err(S3RequestError::construction_failure)?;
-        }
+            range.start
+        } else {
+            0
+        };
 
         let key = format!("/{key}");
         message
@@ -60,6 +63,7 @@ impl S3CrtClient {
             .map_err(S3RequestError::construction_failure)?;
 
         let (sender, receiver) = futures::channel::mpsc::unbounded();
+        let read_window_offset = next_offset + self.inner.initial_read_window_size as u64;
 
         let mut options = S3CrtClientInner::new_meta_request_options(message, S3Operation::GetObject);
         options.part_size(self.inner.read_part_size as u64);
@@ -84,6 +88,9 @@ impl S3CrtClient {
             request,
             finish_receiver: receiver,
             finished: false,
+            enable_backpressure: self.inner.enable_backpressure,
+            next_offset,
+            read_window_offset,
         })
     }
 }
@@ -101,13 +108,21 @@ pub struct S3GetObjectRequest {
     #[pin]
     finish_receiver: UnboundedReceiver<Result<GetBodyPart, Error>>,
     finished: bool,
+    enable_backpressure: bool,
+    next_offset: u64,
+    read_window_offset: u64,
 }
 
 impl GetObjectRequest for S3GetObjectRequest {
     type ClientError = S3RequestError;
 
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
+        self.read_window_offset += len as u64;
         self.request.meta_request.increment_read_window(len as u64);
+    }
+
+    fn read_window_offset(self: Pin<&Self>) -> u64 {
+        self.read_window_offset
     }
 }
 
@@ -122,7 +137,14 @@ impl Stream for S3GetObjectRequest {
         let this = self.project();
 
         if let Poll::Ready(Some(val)) = this.finish_receiver.poll_next(cx) {
-            return Poll::Ready(Some(val.map_err(|e| ObjectClientError::ClientError(e.into()))));
+            let result = match val {
+                Ok(item) => {
+                    *this.next_offset += item.1.len() as u64;
+                    Some(Ok(item))
+                }
+                Err(e) => Some(Err(ObjectClientError::ClientError(e.into()))),
+            };
+            return Poll::Ready(result);
         }
 
         match this.request.poll(cx) {
@@ -134,7 +156,16 @@ impl Stream for S3GetObjectRequest {
                 *this.finished = true;
                 Poll::Ready(Some(Err(e)))
             }
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // If the request is still not finished but the read window is not enough to poll
+                // the next chunk we might want to return error instead of keeping the request blocked.
+                if *this.enable_backpressure && this.read_window_offset <= this.next_offset {
+                    return Poll::Ready(Some(Err(ObjectClientError::ClientError(
+                        S3RequestError::EmptyReadWindow,
+                    ))));
+                }
+                Poll::Pending
+            }
         }
     }
 }

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -206,7 +206,6 @@ pub async fn check_backpressure_get_result(
     range: Option<Range<u64>>,
     expected: &[u8],
 ) {
-    let mut accum_read_window = read_window;
     let mut accum = vec![];
     let mut next_offset = range.map(|r| r.start).unwrap_or(0);
     pin_mut!(result);
@@ -218,9 +217,8 @@ pub async fn check_backpressure_get_result(
 
         // We run out of data to read if read window is smaller than accum length of data,
         // so we keeping adding window size, otherwise the request will be blocked.
-        while accum_read_window <= accum.len() {
+        while next_offset >= result.as_ref().read_window_offset() {
             result.as_mut().increment_read_window(read_window);
-            accum_read_window += read_window;
         }
     }
     assert_eq!(&accum[..], expected, "body does not match");

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -1349,6 +1349,8 @@ mod tests {
         let bucket = "bucket";
         let client = Arc::new(MockClient::new(MockClientConfig {
             bucket: bucket.to_owned(),
+            enable_backpressure: true,
+            initial_read_window_size: 1024 * 1024,
             ..Default::default()
         }));
         // Create "dir1" in the client to avoid creating it locally

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -129,9 +129,12 @@ impl<E: std::error::Error + Send + Sync + 'static> From<PrefetchReadError<E>> fo
                 GetObjectError::PreconditionFailed,
             )) => err!(libc::ESTALE, "object was mutated remotely"),
             PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),
+            PrefetchReadError::PartReadFailed(e) => err!(libc::EIO, source:e, "part read failed"),
             PrefetchReadError::GetRequestFailed(_)
             | PrefetchReadError::GetRequestTerminatedUnexpectedly
-            | PrefetchReadError::GetRequestReturnedWrongOffset { .. } => {
+            | PrefetchReadError::GetRequestReturnedWrongOffset { .. }
+            | PrefetchReadError::BackpressurePreconditionFailed
+            | PrefetchReadError::ReadWindowIncrement => {
                 err!(libc::EIO, source:err, "get request failed")
             }
         }

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -1,12 +1,37 @@
 //! This module implements a prefetcher for GetObject requests.
 //!
-//! It works by making increasingly larger GetObject requests to the CRT. We want the chunks to be
-//! large enough that they can make effective use of the CRT's fan-out parallelism across the S3
-//! frontend, but small enough that we don't accumulate a lot of unread object data in memory or
-//! wastefully download data we'll never read. As the reader continues to make sequential reads,
-//! we increase the size of the GetObject requests up to some maximum. If the reader ever makes a
-//! non-sequential read, we abandon the prefetching and start again with the minimum request size.
+//! It works by relying on the CRT's flow-control window feature. The prefetcher creates a single
+//! GetObject request with entire length of the object (starting from the first read offset) and
+//! makes increasingly larger read window. We want the chunks to be large enough that they can make
+//! effective use of the CRT's fan-out parallelism across the S3 frontend, but small enough that we
+//! don't accumulate a lot of unread object data in memory or wastefully download data we'll never
+//! read. As the reader continues to make sequential reads, we increase the size of the read window
+//! up to some maximum. If the reader ever makes a non-sequential read, we abandon the prefetching
+//! and start again with a new GetObject request with minimum read window size.
+//!
+//! In more technical details, the prefetcher creates a RequestTask when receiving the first read
+//! request from the file system or after it has just been reset. The RequestTask consists of two main
+//! components.
+//! 1.  An ObjectPartStream that has a role to continuously fetch data from the sources which can be
+//!     either S3 or the cache on disk. The ObjectPartStream is spawned and run in a separate thread
+//!     from the prefetcher.
+//! 2.  A PartQueue, where we store data received from the ObjectPartStream, waiting to be read from
+//!     the prefetcher via a RequestTask function.
+//!
+//! A backpressure mechanism is needed to control how much data we want to store in the part queue at
+//! a time as we don't want to download the entire object into memory. For the client part stream, we
+//! may be able to rely on the CRT flow-control flow window to block when we don't increase the read
+//! window size, but for the caching part stream we don't have the machinery to do that yet. That's why
+//! we introduce the BackpressureController and BackpressureLimiter to help solving this.
+//!
+//! Essentially, the BackpressureController and BackpressureLimiter is a pair of sender/receiver of a
+//! channel, created at RequestTask initialization. The sender is handed to the RequestTask. Its role
+//! is to communicate with its receiver to tell "when" it is ready to receive more data. The receiver
+//! is handed to the ObjectPartStream where the stream should call a provided function "before" fetching
+//! more data from the sources and put them into the part queue. The BackpressureLimiter should be used
+//! as a mean to block ObjectPartStream thread to fetch more data.
 
+mod backpressure_controller;
 mod caching_stream;
 mod part;
 mod part_queue;
@@ -14,7 +39,6 @@ mod part_stream;
 mod seek_window;
 mod task;
 
-use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::time::Duration;
 
@@ -24,6 +48,8 @@ use metrics::{counter, histogram};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::ObjectClient;
+use part::PartOperationError;
+use part_stream::RequestTaskConfig;
 use thiserror::Error;
 use tracing::trace;
 
@@ -79,6 +105,15 @@ pub enum PrefetchReadError<E> {
 
     #[error("integrity check failed")]
     Integrity(#[from] IntegrityError),
+
+    #[error("part read failed")]
+    PartReadFailed(#[from] PartOperationError),
+
+    #[error("backpressure must be enabled with non-zero initial read window")]
+    BackpressurePreconditionFailed,
+
+    #[error("read window increment failed")]
+    ReadWindowIncrement,
 }
 
 pub type DefaultPrefetcher<Runtime> = Prefetcher<ClientPartStream<Runtime>>;
@@ -110,10 +145,8 @@ where
 
 #[derive(Debug, Clone, Copy)]
 pub struct PrefetcherConfig {
-    /// Size of the first request in a prefetch run
-    pub first_request_size: usize,
-    /// Maximum size of a single prefetch request
-    pub max_request_size: usize,
+    /// Maximum size of the read window
+    pub max_read_window_size: usize,
     /// Factor to increase the request size by whenever the reader continues making sequential reads
     pub sequential_prefetch_multiplier: usize,
     /// Timeout to wait for a part to become available
@@ -127,19 +160,10 @@ pub struct PrefetcherConfig {
 }
 
 impl Default for PrefetcherConfig {
+    #[allow(clippy::identity_op)]
     fn default() -> Self {
-        #[allow(clippy::identity_op)]
         Self {
-            // This is a weird looking number! We really want our first request size to be 1MiB,
-            // which is a common IO size. But Linux's readahead will try to read an extra 128k on on
-            // top of a 1MiB read, which we'd have to wait for a second request to service. Because
-            // FUSE doesn't know the difference between regular reads and readahead reads, it will
-            // send us a READ request for that 128k, so we'll have to block waiting for it even if
-            // the application doesn't want it. This is all in the noise for sequential IO, but
-            // waiting for the readahead hurts random IO. So we add 128k to the first request size
-            // to avoid the latency hit of the second request.
-            first_request_size: 1 * 1024 * 1024 + 128 * 1024,
-            max_request_size: 2 * 1024 * 1024 * 1024,
+            max_read_window_size: 2 * 1024 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             read_timeout: Duration::from_secs(60),
             // We want these large enough to tolerate a single out-of-order Linux readahead, which
@@ -147,7 +171,7 @@ impl Default for PrefetcherConfig {
             // making a guess about where the optimal cut-off point is before it would be faster to
             // just start a new request instead.
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
-            max_backward_seek_distance: 1 * 1024 * 1024,
+            max_backward_seek_distance: 1024 * 1024,
         }
     }
 }
@@ -206,11 +230,7 @@ pub struct PrefetchGetObject<Stream: ObjectPartStream, Client: ObjectClient> {
     client: Arc<Client>,
     part_stream: Arc<Stream>,
     config: PrefetcherConfig,
-    // Invariant: the offset of the first byte in this task's part queue is always
-    // self.next_sequential_read_offset.
-    current_task: Option<RequestTask<Client::ClientError>>,
-    // Currently we only every spawn at most one future task (see [spawn_next_request])
-    future_tasks: VecDeque<RequestTask<Client::ClientError>>,
+    backpressure_task: Option<RequestTask<Client::ClientError>>,
     // Invariant: the offset of the last byte in this window is always
     // self.next_sequential_read_offset - 1.
     backward_seek_window: SeekWindow,
@@ -221,7 +241,6 @@ pub struct PrefetchGetObject<Stream: ObjectPartStream, Client: ObjectClient> {
     /// Start offset for sequential read, used for calculating contiguous read metric
     sequential_read_start_offset: u64,
     next_sequential_read_offset: u64,
-    next_request_size: usize,
     next_request_offset: u64,
     size: u64,
 }
@@ -273,13 +292,11 @@ where
             client,
             part_stream,
             config,
-            current_task: None,
-            future_tasks: Default::default(),
+            backpressure_task: None,
             backward_seek_window: SeekWindow::new(config.max_backward_seek_distance as usize),
             preferred_part_size: 128 * 1024,
             sequential_read_start_offset: 0,
             next_sequential_read_offset: 0,
-            next_request_size: config.first_request_size,
             next_request_offset: 0,
             bucket: bucket.to_owned(),
             object_id: ObjectId::new(key.to_owned(), etag),
@@ -329,12 +346,13 @@ where
         }
         assert_eq!(self.next_sequential_read_offset, offset);
 
-        self.prepare_requests();
+        if self.backpressure_task.is_none() {
+            self.backpressure_task = Some(self.spawn_read_backpressure_request()?);
+        }
 
         let mut response = ChecksummedBytes::default();
         while to_read > 0 {
-            let Some(current_task) = self.current_task.as_mut() else {
-                // If [prepare_requests] didn't spawn a request, we've reached the end of the object.
+            let Some(current_task) = self.backpressure_task.as_mut() else {
                 trace!(offset, length, "read beyond object size");
                 break;
             };
@@ -342,13 +360,9 @@ where
 
             let part = current_task.read(to_read as usize).await?;
             self.backward_seek_window.push(part.clone());
-            let part_bytes = part
-                .into_bytes(&self.object_id, self.next_sequential_read_offset)
-                .unwrap();
+            let part_bytes = part.into_bytes(&self.object_id, self.next_sequential_read_offset)?;
 
             self.next_sequential_read_offset += part_bytes.len() as u64;
-            self.prepare_requests();
-
             // If we can complete the read with just a single buffer, early return to avoid copying
             // into a new buffer. This should be the common case as long as part size is larger than
             // read size, which it almost always is for real S3 clients and FUSE.
@@ -364,75 +378,45 @@ where
         Ok(response)
     }
 
-    /// Runs on every read to prepare and spawn any requests our prefetching logic requires
-    fn prepare_requests(&mut self) {
-        let current_task = self.current_task.as_ref();
-        if current_task.map(|task| task.remaining() == 0).unwrap_or(true) {
-            // There's no current task, or the current task is finished. Prepare the next request.
-            if let Some(next_task) = self.future_tasks.pop_front() {
-                self.current_task = Some(next_task);
-                return;
-            }
-            self.current_task = self.spawn_next_request();
-        } else if current_task
-            .map(|task| {
-                // Don't trigger prefetch if we're in a fake task created by backward streaming
-                task.is_streaming() && task.remaining() <= task.total_size() / 2
-            })
-            .unwrap_or(false)
-            && self.future_tasks.is_empty()
-        {
-            // The current task is nearing completion, so pre-spawn the next request in anticipation
-            // of it completing.
-            if let Some(task) = self.spawn_next_request() {
-                self.future_tasks.push_back(task);
-            }
-        }
-    }
+    /// Spawn a backpressure GetObject request which has a range from current offset to the end of the file.
+    /// We will be using flow-control window to control how much data we want to download into the prefetcher.
+    fn spawn_read_backpressure_request(
+        &mut self,
+    ) -> Result<RequestTask<Client::ClientError>, PrefetchReadError<Client::ClientError>> {
+        let start = self.next_sequential_read_offset;
+        let object_size = self.size as usize;
+        let range = RequestRange::new(object_size, start, object_size);
 
-    /// Spawn the next required request
-    fn spawn_next_request(&mut self) -> Option<RequestTask<Client::ClientError>> {
-        let start = self.next_request_offset;
-        if start >= self.size {
-            return None;
-        }
+        // The prefetcher now relies on backpressure mechanism so it must be enabled
+        let initial_read_window_size = match self.client.initial_read_window_size() {
+            Some(value) => {
+                // Also, make sure that we don't get blocked from the beginning
+                if value == 0 {
+                    return Err(PrefetchReadError::BackpressurePreconditionFailed);
+                }
+                value
+            }
+            None => return Err(PrefetchReadError::BackpressurePreconditionFailed),
+        };
 
-        let range = RequestRange::new(self.size as usize, start, self.next_request_size);
-        let task = self.part_stream.spawn_get_object_request(
-            &self.client,
-            &self.bucket,
-            self.object_id.key(),
-            self.object_id.etag().clone(),
+        let config = RequestTaskConfig {
+            bucket: self.bucket.clone(),
+            object_id: self.object_id.clone(),
             range,
-            self.preferred_part_size,
-        );
-
-        // [read] will reset these if the reader stops making sequential requests
-        self.next_request_offset += task.total_size() as u64;
-        self.next_request_size = self.get_next_request_size(task.total_size());
-
-        Some(task)
-    }
-
-    /// Suggest next request size.
-    /// The next request size is the current request size multiplied by sequential prefetch multiplier.
-    fn get_next_request_size(&self, request_size: usize) -> usize {
-        // TODO: this logic doesn't work well right now in the case where part_size <
-        // first_request_size and sequential_prefetch_multiplier = 1. It ends up just repeatedly
-        // shrinking the request size until it reaches 1. But this isn't a configuration we
-        // currently expect to ever run in (part_size will always be >= 5MB for MPU reasons, and a
-        // prefetcher with multiplier 1 is not very good).
-        (request_size * self.config.sequential_prefetch_multiplier).min(self.config.max_request_size)
+            preferred_part_size: self.preferred_part_size,
+            initial_read_window_size,
+            max_read_window_size: self.config.max_read_window_size,
+            read_window_size_multiplier: self.config.sequential_prefetch_multiplier,
+        };
+        Ok(self.part_stream.spawn_get_object_request(self.client.clone(), config))
     }
 
     /// Reset this prefetch request to a new offset, clearing any existing tasks queued.
     fn reset_prefetch_to_offset(&mut self, offset: u64) {
-        self.current_task = None;
-        self.future_tasks.drain(..);
+        self.backpressure_task = None;
         self.backward_seek_window.clear();
         self.sequential_read_start_offset = offset;
         self.next_sequential_read_offset = offset;
-        self.next_request_size = self.config.first_request_size;
         self.next_request_offset = offset;
     }
 
@@ -445,7 +429,7 @@ where
         if offset > self.next_sequential_read_offset {
             self.try_seek_forward(offset).await
         } else {
-            self.try_seek_backward(offset)
+            self.try_seek_backward(offset).await
         }
     }
 
@@ -454,43 +438,22 @@ where
         let total_seek_distance = offset - self.next_sequential_read_offset;
         histogram!("prefetch.seek_distance", "dir" => "forward").record(total_seek_distance as f64);
 
-        let Some(current_task) = self.current_task.as_mut() else {
+        let Some(task) = self.backpressure_task.as_mut() else {
             // Can't seek if there's no requests in flight at all
             return Ok(false);
         };
 
-        // Jump ahead to the right request
-        if offset >= current_task.end_offset() {
-            self.next_sequential_read_offset = current_task.end_offset();
-            self.current_task = None;
-            while let Some(next_request) = self.future_tasks.pop_front() {
-                if next_request.end_offset() > offset {
-                    self.current_task = Some(next_request);
-                    break;
-                } else {
-                    self.next_sequential_read_offset = next_request.end_offset();
-                }
-            }
-            if self.current_task.is_none() {
-                // No inflight task containing the target offset.
-                trace!(current_offset=?self.next_sequential_read_offset, requested_offset=?offset, "seek failed: not enough inflight data");
-                return Ok(false);
-            }
-            // We could try harder to preserve the backwards seek buffer if we're near the
-            // request boundary, but it's probably not worth the trouble.
-            self.backward_seek_window.clear();
+        // Not enough data in the read window to serve the forward seek
+        if offset >= task.read_window_offset() {
+            return Ok(false);
         }
 
-        // At this point it's guaranteed by the previous if-block that `offset` is in the range of `self.current_task`
-        let current_task = self
-            .current_task
-            .as_mut()
-            .expect("a request existed that covered this seek offset");
         // If we have enough bytes already downloaded (`available`) to skip straight to this read, then do
         // it. Otherwise, we're willing to wait for the bytes to download only if they're coming "soon", where
         // soon is defined as up to `max_forward_seek_wait_distance` bytes ahead of the available offset.
-        let available_offset = current_task.available_offset();
-        if offset >= available_offset.saturating_add(self.config.max_forward_seek_wait_distance) {
+        let available_offset = task.available_offset();
+        let available_soon_offset = available_offset.saturating_add(self.config.max_forward_seek_wait_distance);
+        if offset >= available_soon_offset {
             trace!(
                 requested_offset = offset,
                 available_offset = available_offset,
@@ -500,7 +463,7 @@ where
         }
         let mut seek_distance = offset - self.next_sequential_read_offset;
         while seek_distance > 0 {
-            let part = current_task.read(seek_distance as usize).await?;
+            let part = task.read(seek_distance as usize).await?;
             seek_distance -= part.len() as u64;
             self.next_sequential_read_offset += part.len() as u64;
             self.backward_seek_window.push(part);
@@ -508,8 +471,14 @@ where
         Ok(true)
     }
 
-    fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+    async fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
         assert!(offset < self.next_sequential_read_offset);
+
+        // When the task is None it means either we have just started prefetching or recently reset it,
+        // in both cases the backward seek window would be empty so we can bail out early.
+        let Some(task) = self.backpressure_task.as_mut() else {
+            return Ok(false);
+        };
         let backwards_length_needed = self.next_sequential_read_offset - offset;
         histogram!("prefetch.seek_distance", "dir" => "backward").record(backwards_length_needed as f64);
 
@@ -517,14 +486,7 @@ where
             trace!("seek failed: not enough data in backwards seek window");
             return Ok(false);
         };
-        // We're going to create a new fake "request" that contains the parts we read out of the
-        // window. That sounds a bit hacky, but it keeps all the read logic simple rather than
-        // needing separate paths for backwards seeks vs others.
-        let request = RequestTask::from_parts(parts, offset);
-        if let Some(current_task) = self.current_task.take() {
-            self.future_tasks.push_front(current_task);
-        }
-        self.current_task = Some(request);
+        task.push_front(parts).await?;
         self.next_sequential_read_offset = offset;
         Ok(true)
     }
@@ -552,12 +514,11 @@ mod tests {
     #![allow(clippy::identity_op)]
 
     use crate::data_cache::InMemoryDataCache;
-    use crate::prefetch::part_stream::ClientPartStream;
 
     use super::caching_stream::CachingPartStream;
     use super::*;
     use futures::executor::{block_on, ThreadPool};
-    use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
+    use mountpoint_s3_client::error::GetObjectError;
     use mountpoint_s3_client::failure_client::{countdown_failure_client, RequestFailureMap};
     use mountpoint_s3_client::mock_client::{ramp_bytes, MockClient, MockClientConfig, MockClientError, MockObject};
     use proptest::proptest;
@@ -571,9 +532,9 @@ mod tests {
     #[derive(Debug, Arbitrary)]
     struct TestConfig {
         #[proptest(strategy = "16usize..1*1024*1024")]
-        first_request_size: usize,
+        initial_read_window_size: usize,
         #[proptest(strategy = "16usize..1*1024*1024")]
-        max_request_size: usize,
+        max_read_window_size: usize,
         #[proptest(strategy = "1usize..8usize")]
         sequential_prefetch_multiplier: usize,
         #[proptest(strategy = "16usize..2*1024*1024")]
@@ -582,6 +543,8 @@ mod tests {
         max_forward_seek_wait_distance: u64,
         #[proptest(strategy = "1u64..4*1024*1024")]
         max_backward_seek_distance: u64,
+        #[proptest(strategy = "16usize..1*1024*1024")]
+        cache_block_size: usize,
     }
 
     fn default_stream() -> ClientPartStream<ThreadPool> {
@@ -604,6 +567,8 @@ mod tests {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size: test_config.client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size: test_config.initial_read_window_size,
             ..Default::default()
         };
         let client = Arc::new(MockClient::new(config));
@@ -613,8 +578,7 @@ mod tests {
         client.add_object("hello", object);
 
         let prefetcher_config = PrefetcherConfig {
-            first_request_size: test_config.first_request_size,
-            max_request_size: test_config.max_request_size,
+            max_read_window_size: test_config.max_read_window_size,
             sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
             read_timeout: Duration::from_secs(5),
             max_forward_seek_wait_distance: test_config.max_forward_seek_wait_distance,
@@ -645,12 +609,13 @@ mod tests {
         Stream: ObjectPartStream + Send + Sync + 'static,
     {
         let config = TestConfig {
-            first_request_size: 256 * 1024,
-            max_request_size: 1024 * 1024 * 1024,
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 1024 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             client_part_size: 8 * 1024 * 1024,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
         run_sequential_read_test(part_stream, 1024 * 1024 + 111, 1024 * 1024, config);
     }
@@ -662,12 +627,13 @@ mod tests {
         Stream: ObjectPartStream + Send + Sync + 'static,
     {
         let config = TestConfig {
-            first_request_size: 256 * 1024,
-            max_request_size: 64 * 1024 * 1024,
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 64 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             client_part_size: 8 * 1024 * 1024,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
         run_sequential_read_test(part_stream, 16 * 1024 * 1024 + 111, 1024 * 1024, config);
     }
@@ -679,15 +645,96 @@ mod tests {
         Stream: ObjectPartStream + Send + Sync + 'static,
     {
         let config = TestConfig {
-            first_request_size: 256 * 1024,
-            max_request_size: 64 * 1024 * 1024,
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 64 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             client_part_size: 8 * 1024 * 1024,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
 
         run_sequential_read_test(part_stream, 256 * 1024 * 1024 + 111, 1024 * 1024, config);
+    }
+
+    fn fail_with_backpressure_precondition_test<Stream>(
+        part_stream: Stream,
+        test_config: TestConfig,
+        client_config: MockClientConfig,
+    ) where
+        Stream: ObjectPartStream + Send + Sync + 'static,
+    {
+        let client = MockClient::new(client_config);
+        let read_size = 1 * MB;
+        let object_size = 8 * MB;
+        let object = MockObject::ramp(0xaa, object_size, ETag::for_tests());
+        let etag = object.etag();
+
+        let prefetcher_config = PrefetcherConfig {
+            max_read_window_size: test_config.max_read_window_size,
+            sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
+            ..Default::default()
+        };
+
+        let prefetcher = Prefetcher::new(part_stream, prefetcher_config);
+        let mut request = prefetcher.prefetch(Arc::new(client), "test-bucket", "hello", object_size as u64, etag);
+        let result = block_on(request.read(0, read_size));
+        assert!(matches!(result, Err(PrefetchReadError::BackpressurePreconditionFailed)));
+    }
+
+    #[test_case(default_stream())]
+    #[test_case(caching_stream(1 * MB))]
+    fn fail_with_backpressure_not_enabled<Stream>(part_stream: Stream)
+    where
+        Stream: ObjectPartStream + Send + Sync + 'static,
+    {
+        let test_config = TestConfig {
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 1024 * 1024 * 1024,
+            sequential_prefetch_multiplier: 8,
+            client_part_size: 8 * 1024 * 1024,
+            max_forward_seek_wait_distance: 16 * 1024 * 1024,
+            max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
+        };
+
+        // backpressure is not enabled for the client
+        let config = MockClientConfig {
+            bucket: "test-bucket".to_string(),
+            part_size: test_config.client_part_size,
+            enable_backpressure: false,
+            ..Default::default()
+        };
+
+        fail_with_backpressure_precondition_test(part_stream, test_config, config);
+    }
+
+    #[test_case(default_stream())]
+    #[test_case(caching_stream(1 * MB))]
+    fn fail_with_backpressure_zero_read_window<Stream>(part_stream: Stream)
+    where
+        Stream: ObjectPartStream + Send + Sync + 'static,
+    {
+        let test_config = TestConfig {
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 1024 * 1024 * 1024,
+            sequential_prefetch_multiplier: 8,
+            client_part_size: 8 * 1024 * 1024,
+            max_forward_seek_wait_distance: 16 * 1024 * 1024,
+            max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
+        };
+
+        // backpressure is enabled but initial read window size is zero
+        let config = MockClientConfig {
+            bucket: "test-bucket".to_string(),
+            part_size: test_config.client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size: 0,
+            ..Default::default()
+        };
+
+        fail_with_backpressure_precondition_test(part_stream, test_config, config);
     }
 
     fn fail_sequential_read_test<Stream: ObjectPartStream + Send + Sync + 'static>(
@@ -700,6 +747,8 @@ mod tests {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size: test_config.client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size: test_config.initial_read_window_size,
             ..Default::default()
         };
         let client = MockClient::new(config);
@@ -711,8 +760,7 @@ mod tests {
         let client = countdown_failure_client(client, get_failures, HashMap::new(), HashMap::new(), HashMap::new());
 
         let prefetcher_config = PrefetcherConfig {
-            first_request_size: test_config.first_request_size,
-            max_request_size: test_config.max_request_size,
+            max_read_window_size: test_config.max_read_window_size,
             sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
             ..Default::default()
         };
@@ -748,23 +796,25 @@ mod tests {
         Stream: ObjectPartStream + Send + Sync + 'static,
     {
         let config = TestConfig {
-            first_request_size: 256 * 1024,
-            max_request_size: 1024 * 1024 * 1024,
+            initial_read_window_size: 256 * 1024,
+            max_read_window_size: 1024 * 1024 * 1024,
             sequential_prefetch_multiplier: 8,
             client_part_size: 8 * 1024 * 1024,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
 
         let mut get_failures = HashMap::new();
-        get_failures.insert(
-            2,
-            Err(ObjectClientError::ClientError(MockClientError(
-                err_value.to_owned().into(),
-            ))),
-        );
+        // We only have one request with backpressure, so we are going to inject the failure at
+        // 2nd read from that request stream.
+        get_failures.insert(1, Ok((2, MockClientError(err_value.to_owned().into()))));
 
-        fail_sequential_read_test(part_stream, 1024 * 1024 + 111, 1024 * 1024, config, get_failures);
+        // Object needs to be bigger than a part size in order to trigger the failure
+        // because the CRT data returns in chunks of part size.
+        let object_size = config.client_part_size + 111;
+
+        fail_sequential_read_test(part_stream, object_size as u64, 1024 * 1024, config, get_failures);
     }
 
     proptest! {
@@ -788,18 +838,17 @@ mod tests {
         fn proptest_sequential_read_with_cache(
             size in 1u64..1 * 1024 * 1024,
             read_size in 1usize..1 * 1024 * 1024,
-            block_size in 16usize..1 * 1024 * 1024,
             config: TestConfig,
         ) {
-            run_sequential_read_test(caching_stream(block_size), size, read_size, config);
+            run_sequential_read_test(caching_stream(config.cache_block_size), size, read_size, config);
         }
 
         #[test]
         fn proptest_sequential_read_small_read_size_with_cache(size in 1u64..1 * 1024 * 1024, read_factor in 1usize..10,
-            block_size in 16usize..1 * 1024 * 1024, config: TestConfig) {
+            config: TestConfig) {
             // Pick read size smaller than the object size
             let read_size = (size as usize / read_factor).max(1);
-            run_sequential_read_test(caching_stream(block_size), size, read_size, config);
+            run_sequential_read_test(caching_stream(config.cache_block_size), size, read_size, config);
         }
     }
 
@@ -808,12 +857,13 @@ mod tests {
         let object_size = 854966;
         let read_size = 161647;
         let config = TestConfig {
-            first_request_size: 484941,
-            max_request_size: 81509,
+            initial_read_window_size: 484941,
+            max_read_window_size: 81509,
             sequential_prefetch_multiplier: 1,
             client_part_size: 181682,
             max_forward_seek_wait_distance: 1,
             max_backward_seek_distance: 18668,
+            cache_block_size: 1 * MB,
         };
         run_sequential_read_test(default_stream(), object_size, read_size, config);
     }
@@ -827,6 +877,8 @@ mod tests {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size: test_config.client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size: test_config.initial_read_window_size,
             ..Default::default()
         };
         let client = Arc::new(MockClient::new(config));
@@ -836,8 +888,7 @@ mod tests {
         client.add_object("hello", object);
 
         let prefetcher_config = PrefetcherConfig {
-            first_request_size: test_config.first_request_size,
-            max_request_size: test_config.max_request_size,
+            max_read_window_size: test_config.max_read_window_size,
             sequential_prefetch_multiplier: test_config.sequential_prefetch_multiplier,
             max_forward_seek_wait_distance: test_config.max_forward_seek_wait_distance,
             max_backward_seek_distance: test_config.max_backward_seek_distance,
@@ -895,11 +946,10 @@ mod tests {
         #[test]
         fn proptest_random_read_with_cache(
             reads in random_read_strategy(1 * 1024 * 1024),
-            block_size in 16usize..1 * 1024 * 1024,
             config: TestConfig,
         ) {
             let (object_size, reads) = reads;
-            run_random_read_test(caching_stream(block_size), object_size, reads, config);
+            run_random_read_test(caching_stream(config.cache_block_size), object_size, reads, config);
         }
     }
 
@@ -908,12 +958,13 @@ mod tests {
         let object_size = 724314;
         let reads = vec![(0, 516883)];
         let config = TestConfig {
-            first_request_size: 3684779,
-            max_request_size: 2147621,
+            initial_read_window_size: 3684779,
+            max_read_window_size: 2147621,
             sequential_prefetch_multiplier: 4,
             client_part_size: 516882,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
         run_random_read_test(default_stream(), object_size, reads, config);
     }
@@ -923,12 +974,13 @@ mod tests {
         let object_size = 755678;
         let reads = vec![(0, 278499), (311250, 1)];
         let config = TestConfig {
-            first_request_size: 556997,
-            max_request_size: 105938,
+            initial_read_window_size: 556997,
+            max_read_window_size: 105938,
             sequential_prefetch_multiplier: 7,
             client_part_size: 1219731,
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
         };
         run_random_read_test(default_stream(), object_size, reads, config);
     }
@@ -938,12 +990,13 @@ mod tests {
         let object_size = 755678;
         let reads = vec![(0, 236766), (291204, 1), (280930, 36002)];
         let config = TestConfig {
-            first_request_size: 556997,
-            max_request_size: 105938,
+            initial_read_window_size: 556997,
+            max_read_window_size: 105938,
             sequential_prefetch_multiplier: 7,
             client_part_size: 1219731,
             max_forward_seek_wait_distance: 2260662,
             max_backward_seek_distance: 2369799,
+            cache_block_size: 1 * MB,
         };
         run_random_read_test(default_stream(), object_size, reads, config);
     }
@@ -953,12 +1006,13 @@ mod tests {
         let object_size = 14201;
         let reads = vec![(3584, 1), (9424, 1460), (3582, 3340), (248, 9218)];
         let config = TestConfig {
-            first_request_size: 457999,
-            max_request_size: 863511,
+            initial_read_window_size: 457999,
+            max_read_window_size: 863511,
             sequential_prefetch_multiplier: 5,
             client_part_size: 1972409,
             max_forward_seek_wait_distance: 2810651,
             max_backward_seek_distance: 3531090,
+            cache_block_size: 1 * MB,
         };
         run_random_read_test(default_stream(), object_size, reads, config);
     }
@@ -971,6 +1025,8 @@ mod tests {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size: PART_SIZE,
+            enable_backpressure: true,
+            initial_read_window_size: PART_SIZE,
             ..Default::default()
         };
 
@@ -1003,11 +1059,7 @@ mod tests {
         ));
 
         // For simplicity, prefetch the whole object in one request.
-        let prefetcher_config = PrefetcherConfig {
-            first_request_size: OBJECT_SIZE,
-            ..Default::default()
-        };
-        let prefetcher = Prefetcher::new(default_stream(), prefetcher_config);
+        let prefetcher = Prefetcher::new(default_stream(), Default::default());
         block_on(async {
             let mut request = prefetcher.prefetch(client, "test-bucket", "hello", OBJECT_SIZE as u64, etag.clone());
 
@@ -1045,6 +1097,8 @@ mod tests {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size,
+            enable_backpressure: true,
+            initial_read_window_size: FIRST_REQUEST_SIZE,
             ..Default::default()
         };
         let client = Arc::new(MockClient::new(config));
@@ -1053,12 +1107,7 @@ mod tests {
 
         client.add_object("hello", object);
 
-        let prefetcher_config = PrefetcherConfig {
-            first_request_size: FIRST_REQUEST_SIZE,
-            ..Default::default()
-        };
-
-        let prefetcher = Prefetcher::new(default_stream(), prefetcher_config);
+        let prefetcher = Prefetcher::new(default_stream(), Default::default());
 
         // Try every possible seek from first_read_size
         for offset in first_read_size + 1..OBJECT_SIZE {
@@ -1079,11 +1128,12 @@ mod tests {
     #[test_case(125, 110; "read in second request")]
     fn test_backward_seek(first_read_size: usize, part_size: usize) {
         const OBJECT_SIZE: usize = 200;
-        const FIRST_REQUEST_SIZE: usize = 100;
 
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
             part_size,
+            enable_backpressure: true,
+            initial_read_window_size: part_size,
             ..Default::default()
         };
         let client = Arc::new(MockClient::new(config));
@@ -1092,11 +1142,7 @@ mod tests {
 
         client.add_object("hello", object);
 
-        let prefetcher_config = PrefetcherConfig {
-            first_request_size: FIRST_REQUEST_SIZE,
-            ..Default::default()
-        };
-        let prefetcher = Prefetcher::new(default_stream(), prefetcher_config);
+        let prefetcher = Prefetcher::new(default_stream(), Default::default());
 
         // Try every possible seek from first_read_size
         for offset in 0..first_read_size {
@@ -1131,16 +1177,18 @@ mod tests {
         fn sequential_read_stress_helper() {
             let mut rng = shuttle::rand::thread_rng();
             let object_size = rng.gen_range(1u64..1 * 1024 * 1024);
-            let first_request_size = rng.gen_range(16usize..1 * 1024 * 1024);
-            let max_request_size = rng.gen_range(16usize..1 * 1024 * 1024);
+            let max_read_window_size = rng.gen_range(16usize..1 * 1024 * 1024);
             let sequential_prefetch_multiplier = rng.gen_range(2usize..16);
             let part_size = rng.gen_range(16usize..1 * 1024 * 1024 + 128 * 1024);
+            let initial_read_window_size = rng.gen_range(16usize..1 * 1024 * 1024 + 128 * 1024);
             let max_forward_seek_wait_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
             let max_backward_seek_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
 
             let config = MockClientConfig {
                 bucket: "test-bucket".to_string(),
                 part_size,
+                enable_backpressure: true,
+                initial_read_window_size,
                 ..Default::default()
             };
             let client = Arc::new(MockClient::new(config));
@@ -1150,8 +1198,7 @@ mod tests {
             client.add_object("hello", object);
 
             let prefetcher_config = PrefetcherConfig {
-                first_request_size,
-                max_request_size,
+                max_read_window_size,
                 sequential_prefetch_multiplier,
                 max_forward_seek_wait_distance,
                 max_backward_seek_distance,
@@ -1184,20 +1231,22 @@ mod tests {
 
         fn random_read_stress_helper() {
             let mut rng = shuttle::rand::thread_rng();
-            let first_request_size = rng.gen_range(16usize..32 * 1024);
-            let max_request_size = rng.gen_range(16usize..32 * 1024);
-            // Try to prevent testing very small reads of very large objects, which are easy to OOM
-            // under Shuttle (lots of concurrent tasks)
-            let max_object_size = first_request_size.min(max_request_size) * 20;
-            let object_size = rng.gen_range(1u64..(64 * 1024).min(max_object_size) as u64);
+            let max_read_window_size = rng.gen_range(16usize..32 * 1024);
             let sequential_prefetch_multiplier = rng.gen_range(2usize..16);
             let part_size = rng.gen_range(16usize..128 * 1024);
+            let initial_read_window_size = rng.gen_range(16usize..128 * 1024);
             let max_forward_seek_wait_distance = rng.gen_range(16u64..192 * 1024);
             let max_backward_seek_distance = rng.gen_range(16u64..192 * 1024);
+            // Try to prevent testing very small reads of very large objects, which are easy to OOM
+            // under Shuttle (lots of concurrent tasks)
+            let max_object_size = initial_read_window_size.min(max_read_window_size) * 20;
+            let object_size = rng.gen_range(1u64..(64 * 1024).min(max_object_size) as u64);
 
             let config = MockClientConfig {
                 bucket: "test-bucket".to_string(),
                 part_size,
+                enable_backpressure: true,
+                initial_read_window_size,
                 ..Default::default()
             };
             let client = Arc::new(MockClient::new(config));
@@ -1207,8 +1256,7 @@ mod tests {
             client.add_object("hello", object);
 
             let prefetcher_config = PrefetcherConfig {
-                first_request_size,
-                max_request_size,
+                max_read_window_size,
                 sequential_prefetch_multiplier,
                 max_forward_seek_wait_distance,
                 max_backward_seek_distance,

--- a/mountpoint-s3/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3/src/prefetch/backpressure_controller.rs
@@ -1,0 +1,169 @@
+use std::ops::Range;
+
+use async_channel::{unbounded, Receiver, Sender};
+use tracing::trace;
+
+use super::PrefetchReadError;
+
+#[derive(Debug)]
+pub enum BackpressureFeedbackEvent {
+    DataRead(usize),
+    PartQueueStall,
+}
+
+#[derive(Debug)]
+pub struct BackpressureController {
+    read_window_updater: Sender<usize>,
+    preferred_read_window_size: usize,
+    max_read_window_size: usize,
+    read_window_size_multiplier: usize,
+    read_window_offset: u64,
+    current_read_offset: u64,
+    request_range: Range<u64>,
+}
+
+#[derive(Debug)]
+pub struct BackpressureLimiter {
+    read_window_incrementing_queue: Receiver<usize>,
+    read_window_offset: u64,
+}
+
+/// Creates a [BackpressureController] and its related [BackpressureLimiter].
+/// We use a pair of these to for providing feedback to backpressure stream.
+///
+/// [BackpressureLimiter] is used on producer side of the object stream, that is, any
+/// [super::part_stream::ObjectPartStream] that support backpressure. The producer can call
+/// `wait_for_read_window_increment` to wait for feedback from the consumer. This method
+/// could block when they know that the producer requires read window incrementing.
+///
+/// [BackpressureController] will be given to the consumer side of the object stream.
+/// It can be used anywhere to set preferred read window size for the stream and tell the
+/// producer when its read window should be increased.
+pub fn new_backpressure_controller(
+    preferred_read_window_size: usize,
+    max_read_window_size: usize,
+    read_window_size_multiplier: usize,
+    read_window_offset: u64,
+    request_range: Range<u64>,
+) -> (BackpressureController, BackpressureLimiter) {
+    let (read_window_updater, read_window_incrementing_queue) = unbounded();
+    let controller = BackpressureController {
+        read_window_updater,
+        preferred_read_window_size,
+        max_read_window_size,
+        read_window_size_multiplier,
+        read_window_offset,
+        current_read_offset: request_range.start,
+        request_range,
+    };
+    let limiter = BackpressureLimiter {
+        read_window_incrementing_queue,
+        read_window_offset,
+    };
+    (controller, limiter)
+}
+
+impl BackpressureController {
+    pub fn read_window_offset(&self) -> u64 {
+        self.read_window_offset
+    }
+
+    /// Send a feedback to the backpressure controller when reading data out of the stream. The backpressure controller
+    /// will ensure that the read window size is enough to read this offset and that it is always close to `preferred_read_window_size`.
+    pub async fn send_feedback<E>(&mut self, event: BackpressureFeedbackEvent) -> Result<(), PrefetchReadError<E>> {
+        match event {
+            BackpressureFeedbackEvent::DataRead(length) => {
+                self.current_read_offset += length as u64;
+                // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
+                while self.remaining_window() < (self.preferred_read_window_size / 2)
+                    && self.read_window_offset < self.request_range.end
+                {
+                    let to_increase = self
+                        .current_read_offset
+                        .saturating_add(self.preferred_read_window_size as u64)
+                        .saturating_sub(self.read_window_offset) as usize;
+                    trace!(
+                        current_read_offset = self.current_read_offset,
+                        read_window_offset = self.read_window_offset,
+                        preferred_read_window_size = self.preferred_read_window_size,
+                        to_increase,
+                        "incrementing read window"
+                    );
+                    self.increment_read_window(to_increase).await?;
+                    self.read_window_offset += to_increase as u64;
+                }
+            }
+            BackpressureFeedbackEvent::PartQueueStall => self.try_scaling_up(),
+        }
+        Ok(())
+    }
+
+    // Send an increment read window request to the stream producer
+    async fn increment_read_window<E>(&self, len: usize) -> Result<(), PrefetchReadError<E>> {
+        // This should not block since the channel is unbounded
+        self.read_window_updater
+            .send(len)
+            .await
+            .map_err(|_| PrefetchReadError::ReadWindowIncrement)
+    }
+
+    fn remaining_window(&self) -> usize {
+        self.read_window_offset.saturating_sub(self.current_read_offset) as usize
+    }
+
+    // Try scaling up preferred read window size with a multiplier configured at initialization.
+    fn try_scaling_up(&mut self) {
+        if self.preferred_read_window_size < self.max_read_window_size {
+            let new_read_window_size =
+                (self.preferred_read_window_size * self.read_window_size_multiplier).min(self.max_read_window_size);
+            trace!(
+                current_size = self.preferred_read_window_size,
+                new_size = new_read_window_size,
+                "scaling up preferred read window"
+            );
+            self.preferred_read_window_size = new_read_window_size;
+        }
+    }
+}
+
+impl BackpressureLimiter {
+    pub fn read_window_offset(&self) -> u64 {
+        self.read_window_offset
+    }
+
+    /// Checks if there is enough read window to put the next item with a given offset to the stream.
+    /// It blocks until receiving enough incrementing read window requests to serve the next part.
+    ///
+    /// Returns the new read window offset.
+    pub async fn wait_for_read_window_increment<E>(
+        &mut self,
+        offset: u64,
+    ) -> Result<Option<u64>, PrefetchReadError<E>> {
+        // There is already enough read window so no need to block
+        if self.read_window_offset > offset {
+            // Check the read window incrementing queue to see there is an early request to increase read window
+            let new_read_window_offset = if let Ok(len) = self.read_window_incrementing_queue.try_recv() {
+                self.read_window_offset += len as u64;
+                Some(self.read_window_offset)
+            } else {
+                None
+            };
+            return Ok(new_read_window_offset);
+        }
+
+        // Reaching here means there is not enough read window, so we block until it is large enough
+        while self.read_window_offset <= offset {
+            trace!(
+                offset,
+                read_window_offset = self.read_window_offset,
+                "blocking for read window increment"
+            );
+            let recv = self.read_window_incrementing_queue.recv().await;
+            match recv {
+                Ok(len) => self.read_window_offset += len as u64,
+                Err(_) => return Err(PrefetchReadError::ReadWindowIncrement),
+            }
+        }
+        Ok(Some(self.read_window_offset))
+    }
+}

--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -4,18 +4,22 @@ use std::{ops::Range, sync::Arc};
 use async_channel::{unbounded, Receiver};
 use bytes::Bytes;
 use futures::task::{Spawn, SpawnExt};
-use futures::{join, pin_mut, StreamExt};
-use mountpoint_s3_client::{types::ETag, ObjectClient};
+use futures::{pin_mut, try_join, StreamExt};
+use mountpoint_s3_client::ObjectClient;
 use tracing::{debug_span, trace, warn, Instrument};
 
 use crate::checksums::ChecksummedBytes;
 use crate::data_cache::{BlockIndex, DataCache};
 use crate::object::ObjectId;
+use crate::prefetch::backpressure_controller::new_backpressure_controller;
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueueProducer};
 use crate::prefetch::part_stream::{read_from_request, ObjectPartStream, RequestRange, RequestReaderOutput};
 use crate::prefetch::task::RequestTask;
 use crate::prefetch::PrefetchReadError;
+
+use super::backpressure_controller::BackpressureLimiter;
+use super::part_stream::RequestTaskConfig;
 
 /// [ObjectPartStream] implementation which maintains a [DataCache] for the object data
 /// retrieved by an [ObjectClient].
@@ -41,67 +45,73 @@ where
 {
     fn spawn_get_object_request<Client>(
         &self,
-        client: &Client,
-        bucket: &str,
-        key: &str,
-        if_match: ETag,
-        range: RequestRange,
-        _preferred_part_size: usize,
+        client: Arc<Client>,
+        config: RequestTaskConfig,
     ) -> RequestTask<<Client as ObjectClient>::ClientError>
     where
-        Client: ObjectClient + Clone + Send + Sync + 'static,
+        Client: ObjectClient + Send + Sync + 'static,
     {
-        let range = range.align(self.cache.block_size(), false);
+        let initial_read_window_offset = config.range.start() + config.initial_read_window_size as u64;
+        let range = config.range;
 
-        let start = range.start();
-        let size = range.len();
-
-        let (part_queue, part_queue_producer) = unbounded_part_queue();
-        trace!(?range, "spawning request");
+        let (backpressure_controller, backpressure_limiter) = new_backpressure_controller(
+            config.initial_read_window_size,
+            config.max_read_window_size,
+            config.read_window_size_multiplier,
+            initial_read_window_offset,
+            range.into(),
+        );
+        let (part_queue, part_queue_producer) = unbounded_part_queue(Some(backpressure_controller));
+        trace!(range=?config.range, "spawning request");
 
         let request_task = {
-            let request = CachingRequest::new(
-                client.clone(),
-                self.cache.clone(),
-                bucket.to_owned(),
-                key.to_owned(),
-                if_match,
-            );
+            let request = CachingRequest::new(client.clone(), self.cache.clone(), backpressure_limiter, config);
             let span = debug_span!("prefetch", ?range);
-            request.get_from_cache(range, part_queue_producer).instrument(span)
+            request
+                .get_from_cache(range, initial_read_window_offset, part_queue_producer)
+                .instrument(span)
         };
 
         let task_handle = self.runtime.spawn_with_handle(request_task).unwrap();
 
-        RequestTask::from_handle(task_handle, size, start, part_queue)
+        RequestTask::from_handle(task_handle, range, part_queue)
     }
 }
 
 #[derive(Debug)]
-struct CachingRequest<Client: ObjectClient + Clone, Cache> {
-    client: Client,
+struct CachingRequest<Client: ObjectClient, Cache> {
+    client: Arc<Client>,
     cache: Arc<Cache>,
-    bucket: String,
-    cache_key: ObjectId,
+    backpressure_limiter: BackpressureLimiter,
+    config: RequestTaskConfig,
 }
 
 impl<Client, Cache> CachingRequest<Client, Cache>
 where
-    Client: ObjectClient + Clone + Send + Sync + 'static,
+    Client: ObjectClient + Send + Sync + 'static,
     Cache: DataCache + Send + Sync,
 {
-    fn new(client: Client, cache: Arc<Cache>, bucket: String, key: String, etag: ETag) -> Self {
-        let cache_key = ObjectId::new(key, etag);
+    fn new(
+        client: Arc<Client>,
+        cache: Arc<Cache>,
+        backpressure_limiter: BackpressureLimiter,
+        config: RequestTaskConfig,
+    ) -> Self {
         Self {
             client,
             cache,
-            bucket,
-            cache_key,
+            backpressure_limiter,
+            config,
         }
     }
 
-    async fn get_from_cache(self, range: RequestRange, part_queue_producer: PartQueueProducer<Client::ClientError>) {
-        let cache_key = &self.cache_key;
+    async fn get_from_cache(
+        mut self,
+        range: RequestRange,
+        initial_read_window_offset: u64,
+        part_queue_producer: PartQueueProducer<Client::ClientError>,
+    ) {
+        let cache_key = &self.config.object_id;
         let block_size = self.cache.block_size();
         let block_range = self.block_indices_for_byte_range(&range);
 
@@ -111,13 +121,24 @@ where
         // request, but since this stream is already behind the prefetcher, the delay is
         // already likely negligible.
         let mut block_offset = block_range.start * block_size;
+
         for block_index in block_range.clone() {
             match self.cache.get_block(cache_key, block_index, block_offset) {
                 Ok(Some(block)) => {
                     trace!(?cache_key, ?range, block_index, "cache hit");
-                    let part = make_part(block, block_index, block_offset, block_size, &self.cache_key, &range);
+
+                    let part = make_part(block, block_index, block_offset, block_size, cache_key, &range);
                     part_queue_producer.push(Ok(part));
                     block_offset += block_size;
+
+                    if let Err(e) = self
+                        .backpressure_limiter
+                        .wait_for_read_window_increment(block_offset)
+                        .await
+                    {
+                        part_queue_producer.push(Err(e));
+                        break;
+                    }
                     continue;
                 }
                 Ok(None) => trace!(?cache_key, block_index, ?range, "cache miss - no data for block"),
@@ -132,56 +153,96 @@ where
             // If a block is uncached or reading it fails, fallback to S3 for the rest of the stream.
             metrics::counter!("prefetch.blocks_served_from_cache").increment(block_index - block_range.start);
             metrics::counter!("prefetch.blocks_requested_to_client").increment(block_range.end - block_index);
-            return self
+            if let Err(e) = self
                 .get_from_client(
                     range.trim_start(block_offset),
                     block_index..block_range.end,
-                    part_queue_producer,
+                    initial_read_window_offset,
+                    part_queue_producer.clone(),
                 )
-                .await;
+                .await
+            {
+                part_queue_producer.push(Err(e));
+            }
+            return;
         }
         // We served the whole range from cache.
         metrics::counter!("prefetch.blocks_served_from_cache").increment(block_range.end - block_range.start);
     }
 
     async fn get_from_client(
-        &self,
+        &mut self,
         range: RequestRange,
         block_range: Range<u64>,
+        initial_read_window_offset: u64,
         part_queue_producer: PartQueueProducer<Client::ClientError>,
-    ) {
-        let key = self.cache_key.key();
+    ) -> Result<(), PrefetchReadError<Client::ClientError>> {
+        let bucket = &self.config.bucket;
+        let cache_key = &self.config.object_id;
         let block_size = self.cache.block_size();
         assert!(block_size > 0);
 
         // Always request a range aligned with block boundaries (or to the end of the object).
         let block_aligned_byte_range =
             (block_range.start * block_size)..(block_range.end * block_size).min(range.object_size() as u64);
+        let request_len = (block_aligned_byte_range.end - block_aligned_byte_range.start) as usize;
+        let block_aligned_byte_range =
+            RequestRange::new(range.object_size(), block_aligned_byte_range.start, request_len);
 
         trace!(
-            ?key,
+            key = self.config.object_id.key(),
             range =? block_aligned_byte_range,
             original_range =? range,
             "fetching data from client"
         );
 
-        let (body_sender, body_receiver) = unbounded();
-        let request_reader_future = read_from_request(
-            body_sender,
-            self.client.clone(),
-            self.bucket.clone(),
-            self.cache_key.clone(),
-            block_aligned_byte_range,
-        );
-        let part_composer_future = compose_parts(
-            body_receiver,
+        let mut part_composer = CachingPartComposer {
             part_queue_producer,
-            self.cache_key.clone(),
-            range,
-            block_range,
-            self.cache.clone(),
-        );
-        join!(request_reader_future, part_composer_future);
+            cache_key: cache_key.clone(),
+            preferred_part_size: self.config.preferred_part_size,
+            original_range: range,
+            block_index: block_range.start,
+            block_offset: block_range.start * block_size,
+            buffer: ChecksummedBytes::default(),
+            cache: self.cache.clone(),
+        };
+
+        // Start by issuing the first request that has a range up to initial read window offset.
+        // This is an optimization to lower time to first bytes, see more details in ClientPartStream about why this is needed.
+        let first_req_range = block_aligned_byte_range.trim_end(initial_read_window_offset);
+        if !first_req_range.is_empty() {
+            let (body_sender, body_receiver) = unbounded();
+            let request_reader_future = read_from_request(
+                body_sender,
+                &mut self.backpressure_limiter,
+                self.client.clone(),
+                bucket.clone(),
+                cache_key.clone(),
+                first_req_range.into(),
+            );
+            let part_composer_future = part_composer.compose_parts(body_receiver);
+            try_join!(request_reader_future, part_composer_future)?;
+        }
+
+        // After the first request is completed we will create the second request for the rest of the stream,
+        // but only if there is something left to be fetched.
+        let range = block_aligned_byte_range.trim_start(initial_read_window_offset);
+        if !range.is_empty() {
+            let (body_sender, body_receiver) = unbounded();
+            let request_reader_future = read_from_request(
+                body_sender,
+                &mut self.backpressure_limiter,
+                self.client.clone(),
+                bucket.clone(),
+                cache_key.clone(),
+                range.into(),
+            );
+            let part_composer_future = part_composer.compose_parts(body_receiver);
+            try_join!(request_reader_future, part_composer_future)?;
+        }
+        part_composer.flush();
+
+        Ok(())
     }
 
     fn block_indices_for_byte_range(&self, range: &RequestRange) -> Range<BlockIndex> {
@@ -196,99 +257,136 @@ where
     }
 }
 
-async fn compose_parts<E, Cache>(
-    body_receiver: Receiver<RequestReaderOutput<E>>,
+struct CachingPartComposer<E: std::error::Error, Cache> {
     part_queue_producer: PartQueueProducer<E>,
-    object_id: ObjectId,
-    range: RequestRange,
-    block_range: Range<u64>,
+    cache_key: ObjectId,
+    preferred_part_size: usize,
+    original_range: RequestRange,
+    block_index: u64,
+    block_offset: u64,
+    buffer: ChecksummedBytes,
     cache: Arc<Cache>,
-) where
+}
+
+impl<E, Cache> CachingPartComposer<E, Cache>
+where
     E: std::error::Error + Send + Sync,
     Cache: DataCache + Send + Sync,
 {
-    let key = object_id.key();
-    let block_size = cache.block_size();
+    async fn compose_parts(
+        &mut self,
+        body_receiver: Receiver<RequestReaderOutput>,
+    ) -> Result<(), PrefetchReadError<E>> {
+        let key = self.cache_key.key();
+        let block_size = self.cache.block_size();
 
-    pin_mut!(body_receiver);
-    let mut block_index = block_range.start;
-    let mut block_offset = block_range.start * block_size;
-    let mut buffer = ChecksummedBytes::default();
-    loop {
-        assert!(
-            buffer.len() < block_size as usize,
-            "buffer should be flushed when we get a full block"
-        );
-        match body_receiver.next().await {
-            Some(Ok((offset, body))) => {
-                let expected_offset = block_offset + buffer.len() as u64;
-                if offset != expected_offset {
-                    warn!(key, offset, expected_offset, "wrong offset for GetObject body part");
-                    part_queue_producer.push(Err(PrefetchReadError::GetRequestReturnedWrongOffset {
-                        offset,
-                        expected_offset,
-                    }));
+        pin_mut!(body_receiver);
+        loop {
+            assert!(
+                self.buffer.len() < block_size as usize,
+                "buffer should be flushed when we get a full block"
+            );
+            let Some((offset, body)) = body_receiver.next().await else {
+                break;
+            };
+
+            let expected_offset = self.block_offset + self.buffer.len() as u64;
+            if offset != expected_offset {
+                warn!(key, offset, expected_offset, "wrong offset for GetObject body part");
+                return Err(PrefetchReadError::GetRequestReturnedWrongOffset {
+                    offset,
+                    expected_offset,
+                });
+            }
+
+            // S3 doesn't provide checksum for us if the request range is not aligned to
+            // object part boundaries, so we're computing our own checksum here.
+            let mut body: ChecksummedBytes = Bytes::from(body).into();
+
+            // Return some bytes to the part queue even before we can fill an entire caching block because we want to
+            // start the feedback loop for the flow-control window.
+            //
+            // We need to do this because the read window might be enough to fetch "some data" from S3 but not the entire block.
+            // For example, consider that we got a file system read request with range 2MB to 4MB and we have to start
+            // reading from block_offset=0 and block_size=5MB. The first read window might have a range up to 4MB which is enough
+            // to serve the read request but if the prefetcher is not able to read anything it cannot tell the stream to move
+            // its read window.
+            //
+            // A side effect from this is delay on the cache updating which is actually good for performance but it makes testing
+            // a bit more complicated because the cache might not be updated immediately.
+            let part_range = self
+                .original_range
+                .trim_start(offset)
+                .trim_end(offset + body.len() as u64);
+            let trim_start = (part_range.start().saturating_sub(offset)) as usize;
+            let trim_end = (part_range.end().saturating_sub(offset)) as usize;
+            // Put to the part queue only if returned data is in the actual request range.
+            if trim_end > trim_start {
+                self.part_queue_producer.split_and_push(
+                    self.cache_key.clone(),
+                    part_range.start(),
+                    body.slice(trim_start..trim_end),
+                    self.preferred_part_size,
+                )?;
+            }
+
+            // Now we can fill the caching blocks.
+            while !body.is_empty() {
+                let remaining = (block_size as usize).saturating_sub(self.buffer.len()).min(body.len());
+                let chunk = body.split_to(remaining);
+                if let Err(e) = self.buffer.extend(chunk) {
+                    warn!(key, error=?e, "integrity check for body part failed");
+                    return Err(e.into());
+                }
+                if self.buffer.len() < block_size as usize {
                     break;
                 }
 
-                // Split the body into blocks.
-                let mut body: Bytes = body.into();
-                while !body.is_empty() {
-                    let remaining = (block_size as usize).saturating_sub(buffer.len()).min(body.len());
-                    let chunk = body.split_to(remaining);
-                    if let Err(e) = buffer.extend(chunk.into()) {
-                        warn!(key, error=?e, "integrity check for body part failed");
-                        part_queue_producer.push(Err(e.into()));
-                        return;
-                    }
-                    if buffer.len() < block_size as usize {
-                        break;
-                    }
-
-                    // We have a full block: write it to the cache, send it to the queue, and flush the buffer.
-                    update_cache(cache.as_ref(), &buffer, block_index, block_offset, &object_id);
-                    part_queue_producer.push(Ok(make_part(
-                        buffer,
-                        block_index,
-                        block_offset,
-                        block_size,
-                        &object_id,
-                        &range,
-                    )));
-                    block_index += 1;
-                    block_offset += block_size;
-                    buffer = ChecksummedBytes::default();
-                }
-            }
-            Some(Err(e)) => {
-                part_queue_producer.push(Err(e));
-                break;
-            }
-            None => {
-                if !buffer.is_empty() {
-                    // If we still have data in the buffer, this must be the last block for this object,
-                    // which can be smaller than block_size (and ends at the end of the object).
-                    assert_eq!(
-                        block_offset as usize + buffer.len(),
-                        range.object_size(),
-                        "a partial block is only allowed at the end of the object"
-                    );
-                    // Write the last block to the cache.
-                    update_cache(cache.as_ref(), &buffer, block_index, block_offset, &object_id);
-                    part_queue_producer.push(Ok(make_part(
-                        buffer,
-                        block_index,
-                        block_offset,
-                        block_size,
-                        &object_id,
-                        &range,
-                    )));
-                }
-                break;
+                // We have a full block: write it to the cache, send it to the queue, and flush the buffer.
+                update_cache(
+                    self.cache.as_ref(),
+                    &self.buffer,
+                    self.block_index,
+                    self.block_offset,
+                    &self.cache_key,
+                );
+                self.block_index += 1;
+                self.block_offset += block_size;
+                self.buffer = ChecksummedBytes::default();
             }
         }
+        trace!("part composer finished");
+        Ok(())
     }
-    trace!("part composer finished");
+
+    // Flush remaining data in the buffer to the cache
+    fn flush(&self) {
+        if !self.buffer.is_empty() {
+            // If we still have data in the buffer, this must be the last block for this object,
+            // which can be smaller than block_size (and ends at the end of the object).
+            assert_eq!(
+                self.block_offset as usize + self.buffer.len(),
+                self.original_range.object_size(),
+                "a partial block is only allowed at the end of the object"
+            );
+            // Write the last block to the cache.
+            update_cache(
+                self.cache.as_ref(),
+                &self.buffer,
+                self.block_index,
+                self.block_offset,
+                &self.cache_key,
+            );
+            self.part_queue_producer.push(Ok(make_part(
+                self.buffer.clone(),
+                self.block_index,
+                self.block_offset,
+                self.cache.block_size(),
+                &self.cache_key,
+                &self.original_range,
+            )));
+        }
+    }
 }
 
 fn update_cache<Cache: DataCache + Send + Sync>(
@@ -346,10 +444,13 @@ mod tests {
     #![allow(clippy::identity_op)]
 
     use futures::executor::{block_on, ThreadPool};
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockObject, Operation};
+    use mountpoint_s3_client::{
+        mock_client::{MockClient, MockClientConfig, MockObject, Operation},
+        types::ETag,
+    };
     use test_case::test_case;
 
-    use crate::data_cache::InMemoryDataCache;
+    use crate::{data_cache::InMemoryDataCache, object::ObjectId};
 
     use super::*;
 
@@ -373,14 +474,20 @@ mod tests {
         let key = "object";
         let seed = 0xaa;
         let object = MockObject::ramp(seed, object_size, ETag::for_tests());
-        let etag = object.etag();
         let id = ObjectId::new(key.to_owned(), object.etag());
+
+        // backpressure config
+        let initial_read_window_size = 1 * MB;
+        let max_read_window_size = 64 * MB;
+        let read_window_size_multiplier = 2;
 
         let cache = InMemoryDataCache::new(block_size as u64);
         let bucket = "test-bucket";
         let config = MockClientConfig {
             bucket: bucket.to_string(),
             part_size: client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size,
             ..Default::default()
         };
         let mock_client = Arc::new(MockClient::new(config));
@@ -393,7 +500,16 @@ mod tests {
         let first_read_count = {
             // First request (from client)
             let get_object_counter = mock_client.new_counter(Operation::GetObject);
-            let request_task = stream.spawn_get_object_request(&mock_client, bucket, key, etag.clone(), range, 0);
+            let config = RequestTaskConfig {
+                bucket: bucket.to_owned(),
+                object_id: id.clone(),
+                range,
+                preferred_part_size: 256 * KB,
+                initial_read_window_size,
+                max_read_window_size,
+                read_window_size_multiplier,
+            };
+            let request_task = stream.spawn_get_object_request(mock_client.clone(), config);
             compare_read(&id, &object, request_task);
             get_object_counter.count()
         };
@@ -402,11 +518,21 @@ mod tests {
         let second_read_count = {
             // Second request (from cache)
             let get_object_counter = mock_client.new_counter(Operation::GetObject);
-            let request_task = stream.spawn_get_object_request(&mock_client, bucket, key, etag.clone(), range, 0);
+            let config = RequestTaskConfig {
+                bucket: bucket.to_owned(),
+                object_id: id.clone(),
+                range,
+                preferred_part_size: 256 * KB,
+                initial_read_window_size,
+                max_read_window_size,
+                read_window_size_multiplier,
+            };
+            let request_task = stream.spawn_get_object_request(mock_client.clone(), config);
             compare_read(&id, &object, request_task);
             get_object_counter.count()
         };
-        assert_eq!(second_read_count, 0);
+        // Just check that some blocks are served from cache
+        assert!(second_read_count < first_read_count);
     }
 
     #[test_case(1 * MB, 8 * MB)]
@@ -418,14 +544,20 @@ mod tests {
         let object_size = 16 * MB;
         let seed = 0xaa;
         let object = MockObject::ramp(seed, object_size, ETag::for_tests());
-        let etag = object.etag();
         let id = ObjectId::new(key.to_owned(), object.etag());
+
+        // backpressure config
+        let initial_read_window_size = 1 * MB;
+        let max_read_window_size = 64 * MB;
+        let read_window_size_multiplier = 2;
 
         let cache = InMemoryDataCache::new(block_size as u64);
         let bucket = "test-bucket";
         let config = MockClientConfig {
             bucket: bucket.to_string(),
             part_size: client_part_size,
+            enable_backpressure: true,
+            initial_read_window_size,
             ..Default::default()
         };
         let mock_client = Arc::new(MockClient::new(config));
@@ -436,8 +568,16 @@ mod tests {
 
         for offset in [0, 512 * KB, 1 * MB, 4 * MB, 9 * MB] {
             for preferred_size in [1 * KB, 512 * KB, 4 * MB, 12 * MB, 16 * MB] {
-                let range = RequestRange::new(object_size, offset as u64, preferred_size);
-                let request_task = stream.spawn_get_object_request(&mock_client, bucket, key, etag.clone(), range, 0);
+                let config = RequestTaskConfig {
+                    bucket: bucket.to_owned(),
+                    object_id: id.clone(),
+                    range: RequestRange::new(object_size, offset as u64, preferred_size),
+                    preferred_part_size: 256 * KB,
+                    initial_read_window_size,
+                    max_read_window_size,
+                    read_window_size_multiplier,
+                };
+                let request_task = stream.spawn_get_object_request(mock_client.clone(), config);
                 compare_read(&id, &object, request_task);
             }
         }

--- a/mountpoint-s3/src/prefetch/part.rs
+++ b/mountpoint-s3/src/prefetch/part.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::checksums::ChecksummedBytes;
+use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::object::ObjectId;
 
 /// A self-identifying part of an S3 object. Users can only retrieve the bytes from this part if
@@ -21,7 +21,13 @@ impl Part {
         }
     }
 
-    pub fn into_bytes(self, id: &ObjectId, offset: u64) -> Result<ChecksummedBytes, PartMismatchError> {
+    pub fn extend(&mut self, other: &Part) -> Result<(), PartOperationError> {
+        let expected_offset = self.offset + self.checksummed_bytes.len() as u64;
+        other.check(&self.id, expected_offset)?;
+        Ok(self.checksummed_bytes.extend(other.clone().checksummed_bytes)?)
+    }
+
+    pub fn into_bytes(self, id: &ObjectId, offset: u64) -> Result<ChecksummedBytes, PartOperationError> {
         self.check(id, offset).map(|_| self.checksummed_bytes)
     }
 
@@ -46,15 +52,15 @@ impl Part {
         self.checksummed_bytes.is_empty()
     }
 
-    fn check(&self, id: &ObjectId, offset: u64) -> Result<(), PartMismatchError> {
+    fn check(&self, id: &ObjectId, offset: u64) -> Result<(), PartOperationError> {
         if self.id != *id {
-            return Err(PartMismatchError::Id {
+            return Err(PartOperationError::IdMismatch {
                 actual: self.id.clone(),
                 requested: id.to_owned(),
             });
         }
         if self.offset != offset {
-            return Err(PartMismatchError::Offset {
+            return Err(PartOperationError::OffsetMismatch {
                 actual: self.offset,
                 requested: offset,
             });
@@ -64,10 +70,117 @@ impl Part {
 }
 
 #[derive(Debug, Error)]
-pub enum PartMismatchError {
+pub enum PartOperationError {
+    #[error("part integrity check failed")]
+    Integrity(#[from] IntegrityError),
+
     #[error("wrong part id: actual={actual:?}, requested={requested:?}")]
-    Id { actual: ObjectId, requested: ObjectId },
+    IdMismatch { actual: ObjectId, requested: ObjectId },
 
     #[error("wrong part offset: actual={actual}, requested={requested}")]
-    Offset { actual: u64, requested: u64 },
+    OffsetMismatch { actual: u64, requested: u64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use mountpoint_s3_client::types::ETag;
+
+    use crate::{checksums::ChecksummedBytes, object::ObjectId, prefetch::part::PartOperationError};
+
+    use super::Part;
+
+    #[test]
+    fn test_append() {
+        let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
+        let first_offset = 0;
+        let first_part_len = 1024;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(first_offset as u8 as usize)
+            .take(first_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes);
+
+        let second_part_len = 512;
+        let second_offset = first_offset + first_part_len as u64;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(second_offset as u8 as usize)
+            .take(second_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let second = Part::new(object_id.clone(), second_offset, checksummed_bytes);
+
+        first.extend(&second).expect("should be able to extend");
+        assert_eq!(first_part_len + second_part_len, first.len());
+        first.check(&object_id, first_offset).expect("the part should be valid");
+    }
+
+    #[test]
+    fn test_append_with_mismatch_object_id() {
+        let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
+        let first_offset = 0;
+        let first_part_len = 1024;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(first_offset as u8 as usize)
+            .take(first_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes);
+
+        let second_object_id = ObjectId::new("other".to_owned(), ETag::for_tests());
+        let second_part_len = 512;
+        let second_offset = first_offset;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(second_offset as u8 as usize)
+            .take(second_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let second = Part::new(second_object_id.clone(), second_offset, checksummed_bytes);
+
+        let result = first.extend(&second);
+        assert!(matches!(
+            result,
+            Err(PartOperationError::IdMismatch {
+                actual: _,
+                requested: _
+            })
+        ));
+    }
+
+    #[test]
+    fn test_append_with_mismatch_offset() {
+        let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
+        let first_offset = 0;
+        let first_part_len = 1024;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(first_offset as u8 as usize)
+            .take(first_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes);
+
+        let second_part_len = 512;
+        let second_offset = first_offset;
+        let body: Box<[u8]> = (0u8..=255)
+            .cycle()
+            .skip(second_offset as u8 as usize)
+            .take(second_part_len)
+            .collect();
+        let checksummed_bytes = ChecksummedBytes::new(body.into());
+        let second = Part::new(object_id.clone(), second_offset, checksummed_bytes);
+
+        let result = first.extend(&second);
+        assert!(matches!(
+            result,
+            Err(PartOperationError::OffsetMismatch {
+                actual: _,
+                requested: _
+            })
+        ));
+    }
 }

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -2,11 +2,16 @@ use std::time::Instant;
 
 use tracing::trace;
 
+use crate::checksums::ChecksummedBytes;
+use crate::object::ObjectId;
+use crate::prefetch::backpressure_controller::BackpressureFeedbackEvent::{DataRead, PartQueueStall};
 use crate::prefetch::part::Part;
 use crate::prefetch::PrefetchReadError;
 use crate::sync::async_channel::{unbounded, Receiver, RecvError, Sender};
 use crate::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use crate::sync::{Arc, AsyncMutex};
+
+use super::backpressure_controller::BackpressureController;
 
 /// A queue of [Part]s where the first part can be partially read from if the reader doesn't want
 /// the entire part in one shot.
@@ -14,6 +19,8 @@ use crate::sync::{Arc, AsyncMutex};
 pub struct PartQueue<E: std::error::Error> {
     current_part: AsyncMutex<Option<Part>>,
     receiver: Receiver<Result<Part, PrefetchReadError<E>>>,
+    /// Optional backpressure controller
+    backpressure_controller: Option<BackpressureController>,
     failed: AtomicBool,
     /// The total number of bytes sent to the underlying queue of `self.receiver`
     bytes_received: Arc<AtomicUsize>,
@@ -28,12 +35,15 @@ pub struct PartQueueProducer<E: std::error::Error> {
 }
 
 /// Creates an unbounded [PartQueue] and its related [PartQueueProducer].
-pub fn unbounded_part_queue<E: std::error::Error>() -> (PartQueue<E>, PartQueueProducer<E>) {
+pub fn unbounded_part_queue<E: std::error::Error>(
+    backpressure_controller: Option<BackpressureController>,
+) -> (PartQueue<E>, PartQueueProducer<E>) {
     let (sender, receiver) = unbounded();
     let bytes_counter = Arc::new(AtomicUsize::new(0));
     let part_queue = PartQueue {
         current_part: AsyncMutex::new(None),
         receiver,
+        backpressure_controller,
         failed: AtomicBool::new(false),
         bytes_received: Arc::clone(&bytes_counter),
     };
@@ -51,7 +61,7 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
     /// empty.
     ///
     /// If this method returns an Err, the PartQueue must never be accessed again.
-    pub async fn read(&self, length: usize) -> Result<Part, PrefetchReadError<E>> {
+    pub async fn read(&mut self, length: usize) -> Result<Part, PrefetchReadError<E>> {
         let mut current_part = self.current_part.lock().await;
 
         assert!(
@@ -66,6 +76,9 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
             if let Ok(part) = self.receiver.try_recv() {
                 part
             } else {
+                if let Some(backpressure_controller) = &mut self.backpressure_controller {
+                    backpressure_controller.send_feedback(PartQueueStall).await?;
+                }
                 let start = Instant::now();
                 let part = self.receiver.recv().await;
                 metrics::histogram!("prefetch.part_queue_starved_us").record(start.elapsed().as_micros() as f64);
@@ -89,12 +102,50 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
             let tail = part.split_off(length);
             *current_part = Some(tail);
         }
+        // Send feedback to the backpressure controller as we read data out of the part queue
+        if let Some(backpressure_controller) = &mut self.backpressure_controller {
+            backpressure_controller.send_feedback(DataRead(part.len())).await?;
+        }
         metrics::gauge!("prefetch.bytes_in_queue").decrement(part.len() as f64);
         Ok(part)
     }
 
+    /// Push a new [Part] onto the front of the queue
+    /// which actually just concatenate it with the current part
+    pub async fn push_front(&self, mut part: Part) -> Result<(), PrefetchReadError<E>> {
+        let mut current_part = self.current_part.lock().await;
+
+        assert!(
+            !self.failed.load(Ordering::SeqCst),
+            "cannot use a PartQueue after failure"
+        );
+
+        if let Some(current_part) = current_part.as_mut() {
+            part.extend(current_part)?;
+            *current_part = part;
+        } else {
+            *current_part = Some(part);
+        }
+        Ok(())
+    }
+
     pub fn bytes_received(&self) -> usize {
         self.bytes_received.load(Ordering::SeqCst)
+    }
+
+    pub fn read_window_offset(&self) -> Option<u64> {
+        self.backpressure_controller
+            .as_ref()
+            .map(|controller| controller.read_window_offset())
+    }
+}
+
+impl<E: std::error::Error + Send + Sync> Clone for PartQueueProducer<E> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            bytes_sent: self.bytes_sent.clone(),
+        }
     }
 }
 
@@ -111,6 +162,46 @@ impl<E: std::error::Error + Send + Sync> PartQueueProducer<E> {
             self.bytes_sent.fetch_add(part_len, Ordering::SeqCst);
             metrics::gauge!("prefetch.bytes_in_queue").increment(part_len as f64);
         }
+    }
+
+    /// Split the given bytes into parts with the given boundaries and push them to the part queue, assuming that
+    /// the boundaries start from offset 0.
+    ///
+    /// Aligning part with the right boundaries can reduce compute time for validating checksum at read. Without
+    /// this, we will have to do multiple splits and extends on the part, which are expensive operations.
+    pub fn split_and_push(
+        &self,
+        id: ObjectId,
+        offset: u64,
+        mut body: ChecksummedBytes,
+        alignment: usize,
+    ) -> Result<(), PrefetchReadError<E>> {
+        if body.is_empty() {
+            return Ok(());
+        }
+        let mut curr_offset = offset;
+
+        // First, align the front to part boundaries
+        if offset % alignment as u64 != 0 {
+            let distance_to_align = alignment - (curr_offset % alignment as u64) as usize;
+            let chunk_size = distance_to_align.min(body.len());
+            let mut chunk = body.split_to(chunk_size);
+            chunk.shrink_to_fit()?;
+            let part = Part::new(id.clone(), curr_offset, chunk);
+            curr_offset += part.len() as u64;
+            self.push(Ok(part));
+        }
+
+        // After that we can just split it evenly
+        while !body.is_empty() {
+            let chunk_size = alignment.min(body.len());
+            let mut chunk = body.split_to(chunk_size);
+            chunk.shrink_to_fit()?;
+            let part = Part::new(id.clone(), curr_offset, chunk);
+            curr_offset += part.len() as u64;
+            self.push(Ok(part));
+        }
+        Ok(())
     }
 }
 
@@ -160,7 +251,7 @@ mod tests {
 
     async fn run_test(ops: Vec<Op>) {
         let part_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let (part_queue, part_queue_producer) = unbounded_part_queue::<DummyError>();
+        let (mut part_queue, part_queue_producer) = unbounded_part_queue::<DummyError>(None);
         let mut current_offset = 0;
         let mut current_length = 0;
         for op in ops {

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::{fmt::Debug, ops::Range};
 use tracing::{debug_span, trace, Instrument};
 
-use crate::checksums::ChecksummedBytes;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::new_backpressure_controller;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueueProducer};
@@ -309,9 +308,7 @@ impl<E: std::error::Error + Send + Sync> ClientPartComposer<E> {
             let Some((offset, body)) = body_receiver.next().await else {
                 break;
             };
-            // S3 doesn't provide checksum for us if the request range is not aligned to
-            // object part boundaries, so we're computing our own checksum here.
-            let body: ChecksummedBytes = Bytes::from(body).into();
+            let body: Bytes = body.into();
             // pre-split the body into multiple parts as suggested by preferred part size
             // in order to avoid validating checksum on large parts at read.
             self.part_queue_producer

--- a/mountpoint-s3/src/prefetch/task.rs
+++ b/mountpoint-s3/src/prefetch/task.rs
@@ -1,49 +1,46 @@
 use futures::future::RemoteHandle;
 
 use crate::prefetch::part::Part;
-use crate::prefetch::part_queue::{unbounded_part_queue, PartQueue};
+use crate::prefetch::part_queue::PartQueue;
 use crate::prefetch::PrefetchReadError;
+
+use super::part_stream::RequestRange;
 
 /// A single GetObject request submitted to the S3 client
 #[derive(Debug)]
 pub struct RequestTask<E: std::error::Error> {
     /// Handle on the task/future. The future is cancelled when handle is dropped. This is None if
     /// the request is fake (created by seeking backwards in the stream)
-    task_handle: Option<RemoteHandle<()>>,
+    _task_handle: RemoteHandle<()>,
     remaining: usize,
-    start_offset: u64,
-    total_size: usize,
+    range: RequestRange,
     part_queue: PartQueue<E>,
 }
 
 impl<E: std::error::Error + Send + Sync> RequestTask<E> {
-    pub fn from_handle(task_handle: RemoteHandle<()>, size: usize, offset: u64, part_queue: PartQueue<E>) -> Self {
+    pub fn from_handle(task_handle: RemoteHandle<()>, range: RequestRange, part_queue: PartQueue<E>) -> Self {
         Self {
-            task_handle: Some(task_handle),
-            remaining: size,
-            start_offset: offset,
-            total_size: size,
+            _task_handle: task_handle,
+            remaining: range.len(),
+            range,
             part_queue,
         }
     }
 
-    pub fn from_parts(parts: impl IntoIterator<Item = Part>, offset: u64) -> Self {
-        let mut size = 0;
-        let (part_queue, part_queue_producer) = unbounded_part_queue();
-        for part in parts {
-            size += part.len();
-            part_queue_producer.push(Ok(part));
+    // Push a given list of parts in front of the part queue
+    pub async fn push_front(&mut self, parts: Vec<Part>) -> Result<(), PrefetchReadError<E>> {
+        // Merge all parts into one single part by pushing them to the front of the part queue.
+        // This could result in a really big part, but we normally use this only for backward seek
+        // so its size should not be bigger than the prefetcher's `max_backward_seek_distance`.
+        for part in parts.into_iter().rev() {
+            self.remaining += part.len();
+            self.part_queue.push_front(part).await?;
         }
-        Self {
-            task_handle: None,
-            remaining: size,
-            start_offset: offset,
-            total_size: size,
-            part_queue,
-        }
+        Ok(())
     }
 
     pub async fn read(&mut self, length: usize) -> Result<Part, PrefetchReadError<E>> {
+        tracing::trace!(length, "read");
         let part = self.part_queue.read(length).await?;
         debug_assert!(part.len() <= self.remaining);
         self.remaining -= part.len();
@@ -51,15 +48,15 @@ impl<E: std::error::Error + Send + Sync> RequestTask<E> {
     }
 
     pub fn start_offset(&self) -> u64 {
-        self.start_offset
+        self.range.start()
     }
 
     pub fn end_offset(&self) -> u64 {
-        self.start_offset + self.total_size as u64
+        self.range.end()
     }
 
     pub fn total_size(&self) -> usize {
-        self.total_size
+        self.range.len()
     }
 
     pub fn remaining(&self) -> usize {
@@ -68,12 +65,10 @@ impl<E: std::error::Error + Send + Sync> RequestTask<E> {
 
     /// Maximum offset which data is known to be already in the `self.part_queue`
     pub fn available_offset(&self) -> u64 {
-        self.start_offset + self.part_queue.bytes_received() as u64
+        self.start_offset() + self.part_queue.bytes_received() as u64
     }
 
-    /// Some requests aren't actually streaming data (they're fake, created by backwards seeks), and
-    /// shouldn't be counted for prefetcher progress.
-    pub fn is_streaming(&self) -> bool {
-        self.task_handle.is_some()
+    pub fn read_window_offset(&self) -> u64 {
+        self.part_queue.read_window_offset().unwrap_or(self.range.end())
     }
 }

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -35,6 +35,8 @@ pub fn make_test_filesystem(
     let client_config = MockClientConfig {
         bucket: bucket.to_string(),
         part_size: 1024 * 1024,
+        enable_backpressure: true,
+        initial_read_window_size: 256 * 1024,
         ..Default::default()
     };
 

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -733,6 +733,8 @@ async fn test_upload_aborted_on_write_failure() {
     let client_config = MockClientConfig {
         bucket: BUCKET_NAME.to_string(),
         part_size: 1024 * 1024,
+        enable_backpressure: true,
+        initial_read_window_size: 256 * 1024,
         ..Default::default()
     };
 
@@ -810,6 +812,8 @@ async fn test_upload_aborted_on_fsync_failure() {
     let client_config = MockClientConfig {
         bucket: BUCKET_NAME.to_string(),
         part_size: 1024 * 1024,
+        enable_backpressure: true,
+        initial_read_window_size: 256 * 1024,
         ..Default::default()
     };
 
@@ -872,6 +876,8 @@ async fn test_upload_aborted_on_release_failure() {
     let client_config = MockClientConfig {
         bucket: BUCKET_NAME.to_string(),
         part_size: 1024 * 1024,
+        enable_backpressure: true,
+        initial_read_window_size: 256 * 1024,
         ..Default::default()
     };
 
@@ -1487,7 +1493,9 @@ async fn test_readdir_rewind_with_local_files_only() {
 async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
-    let client_config = S3ClientConfig::default().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::default()
+        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .read_backpressure(true);
     let client = S3CrtClient::new(client_config).expect("must be able to create a CRT client");
     let fs = make_test_filesystem_with_client(
         client,
@@ -1521,7 +1529,8 @@ async fn test_lookup_forbidden() {
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .read_backpressure(true);
     let client = S3CrtClient::new(client_config).expect("must be able to create a CRT client");
 
     // create an empty file

--- a/mountpoint-s3/tests/mock_s3_tests.rs
+++ b/mountpoint-s3/tests/mock_s3_tests.rs
@@ -134,6 +134,7 @@ fn create_fs_with_mock_s3(bucket: &str) -> (TestS3Filesystem<S3CrtClient>, MockS
     let client_config = S3ClientConfig::default()
         .endpoint_config(endpoint_config)
         .auth_config(S3ClientAuthConfig::NoSigning)
+        .read_backpressure(true)
         .max_attempts(NonZeroUsize::new(3).unwrap()); // retry S3 request 3 times (which equals the existing default)
     let client = S3CrtClient::new(client_config).expect("must be able to create a CRT client");
     (


### PR DESCRIPTION
## Description of change

The prefetcher now uses only one GetObject request to fetch data in advance. This request has a range of entire object but use backpressure mechanism to control how much data it wants to fetch into the part queue instead of spawning up to two requests in parallel.

This should make the throughput more stable because previously the two request tasks could compete with each other when fetching data from S3. Also, it will be easier to control how much data we want to store in the part queue.

## Does this change impact existing behavior?

No, the change only for internal interface.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
