### PR TITLE
Refactor object part stream

### DIFF
--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -13,11 +13,11 @@ use crate::data_cache::{BlockIndex, DataCache};
 use crate::object::ObjectId;
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueueProducer};
-use crate::prefetch::part_stream::{try_read_from_request, ObjectPartStream, RequestRange, RequestReaderOutput};
+use crate::prefetch::part_stream::{
+    try_read_from_request, ObjectPartStream, RequestRange, RequestReaderOutput, RequestTaskConfig,
+};
 use crate::prefetch::task::RequestTask;
 use crate::prefetch::PrefetchReadError;
-
-use super::part_stream::RequestTaskConfig;
 
 /// [ObjectPartStream] implementation which maintains a [DataCache] for the object data
 /// retrieved by an [ObjectClient].


### PR DESCRIPTION
Various refactorings, including a new config type for object part stream task, introducing structs for part composers, consolidating error handling flow in request reader and part composer.

This is a part of https://github.com/awslabs/mountpoint-s3/pull/926.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No, changes are in mountpoint-s3 crate but it does not change any behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
