### PR TITLE
Fix mountpoint-s3-crt-sys build

### DIFF
--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -243,6 +243,7 @@ fn compile_crt(output_dir: &Path) -> PathBuf {
         if lib.package_name == "aws-lc" {
             builder.define("DISABLE_PERL", "ON");
             builder.define("DISABLE_GO", "ON");
+            builder.define("BUILD_TOOL", "OFF");
         }
 
         // Force compiler optimizations for aws-checksums even in debug builds to improve throughput


### PR DESCRIPTION
## Description of change

As a part of [crate size reduction](https://github.com/awslabs/mountpoint-s3/pull/989/files#diff-546af78b1f6f6db59fb0248f3a303924cda9fab7c8461fad3c61c6fc279b363fR40) we've removed some files from the package, including `crt/aws-lc/tool` which is [attempted](https://github.com/aws/aws-lc/blob/2f18797/CMakeLists.txt#L1000) to be built on ` cargo publish -p mountpoint-s3-crt-sys --dry-run --allow-dirty`. Last command fails with error now:
```
  Copying platform assembly files from /local/home/vlaad/local/mountpoint-s3/target/package/mountpoint-s3-crt-sys-0.9.0/crt/aws-lc/generated-src/linux-x86_64/crypto/ to /local/home/vlaad/local/mountpoint-s3/target/package/mountpoint-s3-crt-sys-0.9.0/target/debug/build/mountpoint-s3-crt-sys-c8536eb924979a85/out/build/aws-lc/build/crypto
  CMake Error at CMakeLists.txt:1000 (add_subdirectory):
    add_subdirectory given source "tool" which is not an existing directory.
```

After this change the publish dry-run succeeds.

Relevant issues: No

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No.

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
