### PR TITLE
Update mock-mount-s3 to require '--max-throughput-gbps' argument

### DIFF
--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -36,7 +36,7 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
 
     let Some(max_throughput_gbps) = args.maximum_throughput_gbps else {
         return Err(anyhow!(
-            "must set --max-throughput-gbps when using mock-mount-s3 binary"
+            "must set --maximum-throughput-gbps when using mock-mount-s3 binary"
         ));
     };
     tracing::info!("mock client target network throughput {max_throughput_gbps} Gbps");


### PR DESCRIPTION
## Description of change

It was unclear to me when first using `mock-mount-s3` that it will limit throughput based on the value for `--max-throughput-gbps`, and that this will default to 10Gbps as real Mountpoint does if it can't detect the correct value.

This change requires the argument to be specified, so that the user can be forced to acknowledge this default or choose a better value for the use case.

Relevant issues: N/A

## Does this change impact existing behavior?

It does, but only for the mock binary. You now must specify `--max-throughput-gbps <Gbps>`.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
