### PR TITLE
Allow running install-dependencies script as root

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  run-as-root:
+    description: "Install as root user"
+    required: false
+    type: boolean
+    default: false
 runs:
   using: "composite"
   steps:
@@ -29,7 +34,8 @@ runs:
         --fuse-version ${{ inputs.fuseVersion }} \
         ${{ fromJSON(inputs.llvm) && '--with-llvm' || '' }} \
         ${{ fromJSON(inputs.libunwind) && '--with-libunwind' || '' }} \
-        ${{ fromJSON(inputs.fio) && '--with-fio' || '' }}
+        ${{ fromJSON(inputs.fio) && '--with-fio' || '' }} \
+        ${{ fromJSON(inputs.run-as-root) && '--run-as-root' || '' }}
   - name: Configure FUSE to allow other users to access FS
     shell: bash
-    run: echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+    run: echo 'user_allow_other' | ${{ !fromJSON(inputs.run-as-root) && 'sudo' || '' }} tee -a /etc/fuse.conf


### PR DESCRIPTION
## Description of change

Currently, we always run privilege commands in the script with `sudo`. This makes the script unusable if running as the root user, which we might want to do in some environments such as in a container.

Manually tested in my fork with a [container workflow](https://github.com/monthonk/mountpoint-s3/actions/runs/10317152958/job/28560814445#step:7:5).

## Does this change impact existing behavior?

No, the changes are for the CI only.

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
