### PR TITLE
Fix resource utilization check in the CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,6 +94,7 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+        skip-fetch-gh-pages: true
 
   latency-bench:
     name: Benchmark (Latency)
@@ -218,3 +219,4 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+        skip-fetch-gh-pages: true

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -93,6 +93,7 @@ jobs:
         auto-push: ${{ inputs.publish }}
         comment-on-alert: true
         max-items-in-chart: 20
+        skip-fetch-gh-pages: true
 
   latency-bench:
     name: Benchmark (Latency)


### PR DESCRIPTION
## Description of change

Our CI workflows work by checking out the code from branch `gh-pages` to retrieve benchmark results from previous commits and compare them to values in the current run. However, the resource utilization check was done after the benchmark result check which already has pulled in the branch `gh-pages` resulting in errors because the branch already exists. This change fixes that.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No, only CI changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
