### PR TITLE
Make cache writes async

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -451,7 +451,7 @@ pub fn main<ClientBuilder, Client, Runtime>(client_builder: ClientBuilder) -> an
 where
     ClientBuilder: FnOnce(&CliArgs) -> anyhow::Result<(Client, Runtime, S3Personality)>,
     Client: ObjectClient + Send + Sync + 'static,
-    Runtime: Spawn + Send + Sync + 'static,
+    Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     let args = CliArgs::parse();
     let successful_mount_msg = format!(
@@ -700,7 +700,7 @@ fn mount<ClientBuilder, Client, Runtime>(args: CliArgs, client_builder: ClientBu
 where
     ClientBuilder: FnOnce(&CliArgs) -> anyhow::Result<(Client, Runtime, S3Personality)>,
     Client: ObjectClient + Send + Sync + 'static,
-    Runtime: Spawn + Send + Sync + 'static,
+    Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     tracing::info!("mount-s3 {}", build_info::FULL_VERSION);
     tracing::debug!("{:?}", args);

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -8,6 +8,7 @@ mod cache_directory;
 mod disk_data_cache;
 mod in_memory_data_cache;
 
+use async_trait::async_trait;
 use thiserror::Error;
 
 pub use crate::checksums::ChecksummedBytes;
@@ -39,11 +40,12 @@ pub type DataCacheResult<Value> = Result<Value, DataCacheError>;
 ///
 /// TODO: Deletion and eviction of cache entries.
 /// TODO: Some version information (ETag) independent from [ObjectId] to allow smarter eviction?
+#[async_trait]
 pub trait DataCache {
     /// Get block of data from the cache for the given [ObjectId] and [BlockIndex], if available.
     ///
     /// Operation may fail due to errors, or return [None] if the block was not available in the cache.
-    fn get_block(
+    async fn get_block(
         &self,
         cache_key: &ObjectId,
         block_idx: BlockIndex,
@@ -51,7 +53,7 @@ pub trait DataCache {
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].
-    fn put_block(
+    async fn put_block(
         &self,
         cache_key: ObjectId,
         block_idx: BlockIndex,

--- a/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/in_memory_data_cache.rs
@@ -3,13 +3,15 @@
 use std::collections::HashMap;
 use std::default::Default;
 
+use async_trait::async_trait;
+
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 use crate::object::ObjectId;
-use crate::sync::RwLock;
+use crate::sync::AsyncRwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
 pub struct InMemoryDataCache {
-    data: RwLock<HashMap<ObjectId, HashMap<BlockIndex, ChecksummedBytes>>>,
+    data: AsyncRwLock<HashMap<ObjectId, HashMap<BlockIndex, ChecksummedBytes>>>,
     block_size: u64,
 }
 
@@ -23,14 +25,15 @@ impl InMemoryDataCache {
     }
 
     /// Get number of caching blocks for the given cache key.
-    pub fn block_count(&self, cache_key: &ObjectId) -> usize {
-        let data = self.data.read().unwrap();
+    pub async fn block_count(&self, cache_key: &ObjectId) -> usize {
+        let data = self.data.read().await;
         data.get(cache_key).map_or(0, |cache| cache.len())
     }
 }
 
+#[async_trait]
 impl DataCache for InMemoryDataCache {
-    fn get_block(
+    async fn get_block(
         &self,
         cache_key: &ObjectId,
         block_idx: BlockIndex,
@@ -39,12 +42,12 @@ impl DataCache for InMemoryDataCache {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
         }
-        let data = self.data.read().unwrap();
+        let data = self.data.read().await;
         let block_data = data.get(cache_key).and_then(|blocks| blocks.get(&block_idx)).cloned();
         Ok(block_data)
     }
 
-    fn put_block(
+    async fn put_block(
         &self,
         cache_key: ObjectId,
         block_idx: BlockIndex,
@@ -54,7 +57,7 @@ impl DataCache for InMemoryDataCache {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
         }
-        let mut data = self.data.write().unwrap();
+        let mut data = self.data.write().await;
         let blocks = data.entry(cache_key).or_default();
         blocks.insert(block_idx, bytes);
         Ok(())
@@ -72,8 +75,8 @@ mod tests {
     use bytes::Bytes;
     use mountpoint_s3_client::types::ETag;
 
-    #[test]
-    fn test_put_get() {
+    #[tokio::test]
+    async fn test_put_get() {
         let data_1 = Bytes::from_static(b"Hello world");
         let data_1 = ChecksummedBytes::new(data_1.clone());
         let data_2 = Bytes::from_static(b"Foo bar");
@@ -86,7 +89,7 @@ mod tests {
         let cache_key_1 = ObjectId::new("a".into(), ETag::for_tests());
         let cache_key_2 = ObjectId::new("b".into(), ETag::for_tests());
 
-        let block = cache.get_block(&cache_key_1, 0, 0).expect("cache is accessible");
+        let block = cache.get_block(&cache_key_1, 0, 0).await.expect("cache is accessible");
         assert!(
             block.is_none(),
             "no entry should be available to return but got {:?}",
@@ -96,9 +99,11 @@ mod tests {
         // PUT and GET, OK?
         cache
             .put_block(cache_key_1.clone(), 0, 0, data_1.clone())
+            .await
             .expect("cache is accessible");
         let entry = cache
             .get_block(&cache_key_1, 0, 0)
+            .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -109,9 +114,11 @@ mod tests {
         // PUT AND GET a second file, OK?
         cache
             .put_block(cache_key_2.clone(), 0, 0, data_2.clone())
+            .await
             .expect("cache is accessible");
         let entry = cache
             .get_block(&cache_key_2, 0, 0)
+            .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -122,9 +129,11 @@ mod tests {
         // PUT AND GET a second block in a cache entry, OK?
         cache
             .put_block(cache_key_1.clone(), 1, block_size, data_3.clone())
+            .await
             .expect("cache is accessible");
         let entry = cache
             .get_block(&cache_key_1, 1, block_size)
+            .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(
@@ -135,6 +144,7 @@ mod tests {
         // Entry 1's first block still intact
         let entry = cache
             .get_block(&cache_key_1, 0, 0)
+            .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
         assert_eq!(

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -137,7 +137,7 @@ pub fn caching_prefetch<Cache, Runtime>(
 ) -> CachingPrefetcher<Cache, Runtime>
 where
     Cache: DataCache + Send + Sync + 'static,
-    Runtime: Spawn + Send + Sync + 'static,
+    Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     let part_stream = CachingPartStream::new(runtime, cache);
     Prefetcher::new(part_stream, prefetcher_config)

--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -454,16 +454,12 @@ mod tests {
         };
         assert!(first_read_count > 0);
 
-        fn get_block_count(cache: &InMemoryDataCache, id: &ObjectId) -> usize {
-            block_on(async move { cache.block_count(id).await })
-        }
-
         // Wait until all blocks are saved to the cache before spawning a new request
         let expected_block_count = expected_end_block - expected_start_block;
-        while get_block_count(&stream.cache, &id) < expected_block_count {
+        while stream.cache.block_count(&id) < expected_block_count {
             thread::sleep(Duration::from_millis(10));
         }
-        assert_eq!(expected_block_count, get_block_count(&stream.cache, &id));
+        assert_eq!(expected_block_count, stream.cache.block_count(&id));
 
         let second_read_count = {
             // Second request (from cache)

--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -39,7 +39,7 @@ impl<Cache, Runtime> CachingPartStream<Cache, Runtime> {
 impl<Cache, Runtime> ObjectPartStream for CachingPartStream<Cache, Runtime>
 where
     Cache: DataCache + Send + Sync + 'static,
-    Runtime: Spawn,
+    Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     fn spawn_get_object_request<Client>(
         &self,
@@ -62,7 +62,13 @@ where
         trace!(?range, "spawning request");
 
         let request_task = {
-            let request = CachingRequest::new(client.clone(), self.cache.clone(), backpressure_limiter, config);
+            let request = CachingRequest::new(
+                client.clone(),
+                self.cache.clone(),
+                self.runtime.clone(),
+                backpressure_limiter,
+                config,
+            );
             let span = debug_span!("prefetch", ?range);
             request.get_from_cache(range, part_queue_producer).instrument(span)
         };
@@ -74,27 +80,31 @@ where
 }
 
 #[derive(Debug)]
-struct CachingRequest<Client: ObjectClient, Cache> {
+struct CachingRequest<Client: ObjectClient, Cache, Runtime: Spawn> {
     client: Client,
     cache: Arc<Cache>,
+    runtime: Runtime,
     backpressure_limiter: BackpressureLimiter,
     config: RequestTaskConfig,
 }
 
-impl<Client, Cache> CachingRequest<Client, Cache>
+impl<Client, Cache, Runtime> CachingRequest<Client, Cache, Runtime>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
-    Cache: DataCache + Send + Sync,
+    Cache: DataCache + Send + Sync + 'static,
+    Runtime: Spawn + Clone,
 {
     fn new(
         client: Client,
         cache: Arc<Cache>,
+        runtime: Runtime,
         backpressure_limiter: BackpressureLimiter,
         config: RequestTaskConfig,
     ) -> Self {
         Self {
             client,
             cache,
+            runtime,
             backpressure_limiter,
             config,
         }
@@ -210,8 +220,8 @@ where
             original_range: range,
             block_index: block_range.start,
             block_offset: block_range.start * block_size,
-            buffer: ChecksummedBytes::default(),
             cache: self.cache.clone(),
+            runtime: self.runtime.clone(),
         };
         part_composer.try_compose_parts(request_stream).await;
     }
@@ -228,20 +238,21 @@ where
     }
 }
 
-struct CachingPartComposer<E: std::error::Error, Cache> {
+struct CachingPartComposer<E: std::error::Error, Cache, Runtime: Spawn> {
     part_queue_producer: PartQueueProducer<E>,
     cache_key: ObjectId,
     original_range: RequestRange,
     block_index: u64,
     block_offset: u64,
-    buffer: ChecksummedBytes,
     cache: Arc<Cache>,
+    runtime: Runtime,
 }
 
-impl<E, Cache> CachingPartComposer<E, Cache>
+impl<E, Cache, Runtime> CachingPartComposer<E, Cache, Runtime>
 where
     E: std::error::Error + Send + Sync,
-    Cache: DataCache + Send + Sync,
+    Cache: DataCache + Send + Sync + 'static,
+    Runtime: Spawn,
 {
     async fn try_compose_parts(&mut self, request_stream: impl Stream<Item = RequestReaderOutput<E>>) {
         if let Err(e) = self.compose_parts(request_stream).await {
@@ -257,15 +268,16 @@ where
     ) -> Result<(), PrefetchReadError<E>> {
         let key = self.cache_key.key();
         let block_size = self.cache.block_size();
+        let mut buffer = ChecksummedBytes::default();
 
         pin_mut!(request_stream);
         while let Some(next) = request_stream.next().await {
             assert!(
-                self.buffer.len() < block_size as usize,
+                buffer.len() < block_size as usize,
                 "buffer should be flushed when we get a full block"
             );
             let (offset, body) = next?;
-            let expected_offset = self.block_offset + self.buffer.len() as u64;
+            let expected_offset = self.block_offset + buffer.len() as u64;
             if offset != expected_offset {
                 warn!(key, offset, expected_offset, "wrong offset for GetObject body part");
                 return Err(PrefetchReadError::GetRequestReturnedWrongOffset {
@@ -278,7 +290,7 @@ where
             let mut body: Bytes = body.into();
             let mut offset = offset;
             while !body.is_empty() {
-                let remaining = (block_size as usize).saturating_sub(self.buffer.len()).min(body.len());
+                let remaining = (block_size as usize).saturating_sub(buffer.len()).min(body.len());
                 let chunk: ChecksummedBytes = body.split_to(remaining).into();
 
                 // We need to return some bytes to the part queue even before we can fill an entire caching block because
@@ -297,66 +309,51 @@ where
                     self.part_queue_producer.push(Ok(part));
                 }
                 offset += chunk.len() as u64;
-                self.buffer
+                buffer
                     .extend(chunk)
                     .inspect_err(|e| warn!(key, error=?e, "integrity check for body part failed"))?;
-                if self.buffer.len() < block_size as usize {
+                if buffer.len() < block_size as usize {
                     break;
                 }
 
                 // We have a full block: write it to the cache, send it to the queue, and flush the buffer.
-                update_cache(
-                    self.cache.as_ref(),
-                    &self.buffer,
-                    self.block_index,
-                    self.block_offset,
-                    &self.cache_key,
-                )
-                .await;
+                self.update_cache(buffer, self.block_index, self.block_offset, &self.cache_key);
                 self.block_index += 1;
                 self.block_offset += block_size;
-                self.buffer = ChecksummedBytes::default();
+                buffer = ChecksummedBytes::default();
             }
         }
 
-        if !self.buffer.is_empty() {
+        if !buffer.is_empty() {
             // If we still have data in the buffer, this must be the last block for this object,
             // which can be smaller than block_size (and ends at the end of the object).
             assert_eq!(
-                self.block_offset as usize + self.buffer.len(),
+                self.block_offset as usize + buffer.len(),
                 self.original_range.object_size(),
                 "a partial block is only allowed at the end of the object"
             );
             // Write the last block to the cache.
-            update_cache(
-                self.cache.as_ref(),
-                &self.buffer,
-                self.block_index,
-                self.block_offset,
-                &self.cache_key,
-            )
-            .await;
+            self.update_cache(buffer, self.block_index, self.block_offset, &self.cache_key);
         }
         Ok(())
     }
-}
 
-async fn update_cache<Cache: DataCache + Send + Sync>(
-    cache: &Cache,
-    block: &ChecksummedBytes,
-    block_index: u64,
-    block_offset: u64,
-    object_id: &ObjectId,
-) {
-    // TODO: consider updating the cache asynchronously
-    let start = Instant::now();
-    if let Err(error) = cache
-        .put_block(object_id.clone(), block_index, block_offset, block.clone())
-        .await
-    {
-        warn!(key=?object_id, block_index, ?error, "failed to update cache");
+    fn update_cache(&self, block: ChecksummedBytes, block_index: u64, block_offset: u64, object_id: &ObjectId) {
+        let object_id = object_id.clone();
+        let cache = self.cache.clone();
+        self.runtime
+            .spawn(async move {
+                let start = Instant::now();
+                if let Err(error) = cache
+                    .put_block(object_id.clone(), block_index, block_offset, block)
+                    .await
+                {
+                    warn!(key=?object_id, block_index, ?error, "failed to update cache");
+                }
+                metrics::histogram!("prefetch.cache_update_duration_us").record(start.elapsed().as_micros() as f64);
+            })
+            .unwrap();
     }
-    metrics::histogram!("prefetch.cache_update_duration_us").record(start.elapsed().as_micros() as f64);
 }
 
 /// Creates a Part that can be streamed to the prefetcher if the given bytes


### PR DESCRIPTION
## Description of change

Spawn separate tasks to update cache blocks, rather than writing synchronously and blocking the read path.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
