### PR TITLE
Replace custom `ResultExt` trait with stable `Result::inspect_err`

### DIFF
--- a/mountpoint-s3-crt/src/io/event_loop.rs
+++ b/mountpoint-s3-crt/src/io/event_loop.rs
@@ -20,7 +20,6 @@ use crate::common::task_scheduler::{Task, TaskScheduler, TaskStatus};
 use crate::io::futures::FutureSpawner;
 use crate::io::io_library_init;
 use crate::CrtError as _;
-use crate::ResultExt;
 
 /// An event loop that can be used to schedule and execute tasks
 #[derive(Debug)]
@@ -122,7 +121,7 @@ impl EventLoopGroup {
         let inner = unsafe {
             aws_event_loop_group_new_default(allocator.inner.as_ptr(), max_threads, &shutdown_options)
                 .ok_or_last_error()
-                .on_err(|| abort_shutdown_callback(shutdown_options))?
+                .inspect_err(|_| abort_shutdown_callback(shutdown_options))?
         };
 
         Ok(Self { inner })

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -105,28 +105,6 @@ impl CrtError for i32 {
     }
 }
 
-/// Workaround until Result::inspect_err is stable.
-pub(crate) trait ResultExt: Sized {
-    fn on_err<F>(self, f: F) -> Self
-    where
-        F: FnOnce();
-}
-
-impl<T, E> ResultExt for Result<T, E> {
-    fn on_err<F>(self, f: F) -> Result<T, E>
-    where
-        F: FnOnce(),
-    {
-        match self {
-            Ok(val) => Ok(val),
-            Err(err) => {
-                f();
-                Err(err)
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::common::rust_log_adapter::RustLogAdapter;

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -10,7 +10,7 @@ use crate::http::request_response::{Headers, Message};
 use crate::io::channel_bootstrap::ClientBootstrap;
 use crate::io::retry_strategy::RetryStrategy;
 use crate::s3::s3_library_init;
-use crate::{aws_byte_cursor_as_slice, CrtError, ResultExt, ToAwsByteCursor};
+use crate::{aws_byte_cursor_as_slice, CrtError, ToAwsByteCursor};
 use futures::Future;
 use mountpoint_s3_crt_sys::*;
 
@@ -812,7 +812,7 @@ impl Client {
                 .ok_or_last_error()
                 // Drop the options Box if we failed to make the meta request.
                 // Assumption: CRT won't call shutdown callback if make_meta_request returns null.
-                .on_err(|| std::mem::drop(Box::from_raw(options)))?;
+                .inspect_err(|_| std::mem::drop(Box::from_raw(options)))?;
 
             Ok(MetaRequest { inner })
         }


### PR DESCRIPTION
## Description of change

Before [`Result::inspect_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect_err) was stable, we implemented our own version to use in the codebase. `inspect_err` is now stable as of Rust 1.76.0 (2024-02-08), so we can drop this.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
