### PR TITLE
Avoid extending part on backward seek

### DIFF
--- a/mountpoint-s3/src/prefetch/task.rs
+++ b/mountpoint-s3/src/prefetch/task.rs
@@ -38,9 +38,7 @@ impl<E: std::error::Error + Send + Sync> RequestTask<E> {
 
     // Push a given list of parts in front of the part queue
     pub async fn push_front(&mut self, parts: Vec<Part>) -> Result<(), PrefetchReadError<E>> {
-        // Merge all parts into one single part by pushing them to the front of the part queue.
-        // This could result in a really big part, but we normally use this only for backward seek
-        // so its size should not be bigger than the prefetcher's `max_backward_seek_distance`.
+        // Iterate backwards to push each part to the front of the part queue
         for part in parts.into_iter().rev() {
             self.remaining += part.len();
             self.part_queue.push_front(part).await?;


### PR DESCRIPTION
## Description of change

Currently, we combine parts from the seek window to `current_part` in the part queue whenever we seek backward which mean we also have to re-compute checksums for this combined part. It particularly affect read throughput in some use cases where backward seek rate is high. This change should improve the throughput for those use cases.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No, this  is a performance improvement change

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
