### PR TITLE
Decompose request reading and body splitting logic

### DIFF
--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -219,9 +219,6 @@ async fn compose_parts<Client: ObjectClient, Cache: DataCache + Send + Sync>(
         );
         match body_receiver.next().await {
             Some(Ok((offset, body))) => {
-                trace!(offset, length = body.len(), "received GetObject part");
-                metrics::counter!("s3.client.total_bytes", "type" => "read").increment(body.len() as u64);
-
                 let expected_offset = block_offset + buffer.len() as u64;
                 if offset != expected_offset {
                     warn!(key, offset, expected_offset, "wrong offset for GetObject body part");


### PR DESCRIPTION
## Description of change

We may want to do some common logic upon reading the request. Currently it's only `metrics::counter!("s3.client.total_bytes", "type" => "read").increment(body.len() as u64);`, but with the addition of backpressure this common logic grows bigger.

We decompose the logic by introducing 2 futures: `request_reader_future` and `part_composer_future`. An intermediate channel serves the purpose of passing body chunks from `request_reader_future` to `part_composer_future` exactly as they were supplied by CRT. `part_composer_future` splits (or accumulates) received bodies to `Part`'s of the desired size and pushes them to the `PartQueue`.

Future `request_reader_future` is the only place where we interact with the CRT request when reading data. 

Relevant issues: None

## Does this change impact existing behavior?

Existing behaviour is not changed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
