### PR TITLE
Use separate bucket for bench results, run on PRs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -75,7 +75,7 @@ jobs:
       run: .github/actions/scripts/save-benchmark-results.sh
       env:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
 
   latency-bench:
@@ -128,7 +128,7 @@ jobs:
       run: .github/actions/scripts/save-benchmark-results.sh
       env:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
 
   cache-bench:
@@ -183,5 +183,5 @@ jobs:
       run: .github/actions/scripts/save-benchmark-results.sh
       env:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}

--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -17,6 +17,8 @@ jobs:
     with:
       environment: PR benchmarks
       ref: ${{ github.event.pull_request.head.sha }}
+      # store results with prefix defined by PR id (github.event.number)
+      s3_bench_results_prefix: ${{ github.event_name == 'pull_request_target' && format('results/{0}/s3_standard', github.event.number) || null }}
   s3express-integration:
     name: Benchmarks (s3express)
     uses: ./.github/workflows/bench_s3express.yml
@@ -24,3 +26,5 @@ jobs:
     with:
       environment: PR benchmarks
       ref: ${{ github.event.pull_request.head.sha }}
+      # store results with prefix defined by PR id (github.event.number)
+      s3_bench_results_prefix: ${{ github.event_name == 'pull_request_target' && format('results/{0}/s3_express', github.event.number) || null }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -76,7 +76,7 @@ jobs:
       run: .github/actions/scripts/save-benchmark-results.sh
       env:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
 
   latency-bench:
@@ -129,5 +129,5 @@ jobs:
       run: .github/actions/scripts/save-benchmark-results.sh
       env:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}


### PR DESCRIPTION
## Description of change

In the previous [PR](https://github.com/awslabs/mountpoint-s3/pull/983) we configured results to be stored under a prefix of a bucket which CI does not have access to. Since a change is required a more stable approach would be to store results in a separate bucket.

This change also configures CI to store results to S3 on benches run from a PR.

Relevant issues: none

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No.

## Does this change need a changelog entry in any of the crates?

No.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
