### PR TITLE
Update aws-c-s3 submodule to latest release

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other changes
+
+* Inaccurate reporting of `s3.client.buffer_pool.primary_allocated` CRT statistic is fixed. ([awslabs/aws-c-s3#453](https://github.com/awslabs/aws-c-s3/pull/453))
+
 ## v0.10.0 (September 12, 2024)
 
 ### Breaking changes


### PR DESCRIPTION
## Description of change

Update CRT modules, notably to include:
- https://github.com/awslabs/aws-c-s3/pull/453

Note, a change to `aws-lc` pushes us way beyond the package size limit. I've omitted that update from this change.

<details>
<summary>CRT Changes</summary>

```
Submodule mountpoint-s3-crt-sys/crt/aws-c-s3 502cd624..aede1d8c:
  > Fix MemoryLimit primary_allocated stat (#453)
  > Auto - Update S3 Ruleset & Partition (#451)
```

</details>

Relevant issues: N/A

## Does this change impact existing behavior?

It fixes an inaccurate reporting of used primary memory in CRT.

## Does this change need a changelog entry in any of the crates?

I've added a changelog note to the `mountpoint-s3-client` crate as this is a metric we publish.

I've not added a note to Mountpoint main changelog as I do not believe it is an important enough change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
