### PR TITLE
Re-open the logging file on SIGHUP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,12 +999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,16 +1276,6 @@ checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
  "syn 2.0.61",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
-dependencies = [
- "nix 0.28.0",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1597,7 +1581,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.27.1",
+ "nix",
  "page_size",
  "pkg-config",
  "serde",
@@ -2445,7 +2429,6 @@ dependencies = [
  "const_format",
  "crc32c",
  "ctor",
- "ctrlc",
  "dashmap",
  "filetime",
  "fuser",
@@ -2459,7 +2442,7 @@ dependencies = [
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
- "nix 0.27.1",
+ "nix",
  "owo-colors 4.0.0",
  "predicates",
  "procfs",
@@ -2473,6 +2456,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "shuttle",
+ "signal-hook",
  "supports-color",
  "sysinfo",
  "syslog",
@@ -2589,18 +2573,6 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -3611,6 +3583,16 @@ dependencies = [
  "scoped-tls",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -20,7 +20,6 @@ bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
 const_format = "0.2.30"
 crc32c = "0.6.3"
-ctrlc = { version = "3.2.3", features = ["termination"] }
 dashmap = "5.5.0"
 futures = "0.3.24"
 hdrhistogram = { version = "7.5.2", default-features = false }
@@ -43,6 +42,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+signal-hook = "0.3.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -432,7 +432,7 @@ where
     );
 
     if args.foreground {
-        let log_file_opener = init_logging(args.logging_config()).context("failed to initialize logging")?;
+        let log_file_reopener = init_logging(args.logging_config()).context("failed to initialize logging")?;
 
         let _metrics = metrics::install();
 
@@ -441,7 +441,7 @@ where
 
         println!("{successful_mount_msg}");
 
-        session.join(log_file_opener).context("failed to join session")?;
+        session.join(log_file_reopener).context("failed to join session")?;
     } else {
         // mount file system as a background process
 
@@ -459,7 +459,7 @@ where
         match pid.expect("Failed to fork mount process") {
             ForkResult::Child => {
                 let args = CliArgs::parse();
-                let log_file_opener = init_logging(args.logging_config()).context("failed to initialize logging")?;
+                let log_file_reopener = init_logging(args.logging_config()).context("failed to initialize logging")?;
 
                 let _metrics = metrics::install();
 
@@ -489,7 +489,7 @@ where
                         nix::unistd::close(std::io::stdout().as_raw_fd()).context("couldn't close stdout")?;
                         nix::unistd::close(std::io::stderr().as_raw_fd()).context("couldn't close stderr")?;
 
-                        session.join(log_file_opener).context("failed to join session")?;
+                        session.join(log_file_reopener).context("failed to join session")?;
                     }
                     Err(e) => {
                         tracing::trace!("FUSE session creation failed, sending message back to parent process");

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -432,7 +432,7 @@ where
     );
 
     if args.foreground {
-        init_logging(args.logging_config()).context("failed to initialize logging")?;
+        let log_file_opener = init_logging(args.logging_config()).context("failed to initialize logging")?;
 
         let _metrics = metrics::install();
 
@@ -441,7 +441,7 @@ where
 
         println!("{successful_mount_msg}");
 
-        session.join().context("failed to join session")?;
+        session.join(log_file_opener).context("failed to join session")?;
     } else {
         // mount file system as a background process
 
@@ -459,7 +459,7 @@ where
         match pid.expect("Failed to fork mount process") {
             ForkResult::Child => {
                 let args = CliArgs::parse();
-                init_logging(args.logging_config()).context("failed to initialize logging")?;
+                let log_file_opener = init_logging(args.logging_config()).context("failed to initialize logging")?;
 
                 let _metrics = metrics::install();
 
@@ -489,7 +489,7 @@ where
                         nix::unistd::close(std::io::stdout().as_raw_fd()).context("couldn't close stdout")?;
                         nix::unistd::close(std::io::stderr().as_raw_fd()).context("couldn't close stderr")?;
 
-                        session.join().context("failed to join session")?;
+                        session.join(log_file_opener).context("failed to join session")?;
                     }
                     Err(e) => {
                         tracing::trace!("FUSE session creation failed, sending message back to parent process");


### PR DESCRIPTION
## Description of change

Re-open the logging file [to support rotating](https://github.com/logrotate/logrotate/issues/338#issuecomment-652499270) with no data loss. We re-open the file in our `MakeWriter` implementation to avoid reopening the file in the middle of the log line ([context](https://github.com/tokio-rs/tracing/issues/1931#issuecomment-1042364210)).

This PR is WIP (no tests and probably we'll revisit the rotation mechanism completely).

Relevant issues: None

## Does this change impact existing behavior?

This is not a breaking change. Though we'll need to check for possible performance regressions as we now acquire `RwLock` on each `event!` invocation (i.e. on each logging site), but that is inline with [tracing/logging-appender](https://github.com/tokio-rs/tracing/blob/master/tracing-appender/src/rolling.rs#L88) implementation.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
