### PR TITLE
Build dockerfile.source from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 CRATES = mountpoint-s3-crt-sys mountpoint-s3-crt mountpoint-s3-client mountpoint-s3
 RUST_FEATURES ?= fuse_tests
 
+IMAGE?=$(REGISTRY)/${IMAGE_NAME}
+
 .PHONY: all
 all:
 	cargo build --all-targets
@@ -67,3 +69,12 @@ DISABLED_LINTS += -A clippy::arc-with-non-send-sync  # https://github.com/propte
 clippy:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
 	cargo clippy $$packages --no-deps --all-targets --all-features -- -D warnings -D clippy::all $(DISABLED_LINTS)
+
+
+.PHONY: build-image
+build-image:
+	DOCKER_BUILDKIT=1 docker buildx build -t=${IMAGE}:${TAG} --platform=${PLATFORM} -f docker/Dockerfile.source .
+
+.PHONY: push-image
+push-image:
+	docker push ${IMAGE}:${TAG}

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -1,36 +1,59 @@
-FROM amazonlinux:2023 as builder
+FROM public.ecr.aws/docker/library/centos:7 AS builder
 
-# Install build tools
-RUN dnf upgrade -y && \
-    dnf install -y \
+# Need this because of Centos 7 reached EOL on July 1, 2024 and mirrorlist.centos.org does not exist anymore.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
+RUN yum install -y epel-release centos-release-scl
+
+# Fix up the newly added SCL repos, which don't have altarch baseurls
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+RUN if [ `uname -p` == "aarch64" ]; then sed -i s+centos/7+altarch/7+g /etc/yum.repos.d/*.repo; fi
+
+RUN yum install -y \
         fuse \
         fuse-devel \
+        make \
         cmake3 \
-        clang \
         git \
-        pkg-config && \
-    dnf clean all
+        pkgconfig \
+        dpkg \
+        fakeroot \
+        tar \
+        wget \
+        devtoolset-10-gcc \
+        devtoolset-10-gcc-c++ \
+        llvm-toolset-7.0-clang \
+        && \
+    yum clean all
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     source "$HOME/.cargo/env"
 
+ENV PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/devtoolset-10/root/usr/bin:/root/.cargo/bin:$PATH"
+ENV LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib"
+ENV CC="/opt/rh/devtoolset-10/root/usr/bin/gcc"
+ENV CXX="/opt/rh/devtoolset-10/root/usr/bin/g++"
+
+COPY . mountpoint-s3
+
 # Build mountpoint-s3
-RUN git clone --recurse-submodules https://github.com/awslabs/mountpoint-s3.git && \
-    source "$HOME/.cargo/env" && \
+RUN source "$HOME/.cargo/env" && \
     cd mountpoint-s3 && \
     cargo build --release
 
+FROM public.ecr.aws/docker/library/centos:7 AS release
 
-
-FROM amazonlinux:2023 as release
-COPY --from=builder /mountpoint-s3/target/release/mount-s3 /mount-s3
-
-RUN dnf upgrade -y && \
-    dnf install -y fuse fuse-libs && \
-    dnf clean all
+COPY --from=builder /mountpoint-s3/target/release/mount-s3 /
+COPY --from=builder /lib64/libfuse.so.2 /lib64
+COPY --from=builder /lib64/libgcc_s.so.1 /lib64
 
 RUN echo "user_allow_other" >> /etc/fuse.conf
+ENV PATH="/:$PATH"
 
 # Run in foreground mode so that the container can be detached without exiting Mountpoint
 ENTRYPOINT [ "/mount-s3", "-f" ]


### PR DESCRIPTION
## Description of change

- Dockerfile.source now builds based on `centos:7`
- Add `/` to path so you can run `mount-s3` without a /
- Adds `build-image` and `push-image` targets to makefile



## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

Result from `Dockerfile.source` now builds from Centos rather than AL2023, so has the same support as our release builds.

## Does this change need a changelog entry in any of the crates?

No. `Dockerfile.source` is used as an example rather than an end-user tool

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
