### PR TITLE
Introduce `event_log` feature flag 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ env:
   S3_OLAP_ARN: ${{ vars.S3_OLAP_ARN }}
   S3_MRAP_ARN: ${{ vars.S3_MRAP_ARN }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log
 
 permissions:
   id-token: write

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -80,6 +80,7 @@ built = { version = "0.7.1", features = ["git2"] }
 [features]
 # Unreleased feature flags
 negative_cache = []
+event_log = []
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -79,7 +79,6 @@ built = { version = "0.7.1", features = ["git2"] }
 
 [features]
 # Unreleased feature flags
-negative_cache = []
 event_log = []
 # Features for choosing tests
 fips_tests = []


### PR DESCRIPTION
## Description of change

In order to run tests in the [PR](https://github.com/awslabs/mountpoint-s3/pull/919) we need to add this feature flag separately.

Example usage of a flag: [one](https://github.com/awslabs/mountpoint-s3/pull/919/files#diff-0448e88502e43140837043cf9b0ac8a46803893dc15863f87f1f6bb290fd88b3R230), [two](https://github.com/awslabs/mountpoint-s3/pull/919/files#diff-15d54a298c444c1cfd255cb5bc8157390a6a72e217761687287d51534491aa66R2).

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/721

## Does this change impact existing behavior?

This is not a breaking change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
