### PR TITLE
Expose `s3.client.buffer_pool.forced_used` metric

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Other changes
 
 * Inaccurate reporting of `s3.client.buffer_pool.primary_allocated` CRT statistic is fixed. ([awslabs/aws-c-s3#453](https://github.com/awslabs/aws-c-s3/pull/453))
+* Expose `s3.client.buffer_pool.forced_used` metric which account for buffer allocations that could exceed memory limit in the CRT buffer pool. ([#1025](https://github.com/awslabs/mountpoint-s3/pull/1025))
 
 ## v0.10.0 (September 12, 2024)
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -776,6 +776,7 @@ impl S3CrtClientInner {
         metrics::gauge!("s3.client.buffer_pool.primary_num_blocks").set(buffer_pool_stats.primary_num_blocks as f64);
         metrics::gauge!("s3.client.buffer_pool.secondary_reserved").set(buffer_pool_stats.secondary_reserved as f64);
         metrics::gauge!("s3.client.buffer_pool.secondary_used").set(buffer_pool_stats.secondary_used as f64);
+        metrics::gauge!("s3.client.buffer_pool.forced_used").set(buffer_pool_stats.forced_used as f64);
     }
 
     fn next_request_counter(&self) -> u64 {

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -839,6 +839,9 @@ pub struct BufferPoolUsageStats {
 
     /// Secondary mem reserved. Accurate, maps directly to base allocator.
     pub secondary_used: u64,
+
+    /// Bytes used in "forced" buffers (created even if they exceed memory limits).
+    pub forced_used: u64,
 }
 
 impl Client {
@@ -951,6 +954,7 @@ impl Client {
         let primary_num_blocks = inner_stats.primary_num_blocks as u64;
         let secondary_reserved = inner_stats.secondary_reserved as u64;
         let secondary_used = inner_stats.secondary_used as u64;
+        let forced_used = inner_stats.forced_used as u64;
 
         BufferPoolUsageStats {
             mem_limit,
@@ -961,6 +965,7 @@ impl Client {
             primary_num_blocks,
             secondary_reserved,
             secondary_used,
+            forced_used,
         }
     }
 


### PR DESCRIPTION
## Description of change

The CRT allows buffers to be created even if they exceed memory limit in some cases and reports them in `forced_used` stat. This change exposes the metric as `s3.client.buffer_pool.forced_used` in mountpoint-s3-client.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

Yes, mountpoint-s3-client crate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
