### PR TITLE
Remove feature flag from network interface binding, add documentation

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -335,6 +335,26 @@ The cache directory is not reusable by other Mountpoint processes and will be cl
 When running multiple Mountpoint processes concurrently on the same host,
 you should use unique cache directories to avoid different processes interfering with the others' cache content.
 
+## Using multiple network cards
+
+By default, Mountpoint will use the network interface associated with the default route on the host (such as that specified by `ip route list`).
+
+You can use the `--bind <INTERFACE_NAME>` command-line argument to specify a different network interface for Mountpoint network requests to be routed over.
+This argument can be specified multiple times to allow requests to be fanned-out over multiple network interfaces.
+
+As an example, this command binds to two network interfaces and Mountpoint traffic will be distributed over them both:
+
+```
+mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount --bind ens0 --bind ens1
+```
+
+This feature is a work-in-progress.
+We welcome feedback on how this works for your applications and workloads.
+
+> [!NOTE]
+> This feature requires either Linux 5.7+ or running Mountpoint as the root user.
+> We recommend using a newer Linux kernel version to make use of this feature.
+
 ## Logging
 
 By default, Mountpoint emits high-severity log information to [syslog](https://datatracker.ietf.org/doc/html/rfc5424) if available on your system. You can change what level of information is logged, and to where it is logged. See [LOGGING.md](LOGGING.md) for more details on configuring logging.

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### New features
+
+* Mountpoint now supports specifying one or more network interfaces using `--bind <INTERFACE_NAME>` to be used when making requests to Amazon S3.
+  This feature is work-in-progress and we welcome feedback on it.
+
 ### Other changes
 
 * Fix an issue where `credential_process` field would not be picked up correctly when using `source_profile`. ([awslabs/aws-c-auth#245](https://github.com/awslabs/aws-c-auth/pull/245))

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -315,10 +315,9 @@ pub struct CliArgs {
     )]
     pub upload_checksums: Option<UploadChecksums>,
 
-    #[cfg(feature = "multiple-nw-iface")]
     #[clap(
         long,
-        help = "One or more network interfaces for Mountpoint to use when accessing S3. Requires Linux 5.7+ or running as root.",
+        help = "One or more network interfaces for Mountpoint to use when accessing S3. Requires Linux 5.7+ or running as root. This feature is a work-in-progress.",
         help_heading = CLIENT_OPTIONS_HEADER,
         value_name = "NETWORK_INTERFACE",
     )]


### PR DESCRIPTION
## Description of change

Remove the feature flag on multi-NIC support and add documentation.

This feature is a work-in-progress but we want to make it available to try and collect feedback.

Relevant issues: #815

## Does this change impact existing behavior?

No change to existing behavior, adds support to specify one or more network interfaces.


## Does this change need a changelog entry in any of the crates?

Yes, in Mountpoint's main changelog. It is added.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
