### PR TITLE
Add additional trace logging during mount

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -657,9 +657,7 @@ where
     tracing::debug!("{:?}", args);
 
     validate_mount_point(&args.mount_point)?;
-    {
-        validate_sse_args(args.sse.as_deref(), args.sse_kms_key_id.as_deref())?;
-    }
+    validate_sse_args(args.sse.as_deref(), args.sse_kms_key_id.as_deref())?;
 
     let (client, runtime, s3_personality) = client_builder(&args)?;
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -476,10 +476,12 @@ where
 
                 match session {
                     Ok(session) => {
+                        tracing::trace!("FUSE session created OK, sending message back to parent process");
                         pipe_file
                             .write(&status_success)
                             .context("Failed to write data to the pipe")?;
                         drop(pipe_file);
+                        tracing::trace!("message sent back to parent process");
 
                         // Logging is set up and the mount succeeded, so we can hang up
                         // stdin/out/err now to cleanly daemonize ourselves
@@ -490,9 +492,11 @@ where
                         session.join().context("failed to join session")?;
                     }
                     Err(e) => {
+                        tracing::trace!("FUSE session creation failed, sending message back to parent process");
                         pipe_file
                             .write(&status_failure)
                             .context("Failed to write data to the pipe")?;
+                        tracing::trace!("message sent back to parent process");
                         return Err(anyhow!(e));
                     }
                 }
@@ -717,6 +721,7 @@ where
         }
         metadata_cache_ttl = TimeToLive::Minimal;
     }
+    tracing::trace!("using metadata TTL setting {metadata_cache_ttl:?}");
     filesystem_config.cache_config = CacheConfig::new(metadata_cache_ttl);
 
     if let Some(path) = args.cache {
@@ -780,7 +785,9 @@ where
     Client: ObjectClient + Send + Sync + 'static,
     Prefetcher: Prefetch + Send + Sync + 'static,
 {
+    tracing::trace!(?filesystem_config, "creating file system");
     let fs = S3FuseFilesystem::new(client, prefetcher, bucket_name, prefix, filesystem_config);
+    tracing::debug!(?fuse_session_config, "creating fuse session");
     let session = Session::new(fs, &fuse_session_config.mount_point, &fuse_session_config.options)
         .context("Failed to create FUSE session")?;
     let session = FuseSession::new(session, fuse_session_config.max_threads).context("Failed to start FUSE session")?;


### PR DESCRIPTION
## Description of change

I spent some time reviewing some logs where the mount was failing and the parent process was timing out. From the logs, there was a large portion of the code that emits no logging at all even with trace level logging.

This change adds more trace level logging. The log content isn't necessarily useful however the emission of the log itself is.

There's also a tiny change to remove some code behind an old block used to gate SSE code behind a compile-time flag.

Relevant issues: N/A

## Does this change impact existing behavior?

No, just adds additional trace logging.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
