### PR TITLE
Add temporary way to configure amount of data prefetched per file handle

### DIFF
--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -184,10 +184,10 @@ impl Default for PrefetcherConfig {
 /// This unstable override is expected to be removed once adaptive prefetching based on available memory is available:
 /// https://github.com/awslabs/mountpoint-s3/issues/987
 fn determine_max_read_size() -> usize {
-    let env_var_key = "UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE";
+    const ENV_VAR_KEY: &str = "UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE";
     const DEFAULT_READ_WINDOW_SIZE: usize = 2 * 1024 * 1024 * 1024;
 
-    match std::env::var_os(env_var_key) {
+    match std::env::var_os(ENV_VAR_KEY) {
         Some(val) => match val.to_string_lossy().parse() {
             Ok(val) => {
                 tracing::warn!(
@@ -198,7 +198,7 @@ fn determine_max_read_size() -> usize {
             }
             Err(_) => {
                 tracing::warn!(
-                    "{env_var_key} did not contain a valid positive integer \
+                    "{ENV_VAR_KEY} did not contain a valid positive integer \
                         for prefetch bytes, using {DEFAULT_READ_WINDOW_SIZE} bytes instead",
                 );
                 DEFAULT_READ_WINDOW_SIZE

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -163,7 +163,7 @@ impl Default for PrefetcherConfig {
     #[allow(clippy::identity_op)]
     fn default() -> Self {
         Self {
-            max_read_window_size: 2 * 1024 * 1024 * 1024,
+            max_read_window_size: determine_max_read_size(),
             sequential_prefetch_multiplier: 8,
             read_timeout: Duration::from_secs(60),
             // We want these large enough to tolerate a single out-of-order Linux readahead, which
@@ -173,6 +173,38 @@ impl Default for PrefetcherConfig {
             max_forward_seek_wait_distance: 16 * 1024 * 1024,
             max_backward_seek_distance: 1 * 1024 * 1024,
         }
+    }
+}
+
+/// Provide the maximum read size for the prefetcher, for which there is one prefetcher per file handle.
+///
+/// This allows a way to override the prefetch window rather than using the hardcoded default within Mountpoint.
+/// We do not recommend using the override, and it may be removed at any time.
+///
+/// This unstable override is expected to be removed once adaptive prefetching based on available memory is available:
+/// https://github.com/awslabs/mountpoint-s3/issues/987
+fn determine_max_read_size() -> usize {
+    let env_var_key = "UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE";
+    const DEFAULT_READ_WINDOW_SIZE: usize = 2 * 1024 * 1024 * 1024;
+
+    match std::env::var_os(env_var_key) {
+        Some(val) => match val.to_string_lossy().parse() {
+            Ok(val) => {
+                tracing::warn!(
+                    "successfully overridden prefetch read window size \
+                        with new value {val} bytes from unstable environment config",
+                );
+                val
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "{env_var_key} did not contain a valid positive integer \
+                        for prefetch bytes, using {DEFAULT_READ_WINDOW_SIZE} bytes instead",
+                );
+                DEFAULT_READ_WINDOW_SIZE
+            }
+        },
+        None => DEFAULT_READ_WINDOW_SIZE,
     }
 }
 

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -181,6 +181,10 @@ impl Default for PrefetcherConfig {
 /// This allows a way to override the prefetch window rather than using the hardcoded default within Mountpoint.
 /// We do not recommend using the override, and it may be removed at any time.
 ///
+/// This parameter may not be accurately adopted when using small values.
+/// When prefetching starts, it will fetch 1MiB + 128KiB at time of writing.
+/// This parameter will only be used when scaling up the prefetch window.
+///
 /// This unstable override is expected to be removed once adaptive prefetching based on available memory is available:
 /// https://github.com/awslabs/mountpoint-s3/issues/987
 fn determine_max_read_size() -> usize {


### PR DESCRIPTION
## Description of change

In some use cases (such as those in multi-tenant settings), a very large number of file handles may be opened concurrently. While the default prefetching works fine for environments with fewer open file handles, we see that Mountpoint can use far too much memory otherwise.

This change introduces a temporary way to scale down the maximum amount that Mountpoint will prefetch per file handle. Today, the default is 2GiB and the new parameter can be used to reduce that.

The end goal is to make this parameter obsolete through the work in #987 to make prefetching scale down when available memory is low.

Relevant issues: #502, #566, #630, #987

## Does this change impact existing behavior?

No existing behavior is impacted. This allows a temporary way to override the prefetch window size.

When it is removed, it will not trigger any issue (so long as the root cause is solved on memory usage). We use an environment variable such that this can be removed without breaking deployments.

## Does this change need a changelog entry in any of the crates?

This change does not add a changelog entry as we do not recommend using this override.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
