### PR TITLE
Make s3 client able to report read window offset

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * Allow querying initial read window size and read window end offset for backpressure GetObject. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
-* GetObject now returns an error instead of blocking when backpressure is enabled and there is not enough read window. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
+* When using GetObject with backpressure enabled, an error will be returned when there is not enough read window instead of blocking. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
 
 ## v0.9.0 (June 26, 2024)
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Unreleased
 
-* Allow querying initial read window size and read window end offset for backpressure GetObject. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
+### Breaking changes
+
 * When using GetObject with backpressure enabled, an error will be returned when there is not enough read window instead of blocking. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
+
+### Other changes
+
+* Allow querying initial read window size and read window end offset for backpressure GetObject. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
 
 ## v0.9.0 (June 26, 2024)
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Allow querying initial read window size and read window end offset for backpressure GetObject. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
+* GetObject now returns an error instead of blocking when backpressure is enabled and there is not enough read window. ([#971](https://github.com/awslabs/mountpoint-s3/pull/971))
+
 ## v0.9.0 (June 26, 2024)
 
 * Adds support for `AWS_ENDPOINT_URL` environment variable. ([#895](https://github.com/awslabs/mountpoint-s3/pull/895))

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -81,6 +81,10 @@ where
         self.client.write_part_size()
     }
 
+    fn initial_read_window_size(&self) -> Option<usize> {
+        self.client.initial_read_window_size()
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,
@@ -187,6 +191,11 @@ impl<Client: ObjectClient, FailState: Send> GetObjectRequest for FailureGetReque
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);
+    }
+
+    fn read_window_end_offset(self: Pin<&Self>) -> u64 {
+        let this = self.project_ref();
+        this.request.read_window_end_offset()
     }
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -596,15 +596,7 @@ impl ObjectClient for MockClient {
         range: Option<Range<u64>>,
         if_match: Option<ETag>,
     ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
-        trace!(
-            bucket,
-            key,
-            ?range,
-            ?if_match,
-            enable_back_pressure = self.config.enable_backpressure,
-            initial_read_window_size = self.config.initial_read_window_size,
-            "GetObject"
-        );
+        trace!(bucket, key, ?range, ?if_match, "GetObject");
         self.inc_op_count(Operation::GetObject);
 
         if bucket != self.config.bucket {

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -72,6 +72,11 @@ impl GetObjectRequest for ThroughputGetObjectRequest {
         let this = self.project();
         this.request.increment_read_window(len);
     }
+
+    fn read_window_end_offset(self: Pin<&Self>) -> u64 {
+        let this = self.project_ref();
+        this.request.read_window_end_offset()
+    }
 }
 
 impl Stream for ThroughputGetObjectRequest {
@@ -103,6 +108,10 @@ impl ObjectClient for ThroughputMockClient {
 
     fn write_part_size(&self) -> Option<usize> {
         self.inner.write_part_size()
+    }
+
+    fn initial_read_window_size(&self) -> Option<usize> {
+        self.inner.initial_read_window_size()
     }
 
     async fn delete_object(

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -383,8 +383,8 @@ pub trait GetObjectRequest:
     /// no backpressure is being applied and data is being downloaded as fast as possible.
     fn increment_read_window(self: Pin<&mut Self>, len: usize);
 
-    /// Get the upper bound of the range for read window. `GetObjectRequest` can only return data up to
-    /// this offset *exclusively*.
+    /// Get the upper bound of the current read window. When backpressure is enabled, [GetObjectRequest] can
+    /// return data up to this offset *exclusively*.
     fn read_window_end_offset(self: Pin<&Self>) -> u64;
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -85,6 +85,10 @@ pub trait ObjectClient {
     /// can be `None` if the client does not do multi-part operations.
     fn write_part_size(&self) -> Option<usize>;
 
+    /// Query the initial read window size this client uses for backpressure GetObject requests.
+    /// This can be `None` if backpressure is disabled.
+    fn initial_read_window_size(&self) -> Option<usize>;
+
     /// Delete a single object from the object store.
     ///
     /// DeleteObject will succeed even if the object within the bucket does not exist.
@@ -378,6 +382,10 @@ pub trait GetObjectRequest:
     /// If `enable_read_backpressure` is false this call will have no effect,
     /// no backpressure is being applied and data is being downloaded as fast as possible.
     fn increment_read_window(self: Pin<&mut Self>, len: usize);
+
+    /// Get the upper bound of the range for read window. `GetObjectRequest` can only return data up to
+    /// this offset *exclusively*.
+    fn read_window_end_offset(self: Pin<&Self>) -> u64;
 }
 
 /// A streaming put request which allows callers to asynchronously write the body of the request.

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -977,8 +977,10 @@ pub enum S3RequestError {
     #[error("Request throttled")]
     Throttled,
 
-    /// The request cannot fetch more data because window size is empty
-    #[error("Empty read window")]
+    /// Cannot fetch more data because current read window is exhausted. The read window must
+    /// be advanced using [GetObjectRequest::increment_read_window(u64)] to continue fetching
+    /// new data.
+    #[error("Polled for data with empty read window")]
     EmptyReadWindow,
 }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -73,15 +73,16 @@ pub fn get_test_client() -> S3CrtClient {
     S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client")
 }
 
-pub fn get_test_backpressure_client(initial_read_window: usize) -> S3CrtClient {
+pub fn get_test_backpressure_client(initial_read_window: usize, part_size: Option<usize>) -> S3CrtClient {
     let endpoint_config = EndpointConfig::new(&get_test_region());
-    S3CrtClient::new(
-        S3ClientConfig::new()
-            .endpoint_config(endpoint_config)
-            .read_backpressure(true)
-            .initial_read_window(initial_read_window),
-    )
-    .expect("could not create test client")
+    let mut config = S3ClientConfig::new()
+        .endpoint_config(endpoint_config)
+        .read_backpressure(true)
+        .initial_read_window(initial_read_window);
+    if let Some(part_size) = part_size {
+        config = config.part_size(part_size);
+    }
+    S3CrtClient::new(config).expect("could not create test client")
 }
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -206,7 +206,6 @@ pub async fn check_backpressure_get_result(
     range: Option<Range<u64>>,
     expected: &[u8],
 ) {
-    let mut accum_read_window = read_window;
     let mut accum = vec![];
     let mut next_offset = range.map(|r| r.start).unwrap_or(0);
     pin_mut!(result);
@@ -218,9 +217,8 @@ pub async fn check_backpressure_get_result(
 
         // We run out of data to read if read window is smaller than accum length of data,
         // so we keeping adding window size, otherwise the request will be blocked.
-        while accum_read_window <= accum.len() {
+        while next_offset >= result.as_ref().read_window_end_offset() {
             result.as_mut().increment_read_window(read_window);
-            accum_read_window += read_window;
         }
     }
     assert_eq!(&accum[..], expected, "body does not match");

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -90,7 +90,7 @@ async fn test_get_object_backpressure(size: usize, range: Option<Range<u64>>) {
     check_backpressure_get_result(initial_window_size, request, range, expected).await;
 }
 
-// Verify that the request is blocked when we don't increment read window size
+// Verify that an error is returned when we don't increment read window size
 #[tokio::test]
 async fn verify_backpressure_get_object() {
     let initial_window_size = 256;

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -77,7 +77,7 @@ async fn test_get_object_backpressure(size: usize, range: Option<Range<u64>>) {
         .unwrap();
 
     let initial_window_size = 8 * 1024 * 1024;
-    let client: S3CrtClient = get_test_backpressure_client(initial_window_size);
+    let client: S3CrtClient = get_test_backpressure_client(initial_window_size, None);
 
     let request = client
         .get_object(&bucket, &key, range.clone(), None)
@@ -94,7 +94,7 @@ async fn test_get_object_backpressure(size: usize, range: Option<Range<u64>>) {
 #[tokio::test]
 async fn verify_backpressure_get_object() {
     let initial_window_size = 256;
-    let client: S3CrtClient = get_test_backpressure_client(initial_window_size);
+    let client: S3CrtClient = get_test_backpressure_client(initial_window_size, None);
     let part_size = client.read_part_size().unwrap();
 
     let size = part_size * 2;
@@ -137,10 +137,9 @@ async fn verify_backpressure_get_object() {
 
 #[tokio::test]
 async fn test_mutated_during_get_object_backpressure() {
-    let initial_window_size = 8 * 1024 * 1024;
-    let client: S3CrtClient = get_test_backpressure_client(initial_window_size);
-    let part_size = client.read_part_size().unwrap();
-    assert_eq!(part_size, initial_window_size);
+    let part_size = 8 * 1024 * 1024;
+    let initial_window_size = part_size;
+    let client: S3CrtClient = get_test_backpressure_client(initial_window_size, Some(part_size));
 
     let size = part_size * 2;
     let range = 0..(part_size + 1) as u64;


### PR DESCRIPTION
## Description of change

A few changes to make the GetObject request able to report current read window offset when backpressure is enabled and also make it return error instead of blocking when there is not enough read window. This is a part of bigger change (https://github.com/awslabs/mountpoint-s3/pull/926) but I would like to split it up into smaller PRs.

## Does this change impact existing behavior?

No, backpressure is disabled by default and we don't use it in mountpoint today.

## Does this change need a changelog entry in any of the crates?

Yes, updated changelog for mountpoint-s3-client.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
