### PR TITLE
Run benchmarks once a day

### DIFF
--- a/.github/actions/scripts/save-benchmark-results.sh
+++ b/.github/actions/scripts/save-benchmark-results.sh
@@ -4,10 +4,10 @@ set -e
 
 aws --version || (curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install)
 
+echo "{\"commit\": {\"id\": \"${COMMIT_ID}\"}, \"benches\": $(cat results/output.json)}" > results/s3_output.json
 DATE=$(date +%s)
 echo "Storing benchmark results as ${S3_BENCH_RESULTS_PREFIX}/${DATE}.json"
 aws s3 cp \
     --region ${S3_BENCH_REGION} \
-    results/output.json \
-    s3://${S3_BENCH_BUCKET_NAME}/${S3_BENCH_RESULTS_PREFIX}/${DATE}.json \
-    > /dev/null 2>&1
+    results/s3_output.json \
+    s3://${S3_BENCH_BUCKET_NAME}/${S3_BENCH_RESULTS_PREFIX}/${DATE}.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -77,6 +77,7 @@ jobs:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
         S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
 
   latency-bench:
     name: Benchmark (Latency)
@@ -130,6 +131,7 @@ jobs:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
         S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
 
   cache-bench:
     name: Benchmark (Cache)
@@ -185,3 +187,4 @@ jobs:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
         S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}

--- a/.github/workflows/bench_main.yml
+++ b/.github/workflows/bench_main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main", "wf-changes/**" ]
   schedule:
-    - cron: "0 */8 * * *" # every 8 hours
+    - cron: "0 2 * * *" # Daily at 02:00 UTC
 
 permissions:
   id-token: write
@@ -14,14 +14,16 @@ jobs:
   integration:
     name: Benchmarks
     uses: ./.github/workflows/bench.yml
+    if: github.event_name != 'schedule' || github.repository == 'awslabs/mountpoint-s3'
     with:
-      ref: ${{ github.event.after }}
+      ref: ${{ github.sha }}
       publish: ${{ github.event.ref == 'refs/heads/main' }}
       s3_bench_results_prefix: ${{ github.event_name == 'schedule' && 'results/main/s3_standard' || null }}
   s3express-integration:
     name: Benchmarks (s3express)
     uses: ./.github/workflows/bench_s3express.yml
+    if: github.event_name != 'schedule' || github.repository == 'awslabs/mountpoint-s3'
     with:
-      ref: ${{ github.event.after }}
+      ref: ${{ github.sha }}
       publish: ${{ github.event.ref == 'refs/heads/main' }}
       s3_bench_results_prefix: ${{ github.event_name == 'schedule' && 'results/main/s3_express' || null }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -78,6 +78,7 @@ jobs:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
         S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
 
   latency-bench:
     name: Benchmark (Latency)
@@ -131,3 +132,4 @@ jobs:
         S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
         S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
         S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}


### PR DESCRIPTION
## Description of change

Reduce frequency so benchmarks are run once a day. Also:

* no scheduled runs on forks
* store commit id in s3
* use `github.sha` for commit id (same as in [integration tests workflow](https://github.com/awslabs/mountpoint-s3/blob/main/.github/workflows/integration_main.yml#L27), it's better [documented](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) for scheduled runs)

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No.

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
