### PR TITLE
Support rename of objects

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -583,6 +583,14 @@ where
     fn next_handle(&self) -> u64 {
         self.next_handle.fetch_add(1, Ordering::SeqCst)
     }
+
+    pub fn get_bucket_name(&self) -> String {
+        return self.bucket.clone();
+    }
+
+    pub fn get_client(&self) -> Arc<Client> {
+        return self.client.clone();
+    }
 }
 
 /// Reply to a `lookup` call


### PR DESCRIPTION
## Description of change

Support renaming of objects on buckets mounted using mount-s3.

To test:
1. Deploy a local MinIO cluster
2. Create a bucket `test-bucket` and add few objects
3. Mount the bucket using `./target/debug/mount-s3 --endpoint-url http://localhost:9000 --foreground --force-path-style test-bucket s3-mnt/`
4. Try rename of object using `mc <EXISTING-OBJ> <NEW-OBJ>`

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

This new feature and not a breaking change

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
