### PR TITLE
Fixing 'package' CI workflow after CentOS 7 reached end of life.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,15 +2,15 @@ FROM public.ecr.aws/docker/library/centos:7
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 RUN yum install -y epel-release centos-release-scl
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 RUN yum install -y \
         fuse \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,18 +1,20 @@
 FROM public.ecr.aws/docker/library/centos:8
 
-# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+# Need this because of Centos reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install -y epel-release
+RUN dnf install -y epel-release
 
-# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+RUN dnf -y group install "Development Tools"
+
+# Need this because of Centos reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install -y \
+RUN dnf install -y \
         fuse \
         fuse-devel \
         make \
@@ -26,8 +28,11 @@ RUN yum install -y \
         python3 \
         python3-pip \
         wget \
+#        devtoolset-10-gcc \
+#        devtoolset-10-gcc-c++ \
+#        llvm-toolset-7.0-clang \
         && \
-    yum clean all
+    dnf clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,7 +5,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install -y epel-release centos-release-scl
+RUN yum install -y epel-release
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,20 +1,19 @@
-FROM public.ecr.aws/docker/library/centos:8
+FROM public.ecr.aws/docker/library/centos:7
 
-# Need this because of Centos reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
 
-RUN dnf install -y epel-release
+RUN yum install -y epel-release centos-release-scl
 
-RUN dnf -y group install "Development Tools"
-
-# Need this because of Centos reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+# Fix up the newly added SCL repos, which don't have altarch baseurls
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+RUN if [ `uname -p` == "aarch64" ]; then sed -i s+centos/7+altarch/7+g /etc/yum.repos.d/*.repo; fi
 
-RUN dnf install -y \
+RUN yum install -y \
         fuse \
         fuse-devel \
         make \
@@ -28,11 +27,11 @@ RUN dnf install -y \
         python3 \
         python3-pip \
         wget \
-#        devtoolset-10-gcc \
-#        devtoolset-10-gcc-c++ \
-#        llvm-toolset-7.0-clang \
+        devtoolset-10-gcc \
+        devtoolset-10-gcc-c++ \
+        llvm-toolset-7.0-clang \
         && \
-    dnf clean all
+    yum clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,11 +1,11 @@
-FROM public.ecr.aws/docker/library/centos:7
+FROM public.ecr.aws/docker/library/centos:8
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install -y epel-release centos-release-scl
+RUN yum install -y epel-release
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
@@ -26,9 +26,6 @@ RUN yum install -y \
         python3 \
         python3-pip \
         wget \
-        devtoolset-10-gcc \
-        devtoolset-10-gcc-c++ \
-        llvm-toolset-7.0-clang \
         && \
     yum clean all
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,13 @@
 FROM public.ecr.aws/docker/library/centos:7
 
-RUN yum install -y epel-release centos-release-scl
+# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y \
+        epel-release \
+        centos-release-scl \
         fuse \
         fuse-devel \
         make \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,7 +5,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install -y epel-release
+RUN yum install -y epel-release centos-release-scl
 
 # Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,9 +5,14 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
 
+RUN yum install -y epel-release centos-release-scl
+
+# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y \
-        epel-release \
-        centos-release-scl \
         fuse \
         fuse-devel \
         make \


### PR DESCRIPTION
## Description of change

Fixing 'package' CI workflow after CentOS 7 reached end of life.

Used what was proposed in https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
