### PR TITLE
Upload benchmark results to S3 when the check step failed

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -166,6 +166,14 @@ jobs:
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
       run: mountpoint-s3/scripts/fs_cache_bench.sh
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -180,11 +188,3 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-    - name: Save benchmark results in S3
-      if: inputs.s3_bench_results_prefix
-      run: .github/actions/scripts/save-benchmark-results.sh
-      env:
-        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
-        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
-        COMMIT_ID: ${{ inputs.ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,14 @@ jobs:
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_bench.sh
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -70,14 +78,6 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-    - name: Save benchmark results in S3
-      if: inputs.s3_bench_results_prefix
-      run: .github/actions/scripts/save-benchmark-results.sh
-      env:
-        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
-        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
-        COMMIT_ID: ${{ inputs.ref }}
 
   latency-bench:
     name: Benchmark (Latency)
@@ -110,6 +110,14 @@ jobs:
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_latency_bench.sh
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -124,14 +132,6 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-    - name: Save benchmark results in S3
-      if: inputs.s3_bench_results_prefix
-      run: .github/actions/scripts/save-benchmark-results.sh
-      env:
-        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
-        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
-        COMMIT_ID: ${{ inputs.ref }}
 
   cache-bench:
     name: Benchmark (Cache)

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -111,6 +111,14 @@ jobs:
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_latency_bench.sh
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -125,11 +133,3 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-    - name: Save benchmark results in S3
-      if: inputs.s3_bench_results_prefix
-      run: .github/actions/scripts/save-benchmark-results.sh
-      env:
-        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
-        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
-        COMMIT_ID: ${{ inputs.ref }}

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -57,6 +57,14 @@ jobs:
       run: cargo build --release
     - name: Run Benchmark
       run: mountpoint-s3/scripts/fs_bench.sh
+    - name: Save benchmark results in S3
+      if: inputs.s3_bench_results_prefix
+      run: .github/actions/scripts/save-benchmark-results.sh
+      env:
+        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
+        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
+        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
+        COMMIT_ID: ${{ inputs.ref }}
     - name: Check benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -71,14 +79,6 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
-    - name: Save benchmark results in S3
-      if: inputs.s3_bench_results_prefix
-      run: .github/actions/scripts/save-benchmark-results.sh
-      env:
-        S3_BENCH_REGION: ${{ vars.S3_BENCH_REGION }}
-        S3_BENCH_BUCKET_NAME: ${{ vars.S3_BENCH_RESULTS_BUCKET_NAME }}
-        S3_BENCH_RESULTS_PREFIX: ${{ inputs.s3_bench_results_prefix }}/${{ github.job }}
-        COMMIT_ID: ${{ inputs.ref }}
 
   latency-bench:
     name: Benchmark (Latency)


### PR DESCRIPTION
## Description of change

Recently [we've started](https://github.com/awslabs/mountpoint-s3/pull/983) uploading benchmark results to S3 alongside GH pages, and do that even for runs triggered by pull requests.

When the PR's benchmarking workflow detects a 2x drop, [it fails](https://github.com/awslabs/mountpoint-s3/actions/runs/10708948863/job/29692450294?pr=991) before reaching the step performing the s3 upload, which is unfortunate as these are the most interesting results to visualise.

Relevant issues: None

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No, just CI changes.

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

No, just CI changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
