### PR TITLE
Add `UNSTABLE_CACHE_KEY` environment variable

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -791,8 +791,9 @@ where
         if let Some(cache_config) = cache_config {
             let managed_cache_dir = match env_unstable_cache_key() {
                 None => ManagedCacheDir::new_from_parent(path),
-                Some(cache_key) => ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key)
-            }.context("failed to create cache directory")?;
+                Some(cache_key) => ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key),
+            }
+            .context("failed to create cache directory")?;
 
             let cache = DiskDataCache::new(managed_cache_dir.as_path_buf(), cache_config);
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
@@ -963,7 +964,6 @@ fn env_region() -> Option<String> {
 fn env_unstable_cache_key() -> Option<String> {
     env::var_os("UNSTABLE_CACHE_KEY").map(|val| val.to_string_lossy().into())
 }
-
 
 /// Determine the region using the following sources (in order):
 ///  * `--region` flag (user-provided),

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -790,8 +790,9 @@ where
         };
 
         if let Some(cache_config) = cache_config {
-            let cache_key = env_unstable_cache_key().unwrap_or(OsString::new());
-            let managed_cache_dir = ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key).context("failed to create cache directory")?;
+            let cache_key = env_unstable_cache_key();
+            let managed_cache_dir = ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key)
+                .context("failed to create cache directory")?;
 
             let cache = DiskDataCache::new(managed_cache_dir.as_path_buf(), cache_config);
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsString;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::num::NonZeroUsize;
@@ -789,11 +790,8 @@ where
         };
 
         if let Some(cache_config) = cache_config {
-            let managed_cache_dir = match env_unstable_cache_key() {
-                None => ManagedCacheDir::new_from_parent(path),
-                Some(cache_key) => ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key),
-            }
-            .context("failed to create cache directory")?;
+            let cache_key = env_unstable_cache_key().unwrap_or(OsString::new());
+            let managed_cache_dir = ManagedCacheDir::new_from_parent_with_cache_key(path, cache_key).context("failed to create cache directory")?;
 
             let cache = DiskDataCache::new(managed_cache_dir.as_path_buf(), cache_config);
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
@@ -961,8 +959,8 @@ fn env_region() -> Option<String> {
     env::var_os("AWS_REGION").map(|val| val.to_string_lossy().into())
 }
 
-fn env_unstable_cache_key() -> Option<String> {
-    env::var_os("UNSTABLE_CACHE_KEY").map(|val| val.to_string_lossy().into())
+fn env_unstable_cache_key() -> Option<OsString> {
+    env::var_os("UNSTABLE_MOUNTPOINT_CACHE_KEY")
 }
 
 /// Determine the region using the following sources (in order):

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Cache directory that has been created and emptied, and will be emptied when dropped.
+/// When using a `cache_key`, the key is hashed and added as a subdirectory of `mountpoint-cache`.
 #[derive(Debug)]
 pub struct ManagedCacheDir {
     wrapping_path: PathBuf,

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 /// Cache directory that has been created and emptied, and will be emptied when dropped.
 #[derive(Debug)]
 pub struct ManagedCacheDir {
+    outer_path: PathBuf,
     managed_path: PathBuf,
 }
 
@@ -31,36 +32,53 @@ impl ManagedCacheDir {
     /// Create a new directory inside the provided parent path.
     /// If the directory already exists, it will be deleted before being recreated.
     pub fn new_from_parent<P: AsRef<Path>>(parent_path: P) -> Result<Self, ManagedCacheDirError> {
+        Self::new_from_parent_with_cache_key(parent_path, PathBuf::new())
+    }
+
+    pub fn new_from_parent_with_cache_key<P: AsRef<Path>, P2: AsRef<Path>>(parent_path: P, cache_key: P2) -> Result<Self, ManagedCacheDirError> {
+        let outer_path = parent_path.as_ref().join("mountpoint-cache");
         let managed_cache_dir = Self {
-            managed_path: parent_path.as_ref().join("mountpoint-cache"),
+            managed_path: outer_path.join(cache_key),
+            outer_path,
         };
 
         managed_cache_dir.remove()?;
+        managed_cache_dir.create_cache_dir()?;
+        Ok(managed_cache_dir)
+    }
 
-        let mkdir_result = fs::DirBuilder::new().mode(0o700).create(managed_cache_dir.as_path());
+    /// Remove the cache sub-directory, along with its contents if any
+    fn remove(&self) -> Result<(), ManagedCacheDirError> {
+        tracing::debug!(cache_subdirectory = ?self.outer_path, "removing the cache sub-directory and any contents");
+        if let Err(remove_dir_err) = fs::remove_dir_all(&self.outer_path) {
+            match remove_dir_err.kind() {
+                io::ErrorKind::NotFound => (),
+                _kind => return Err(ManagedCacheDirError::CleanupFailure(remove_dir_err)),
+            }
+        }
+        tracing::trace!(cache_subdirectory = ?self.outer_path, "cache sub-directory removal complete");
+        Ok(())
+    }
+
+    /// Create the cache sub-directory, assumes the parent path exists.
+    fn create_cache_dir(&self) -> Result<(), ManagedCacheDirError> {
+        Self::create_dir(&self.outer_path)?;
+        Self::create_dir(self.as_path())
+    }
+
+    /// Create a directory, assuming the parent path exists.
+    fn create_dir(path: &Path) -> Result<(), ManagedCacheDirError> {
+        let mkdir_result = fs::DirBuilder::new().mode(0o700).create(path);
         if let Err(mkdir_err) = mkdir_result {
             match mkdir_err.kind() {
                 io::ErrorKind::AlreadyExists => tracing::warn!(
-                    cache_dir = ?managed_cache_dir.as_path(),
+                    cache_dir = ?path,
                     "cache sub-directory already existed immediately after removal",
                 ),
                 _kind => return Err(ManagedCacheDirError::CreationFailure(mkdir_err)),
             }
         }
 
-        Ok(managed_cache_dir)
-    }
-
-    /// Remove the cache sub-directory, along with its contents if any
-    fn remove(&self) -> Result<(), ManagedCacheDirError> {
-        tracing::debug!(cache_subdirectory = ?self.managed_path, "removing the cache sub-directory and any contents");
-        if let Err(remove_dir_err) = fs::remove_dir_all(&self.managed_path) {
-            match remove_dir_err.kind() {
-                io::ErrorKind::NotFound => (),
-                _kind => return Err(ManagedCacheDirError::CleanupFailure(remove_dir_err)),
-            }
-        }
-        tracing::trace!(cache_subdirectory = ?self.managed_path, "cache sub-directory removal complete");
         Ok(())
     }
 
@@ -78,7 +96,7 @@ impl ManagedCacheDir {
 impl Drop for ManagedCacheDir {
     fn drop(&mut self) {
         if let Err(err) = self.remove() {
-            tracing::error!(cache_subdirectory = ?self.managed_path, "failed to remove cache sub-directory: {err}");
+            tracing::error!(cache_subdirectory = ?self.outer_path, "failed to remove cache sub-directory: {err}");
         }
     }
 }
@@ -89,6 +107,7 @@ mod tests {
 
     use std::fs;
     use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    use std::path::{Path, PathBuf};
 
     const EXPECTED_DIR_MODE: u32 = 0o700;
 
@@ -99,20 +118,32 @@ mod tests {
 
         let managed_dir =
             ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
-        let dir_mode = fs::metadata(&expected_path)
-            .expect("path should exist")
-            .permissions()
-            .mode();
-        assert_eq!(
-            dir_mode & 0o777,
-            EXPECTED_DIR_MODE,
-            "path should have {EXPECTED_DIR_MODE:#o} permission mode but had {dir_mode:#o}",
-        );
+        assert_dir_exists_with_permissions(&expected_path);
 
         drop(managed_dir);
         assert!(
             !expected_path.try_exists().unwrap(),
             "{expected_path:?} should not exist"
+        );
+
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_cache_key_unused() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_key = Path::new("cache_key");
+        let should_exist = temp_dir.path().join("mountpoint-cache").join("cache_key");
+
+        let managed_dir =
+            ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key).expect("creating managed dir should succeed");
+        assert_dir_exists_with_permissions(&should_exist);
+
+        drop(managed_dir);
+        let should_not_exist = temp_dir.path().join("mountpoint-cache");
+        assert!(
+            !should_not_exist.try_exists().unwrap(),
+            "{should_not_exist:?} should not exist"
         );
 
         temp_dir.close().unwrap();
@@ -125,15 +156,32 @@ mod tests {
 
         let managed_dir =
             ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
-        let dir_mode = fs::metadata(&expected_path)
-            .expect("path should exist")
-            .permissions()
-            .mode();
-        assert_eq!(
-            dir_mode & 0o777,
-            EXPECTED_DIR_MODE,
-            "path should have {EXPECTED_DIR_MODE:#o} permission mode but had {dir_mode:#o}",
+        assert_dir_exists_with_permissions(&expected_path);
+
+        fs::File::create(expected_path.join("file.txt"))
+            .expect("should be able to create file within managed directory");
+        fs::create_dir(expected_path.join("dir")).expect("should be able to create dir within managed directory");
+        fs::File::create(expected_path.join("dir/file.txt"))
+            .expect("should be able to create file within subdirectory");
+
+        drop(managed_dir);
+        assert!(
+            !expected_path.try_exists().unwrap(),
+            "{expected_path:?} should not exist"
         );
+
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_cache_key_used() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_key = Path::new("cache_key");
+        let expected_path = temp_dir.path().join("mountpoint-cache").join("cache_key");
+
+        let managed_dir =
+            ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key).expect("creating managed dir should succeed");
+        assert_dir_exists_with_permissions(&expected_path);
 
         fs::File::create(expected_path.join("file.txt"))
             .expect("should be able to create file within managed directory");
@@ -165,15 +213,7 @@ mod tests {
         let managed_dir =
             ManagedCacheDir::new_from_parent(temp_dir.path()).expect("creating managed dir should succeed");
 
-        let dir_mode = fs::metadata(&expected_path)
-            .expect("path should exist")
-            .permissions()
-            .mode();
-        assert_eq!(
-            dir_mode & 0o777,
-            EXPECTED_DIR_MODE,
-            "path should have {EXPECTED_DIR_MODE:#o} permission mode but had {dir_mode:#o}",
-        );
+        assert_dir_exists_with_permissions(&expected_path);
 
         let dir_entries = fs::read_dir(&expected_path).unwrap().count();
         assert!(dir_entries == 0, "directory should be empty");
@@ -185,5 +225,17 @@ mod tests {
         );
 
         temp_dir.close().unwrap();
+    }
+
+    fn assert_dir_exists_with_permissions(expected_path: &PathBuf) {
+        let dir_mode = fs::metadata(expected_path)
+            .expect("path should exist")
+            .permissions()
+            .mode();
+        assert_eq!(
+            dir_mode & 0o777,
+            EXPECTED_DIR_MODE,
+            "path should have {EXPECTED_DIR_MODE:#o} permission mode but had {dir_mode:#o}",
+        );
     }
 }

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -111,9 +111,7 @@ impl Drop for ManagedCacheDir {
 
 /// Hash the cache_key to avoid path traversal attacks.
 fn hash_cache_key(cache_key: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(cache_key);
-    let hashed_key: [u8; 32] = hasher.finalize().into();
+    let hashed_key = Sha256::digest(cache_key);
     hex::encode(hashed_key)
 }
 

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -46,7 +46,7 @@ impl ManagedCacheDir {
         let mountpoint_cache_path = parent_path.as_ref().join("mountpoint-cache");
         let managed_cache_path = match cache_key {
             None => mountpoint_cache_path.clone(),
-            Some(cache_key) => mountpoint_cache_path.join(hash_cache_key(cache_key.as_bytes())),
+            Some(ref cache_key) => mountpoint_cache_path.join(hash_cache_key(cache_key.as_bytes())),
         };
         let managed_cache_dir = Self {
             mountpoint_cache_path,
@@ -54,7 +54,10 @@ impl ManagedCacheDir {
         };
 
         managed_cache_dir.remove()?;
-        managed_cache_dir.create_cache_dir()?;
+        Self::create_dir(&managed_cache_dir.mountpoint_cache_path)?;
+        if cache_key.is_some() {
+            Self::create_dir(&managed_cache_dir.managed_cache_path)?;
+        }
         Ok(managed_cache_dir)
     }
 
@@ -68,15 +71,6 @@ impl ManagedCacheDir {
             }
         }
         tracing::trace!(cache_subdirectory = ?self.mountpoint_cache_path, "cache sub-directory removal complete");
-        Ok(())
-    }
-
-    /// Create the cache sub-directory, assumes the parent path exists.
-    fn create_cache_dir(&self) -> Result<(), ManagedCacheDirError> {
-        Self::create_dir(&self.mountpoint_cache_path)?;
-        if self.mountpoint_cache_path != self.managed_cache_path {
-            Self::create_dir(&self.managed_cache_path)?;
-        }
         Ok(())
     }
 

--- a/mountpoint-s3/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3/src/data_cache/cache_directory.rs
@@ -35,7 +35,10 @@ impl ManagedCacheDir {
         Self::new_from_parent_with_cache_key(parent_path, PathBuf::new())
     }
 
-    pub fn new_from_parent_with_cache_key<P: AsRef<Path>, P2: AsRef<Path>>(parent_path: P, cache_key: P2) -> Result<Self, ManagedCacheDirError> {
+    pub fn new_from_parent_with_cache_key<P: AsRef<Path>, P2: AsRef<Path>>(
+        parent_path: P,
+        cache_key: P2,
+    ) -> Result<Self, ManagedCacheDirError> {
         let outer_path = parent_path.as_ref().join("mountpoint-cache");
         let managed_cache_dir = Self {
             managed_path: outer_path.join(cache_key),
@@ -135,8 +138,8 @@ mod tests {
         let cache_key = Path::new("cache_key");
         let should_exist = temp_dir.path().join("mountpoint-cache").join("cache_key");
 
-        let managed_dir =
-            ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key).expect("creating managed dir should succeed");
+        let managed_dir = ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key)
+            .expect("creating managed dir should succeed");
         assert_dir_exists_with_permissions(&should_exist);
 
         drop(managed_dir);
@@ -179,8 +182,8 @@ mod tests {
         let cache_key = Path::new("cache_key");
         let expected_path = temp_dir.path().join("mountpoint-cache").join("cache_key");
 
-        let managed_dir =
-            ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key).expect("creating managed dir should succeed");
+        let managed_dir = ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), cache_key)
+            .expect("creating managed dir should succeed");
         assert_dir_exists_with_permissions(&expected_path);
 
         fs::File::create(expected_path.join("file.txt"))


### PR DESCRIPTION
## Description of change

Add `UNSTABLE_CACHE_KEY` environment variable.
Using `UNSTABLE_CACHE_KEY` allows users to specify a cache path disambiguator. This key can be used to ensure that cache directories are unique, even if the cache directory specified is shared.

<!-- Please describe your contribution here. What and why? -->

Relevant issues: N/A

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No breaking changes. This will change behaviour when the `UNSTABLE_CACHE_KEY` variable is passed.

## Does this change need a changelog entry in any of the crates?

No, this is being added as an unstable feature without documentation or promise for continued support.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
