### PR TITLE
Backwards seek window does not affect the read window

### DIFF
--- a/mountpoint-s3/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3/src/prefetch/backpressure_controller.rs
@@ -92,9 +92,9 @@ impl BackpressureController {
             // Note, that this may come from a backwards seek, so offsets observed by this method are not necessarily ascending
             BackpressureFeedbackEvent::DataRead { offset, length } => {
                 let next_read_offset = offset + length as u64;
-                let remaining_window = self.read_window_end_offset.saturating_sub(next_read_offset);
+                let remaining_window = self.read_window_end_offset.saturating_sub(next_read_offset) as usize;
                 // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
-                if remaining_window < (self.preferred_read_window_size / 2) as u64
+                if remaining_window < (self.preferred_read_window_size / 2)
                     && self.read_window_end_offset < self.request_end_offset
                 {
                     let new_read_window_end_offset = next_read_offset

--- a/mountpoint-s3/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3/src/prefetch/backpressure_controller.rs
@@ -8,7 +8,7 @@ use super::PrefetchReadError;
 #[derive(Debug)]
 pub enum BackpressureFeedbackEvent {
     /// An event where data with a certain length has been read out of the stream
-    DataRead(u64, usize),
+    DataRead { offset: u64, length: usize },
     /// An event indicating part queue stall
     PartQueueStall,
 }
@@ -90,7 +90,7 @@ impl BackpressureController {
     pub async fn send_feedback<E>(&mut self, event: BackpressureFeedbackEvent) -> Result<(), PrefetchReadError<E>> {
         match event {
             // Note, that this may come from a backwards seek, so offsets observed by this method are not necessarily ascending
-            BackpressureFeedbackEvent::DataRead(offset, length) => {
+            BackpressureFeedbackEvent::DataRead { offset, length } => {
                 let next_read_offset = offset + length as u64;
                 let remaining_window = self.read_window_end_offset.saturating_sub(next_read_offset);
                 // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.

--- a/mountpoint-s3/src/prefetch/task.rs
+++ b/mountpoint-s3/src/prefetch/task.rs
@@ -54,7 +54,9 @@ impl<E: std::error::Error + Send + Sync> RequestTask<E> {
         self.remaining -= part.len();
 
         // We read some data out of the part queue so the read window should be moved
-        self.backpressure_controller.send_feedback(DataRead(part.len())).await?;
+        self.backpressure_controller
+            .send_feedback(DataRead(part.offset(), part.len()))
+            .await?;
 
         let next_offset = part.offset() + part.len() as u64;
         let remaining_in_queue = self.available_offset().saturating_sub(next_offset) as usize;

--- a/mountpoint-s3/src/prefetch/task.rs
+++ b/mountpoint-s3/src/prefetch/task.rs
@@ -55,7 +55,10 @@ impl<E: std::error::Error + Send + Sync> RequestTask<E> {
 
         // We read some data out of the part queue so the read window should be moved
         self.backpressure_controller
-            .send_feedback(DataRead(part.offset(), part.len()))
+            .send_feedback(DataRead {
+                offset: part.offset(),
+                length: part.len(),
+            })
             .await?;
 
         let next_offset = part.offset() + part.len() as u64;


### PR DESCRIPTION
## Description of change

This change fixes the situation when the `read_window_end_offset` set on the client would be more than the configured read window above the last read offset by client application. This was happening because we were accounting some bytes from the client twice -- first time it was read from the `receiver` (client) and the second time when it was read from `current_part` (which contains bytes from backwards seek window, when backwards seek occurs).

Relevant issues: https://github.com/awslabs/mountpoint-s3/issues/987

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

This is a part of memory control change, which affects existing behaviour but not in a breaking way.

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

This is a part of memory control change, which should have a changelog entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
