### PR TITLE
Fix bind command-line argument being ignored

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Other changes
 
-* Fix an issue where `--bind` argument was would not be picked up correctly. ([#1020](https://github.com/awslabs/mountpoint-s3/pull/1020))
+* Fix an issue where `--bind` argument would not be picked up correctly. ([#1020](https://github.com/awslabs/mountpoint-s3/pull/1020))
 
 ## v1.9.0
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other changes
+
+* Fix an issue where `--bind` argument was would not be picked up correctly. ([#1020](https://github.com/awslabs/mountpoint-s3/pull/1020))
+
 ## v1.9.0
 
 ### New features

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -81,7 +81,6 @@ built = { version = "0.7.1", features = ["git2"] }
 [features]
 # Unreleased feature flags
 event_log = []
-multiple-nw-iface = []
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -642,7 +642,6 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
     if let Some(ttl) = args.metadata_ttl {
         user_agent.key_value("mp-cache-ttl", &ttl.to_string());
     }
-    #[cfg(feature = "multiple-nw-iface")]
     if let Some(interfaces) = &args.bind {
         user_agent.key_value("mp-nw-interfaces", &interfaces.len().to_string());
     }
@@ -667,7 +666,6 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
         .read_backpressure(true)
         .initial_read_window(initial_read_window_size)
         .user_agent(user_agent);
-    #[cfg(feature = "multiple-nw-iface")]
     if let Some(interfaces) = &args.bind {
         client_config = client_config.network_interface_names(interfaces.clone());
     }


### PR DESCRIPTION
## Description of change

The `--bind` argument was not actually configuring the network interfaces in standard release builds of Mountpoint, as it still had the feature flag hiding the configuration.

This change fixes the issue for now. In the meantime, I'll take some time to understand how this type of issue can be avoided in future.

Relevant issues: #815

## Does this change impact existing behavior?

Fixes issue where `--bind` argument wasn't respected.

## Does this change need a changelog entry in any of the crates?

Added fix note in change log.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
