### PR TITLE
Update PR template to prompt thinking on change log entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,11 @@ Relevant issues: <!-- Please add issue numbers. -->
 
 <!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
 
+## Does this change need a changelog entry in any of the crates?
+
+<!-- Please confirm yes or no. -->
+<!-- If no, add justification. If unsure, ask a reviewer. -->
+
 ---
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,16 @@ Relevant issues: <!-- Please add issue numbers. -->
 
 ## Does this change need a changelog entry in any of the crates?
 
-<!-- Please confirm yes or no. -->
-<!-- If no, add justification. If unsure, ask a reviewer. -->
+<!--
+    Please confirm yes or no.
+    If no, add justification. If unsure, ask a reviewer.
+
+    You can find the changelog for each crate here:
+    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
+    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
+    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
+    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
+-->
 
 ---
 


### PR DESCRIPTION
## Description of change

We want to encourage updating the changelog alongside the change itself.

This updates the PR template to prompt this thinking. 

Relevant issues: N/A

## Does this change impact existing behavior?

No, PR template only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
