### PR TITLE
Initial implementation of a shared cache on S3 Express

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -80,6 +80,7 @@ built = { version = "0.7.1", features = ["git2"] }
 
 [features]
 # Unreleased feature flags
+express_cache = ["block_size"]
 block_size = []
 event_log = []
 # Features for choosing tests

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -80,6 +80,7 @@ built = { version = "0.7.1", features = ["git2"] }
 
 [features]
 # Unreleased feature flags
+block_size = []
 event_log = []
 # Features for choosing tests
 fips_tests = []

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -10,6 +10,8 @@
 //!
 //! This binary is intended only for use in testing and development of Mountpoint.
 
+use std::sync::Arc;
+
 use anyhow::anyhow;
 use futures::executor::ThreadPool;
 
@@ -23,7 +25,7 @@ fn main() -> anyhow::Result<()> {
     mountpoint_s3::cli::main(create_mock_client)
 }
 
-fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, ThreadPool, S3Personality)> {
+fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClient>, ThreadPool, S3Personality)> {
     // An extra little safety thing to make sure we can distinguish the real mount-s3 binary and
     // this one. Buckets starting with "sthree-" are always invalid against real S3:
     // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
@@ -81,5 +83,5 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(ThroughputMockClient, T
         MockObject::from_bytes(b"hello world", ETag::for_tests()),
     );
 
-    Ok((client, runtime, s3_personality))
+    Ok((Arc::new(client), runtime, s3_personality))
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -851,10 +851,12 @@ where
     }
 
     if let Some(express_bucket_name) = args.cache_express_bucket_name() {
+        // The cache can be shared across instances mounting the same bucket (including with different prefixes)
+        let source_description = &args.bucket_name;
         let cache = ExpressDataCache::new(
             express_bucket_name,
             client.clone(),
-            &bucket_description,
+            source_description,
             args.cache_block_size_in_bytes(),
         );
         let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -468,7 +468,7 @@ impl CliArgs {
 pub fn main<ClientBuilder, Client, Runtime>(client_builder: ClientBuilder) -> anyhow::Result<()>
 where
     ClientBuilder: FnOnce(&CliArgs) -> anyhow::Result<(Client, Runtime, S3Personality)>,
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     let args = CliArgs::parse();
@@ -717,7 +717,7 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
 fn mount<ClientBuilder, Client, Runtime>(args: CliArgs, client_builder: ClientBuilder) -> anyhow::Result<FuseSession>
 where
     ClientBuilder: FnOnce(&CliArgs) -> anyhow::Result<(Client, Runtime, S3Personality)>,
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Runtime: Spawn + Clone + Send + Sync + 'static,
 {
     tracing::info!("mount-s3 {}", build_info::FULL_VERSION);
@@ -849,7 +849,7 @@ fn create_filesystem<Client, Prefetcher>(
     bucket_description: &str,
 ) -> anyhow::Result<FuseSession>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch + Send + Sync + 'static,
 {
     tracing::trace!(?filesystem_config, "creating file system");

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -851,7 +851,12 @@ where
     }
 
     if let Some(express_bucket_name) = args.cache_express_bucket_name() {
-        let cache = ExpressDataCache::new(express_bucket_name, client.clone(), args.cache_block_size_in_bytes());
+        let cache = ExpressDataCache::new(
+            express_bucket_name,
+            client.clone(),
+            &bucket_description,
+            args.cache_block_size_in_bytes(),
+        );
         let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
         let fuse_session = create_filesystem(
             client,

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -27,7 +27,7 @@ pub type BlockIndex = u64;
 #[derive(Debug, Error)]
 pub enum DataCacheError {
     #[error("IO error when reading or writing from cache: {0}")]
-    IoFailure(#[from] std::io::Error),
+    IoFailure(#[source] anyhow::Error),
     #[error("Block content was not valid/readable")]
     InvalidBlockContent,
     #[error("Block offset does not match block index")]

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -6,6 +6,7 @@
 
 mod cache_directory;
 mod disk_data_cache;
+mod express_data_cache;
 mod in_memory_data_cache;
 
 use async_trait::async_trait;
@@ -14,6 +15,7 @@ use thiserror::Error;
 pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
+pub use crate::data_cache::express_data_cache::ExpressDataCache;
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 
 use crate::object::ObjectId;

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -45,21 +45,18 @@ pub struct DiskDataCacheConfig {
     pub limit: CacheLimit,
 }
 
-impl Default for DiskDataCacheConfig {
-    fn default() -> Self {
-        Self {
-            block_size: 1024 * 1024,                               // 1 MiB block size
-            limit: CacheLimit::AvailableSpace { min_ratio: 0.05 }, // Preserve 5% available space
-        }
-    }
-}
-
 /// Limit the cache size.
 #[derive(Debug)]
 pub enum CacheLimit {
     Unbounded,
     TotalSize { max_size: usize },
     AvailableSpace { min_ratio: f64 },
+}
+
+impl Default for CacheLimit {
+    fn default() -> Self {
+        CacheLimit::AvailableSpace { min_ratio: 0.05 } // Preserve 5% available space
+    }
 }
 
 /// Describes additional information about the data stored in the block.

--- a/mountpoint-s3/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/disk_data_cache.rs
@@ -200,6 +200,12 @@ impl DiskBlock {
     }
 }
 
+impl From<std::io::Error> for DataCacheError {
+    fn from(e: std::io::Error) -> Self {
+        DataCacheError::IoFailure(e.into())
+    }
+}
+
 impl DiskDataCache {
     /// Create a new instance of an [DiskDataCache] with the specified configuration.
     pub fn new(cache_directory: PathBuf, config: DiskDataCacheConfig) -> Self {

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -1,0 +1,121 @@
+use crate::object::ObjectId;
+
+use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use futures::{pin_mut, StreamExt};
+use mountpoint_s3_client::types::PutObjectParams;
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
+use sha2::{Digest, Sha256};
+use tracing::{trace, Instrument};
+
+const CACHE_VERSION: &str = "V1";
+
+pub struct ExpressDataCache<Client: ObjectClient> {
+    bucket_name: String,
+    client: Client,
+    block_size: u64,
+}
+
+impl<Client> ExpressDataCache<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    pub fn new(bucket_name: &str, client: Client, block_size: u64) -> Self {
+        Self {
+            client,
+            bucket_name: bucket_name.to_owned(),
+            block_size,
+        }
+    }
+}
+
+#[async_trait]
+impl<Client> DataCache for ExpressDataCache<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    async fn get_block(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        _block_offset: u64, // TODO: should we use this?
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        let object_key = object_key(cache_key, block_idx);
+        let result = match self.client.get_object(&self.bucket_name, &object_key, None, None).await {
+            Ok(ok_result) => ok_result,
+            Err(_e) => {
+                //TODO: assuming that key does not exists but it could be something else, so we will need to do something smarter here
+                return DataCacheResult::Ok(None);
+            }
+        };
+
+        pin_mut!(result);
+
+        let mut buffer = BytesMut::default();
+        loop {
+            trace!("ExpressDataCache::get_block {}", object_key);
+            match result.next().await {
+                Some(Ok((_offset, body))) => {
+                    // TODO: check offset expectation
+                    buffer.extend_from_slice(&body);
+                }
+                Some(Err(_e)) => {
+                    // TODO: what should we do here? anything better?
+                    return DataCacheResult::Ok(None);
+                }
+                None => {
+                    break;
+                }
+            }
+        }
+        let buffer = buffer.freeze();
+        DataCacheResult::Ok(Some(buffer.into()))
+    }
+
+    async fn put_block(
+        &self,
+        cache_key: ObjectId,
+        block_idx: BlockIndex,
+        _block_offset: u64,
+        bytes: ChecksummedBytes,
+    ) -> DataCacheResult<()> {
+        let object_key = object_key(&cache_key, block_idx);
+        trace!("ExpressDataCache::put_block {}", object_key);
+        // TODO: handle errors in a better way than just expects
+        let params = PutObjectParams::new();
+        let mut req = self
+            .client
+            .put_object(&self.bucket_name, &object_key, &params)
+            .in_current_span()
+            .await
+            .expect("could not create req");
+        let (data, _crc) = bytes.into_inner().expect("could not unpack checksummed bytes");
+        req.write(&data).await.expect("unable to write");
+        req.complete().await.expect("unable to complete upload");
+
+        DataCacheResult::Ok(())
+    }
+
+    fn block_size(&self) -> u64 {
+        self.block_size
+    }
+}
+
+/// Hash the cache key using its fields as well as the [CACHE_VERSION].
+fn hash_cache_key_raw(cache_key: &ObjectId) -> [u8; 32] {
+    let s3_key = cache_key.key();
+    let etag = cache_key.etag();
+
+    let mut hasher = Sha256::new();
+    hasher.update(CACHE_VERSION.as_bytes());
+    hasher.update(s3_key);
+    hasher.update(etag.as_str());
+    hasher.finalize().into()
+}
+
+fn object_key(cache_key: &ObjectId, block_idx: BlockIndex) -> String {
+    let hashed_cache_key = hex::encode(hash_cache_key_raw(cache_key));
+    format!("{}/{:010}", hashed_cache_key, block_idx)
+}

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -133,3 +133,105 @@ fn block_key(prefix: &str, cache_key: &ObjectId, block_idx: BlockIndex) -> Strin
     );
     format!("{}/{}/{:010}", prefix, hashed_cache_key, block_idx)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checksums::ChecksummedBytes;
+    use crate::sync::Arc;
+
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+    use mountpoint_s3_client::types::ETag;
+
+    #[tokio::test]
+    async fn test_put_get() {
+        let data_1 = ChecksummedBytes::new("Foo".into());
+        let data_2 = ChecksummedBytes::new("Bar".into());
+        let data_3 = ChecksummedBytes::new("Baz".into());
+
+        let bucket = "test-bucket";
+        let part_size = 8 * 1024 * 1024;
+        let config = MockClientConfig {
+            bucket: bucket.to_string(),
+            part_size,
+            enable_backpressure: true,
+            initial_read_window_size: part_size,
+            ..Default::default()
+        };
+        let client = Arc::new(MockClient::new(config));
+
+        let block_size = 512 * 1024;
+        let cache = ExpressDataCache::new(bucket, client, "unique source description", block_size);
+        let cache_key_1 = ObjectId::new("a".into(), ETag::for_tests());
+        let cache_key_2 = ObjectId::new(
+            "longkey_".repeat(128), // 1024 bytes, max length for S3 keys
+            ETag::for_tests(),
+        );
+
+        let block = cache
+            .get_block(&cache_key_1, 0, 0)
+            .await
+            .expect("cache should be accessible");
+        assert!(
+            block.is_none(),
+            "no entry should be available to return but got {:?}",
+            block,
+        );
+
+        // PUT and GET, OK?
+        cache
+            .put_block(cache_key_1.clone(), 0, 0, data_1.clone())
+            .await
+            .expect("cache should be accessible");
+        let entry = cache
+            .get_block(&cache_key_1, 0, 0)
+            .await
+            .expect("cache should be accessible")
+            .expect("cache entry should be returned");
+        assert_eq!(
+            data_1, entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // PUT AND GET block for a second key, OK?
+        cache
+            .put_block(cache_key_2.clone(), 0, 0, data_2.clone())
+            .await
+            .expect("cache should be accessible");
+        let entry = cache
+            .get_block(&cache_key_2, 0, 0)
+            .await
+            .expect("cache should be accessible")
+            .expect("cache entry should be returned");
+        assert_eq!(
+            data_2, entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // PUT AND GET a second block in a cache entry, OK?
+        cache
+            .put_block(cache_key_1.clone(), 1, block_size, data_3.clone())
+            .await
+            .expect("cache should be accessible");
+        let entry = cache
+            .get_block(&cache_key_1, 1, block_size)
+            .await
+            .expect("cache should be accessible")
+            .expect("cache entry should be returned");
+        assert_eq!(
+            data_3, entry,
+            "cache entry returned should match original bytes after put"
+        );
+
+        // Entry 1's first block still intact
+        let entry = cache
+            .get_block(&cache_key_1, 0, 0)
+            .await
+            .expect("cache should be accessible")
+            .expect("cache entry should be returned");
+        assert_eq!(
+            data_1, entry,
+            "cache entry returned should match original bytes after put"
+        );
+    }
+}

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -1,17 +1,19 @@
 use crate::object::ObjectId;
 
-use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
+use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures::{pin_mut, StreamExt};
+use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::PutObjectParams;
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
 use sha2::{Digest, Sha256};
-use tracing::{trace, Instrument};
+use tracing::Instrument;
 
 const CACHE_VERSION: &str = "V1";
 
+/// A data cache on S3 Express One Zone that can be shared across Mountpoint instances.
 pub struct ExpressDataCache<Client: ObjectClient> {
     client: Client,
     bucket_name: String,
@@ -19,10 +21,23 @@ pub struct ExpressDataCache<Client: ObjectClient> {
     block_size: u64,
 }
 
+impl<S, C> From<ObjectClientError<S, C>> for DataCacheError
+where
+    S: std::error::Error + Send + Sync + 'static,
+    C: std::error::Error + Send + Sync + 'static,
+{
+    fn from(e: ObjectClientError<S, C>) -> Self {
+        DataCacheError::IoFailure(e.into())
+    }
+}
+
 impl<Client> ExpressDataCache<Client>
 where
     Client: ObjectClient + Send + Sync + 'static,
 {
+    /// Create a new instance.
+    ///
+    /// TODO: consider adding some validation of the bucket.
     pub fn new(bucket_name: &str, client: Client, source_description: &str, block_size: u64) -> Self {
         let prefix = hex::encode(
             Sha256::new()
@@ -49,35 +64,29 @@ where
         &self,
         cache_key: &ObjectId,
         block_idx: BlockIndex,
-        _block_offset: u64, // TODO: should we use this?
+        block_offset: u64,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        if block_offset != block_idx * self.block_size {
+            return Err(DataCacheError::InvalidBlockOffset);
+        }
+
         let object_key = block_key(&self.prefix, cache_key, block_idx);
         let result = match self.client.get_object(&self.bucket_name, &object_key, None, None).await {
-            Ok(ok_result) => ok_result,
-            Err(_e) => {
-                //TODO: assuming that key does not exists but it could be something else, so we will need to do something smarter here
-                return DataCacheResult::Ok(None);
-            }
+            Ok(result) => result,
+            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey)) => return Ok(None),
+            Err(e) => return Err(e.into()),
         };
 
         pin_mut!(result);
 
+        // TODO: optimize for the common case of a single chunk.
         let mut buffer = BytesMut::default();
-        loop {
-            trace!("ExpressDataCache::get_block {}", object_key);
-            match result.next().await {
-                Some(Ok((_offset, body))) => {
-                    // TODO: check offset expectation
-                    buffer.extend_from_slice(&body);
-                }
-                Some(Err(_e)) => {
-                    // TODO: what should we do here? anything better?
-                    return DataCacheResult::Ok(None);
-                }
-                None => {
-                    break;
-                }
+        while let Some(chunk) = result.next().await {
+            let (offset, body) = chunk?;
+            if offset != buffer.len() as u64 {
+                return Err(DataCacheError::InvalidBlockOffset);
             }
+            buffer.extend_from_slice(&body);
         }
         let buffer = buffer.freeze();
         DataCacheResult::Ok(Some(buffer.into()))
@@ -87,22 +96,25 @@ where
         &self,
         cache_key: ObjectId,
         block_idx: BlockIndex,
-        _block_offset: u64,
+        block_offset: u64,
         bytes: ChecksummedBytes,
     ) -> DataCacheResult<()> {
+        if block_offset != block_idx * self.block_size {
+            return Err(DataCacheError::InvalidBlockOffset);
+        }
+
         let object_key = block_key(&self.prefix, &cache_key, block_idx);
-        trace!("ExpressDataCache::put_block {}", object_key);
-        // TODO: handle errors in a better way than just expects
+
+        // TODO: ideally we should use a simple Put rather than MPU.
         let params = PutObjectParams::new();
         let mut req = self
             .client
             .put_object(&self.bucket_name, &object_key, &params)
             .in_current_span()
-            .await
-            .expect("could not create req");
-        let (data, _crc) = bytes.into_inner().expect("could not unpack checksummed bytes");
-        req.write(&data).await.expect("unable to write");
-        req.complete().await.expect("unable to complete upload");
+            .await?;
+        let (data, _crc) = bytes.into_inner().map_err(|_| DataCacheError::InvalidBlockContent)?;
+        req.write(&data).await?;
+        req.complete().await?;
 
         DataCacheResult::Ok(())
     }

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -67,7 +67,7 @@ impl DirHandle {
 #[derive(Debug)]
 struct FileHandle<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     inode: Inode,
@@ -77,7 +77,7 @@ where
 
 enum FileHandleState<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     /// The file handle has been assigned as a read handle
@@ -91,7 +91,7 @@ where
 
 impl<Client, Prefetcher> std::fmt::Debug for FileHandleState<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static + std::fmt::Debug,
+    Client: ObjectClient + Clone + Send + Sync + 'static + std::fmt::Debug,
     Prefetcher: Prefetch,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -104,7 +104,7 @@ where
 
 impl<Client, Prefetcher> FileHandleState<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync,
+    Client: ObjectClient + Clone + Send + Sync,
     Prefetcher: Prefetch,
 {
     async fn new_write_handle(
@@ -521,11 +521,11 @@ pub enum SseCorruptedError {
 #[derive(Debug)]
 pub struct S3Filesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     config: S3FilesystemConfig,
-    client: Arc<Client>,
+    client: Client,
     superblock: Superblock,
     prefetcher: Prefetcher,
     uploader: Uploader<Client>,
@@ -539,7 +539,7 @@ where
 
 impl<Client, Prefetcher> S3Filesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     pub fn new(
@@ -556,8 +556,6 @@ where
             s3_personality: config.s3_personality,
         };
         let superblock = Superblock::new(bucket, prefix, superblock_config);
-
-        let client = Arc::new(client);
 
         let uploader = Uploader::new(
             client.clone(),
@@ -627,7 +625,7 @@ pub struct DirectoryEntry {
 
 impl<Client, Prefetcher> S3Filesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     pub async fn init(&self, config: &mut KernelConfig) -> Result<(), libc::c_int> {

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -65,7 +65,7 @@ macro_rules! fuse_unsupported {
 /// so that we can test our actual filesystem implementation without having actual FUSE in the loop.
 pub struct S3FuseFilesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     fs: S3Filesystem<Client, Prefetcher>,
@@ -73,7 +73,7 @@ where
 
 impl<Client, Prefetcher> S3FuseFilesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     pub fn new(
@@ -91,7 +91,7 @@ where
 
 impl<Client, Prefetcher> Filesystem for S3FuseFilesystem<Client, Prefetcher>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
     #[instrument(level="warn", skip_all, fields(req=_req.unique()))]

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -24,7 +24,7 @@ pub struct Uploader<Client> {
 
 #[derive(Debug)]
 struct UploaderInner<Client> {
-    client: Arc<Client>,
+    client: Client,
     storage_class: Option<String>,
     server_side_encryption: ServerSideEncryption,
     use_additional_checksums: bool,
@@ -41,7 +41,7 @@ pub enum UploadPutError<S, C> {
 impl<Client: ObjectClient> Uploader<Client> {
     /// Create a new [Uploader] that will make requests to the given client.
     pub fn new(
-        client: Arc<Client>,
+        client: Client,
         storage_class: Option<String>,
         server_side_encryption: ServerSideEncryption,
         use_additional_checksums: bool,
@@ -419,7 +419,7 @@ mod tests {
             ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key_alias".to_string())),
             true,
         );
-        std::sync::Arc::<UploaderInner<MockClient>>::get_mut(&mut uploader.inner)
+        std::sync::Arc::<UploaderInner<Arc<MockClient>>>::get_mut(&mut uploader.inner)
             .unwrap()
             .server_side_encryption
             .corrupt_data(sse_type_corrupted.map(String::from), key_id_corrupted.map(String::from));

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -84,7 +84,7 @@ fn create_fuse_session<Client, Prefetcher>(
     filesystem_config: S3FilesystemConfig,
 ) -> BackgroundSession
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch + Send + Sync + 'static,
 {
     let options = vec![

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -54,7 +54,7 @@ pub fn make_test_filesystem_with_client<Client>(
     config: S3FilesystemConfig,
 ) -> TestS3Filesystem<Client>
 where
-    Client: ObjectClient + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
     let prefetcher = default_prefetch(runtime, Default::default());


### PR DESCRIPTION
## Description of change

Initial implementation with minimal testing. Only enabled using the new compile-time feature flag `express_cache`.

Also introduces the `--cache-block-size` cli option to experiment with block sizes. Applies to both the existing disk cache and the new shared cache. Only available when building with the `block_size` feature flag.

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
