### PR TITLE
Store bench results in S3

### DIFF
--- a/.github/actions/scripts/save-benchmark-results.sh
+++ b/.github/actions/scripts/save-benchmark-results.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+aws --version || (curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install)
+
+DATE=$(date +%s)
+echo "Storing benchmark results as ${S3_BENCH_RESULTS_PREFIX}/${DATE}.json"
+aws s3 cp \
+    --region ${S3_BENCH_REGION} \
+    results/output.json \
+    s3://${S3_BENCH_BUCKET_NAME}/${S3_BENCH_RESULTS_PREFIX}/${DATE}.json \
+    > /dev/null 2>&1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,8 @@ on:
       ref:
         required: true
         type: string
+      s3_bench_results_prefix:
+        type: string
 
 env:
   RUST_BACKTRACE: 1
@@ -68,7 +70,14 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-  
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+
   latency-bench:
     name: Benchmark (Latency)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
@@ -114,6 +123,13 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
 
   cache-bench:
     name: Benchmark (Cache)
@@ -162,3 +178,10 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}

--- a/.github/workflows/bench_main.yml
+++ b/.github/workflows/bench_main.yml
@@ -3,6 +3,8 @@ name: Benchmarks
 on:
   push:
     branches: [ "main", "wf-changes/**" ]
+  schedule:
+    - cron: "0 */8 * * *" # every 8 hours
 
 permissions:
   id-token: write
@@ -15,9 +17,11 @@ jobs:
     with:
       ref: ${{ github.event.after }}
       publish: ${{ github.event.ref == 'refs/heads/main' }}
+      s3_bench_results_prefix: ${{ github.event_name == 'schedule' && 'results/main' || null }}
   s3express-integration:
     name: Benchmarks (s3express)
     uses: ./.github/workflows/bench_s3express.yml
     with:
       ref: ${{ github.event.after }}
       publish: ${{ github.event.ref == 'refs/heads/main' }}
+      s3_bench_results_prefix: ${{ github.event_name == 'schedule' && 'results/main' || null }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -13,6 +13,8 @@ on:
       ref:
         required: true
         type: string
+      s3_bench_results_prefix:
+        type: string
 
 env:
   RUST_BACKTRACE: 1
@@ -69,7 +71,14 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-  
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+
   latency-bench:
     name: Benchmark (Latency)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
@@ -115,3 +124,10 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}


### PR DESCRIPTION
## Description of change

This PR configures CI to run benchmark on schedule every 8 hours. Results are stored in the `S3_BENCH_BUCKET_NAME` bucket for further processing. 

Relevant issues: none

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No.

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

No.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
