### PR TITLE
Add `--log-rotation-frequency` CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2491,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
  "walkdir",
@@ -4026,6 +4036,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -43,6 +43,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+tracing-appender = "0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -237,6 +237,14 @@ pub struct CliArgs {
 
     #[clap(
         long,
+        help = "Frequency of log file rotation [default: no rotation]",
+        help_heading = LOGGING_OPTIONS_HEADER,
+        requires = "log_directory",
+    )]
+    pub log_rotation_frequency: Option<LogRotationFrequency>,
+
+    #[clap(
+        long,
         help = "Enable caching of object content to the given directory and set metadata TTL to 60 seconds",
         help_heading = CACHING_OPTIONS_HEADER,
         value_name = "DIRECTORY",
@@ -342,6 +350,27 @@ impl ValueEnum for UploadChecksums {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum LogRotationFrequency {
+    Minutely,
+    Hourly,
+    Daily,
+}
+
+impl ValueEnum for LogRotationFrequency {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Minutely, Self::Hourly, Self::Daily]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        match self {
+            Self::Minutely => Some(clap::builder::PossibleValue::new("minutely")),
+            Self::Hourly => Some(clap::builder::PossibleValue::new("hourly")),
+            Self::Daily => Some(clap::builder::PossibleValue::new("daily")),
+        }
+    }
+}
+
 impl CliArgs {
     fn addressing_style(&self) -> AddressingStyle {
         if self.force_path_style {
@@ -376,6 +405,7 @@ impl CliArgs {
             log_directory: self.log_directory.clone(),
             log_to_stdout: self.foreground,
             default_filter,
+            log_rotation_frequency: self.log_rotation_frequency,
         }
     }
 

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -1,11 +1,13 @@
 use std::backtrace::Backtrace;
-use std::fs::{DirBuilder, OpenOptions};
+use std::fs::{DirBuilder, File, OpenOptions};
+use std::io;
 use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::prelude::OpenOptionsExt;
 use std::panic::{self, PanicInfo};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::thread;
 
+use crate::cli::LogRotationFrequency;
 use crate::metrics::metrics_tracing_span_layer;
 use anyhow::Context;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
@@ -13,7 +15,9 @@ use time::format_description::FormatItem;
 use time::macros;
 use time::OffsetDateTime;
 use tracing::Span;
+use tracing_appender::rolling;
 use tracing_subscriber::filter::{EnvFilter, Filtered, LevelFilter};
+use tracing_subscriber::fmt::writer::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, Registry};
@@ -31,6 +35,23 @@ pub struct LoggingConfig {
     /// The default filter directive (in the sense of [tracing_subscriber::filter::EnvFilter]) to
     /// use for logs. Will be overridden by the `MOUNTPOINT_LOG` environment variable if set.
     pub default_filter: String,
+    /// Create a new log file with this frequency (if specified)
+    pub log_rotation_frequency: Option<LogRotationFrequency>,
+}
+
+/// Used by `tracing-subscriber::fmt` layer to obtain a log writer (any type implementing `io::Write`).
+/// Holds a `std::fs::File` or a `rolling::RollingFileAppender`, if log rotation is configured. Both
+/// types implement `MakeWriter` trait, and this type just dispatches `make_writer` call to the chosen
+/// variant. This type is used in `Layer::with_writer` call and helps us to avoid code duplication.
+enum LogWriterFactory {
+    File(File),
+    Rolling(rolling::RollingFileAppender),
+}
+
+/// Does the actual log writing. This type implements `io::Write` and just dispatches calls to chosen variants.
+enum LogWriter<'a> {
+    File(&'a File),
+    Rolling(rolling::RollingWriter<'a>),
 }
 
 /// Set up all our logging infrastructure.
@@ -93,26 +114,10 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
     RustLogAdapter::try_init().context("failed to initialize CRT logger")?;
 
     let file_layer = if let Some(path) = &config.log_directory {
-        const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
-            macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
-        let filename = OffsetDateTime::now_utc()
-            .format(LOG_FILE_NAME_FORMAT)
-            .context("couldn't format log file name")?;
-
-        // log directories and files created by Mountpoint should not be accessible by other users
-        let mut dir_builder = DirBuilder::new();
-        dir_builder.recursive(true).mode(0o750);
-        let mut file_options = OpenOptions::new();
-        file_options.mode(0o640).append(true).create(true);
-
-        dir_builder.create(path).context("failed to create log folder")?;
-        let file = file_options
-            .open(path.join(filename))
-            .context("failed to create log file")?;
-
+        let writer = LogWriterFactory::new(path, config.log_rotation_frequency)?;
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
-            .with_writer(file)
+            .with_writer(writer)
             .with_filter(env_filter);
         Some(file_layer)
     } else {
@@ -151,4 +156,70 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
 
 pub fn record_name(name: &str) -> Span {
     Span::current().record("name", name).clone()
+}
+
+impl LogWriterFactory {
+    /// Construct the log writer factory, which may either be a simple file or a rotated one.
+    /// Creates logging directory and file if they do not exist.
+    fn new(dir_path: &Path, log_rotation_frequency: Option<LogRotationFrequency>) -> anyhow::Result<Self> {
+        const LOG_FILE_NAME_FORMAT: &[FormatItem<'static>] =
+            macros::format_description!("mountpoint-s3-[year]-[month]-[day]T[hour]-[minute]-[second]Z.log");
+        let filename = OffsetDateTime::now_utc()
+            .format(LOG_FILE_NAME_FORMAT)
+            .context("couldn't format log file name")?;
+        let rolling_filename_prefix = "mountpoint-s3";
+
+        // log directories and files created by Mountpoint should not be accessible by other users
+        let mut dir_builder = DirBuilder::new();
+        dir_builder.recursive(true).mode(0o750);
+        dir_builder.create(dir_path).context("failed to create log folder")?;
+
+        let writer = match log_rotation_frequency {
+            Some(LogRotationFrequency::Minutely) => {
+                LogWriterFactory::Rolling(rolling::minutely(dir_path, rolling_filename_prefix))
+            }
+            Some(LogRotationFrequency::Hourly) => {
+                LogWriterFactory::Rolling(rolling::hourly(dir_path, rolling_filename_prefix))
+            }
+            Some(LogRotationFrequency::Daily) => {
+                LogWriterFactory::Rolling(rolling::daily(dir_path, rolling_filename_prefix))
+            }
+            None => {
+                let mut file_options = OpenOptions::new();
+                file_options.mode(0o640).append(true).create(true);
+                let file = file_options
+                    .open(dir_path.join(filename))
+                    .context("failed to create log file")?;
+                LogWriterFactory::File(file)
+            }
+        };
+        Ok(writer)
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogWriterFactory {
+    type Writer = LogWriter<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        match self {
+            LogWriterFactory::File(file) => LogWriter::File(file),
+            LogWriterFactory::Rolling(rolling_appender) => LogWriter::Rolling(rolling_appender.make_writer()),
+        }
+    }
+}
+
+impl<'a> io::Write for LogWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            LogWriter::File(file) => file.write(buf),
+            LogWriter::Rolling(rolling_writer) => rolling_writer.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            LogWriter::File(file) => file.flush(),
+            LogWriter::Rolling(rolling_writer) => rolling_writer.flush(),
+        }
+    }
 }


### PR DESCRIPTION
## Description of change

This is an alternative approach for log rotation, proposed in the [PR](https://github.com/awslabs/mountpoint-s3/pull/941). With this approach MP does not rely on external tool (e.g. `logrotate`) to do the file copying, but does it itself.

Relevant issues: None

## Does this change impact existing behavior?

This is not a breaking change. Though we'll need to check for possible performance regressions as we now [acquire](https://github.com/tokio-rs/tracing/blob/master/tracing-appender/src/rolling.rs#L88) RwLock on each event! invocation (i.e. on each logging site).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
