### PR TITLE
Add support for concurrent downloads to prefetch_benchmark example

### DIFF
--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -7,7 +8,7 @@ use futures::executor::{block_on, ThreadPool};
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::types::ETag;
-use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -32,7 +33,6 @@ fn main() {
         .about("Download a single key from S3 and ignore its contents")
         .arg(Arg::new("bucket").required(true))
         .arg(Arg::new("key").required(true))
-        .arg(Arg::new("size").required(true))
         .arg(
             Arg::new("throughput-target-gbps")
                 .long("throughput-target-gbps")
@@ -43,6 +43,7 @@ fn main() {
                 .long("part-size")
                 .help("Part size for multi-part GET and PUT"),
         )
+        .arg(Arg::new("read-size").long("read-size").help("Size of read requests"))
         .arg(
             Arg::new("iterations")
                 .long("iterations")
@@ -53,23 +54,26 @@ fn main() {
 
     let bucket = matches.get_one::<String>("bucket").unwrap();
     let key = matches.get_one::<String>("key").unwrap();
-    let size = matches
-        .get_one::<String>("size")
-        .unwrap()
-        .parse::<u64>()
-        .expect("size must be u64");
     let throughput_target_gbps = matches
         .get_one::<String>("throughput-target-gbps")
         .map(|s| s.parse::<f64>().expect("throughput target must be an f64"));
     let part_size = matches
         .get_one::<String>("part-size")
         .map(|s| s.parse::<usize>().expect("part size must be a usize"));
+    let read_size = matches
+        .get_one::<String>("read-size")
+        .map(|s| s.parse::<usize>().expect("read size must be a usize"))
+        .unwrap_or(128 * 1024);
     let iterations = matches
         .get_one::<String>("iterations")
         .map(|s| s.parse::<usize>().expect("iterations must be a number"));
     let region = matches.get_one::<String>("region").unwrap();
 
-    let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
+    let initial_read_window_size = 1024 * 1024 + 128 * 1024;
+    let mut config = S3ClientConfig::new()
+        .endpoint_config(EndpointConfig::new(region))
+        .read_backpressure(true)
+        .initial_read_window(initial_read_window_size);
     if let Some(throughput_target_gbps) = throughput_target_gbps {
         config = config.throughput_target_gbps(throughput_target_gbps);
     }
@@ -78,28 +82,30 @@ fn main() {
     }
     let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
 
+    let head_object_result = block_on(client.head_object(bucket, key)).expect("HeadObject failed");
+    let size = head_object_result.object.size;
+    let etag = ETag::from_str(&head_object_result.object.etag).unwrap();
+
     for i in 0..iterations.unwrap_or(1) {
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let manager = default_prefetch(runtime, Default::default());
-        let received_size = Arc::new(AtomicU64::new(0));
+        let received_bytes = Arc::new(AtomicU64::new(0));
 
         let start = Instant::now();
 
-        let mut request = manager.prefetch(client.clone(), bucket, key, size, ETag::for_tests());
+        let mut request = manager.prefetch(client.clone(), bucket, key, size, etag.clone());
         block_on(async {
-            loop {
-                let offset = received_size.load(Ordering::SeqCst);
-                if offset >= size {
-                    break;
-                }
-                let bytes = request.read(offset, 1 << 20).await.unwrap();
-                received_size.fetch_add(bytes.len() as u64, Ordering::SeqCst);
+            let mut offset = 0;
+            while offset < size {
+                let bytes = request.read(offset, read_size).await.unwrap();
+                offset += bytes.len() as u64;
+                received_bytes.fetch_add(bytes.len() as u64, Ordering::SeqCst);
             }
         });
 
         let elapsed = start.elapsed();
 
-        let received_size = received_size.load(Ordering::SeqCst);
+        let received_size = received_bytes.load(Ordering::SeqCst);
         println!(
             "{}: received {} bytes in {:.2}s: {:.2}MiB/s",
             i,

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Instant;
 
 use clap::{Arg, Command};
-use futures::executor::{block_on, ThreadPool};
+use futures::executor::block_on;
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::types::ETag;
@@ -97,7 +97,7 @@ fn main() {
     let etag = ETag::from_str(&head_object_result.object.etag).unwrap();
 
     for i in 0..iterations.unwrap_or(1) {
-        let runtime = ThreadPool::builder().pool_size(downloads).create().unwrap();
+        let runtime = client.event_loop_group();
         let manager = default_prefetch(runtime, Default::default());
         let received_bytes = Arc::new(AtomicU64::new(0));
 


### PR DESCRIPTION
## Description of change

Add a new optional `--downloads <N>` flag to the `client_benchmark` example binary in `mountpoint-s3-client`, which controls the number of concurrent downloads to perform. If omitted, it defaults to `N = 1` which reproduces the previous behavior.

Additional changes:
* Performs an initial HEAD request to determine the object size (and remove the `--size` flag)
* Introduce a `--read-size` flag to configure the read buffer size

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No. The change only affects one of the example binaries.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
