### PR TITLE
Rename docs_rs config condition to docsrs

### DIFF
--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -72,7 +72,3 @@ s3express_tests = []
 
 [lib]
 doctest = false
-
-# Make async trait docs not-ugly on docs.rs (https://github.com/dtolnay/async-trait/issues/213)
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docs_rs"]

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -62,7 +62,7 @@ pub struct FailureClient<Client: ObjectClient, State, RequestWrapperState> {
     >,
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl<Client, State, GetWrapperState> ObjectClient for FailureClient<Client, State, GetWrapperState>
 where
     Client: ObjectClient + Send + Sync + 'static,
@@ -202,7 +202,7 @@ pub struct FailurePutObjectRequest<Client: ObjectClient, PutWrapperState> {
     result_fn: fn(&mut PutWrapperState) -> Result<(), Client::ClientError>,
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl<Client: ObjectClient, PutWrapperState> PutObjectRequest for FailurePutObjectRequest<Client, PutWrapperState>
 where
     Client::PutObjectRequest: Send,

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -41,7 +41,7 @@
 //! [awscrt]: https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html
 
 // Make async trait docs not-ugly on docs.rs (https://github.com/dtolnay/async-trait/issues/213)
-#![cfg_attr(docs_rs, feature(async_fn_in_trait))]
+#![cfg_attr(docsrs, feature(async_fn_in_trait))]
 
 mod build_info;
 pub mod checksums;

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -548,7 +548,7 @@ fn mock_client_error<T, E>(s: impl Into<Cow<'static, str>>) -> ObjectClientResul
     Err(ObjectClientError::ClientError(MockClientError(s.into())))
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl ObjectClient for MockClient {
     type GetObjectRequest = MockGetObjectRequest;
     type PutObjectRequest = MockPutObjectRequest;
@@ -845,7 +845,7 @@ impl Drop for MockPutObjectRequest {
     }
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl PutObjectRequest for MockPutObjectRequest {
     type ClientError = MockClientError;
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -70,7 +70,7 @@ impl FromStr for ETag {
 /// This is an async trait defined with the [async-trait](https://crates.io/crates/async-trait)
 /// crate, and so implementations of this trait must use the `#[async_trait::async_trait]`
 /// attribute.
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 #[auto_impl(Arc)]
 pub trait ObjectClient {
     type GetObjectRequest: GetObjectRequest<ClientError = Self::ClientError>;
@@ -353,7 +353,7 @@ pub type ChecksumAlgorithm = mountpoint_s3_crt::s3::client::ChecksumAlgorithm;
 /// This struct implements [`futures::Stream`], which you can use to read the body of the object.
 /// Each item of the stream is a part of the object body together with the part's offset within the
 /// object.
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 pub trait GetObjectRequest:
     Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send
 {
@@ -386,7 +386,7 @@ pub trait GetObjectRequest:
 /// This is an async trait defined with the [async-trait](https://crates.io/crates/async-trait)
 /// crate, and so implementations of this trait must use the `#[async_trait::async_trait]`
 /// attribute.
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 pub trait PutObjectRequest: Send {
     type ClientError: std::error::Error + Send + Sync + 'static;
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1139,7 +1139,7 @@ fn emit_throughput_metric(bytes: u64, duration: Duration, op: &'static str) {
     metrics::histogram!("s3.meta_requests.throughput_mibs", "op" => op, "size" => bucket).record(throughput_mbps);
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl ObjectClient for S3CrtClient {
     type GetObjectRequest = S3GetObjectRequest;
     type PutObjectRequest = S3PutObjectRequest;

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -175,7 +175,7 @@ fn try_get_header_value(headers: &Headers, key: &str) -> Option<String> {
     headers.get(key).ok()?.value().clone().into_string().ok()
 }
 
-#[cfg_attr(not(docs_rs), async_trait)]
+#[cfg_attr(not(docsrs), async_trait)]
 impl PutObjectRequest for S3PutObjectRequest {
     type ClientError = S3RequestError;
 


### PR DESCRIPTION
## Description of change

This change is made to avoid config condition errors now that check config is run by default in Rust 1.80+.

Without this change, compilation will fail like below:

```
error: unexpected `cfg` condition name: `docs_rs`
    --> mountpoint-s3-client/src/s3_crt_client.rs:1162:16
     |
1162 | #[cfg_attr(not(docs_rs), async_trait)]
     |                ^^^^^^^ help: there is a config with a similar name: `docsrs`
     |
     = help: consider using a Cargo feature instead
     = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
              [lints.rust]
              unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docs_rs)'] }
     = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(docs_rs)");` to the top of the `build.rs`
     = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

Rather than specifying the `docs_rs` config condition in our Cargo.toml, we can use the one already existing and documented by docs.rs: https://docs.rs/about/builds#detecting-docsrs

> To recognize Docs.rs from your Rust code, you can test for the docsrs cfg, e.g.:
>
>```rust
>#[cfg(docsrs)]
>mod documentation;
>```

This change removes the setting of `docs_rs` cfg condition and updates all conditions to use the existing condition set by docs.rs.

Checked using the following command that the docs aren't a mess by looking at `mountpoint_s3_client::object_client::PutObjectRequest`:

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps
```

Fixes CI issue blocking PR #949.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
