### PR TITLE
Update NoSigningCredentials error message, add troubleshooting entry

### DIFF
--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -261,3 +261,26 @@ mountpoint_s3::fuse: write failed: upload error: object exceeded maximum upload 
 
 For workloads uploading files larger than 78GiB, we recommend configuring a larger part size using the `--write-part-size <MiB>` command-line argument.
 For more information, see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#maximum-object-size).
+
+## Credentials errors
+
+If you are seeing errors such as "No signing credentials available, see CRT debug logs" or "No signing credentials found",
+this means that Mountpoint was unable to load credentials to sign the request it was attempting to make.
+This could be due to no credentials being available or an error with the credentials provider.
+
+We recommend reviewing the AWS Common Runtime (CRT) client logs to identify the issue by using the `--debug-crt` command-line argument.
+The output is verbose, however it should be possible to identify the error coming from the AWS CRT.
+Review [Mountpoint's logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#advanced-logging-verbosity-options) for more information on how to configure logging.
+
+As an example, the logs below shows some error emitted when using an invalid `credential_source` property in an AWS Profile.
+
+```
+DEBUG awscrt::AWSProfile: Creating profile collection from file at "/home/ec2-user/.aws/config"
+INFO awscrt::AuthCredentialsProvider: static: profile my-profile has role_arn property is set to arn:aws:iam::111122223333:role/my-iam-role, attempting to create an STS credentials provider.
+DEBUG awscrt::AuthCredentialsProvider: static: computed session_name as aws-common-runtime-profile-config-19
+INFO awscrt::AuthCredentialsProvider: static: credential_source property set to SomeWrongSource
+ERROR awscrt::AuthCredentialsProvider: static: invalid credential_source property: SomeWrongSource
+```
+
+For more information on how to configure the AWS credentials Mountpoint uses,
+see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#aws-credentials).

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -963,8 +963,8 @@ pub enum S3RequestError {
     #[error("Forbidden: {0}")]
     Forbidden(String, ClientErrorMetadata),
 
-    /// No signing credential is set for requests
-    #[error("No signing credentials found")]
+    /// The request was attempted but could not be signed due to no available credentials
+    #[error("No signing credentials available, see CRT debug logs")]
     NoSigningCredentials,
 
     /// The request was canceled


### PR DESCRIPTION
## Description of change

The error message for failure to get credentials is not super helpful right now. This change proposes to update it to be a bit clearer, provide some pointer of what to do next, and also adds a troubleshooting entry for this error case.

Relevant issues: N/A

## Does this change impact existing behavior?

This changes the string error message, which is meant to be read by people - not computers. :)

## Does this change need a changelog entry in any of the crates?

This doesn't require a changelog entry, as it is only changing an error message meant for people.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
