### PR TITLE
Add new 'mock' feature for 'mock-mount-s3' binary

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -87,6 +87,8 @@ fuse_tests = []
 s3_tests = []
 s3express_tests = []
 shuttle = []
+# Other feature flags
+mock = ["mountpoint-s3-client/mock", "futures/thread-pool"]
 
 [[bin]]
 name = "mount-s3"
@@ -95,4 +97,4 @@ path = "src/main.rs"
 [[bin]]
 name = "mock-mount-s3"
 path = "src/bin/mock-mount-s3.rs"
-required-features = ["mountpoint-s3-client/mock"]
+required-features = ["mock"]


### PR DESCRIPTION
## Description of change

Without this change, we get a compilation error due to missing dependencies:

```
   Compiling mountpoint-s3-crt v0.9.0 (/Users/djonesoa/devel/mountpoint-s3/mountpoint-s3-crt)
error[E0432]: unresolved import `futures::executor::ThreadPool`
   --> mountpoint-s3/src/bin/mock-mount-s3.rs:13:5
    |
13  | use futures::executor::ThreadPool;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ThreadPool` in `executor`
    |
note: found an item that was configured out
   --> /Users/djonesoa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-0.3.30/src/lib.rs:203:32
    |
203 |     pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
    |                                ^^^^^^^^^^
    = note: the item is gated behind the `thread-pool` feature

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mountpoint-s3` (bin "mock-mount-s3") due to 1 previous error
```

This change adds a new `mock` feature to the `mountpoint-s3` crate, which implies both `mountpoint-s3-client/mock` and `futures/thread-pool`. We mark the `mock-mount-s3` client as requiring the `mock` feature, so building will fail as follows:

```
❯ cargo run --bin mock-mount-s3 -- sthree-test ~/mnt/s3                
error: target `mock-mount-s3` in package `mountpoint-s3` requires the features: `mock`
Consider enabling them by passing, e.g., `--features="mock"`
```

By building with the feature enabled, building completes.

```
❯ cargo build --bin mock-mount-s3 --features mock   
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
```

Relevant issues: #1018

## Does this change impact existing behavior?

It changes the features required to build the `mock-mount-s3` binary. This is not stable.

## Does this change need a changelog entry in any of the crates?

No, this is not customer facing behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
