### PR TITLE
Enable backpressure in mock-mount-s3 binary

### DIFF
--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -39,7 +39,8 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
         bucket: args.bucket_name.clone(),
         part_size: args.part_size as usize,
         unordered_list_seed: None,
-        ..Default::default()
+        enable_backpressure: true,
+        initial_read_window_size: 1024 * 1024 + 128 * 1024, // matching real MP
     };
     let client = ThroughputMockClient::new(config, max_throughput_gbps);
 


### PR DESCRIPTION
## Description of change

For the mock binary, it should behave the same way as Mountpoint does in terms of using the new backpressure mechanism. This change simply configures backpressure in mock client for mock binary only (leaving defaults the same for raw mock client).

The new value doesn't quite match Mountpoint

Relevant issues: N/A

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
