### PR TITLE
Add support for passthrough mount options

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+* Add support for passthrough mount options.
+
 ## v1.8.0
 
 ### New features

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -139,6 +139,13 @@ pub struct CliArgs {
 
     #[clap(
         long,
+        help = "Additional comma separated mount options. This will be passed verbatim to the mount command as -o <mount_options>",
+        help_heading = MOUNT_OPTIONS_HEADER,
+    )]
+    pub mount_options: Option<String>,
+
+    #[clap(
+        long,
         help = "Maximum throughput in Gbps [default: auto-detected on EC2 instances, 10 Gbps elsewhere]",
         value_name = "N",
         value_parser = value_parser!(u64).range(1..),
@@ -427,6 +434,10 @@ impl CliArgs {
         }
         if self.allow_other {
             options.push(MountOption::AllowOther);
+        }
+
+        if let Some(mount_options) = &self.mount_options {
+            options.push(MountOption::CUSTOM(mount_options.clone()));
         }
 
         let mount_point = self.mount_point.to_owned();


### PR DESCRIPTION
## Description of change

Add support for passthrough mount options. For example, this allows mounting on a non empty directory by specifying `--mount-options nonempty`.

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/954

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

Yes and it is done.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
