### PR TITLE
Add support for distributing requests over multiple NW interfaces behind feature flag

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -93,6 +93,7 @@ pub struct S3ClientConfig {
     max_attempts: Option<NonZeroUsize>,
     read_backpressure: bool,
     initial_read_window: usize,
+    network_interface_names: Option<Vec<String>>,
 }
 
 impl Default for S3ClientConfig {
@@ -109,6 +110,7 @@ impl Default for S3ClientConfig {
             max_attempts: None,
             read_backpressure: false,
             initial_read_window: DEFAULT_PART_SIZE,
+            network_interface_names: None,
         }
     }
 }
@@ -186,6 +188,13 @@ impl S3ClientConfig {
     #[must_use = "S3ClientConfig follows a builder pattern"]
     pub fn initial_read_window(mut self, initial_read_window: usize) -> Self {
         self.initial_read_window = initial_read_window;
+        self
+    }
+
+    /// Set a list of network interfaces to distribute S3 requests over
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn network_interface_names(mut self, network_interface_names: Vec<String>) -> Self {
+        self.network_interface_names = Some(network_interface_names);
         self
     }
 }
@@ -359,6 +368,10 @@ impl S3CrtClientInner {
             )));
         }
         client_config.part_size(config.part_size);
+
+        if let Some(network_interface_names) = config.network_interface_names {
+            client_config.network_interface_names(network_interface_names);
+        }
 
         let user_agent = config.user_agent.unwrap_or_else(|| UserAgent::new(None));
         let user_agent_header = user_agent.build();

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -93,7 +93,7 @@ pub struct S3ClientConfig {
     max_attempts: Option<NonZeroUsize>,
     read_backpressure: bool,
     initial_read_window: usize,
-    network_interface_names: Option<Vec<String>>,
+    network_interface_names: Vec<String>,
 }
 
 impl Default for S3ClientConfig {
@@ -110,7 +110,7 @@ impl Default for S3ClientConfig {
             max_attempts: None,
             read_backpressure: false,
             initial_read_window: DEFAULT_PART_SIZE,
-            network_interface_names: None,
+            network_interface_names: vec![],
         }
     }
 }
@@ -194,7 +194,7 @@ impl S3ClientConfig {
     /// Set a list of network interfaces to distribute S3 requests over
     #[must_use = "S3ClientConfig follows a builder pattern"]
     pub fn network_interface_names(mut self, network_interface_names: Vec<String>) -> Self {
-        self.network_interface_names = Some(network_interface_names);
+        self.network_interface_names = network_interface_names;
         self
     }
 }
@@ -369,8 +369,8 @@ impl S3CrtClientInner {
         }
         client_config.part_size(config.part_size);
 
-        if let Some(network_interface_names) = config.network_interface_names {
-            client_config.network_interface_names(network_interface_names);
+        if !config.network_interface_names.is_empty() {
+            client_config.network_interface_names(config.network_interface_names);
         }
 
         let user_agent = config.user_agent.unwrap_or_else(|| UserAgent::new(None));

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -61,6 +61,55 @@ pub struct ClientConfig {
 
     /// The region
     region: Option<String>,
+
+    /// List of network interfaces to be used by the client.
+    ///
+    /// The client will determine the logic for balancing requests over the network interfaces
+    /// according to its own logic.
+    network_interface_names: Option<NetworkInterfaceNames>,
+}
+
+/// This struct bundles together the list of owned strings for the network interfaces, and the
+/// cursors pointing to them.
+///
+/// This is necessary because the CRT expects a pointer to the list of cursors,
+/// and the lifetime of the cursors must meet or exceed the lifetime of the [ClientConfig].
+/// By wrapping the array of cursors in this struct, we know the cursors will be valid
+/// and we can ensure the memory will be freed when dropped at the same time as [ClientConfig].
+#[derive(Debug)]
+struct NetworkInterfaceNames {
+    /// The list of network interface names.
+    ///
+    /// We use a boxed array of strings, as we have no need for a mutable list like [Vec].
+    _names: Box<[String]>,
+
+    /// List of owned cursors. This will be pointed at by [ClientConfig]'s inner [aws_s3_client_config].
+    cursors: Box<[aws_byte_cursor]>,
+}
+
+impl NetworkInterfaceNames {
+    /// Create a new [NetworkInterfaceNamesInner].
+    pub fn new(names: Vec<String>) -> Self {
+        // Turn this into a read-only representation of the vector of strings.
+        let names = names.into_boxed_slice();
+
+        let cursors = names
+            .iter()
+            .map(|name| {
+                // SAFETY: The names are stored alongside the cursors in NetworkInterfaceNamesInner.
+                //         The lifetime of NetworkInterfaceNamesInner will always meet the lifetime of the cursors.
+                unsafe { name.as_aws_byte_cursor() }
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        Self { _names: names, cursors }
+    }
+
+    /// Immutable slice of interface names as [aws_byte_cursor].
+    pub fn aws_byte_cursors(&self) -> &[aws_byte_cursor] {
+        self.cursors.as_ref()
+    }
 }
 
 impl ClientConfig {
@@ -81,6 +130,19 @@ impl ClientConfig {
         self.region = Some(region.to_owned());
         // SAFETY: `self.inner.region` is not mutated further and lives as long as the `ClientConfig`, which outlives the client
         self.inner.region = unsafe { self.region.as_ref().unwrap().as_aws_byte_cursor() };
+        self
+    }
+
+    /// Replace list of network interface names to be used by S3 clients created with this config.
+    pub fn network_interface_names(&mut self, network_interface_names: Vec<String>) -> &mut Self {
+        let network_interface_names = self
+            .network_interface_names
+            .insert(NetworkInterfaceNames::new(network_interface_names));
+
+        // The cursor array will always outlive the inner config.
+        self.inner.network_interface_names_array = network_interface_names.aws_byte_cursors().as_ptr();
+        self.inner.num_network_interface_names = network_interface_names.aws_byte_cursors().len();
+
         self
     }
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -80,6 +80,7 @@ built = { version = "0.7.1", features = ["git2"] }
 [features]
 # Unreleased feature flags
 event_log = []
+multiple-nw-iface = []
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -297,12 +297,11 @@ pub struct CliArgs {
     #[cfg(feature = "multiple-nw-iface")]
     #[clap(
         long,
-        help = "One or more comma-delimited network interfaces for Mountpoint to use when accessing S3. Requires Linux 5.7+ or running as root.",
+        help = "One or more network interfaces for Mountpoint to use when accessing S3. Requires Linux 5.7+ or running as root.",
         help_heading = CLIENT_OPTIONS_HEADER,
-        value_delimiter = ',',
-        value_name = "INTERFACE_NAMES",
+        value_name = "NETWORK_INTERFACE",
     )]
-    pub network_interfaces: Option<Vec<String>>,
+    pub bind: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -625,7 +624,7 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
         user_agent.key_value("mp-cache-ttl", &ttl.to_string());
     }
     #[cfg(feature = "multiple-nw-iface")]
-    if let Some(interfaces) = &args.network_interfaces {
+    if let Some(interfaces) = &args.bind {
         user_agent.key_value("mp-nw-interfaces", &interfaces.len().to_string());
     }
 
@@ -635,7 +634,7 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
         .part_size(args.part_size as usize)
         .user_agent(user_agent);
     #[cfg(feature = "multiple-nw-iface")]
-    if let Some(interfaces) = &args.network_interfaces {
+    if let Some(interfaces) = &args.bind {
         client_config = client_config.network_interface_names(interfaces.clone());
     }
     if args.requester_pays {


### PR DESCRIPTION
## Description of change

This change adds experimental support for distributing S3 requests over multiple network interfaces. It introduces the feature behind a compile-time feature flag.

We have requests to support distributing network requests over multiple network interfaces (#815). This is especially useful on larger EC2 instances where we have a very large amount of aggregate throughput but we only leverage one of the network interfaces today. This change is one step towards addressing this, by allowing the operator of Mountpoint to specify a list of network interfaces.

The AWS CRT added (experimental) support for multiple network interfaces in https://github.com/awslabs/aws-c-s3/pull/444.

This change is currently being tested on `dl1.24xlarge` to verify the expected behavior.

Relevant issues: #815

## Does this change impact existing behavior?

No change to existing behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
