### PR TITLE
Consolidate test credential helpers into creds modules

### DIFF
--- a/mountpoint-s3-client/tests/common/creds.rs
+++ b/mountpoint-s3-client/tests/common/creds.rs
@@ -2,12 +2,7 @@
 //!
 //! Some methods are duplicated in `mountpoint-s3::tests::common::creds`.
 
-use aws_config::sts::AssumeRoleProvider;
-use aws_config::Region;
-use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::Credentials;
-
-use crate::common::get_test_region;
 
 /// Detect if running on GitHub Actions (GHA) and if so,
 /// emit masking string to avoid credentials accidentally being printed.
@@ -24,51 +19,66 @@ fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
     }
 }
 
-/// Grab a set of SDK [Credentials] from the default credential provider chain.
-pub async fn get_sdk_default_chain_creds() -> Credentials {
-    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+#[allow(unused_imports)]
+#[cfg(feature = "s3_tests")]
+pub use integ_only::*;
+
+/// Further methods defined only for integration tests.
+#[cfg(feature = "s3_tests")]
+mod integ_only {
+    use super::*;
+
+    use aws_config::sts::AssumeRoleProvider;
+    use aws_config::Region;
     use aws_credential_types::provider::ProvideCredentials;
 
-    let sdk_provider = DefaultCredentialsChain::builder().build().await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+    use crate::common::get_test_region;
 
-/// Takes the provided IAM Policy and assumes the configured subsession role,
-/// applying the given policy to scope down the permissions available.
-///
-/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
-/// The permissions are the intersection of the identity-based policy of the principal creating the session
-/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
-/// this method can only reduce the scope of permissions.
-///
-/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
-///
-/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
-pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
-    let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
-        .region(Region::new(get_test_region()))
-        .session_name("test_mountpoint-s3")
-        .policy(policy.as_ref())
-        .build()
-        .await;
-    let credentials = provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+    /// Grab a set of SDK [Credentials] from the default credential provider chain.
+    pub async fn get_sdk_default_chain_creds() -> Credentials {
+        use aws_config::default_provider::credentials::DefaultCredentialsChain;
+        use aws_credential_types::provider::ProvideCredentials;
 
-/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
-///
-/// You should use other functions in this module to obtain session credentials.
-/// Only use this if you need a Role ARN (such as when crafting a config file entry).
-#[cfg(feature = "s3_tests")]
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+        let sdk_provider = DefaultCredentialsChain::builder().build().await;
+        let credentials = sdk_provider
+            .provide_credentials()
+            .await
+            .expect("default chain credentials should be available");
+        mask_aws_creds_if_on_gha(&credentials);
+        credentials
+    }
+
+    /// Takes the provided IAM Policy and assumes the configured subsession role,
+    /// applying the given policy to scope down the permissions available.
+    ///
+    /// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+    /// The permissions are the intersection of the identity-based policy of the principal creating the session
+    /// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+    /// this method can only reduce the scope of permissions.
+    ///
+    /// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+    ///
+    /// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+    pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
+        let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
+            .region(Region::new(get_test_region()))
+            .session_name("test_mountpoint-s3-client")
+            .policy(policy.as_ref())
+            .build()
+            .await;
+        let credentials = provider
+            .provide_credentials()
+            .await
+            .expect("default chain credentials should be available");
+        mask_aws_creds_if_on_gha(&credentials);
+        credentials
+    }
+
+    /// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+    ///
+    /// You should use other functions in this module to obtain session credentials.
+    /// Only use this if you need a Role ARN (such as when crafting a config file entry).
+    pub fn get_subsession_iam_role() -> String {
+        std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+    }
 }

--- a/mountpoint-s3-client/tests/common/creds.rs
+++ b/mountpoint-s3-client/tests/common/creds.rs
@@ -1,0 +1,74 @@
+//! Module providing methods for accessing different types of credentials for tests.
+//!
+//! Some methods are duplicated in `mountpoint-s3::tests::common::creds`.
+
+use aws_config::sts::AssumeRoleProvider;
+use aws_config::Region;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
+
+use crate::common::get_test_region;
+
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Takes the provided IAM Policy and assumes the configured subsession role,
+/// applying the given policy to scope down the permissions available.
+///
+/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+/// The permissions are the intersection of the identity-based policy of the principal creating the session
+/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+/// this method can only reduce the scope of permissions.
+///
+/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+///
+/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
+    let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
+        .region(Region::new(get_test_region()))
+        .session_name("test_mountpoint-s3")
+        .policy(policy.as_ref())
+        .build()
+        .await;
+    let credentials = provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+///
+/// You should use other functions in this module to obtain session credentials.
+/// Only use this if you need a Role ARN (such as when crafting a config file entry).
+#[cfg(feature = "s3_tests")]
+pub fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -20,6 +20,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
 
+pub mod creds;
 pub mod tracing_test;
 
 /// Enable tracing and CRT logging when running unit tests.
@@ -131,10 +132,6 @@ pub fn get_secondary_test_region() -> String {
 
 pub fn get_test_domain() -> String {
     std::env::var("S3_DOMAIN").unwrap_or(String::from("amazonaws.com"))
-}
-
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
 }
 
 pub async fn get_test_sdk_client() -> s3::Client {

--- a/mountpoint-s3/tests/common/creds.rs
+++ b/mountpoint-s3/tests/common/creds.rs
@@ -2,15 +2,7 @@
 //!
 //! Some methods are duplicated in `mountpoint-s3-client::tests::common::creds`.
 
-#[cfg(feature = "s3_tests")]
-use aws_config::sts::AssumeRoleProvider;
-use aws_config::Region;
-#[cfg(feature = "s3_tests")]
-use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::Credentials;
-
-#[cfg(feature = "s3_tests")]
-use crate::common::s3::get_test_region;
 
 /// Detect if running on GitHub Actions (GHA) and if so,
 /// emit masking string to avoid credentials accidentally being printed.
@@ -27,52 +19,66 @@ fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
     }
 }
 
-/// Grab a set of SDK [Credentials] from the default credential provider chain.
+#[allow(unused_imports)]
 #[cfg(feature = "s3_tests")]
-pub async fn get_sdk_default_chain_creds() -> Credentials {
-    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+pub use integ_only::*;
+
+/// Further methods defined only for integration tests.
+#[cfg(feature = "s3_tests")]
+mod integ_only {
+    use super::*;
+
+    use aws_config::sts::AssumeRoleProvider;
+    use aws_config::Region;
     use aws_credential_types::provider::ProvideCredentials;
 
-    let sdk_provider = DefaultCredentialsChain::builder().build().await;
-    let credentials = sdk_provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+    use crate::common::s3::get_test_region;
 
-/// Takes the provided IAM Policy and assumes the configured subsession role,
-/// applying the given policy to scope down the permissions available.
-///
-/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
-/// The permissions are the intersection of the identity-based policy of the principal creating the session
-/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
-/// this method can only reduce the scope of permissions.
-///
-/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
-///
-/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
-pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
-    let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
-        .region(Region::new(get_test_region()))
-        .session_name("test_mountpoint-s3")
-        .policy(policy.as_ref())
-        .build()
-        .await;
-    let credentials = provider
-        .provide_credentials()
-        .await
-        .expect("default chain credentials should be available");
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
-}
+    /// Grab a set of SDK [Credentials] from the default credential provider chain.
+    pub async fn get_sdk_default_chain_creds() -> Credentials {
+        use aws_config::default_provider::credentials::DefaultCredentialsChain;
+        use aws_credential_types::provider::ProvideCredentials;
 
-/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
-///
-/// You should use other functions in this module to obtain session credentials.
-/// Only use this if you need a Role ARN (such as when crafting a config file entry).
-#[cfg(feature = "s3_tests")]
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+        let sdk_provider = DefaultCredentialsChain::builder().build().await;
+        let credentials = sdk_provider
+            .provide_credentials()
+            .await
+            .expect("default chain credentials should be available");
+        mask_aws_creds_if_on_gha(&credentials);
+        credentials
+    }
+
+    /// Takes the provided IAM Policy and assumes the configured subsession role,
+    /// applying the given policy to scope down the permissions available.
+    ///
+    /// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+    /// The permissions are the intersection of the identity-based policy of the principal creating the session
+    /// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+    /// this method can only reduce the scope of permissions.
+    ///
+    /// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+    ///
+    /// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+    pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
+        let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
+            .region(Region::new(get_test_region()))
+            .session_name("test_mountpoint-s3")
+            .policy(policy.as_ref())
+            .build()
+            .await;
+        let credentials = provider
+            .provide_credentials()
+            .await
+            .expect("default chain credentials should be available");
+        mask_aws_creds_if_on_gha(&credentials);
+        credentials
+    }
+
+    /// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+    ///
+    /// You should use other functions in this module to obtain session credentials.
+    /// Only use this if you need a Role ARN (such as when crafting a config file entry).
+    pub fn get_subsession_iam_role() -> String {
+        std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+    }
 }

--- a/mountpoint-s3/tests/common/creds.rs
+++ b/mountpoint-s3/tests/common/creds.rs
@@ -1,0 +1,78 @@
+//! Module providing methods for accessing different types of credentials for tests.
+//!
+//! Some methods are duplicated in `mountpoint-s3-client::tests::common::creds`.
+
+#[cfg(feature = "s3_tests")]
+use aws_config::sts::AssumeRoleProvider;
+use aws_config::Region;
+#[cfg(feature = "s3_tests")]
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
+
+#[cfg(feature = "s3_tests")]
+use crate::common::s3::get_test_region;
+
+/// Detect if running on GitHub Actions (GHA) and if so,
+/// emit masking string to avoid credentials accidentally being printed.
+fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
+        // If we think we're in GitHub Actions environment, register each in stdout.
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
+        println!("::add-mask::{}", credentials.access_key_id());
+        println!("::add-mask::{}", credentials.secret_access_key());
+        if let Some(token) = credentials.session_token() {
+            println!("::add-mask::{}", token);
+        }
+    }
+}
+
+/// Grab a set of SDK [Credentials] from the default credential provider chain.
+#[cfg(feature = "s3_tests")]
+pub async fn get_sdk_default_chain_creds() -> Credentials {
+    use aws_config::default_provider::credentials::DefaultCredentialsChain;
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let sdk_provider = DefaultCredentialsChain::builder().build().await;
+    let credentials = sdk_provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// Takes the provided IAM Policy and assumes the configured subsession role,
+/// applying the given policy to scope down the permissions available.
+///
+/// This method works by making an AWS Security Token Service (STS) AssumeRole call providing the policy request field.
+/// The permissions are the intersection of the identity-based policy of the principal creating the session
+/// and the session policies. This means that the subsession role must already have any permissions you wish to use -
+/// this method can only reduce the scope of permissions.
+///
+/// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
+///
+/// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
+pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
+    let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
+        .region(Region::new(get_test_region()))
+        .session_name("test_mountpoint-s3")
+        .policy(policy.as_ref())
+        .build()
+        .await;
+    let credentials = provider
+        .provide_credentials()
+        .await
+        .expect("default chain credentials should be available");
+    mask_aws_creds_if_on_gha(&credentials);
+    credentials
+}
+
+/// ARN of an AWS IAM Role that can be assumed by individual tests to scope down permissions.
+///
+/// You should use other functions in this module to obtain session credentials.
+/// Only use this if you need a Role ARN (such as when crafting a config file entry).
+#[cfg(feature = "s3_tests")]
+pub fn get_subsession_iam_role() -> String {
+    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
+}

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -2,13 +2,15 @@
 //! Allow for unused items since this is included independently in each module.
 #![allow(dead_code)]
 
+pub mod creds;
+
 #[cfg(feature = "fuse_tests")]
 pub mod fuse;
 
 #[cfg(feature = "s3_tests")]
 pub mod s3;
 
-use aws_sdk_s3::config::Credentials;
+use aws_credential_types::Credentials;
 use fuser::{FileAttr, FileType};
 use futures::executor::ThreadPool;
 use mountpoint_s3::fs::{DirectoryEntry, DirectoryReplier};

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -1,6 +1,5 @@
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts::config::Credentials;
 use rand::RngCore;
 use rand_chacha::rand_core::OsRng;
 
@@ -42,10 +41,6 @@ pub fn get_non_test_region() -> String {
     }
 }
 
-pub fn get_subsession_iam_role() -> String {
-    std::env::var("S3_SUBSESSION_IAM_ROLE").expect("Set S3_SUBSESSION_IAM_ROLE to run integration tests")
-}
-
 pub async fn get_test_sdk_client(region: &str) -> aws_sdk_s3::Client {
     let sdk_config = aws_config::defaults(BehaviorVersion::latest())
         .region(Region::new(region.to_owned()))
@@ -70,55 +65,6 @@ pub fn create_objects(bucket: &str, prefix: &str, region: &str, key: &str, value
             .send(),
     )
     .unwrap();
-}
-
-/// Detect if running on GitHub Actions (GHA) and if so,
-/// emit masking string to avoid credentials accidentally being printed.
-fn mask_aws_creds_if_on_gha(credentials: &Credentials) {
-    if std::env::var_os("GITHUB_ACTIONS").is_some() {
-        // GitHub Actions aren't aware of these credential strings since we're sourcing them inside the tests.
-        // If we think we're in GitHub Actions environment, register each in stdout.
-        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log
-        println!("::add-mask::{}", credentials.access_key_id());
-        println!("::add-mask::{}", credentials.secret_access_key());
-        if let Some(token) = credentials.session_token() {
-            println!("::add-mask::{}", token);
-        }
-    }
-}
-
-pub async fn get_test_sdk_sts_client() -> aws_sdk_sts::Client {
-    let config = aws_config::defaults(BehaviorVersion::latest())
-        .region(Region::new(get_test_region()))
-        .load()
-        .await;
-    aws_sdk_sts::Client::new(&config)
-}
-
-pub async fn get_scoped_down_credentials(policy: &str) -> Credentials {
-    let sts_client = get_test_sdk_sts_client().await;
-    let nonce = OsRng.next_u64();
-    let assume_role_response = sts_client
-        .assume_role()
-        .role_arn(get_subsession_iam_role())
-        .role_session_name(format!("mountpoint-s3-tests-{nonce}"))
-        .policy(policy)
-        .send()
-        .await
-        .expect("assume_role with valid ARN and policy should succeed");
-    let credentials = assume_role_response
-        .credentials()
-        .expect("credentials should be present if assume_role succeeded")
-        .to_owned();
-    let credentials = Credentials::new(
-        credentials.access_key_id(),
-        credentials.secret_access_key(),
-        Some(credentials.session_token().to_owned()),
-        None,
-        "scoped_down_sts_creds",
-    );
-    mask_aws_creds_if_on_gha(&credentials);
-    credentials
 }
 
 pub fn deny_single_object_access_policy(bucket: &str, key: &str) -> String {

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -34,12 +34,11 @@ use std::time::{Duration, SystemTime};
 use test_case::test_case;
 
 mod common;
+#[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
+use common::creds::get_scoped_down_credentials;
 use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply, TestS3Filesystem};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
-use common::{
-    get_crt_client_auth_config,
-    s3::{deny_single_object_access_policy, get_scoped_down_credentials},
-};
+use common::{get_crt_client_auth_config, s3::deny_single_object_access_policy};
 
 #[cfg(feature = "s3_tests")]
 use crate::common::s3::{get_test_bucket_and_prefix, get_test_region};

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -2,13 +2,10 @@
 #![cfg(feature = "s3_tests")]
 
 use assert_cmd::prelude::*;
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_config::BehaviorVersion;
-use aws_credential_types::provider::ProvideCredentials;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_sts::config::Region;
 use std::fs::{self, File};
 #[cfg(not(feature = "s3express_tests"))]
 use std::io::Read;
@@ -20,14 +17,14 @@ use std::{path::PathBuf, process::Command};
 use tempfile::NamedTempFile;
 use test_case::test_case;
 
+use crate::common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
 use crate::common::fuse::read_dir_to_entry_names;
 use crate::common::s3::{
-    create_objects, get_subsession_iam_role, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region,
-    get_test_sdk_client,
+    create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_region, get_test_sdk_client,
 };
-#[cfg(not(feature = "s3express_tests"))]
-use crate::common::s3::{get_non_test_region, get_scoped_down_credentials, get_test_kms_key_id};
 use crate::common::tokio_block_on;
+#[cfg(not(feature = "s3express_tests"))]
+use crate::common::{creds::get_scoped_down_credentials, s3::get_non_test_region, s3::get_test_kms_key_id};
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -385,7 +382,6 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
     let subprefix = format!("{prefix}sub/");
     let mount_point = assert_fs::TempDir::new()?;
     let region = get_test_region();
-    let subsession_role = get_subsession_iam_role();
 
     // Get scoped down credentials to the subprefix
     let policy = r#"{"Statement": [
@@ -393,22 +389,7 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
         {"Effect": "Allow", "Action": "s3:ListBucket", "Resource": "arn:aws:s3:::__BUCKET__", "Condition": {"StringLike": {"s3:prefix": "__PREFIX__*"}}}
     ]}"#;
     let policy = policy.replace("__BUCKET__", &bucket).replace("__PREFIX__", &subprefix);
-    let config = tokio_block_on(
-        aws_config::defaults(BehaviorVersion::latest())
-            .region(Region::new(get_test_region()))
-            .load(),
-    );
-    let sts_client = aws_sdk_sts::Client::new(&config);
-    let credentials = tokio_block_on(
-        sts_client
-            .assume_role()
-            .role_arn(subsession_role)
-            .role_session_name("test_scoped_credentials")
-            .policy(policy)
-            .send(),
-    )
-    .unwrap();
-    let credentials = credentials.credentials().unwrap();
+    let credentials = tokio_block_on(get_scoped_down_credentials(policy));
 
     // First try without the subprefix -- mount should fail as we don't have permissions on it
     let mut cmd = Command::cargo_bin("mount-s3")?;
@@ -994,17 +975,7 @@ fn create_cli_config_file(
     let mut config_file = NamedTempFile::new()?;
 
     // Populate source profile from the default credentials chain
-    let credentials = tokio_block_on(async {
-        // Get some static credentials by just using the SDK's default provider, which we know works
-        let sdk_provider = DefaultCredentialsChain::builder()
-            .region(Region::new(get_test_region()))
-            .build()
-            .await;
-        sdk_provider
-            .provide_credentials()
-            .await
-            .expect("static credentials should be available")
-    });
+    let credentials = tokio_block_on(get_sdk_default_chain_creds());
     writeln!(config_file, "[profile {}]", source_profile).unwrap();
     writeln!(config_file, "aws_access_key_id={}", credentials.access_key_id()).unwrap();
     writeln!(config_file, "aws_secret_access_key={}", credentials.secret_access_key()).unwrap();

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -17,7 +17,7 @@ use mountpoint_s3::ServerSideEncryption;
 
 use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
-use crate::common::s3::{get_scoped_down_credentials, get_test_kms_key_id};
+use crate::common::{creds::get_scoped_down_credentials, s3::get_test_kms_key_id};
 
 fn open_for_write(path: impl AsRef<Path>, append: bool, write_only: bool) -> std::io::Result<File> {
     let mut options = File::options();


### PR DESCRIPTION
## Description of change

Across the code base, we have many ways to assume or fetch credentials. We had different needs at different times, and so this was done in each case where needed. This ended up being quite complex.

This change brings most of those functions under a `test::common::creds` module in both crates.

The goal here is to simplify, especially to help reduce the changes in PRs like #684.

Relevant issues: #684

## Does this change impact existing behavior?

No breaking change, tests only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).