### PR TITLE
Leverage async stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +2454,7 @@ dependencies = [
  "assert_fs",
  "async-channel 2.2.1",
  "async-lock 3.3.0",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-credential-types",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -43,6 +43,7 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
+async-stream = "0.3.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0", default-features = false }

--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -166,8 +166,7 @@ where
             cache_key.clone(),
             block_aligned_byte_range,
         );
-        let part_composer_future = part_composer.try_compose_parts(request_stream);
-        part_composer_future.await;
+        part_composer.try_compose_parts(request_stream).await;
     }
 
     fn block_indices_for_byte_range(&self, range: &RequestRange) -> Range<BlockIndex> {

--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -1,10 +1,9 @@
 use std::time::Instant;
 use std::{ops::Range, sync::Arc};
 
-use async_channel::{unbounded, Receiver};
 use bytes::Bytes;
 use futures::task::{Spawn, SpawnExt};
-use futures::{join, pin_mut, StreamExt};
+use futures::{pin_mut, Stream, StreamExt};
 use mountpoint_s3_client::ObjectClient;
 use tracing::{debug_span, trace, warn, Instrument};
 
@@ -14,7 +13,7 @@ use crate::object::ObjectId;
 use crate::prefetch::part::Part;
 use crate::prefetch::part_queue::{unbounded_part_queue, PartQueueProducer};
 use crate::prefetch::part_stream::{
-    try_read_from_request, ObjectPartStream, RequestRange, RequestReaderOutput, RequestTaskConfig,
+    read_from_request, ObjectPartStream, RequestRange, RequestReaderOutput, RequestTaskConfig,
 };
 use crate::prefetch::task::RequestTask;
 use crate::prefetch::PrefetchReadError;
@@ -161,16 +160,14 @@ where
             cache: self.cache.clone(),
         };
 
-        let (body_sender, body_receiver) = unbounded();
-        let request_reader_future = try_read_from_request(
-            body_sender,
+        let request_stream = read_from_request(
             self.client.clone(),
             bucket.clone(),
             cache_key.clone(),
             block_aligned_byte_range,
         );
-        let part_composer_future = part_composer.try_compose_parts(body_receiver);
-        join!(request_reader_future, part_composer_future);
+        let part_composer_future = part_composer.try_compose_parts(request_stream);
+        part_composer_future.await;
     }
 
     fn block_indices_for_byte_range(&self, range: &RequestRange) -> Range<BlockIndex> {
@@ -200,8 +197,8 @@ where
     E: std::error::Error + Send + Sync,
     Cache: DataCache + Send + Sync,
 {
-    async fn try_compose_parts(&mut self, body_receiver: Receiver<RequestReaderOutput<E>>) {
-        if let Err(e) = self.compose_parts(body_receiver).await {
+    async fn try_compose_parts(&mut self, request_stream: impl Stream<Item = RequestReaderOutput<E>>) {
+        if let Err(e) = self.compose_parts(request_stream).await {
             trace!(error=?e, "part stream task failed");
             self.part_queue_producer.push(Err(e));
         }
@@ -210,13 +207,13 @@ where
 
     async fn compose_parts(
         &mut self,
-        body_receiver: Receiver<RequestReaderOutput<E>>,
+        request_stream: impl Stream<Item = RequestReaderOutput<E>>,
     ) -> Result<(), PrefetchReadError<E>> {
         let key = self.cache_key.key();
         let block_size = self.cache.block_size();
 
-        pin_mut!(body_receiver);
-        while let Some(next) = body_receiver.next().await {
+        pin_mut!(request_stream);
+        while let Some(next) = request_stream.next().await {
             assert!(
                 self.buffer.len() < block_size as usize,
                 "buffer should be flushed when we get a full block"

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -203,8 +203,7 @@ where
                     };
 
                     let request_stream = read_from_request(client, bucket, config.object_id, request_range.into());
-                    let part_composer_future = part_composer.try_compose_parts(request_stream);
-                    part_composer_future.await;
+                    part_composer.try_compose_parts(request_stream).await;
                 }
                 .instrument(span),
             )


### PR DESCRIPTION
## Description of change

When reading data from `GetObject` request in `ObjectPartStream`, return them as `Stream` instead of writing into a channel. This makes the flow easier to follow.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No, changes are in mountpoint-s3 crate but it does not change any behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
