### PR TITLE
Add option to pass memory limit to CRT.

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -87,7 +87,9 @@ def _mount_mp(cfg: DictConfig, metadata: dict[str, any], mount_dir :str) -> str:
             raise ValueError(f"Unknown stub_reading_mode: {stub_reading_mode}")
 
     if cfg['mp_prefetcher_window_size'] is not None:
-        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE"] = cfg['mp_prefetcher_window_size']
+        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE"] = str(cfg['mp_prefetcher_window_size'])
+    if cfg['mp_backpressure_fixed_threshold'] is not None:
+        subprocess_env["UNSTABLE_MOUNTPOINT_BACKPRESSURE_FIXED_THRESHOLD"] = str(cfg['mp_backpressure_fixed_threshold'])
 
     log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     metadata["mount_s3_command"] = " ".join(subprocess_args)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -90,6 +90,10 @@ def _mount_mp(cfg: DictConfig, metadata: dict[str, any], mount_dir :str) -> str:
         subprocess_env["UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE"] = str(cfg['mp_prefetcher_window_size'])
     if cfg['mp_backpressure_fixed_threshold'] is not None:
         subprocess_env["UNSTABLE_MOUNTPOINT_BACKPRESSURE_FIXED_THRESHOLD"] = str(cfg['mp_backpressure_fixed_threshold'])
+    if cfg['mp_max_background'] is not None:
+        subprocess_env["UNSTABLE_MAX_BACKGROUND"] = str(cfg['mp_max_background'])
+    if cfg['mp_congestion_threshold'] is not None:
+        subprocess_env['UNSTABLE_CONGESTION_THRESHOLD'] = str(cfg['mp_congestion_threshold'])
 
     log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     metadata["mount_s3_command"] = " ".join(subprocess_args)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -67,6 +67,8 @@ def _mount_mp(cfg: DictConfig, metadata: dict[str, any], mount_dir :str) -> str:
             subprocess_args.append(f"--bind={network_interface}")
         if network['maximum_throughput_gbps'] is not None:
             subprocess_args.append(f"--maximum-throughput-gbps={network['maximum_throughput_gbps']}")
+    if cfg['crt_mem_limit_mib'] is not None:
+        subprocess_args.append(f"--crt-mem-limit-mib={cfg['crt_mem_limit_mib']}")
     subprocess_env = {
         "PID_FILE": "mount-s3.pid",
         "STUB_CRC32C": str(cfg['stub_crc32c']),

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -49,7 +49,6 @@ def _mount_mp(cfg: DictConfig, metadata: dict[str, any], mount_dir :str) -> str:
         "--allow-overwrite",
         "--allow-delete",
         f"--log-directory={MP_LOGS_DIRECTORY}",
-        "--write-part-size=16777216", # 16MiB, to allow upload of 100GiB
     ]
     if cfg['s3_prefix'] is not None:
         subprocess_args.append(f"--prefix={cfg['s3_prefix']}")
@@ -69,6 +68,8 @@ def _mount_mp(cfg: DictConfig, metadata: dict[str, any], mount_dir :str) -> str:
             subprocess_args.append(f"--maximum-throughput-gbps={network['maximum_throughput_gbps']}")
     if cfg['crt_mem_limit_mib'] is not None:
         subprocess_args.append(f"--crt-mem-limit-mib={cfg['crt_mem_limit_mib']}")
+    if cfg['write_part_size_bytes'] is not None:
+        subprocess_args.append(f"--write-part-size={cfg['write_part_size_bytes']}")
     subprocess_env = {
         "PID_FILE": "mount-s3.pid",
         "STUB_CRC32C": str(cfg['stub_crc32c']),

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -53,6 +53,8 @@ write_part_size_bytes: 16777216
 # based on hardware and max throughput specified.
 crt_mem_limit_mib: !!null
 
+mp_backpressure_fixed_threshold: !!null
+
 iterations: 1
 iteration: 0 # placeholder; use iterations to configure for multirun
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -54,6 +54,8 @@ write_part_size_bytes: 16777216
 crt_mem_limit_mib: !!null
 
 mp_backpressure_fixed_threshold: !!null
+mp_max_background: !!null
+mp_congestion_threshold: !!null
 
 iterations: 1
 iteration: 0 # placeholder; use iterations to configure for multirun

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -44,7 +44,10 @@ stub_crc32c: false
 mp_prefetcher_window_size: !!null
 
 # For S3 implementations not supporting additional checksums. Passed as `--upload-checksums` argument.
-upload_checksums: !!null
+upload_checksums: "off"
+
+# Use w 16MB part size so that 100GB objects work (due to number of parts limit in S3)
+write_part_size_bytes: 16777216
 
 # CRT memory limit: normally passed in megabytes, default is to use the CRT's default value which is
 # based on hardware and max throughput specified.

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -46,6 +46,10 @@ mp_prefetcher_window_size: !!null
 # For S3 implementations not supporting additional checksums. Passed as `--upload-checksums` argument.
 upload_checksums: !!null
 
+# CRT memory limit: normally passed in megabytes, default is to use the CRT's default value which is
+# based on hardware and max throughput specified.
+crt_mem_limit_mib: !!null
+
 iterations: 1
 iteration: 0 # placeholder; use iterations to configure for multirun
 

--- a/benchmark/run_combinations.sh
+++ b/benchmark/run_combinations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+(
+    cd ..
+    cargo build --release -F multiple-nw-iface;
+)
+
+HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
+    s3_bucket=adpeace-mountpoint-perf-test \
+    fuse_threads=16 \
+    application_workers="1,16,32" \
+    stub_crc32c="false" stub_reading_mode=off \
+    network=1_nic,2_nic,4_nic iterations=5 \
+    available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
+    fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
+    crt_mem_limit_mib="8192,65535"
+

--- a/benchmark/run_combinations.sh
+++ b/benchmark/run_combinations.sh
@@ -8,10 +8,12 @@
 HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
     s3_bucket=adpeace-mountpoint-perf-test \
     fuse_threads=16 \
-    application_workers="1,16,32" \
-    stub_crc32c="false" stub_reading_mode=off \
-    network=1_nic,2_nic,4_nic iterations=5 \
+    application_workers="16,32" \
+    stub_crc32c="false" stub_reading_mode=s3_client \
+    network=1_nic iterations=3 \
     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
-    crt_mem_limit_mib="8192,65535"
+    crt_mem_limit_mib="8192" \
+    mp_prefetcher_window_size="$((2 * 1024 * 1024 * 1024)),$((8 * 1024 * 1024 * 1024))" \
+    mp_backpressure_fixed_threshold=1,0
 

--- a/benchmark/run_combinations.sh
+++ b/benchmark/run_combinations.sh
@@ -7,13 +7,58 @@
 
 HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
     s3_bucket=adpeace-mountpoint-perf-test \
-    fuse_threads=16 \
-    application_workers="16,32" \
-    stub_crc32c="false" stub_reading_mode=s3_client \
-    network=1_nic iterations=3 \
+    fuse_threads=16,32,64 \
+    application_workers=16,32,64 \
+    stub_crc32c="false" stub_reading_mode=off \
+    network=1_nic,2_nic,4_nic iterations=5 \
     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
-    crt_mem_limit_mib="8192" \
-    mp_prefetcher_window_size="$((2 * 1024 * 1024 * 1024)),$((8 * 1024 * 1024 * 1024))" \
-    mp_backpressure_fixed_threshold=1,0
+    mp_max_background=16,128
 
+# HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
+#     s3_bucket=adpeace-mountpoint-perf-test \
+#     fuse_threads=16,32,64 \
+#     application_workers=16,32,64 \
+#     stub_crc32c="false" stub_reading_mode=off \
+#     network=4_nic iterations=3 \
+#     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
+#     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
+#     crt_mem_limit_mib="8192,65535" \
+#     mp_prefetcher_window_size="$((2 * 1024 * 1024 * 1024)),$((8 * 1024 * 1024 * 1024))" \
+#     mp_backpressure_fixed_threshold=1 \
+#     mp_max_background=16,128
+
+# HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
+#     s3_bucket=adpeace-mountpoint-perf-test \
+#     fuse_threads=1 \
+#     application_workers=1,16 \
+#     stub_crc32c="false" stub_reading_mode=off \
+#     network=4_nic iterations=3 \
+#     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
+#     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
+#     crt_mem_limit_mib="8192,65535" \
+#     mp_prefetcher_window_size="$((2 * 1024 * 1024 * 1024)),$((8 * 1024 * 1024 * 1024))" \
+#     mp_backpressure_fixed_threshold=1 \
+#     mp_max_background=16,128
+
+# HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
+#     s3_bucket=adpeace-mountpoint-perf-test \
+#     fuse_threads=16,32,64 \
+#     application_workers=16,32,64 \
+#     stub_crc32c="false" stub_reading_mode=s3_client \
+#     network=4_nic iterations=3 \
+#     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
+#     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
+#     mp_max_background=16,128
+
+# HYDRA_FULL_ERROR=1 poetry run python benchmark.py -r \
+#     s3_bucket=adpeace-mountpoint-perf-test \
+#     fuse_threads=16,32,64 \
+#     application_workers="16,32,64" \
+#     stub_crc32c="false" stub_reading_mode=off \
+#     network=1_nic,2_nic,4_nic iterations=3 \
+#     available_network_interfaces="[{interface_name: 'ens32'}, {interface_name: 'ens64'}, {interface_name: 'ens96'}, {interface_name: 'ens128'}]" \
+#     fio_benchmark=sequential_read with_perf=true with_bwm=true direct_io="true,false" \
+#     crt_mem_limit_mib="8192,65535" \
+#     mp_prefetcher_window_size="$((2 * 1024 * 1024 * 1024)),$((8 * 1024 * 1024 * 1024))" \
+#     mp_backpressure_fixed_threshold=1,0

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -206,6 +206,12 @@ impl ClientConfig {
         self.inner.max_active_connections_override = max_active_connections_override;
         self
     }
+
+    /// Set memory limit.  TODO fixme doc.
+    pub fn memory_limit_in_bytes(&mut self, memory_limit_in_bytes: u64) -> &mut Self {
+        self.inner.memory_limit_in_bytes = memory_limit_in_bytes;
+        self
+    }
 }
 
 /// Callback for telemetry received as part of a successful meta request.

--- a/mountpoint-s3/examples/s3fs_benchmark.rs
+++ b/mountpoint-s3/examples/s3fs_benchmark.rs
@@ -5,7 +5,9 @@ use std::time::Instant;
 
 use clap::{Arg, Command};
 use futures::executor::{block_on, ThreadPool};
+use mountpoint_s3::fs::FUSE_ROOT_INODE;
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
+use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::S3CrtClient;
@@ -13,7 +15,7 @@ use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
-use mountpoint_s3::metrics;
+use mountpoint_s3::{metrics, S3Filesystem, S3FilesystemConfig};
 
 /// Like `tracing_subscriber::fmt::init` but sends logs to stderr
 fn init_tracing_subscriber() {
@@ -21,7 +23,7 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(std::io::stderr)
+        .with_writer(std::io::stdout)
         .with_ansi(false)
         .finish();
 
@@ -37,7 +39,6 @@ fn main() {
         .arg(Arg::new("bucket").required(true))
         .arg(Arg::new("key").required(true))
         .arg(Arg::new("size").required(true))
-        .arg(Arg::new("etag").required(true))
         .arg(
             Arg::new("throughput-target-gbps")
                 .long("throughput-target-gbps")
@@ -54,13 +55,10 @@ fn main() {
                 .help("Number of times to download"),
         )
         .arg(Arg::new("region").long("region").default_value("us-east-1"))
-        .arg(Arg::new("crt-mem-limit-mib").long("crt-mem-limit-mib"))
-        .arg(Arg::new("initial-read-window-size-mib").long("initial-read-window-size-mib"))
         .get_matches();
 
     let bucket = matches.get_one::<String>("bucket").unwrap();
     let key = matches.get_one::<String>("key").unwrap();
-    let etag = matches.get_one::<String>("etag").unwrap();
     let size = matches
         .get_one::<String>("size")
         .unwrap()
@@ -76,14 +74,8 @@ fn main() {
         .get_one::<String>("iterations")
         .map(|s| s.parse::<usize>().expect("iterations must be a number"));
     let region = matches.get_one::<String>("region").unwrap();
-    let crt_mem_limit_mib = matches
-        .get_one::<String>("crt-mem-limit-mib")
-        .map(|s| s.parse::<usize>().expect("crt-mem-limit-mib must be a number"));
-    let initial_read_window_size_mib = matches
-        .get_one::<String>("initial-read-window-size-mib")
-        .map(|s| s.parse::<usize>().expect("initial-read-window-size-mib must be a number"));
 
-    let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
+    let mut config: S3ClientConfig = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
     if let Some(throughput_target_gbps) = throughput_target_gbps {
         config = config.throughput_target_gbps(throughput_target_gbps);
     }
@@ -92,33 +84,37 @@ fn main() {
     }
     config = config.initial_read_window(8 * 1024 * 1024)
         .read_backpressure(true)
-        .auth_config(mountpoint_s3_client::config::S3ClientAuthConfig::Default);
+        .auth_config(mountpoint_s3_client::config::S3ClientAuthConfig::Default)
+        .crt_memory_limit_bytes(64 * 1024 * 1024 * 1024);
 
-    if let Some(crt_mem_limit) = crt_mem_limit_mib {
-        config = config.crt_memory_limit_bytes(crt_mem_limit as u64 * 1024 * 1024);
-    }
-    if let Some(initial_read_window) = initial_read_window_size_mib {
-        config = config.initial_read_window(initial_read_window * 1024 * 1024);
-    }
-
-    let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
 
     for i in 0..iterations.unwrap_or(1) {
+        let client = Arc::new(S3CrtClient::new(config.clone()).expect("couldn't create client"));
         let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
         let prefetcher = default_prefetch(runtime, Default::default());
         let received_size = Arc::new(AtomicU64::new(0));
 
-        let start = Instant::now();
+        // set up S3Filesystem:
+        let s3fs = S3Filesystem::new(
+            client, prefetcher, bucket, &Prefix::from_str("").unwrap(),
+            S3FilesystemConfig::default()
+        );
+        let entry =
+            block_on(s3fs.lookup(FUSE_ROOT_INODE, key.as_ref())).unwrap();
+        let handle =
+            block_on(s3fs.open(entry.attr.ino, libc::O_RDONLY, 0)).unwrap();
 
-        let mut request = prefetcher.prefetch(client.clone(), bucket, key, size,
-                ETag::from_str(etag).unwrap());
+        let start = Instant::now();
         block_on(async {
             loop {
                 let offset = received_size.load(Ordering::SeqCst);
                 if offset >= size {
                     break;
                 }
-                let result = request.read(offset, 256 << 10).await;
+                let result = s3fs.read(
+                    entry.attr.ino, handle.fh, offset as i64, 256 << 10,
+                    0 as i32, None
+                ).await;
                 match result {
                     Ok(bytes) => {received_size.fetch_add(bytes.len() as u64, Ordering::SeqCst); }
                     Err(e) => panic!("error: {}", e),
@@ -127,14 +123,13 @@ fn main() {
         });
 
         let elapsed = start.elapsed();
-
         let received_size = received_size.load(Ordering::SeqCst);
         println!(
-            "{}: received {} bytes in {:.2}s: {:.2}Gbps",
+            "{}: received {} bytes in {:.2}s: {:.2}MiB/s",
             i,
             received_size,
             elapsed.as_secs_f64(),
-            (8.8 * received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024 * 1024) as f64
+            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024) as f64
         );
     }
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -325,6 +325,14 @@ pub struct CliArgs {
         value_name = "NETWORK_INTERFACE",
     )]
     pub bind: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Set memory limit for CRT bufferpool",
+        help_heading = CLIENT_OPTIONS_HEADER,
+        value_name = "MiB",
+    )]
+    pub crt_mem_limit_mib: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -688,6 +696,9 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
         .read_backpressure(true)
         .initial_read_window(initial_read_window_size)
         .user_agent(user_agent);
+    if let Some(limit_mib) = args.crt_mem_limit_mib {
+        client_config = client_config.crt_memory_limit_bytes(limit_mib * 1024 * 1024);
+    }
     #[cfg(feature = "multiple-nw-iface")]
     if let Some(interfaces) = &args.bind {
         client_config = client_config.network_interface_names(interfaces.clone());

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -632,6 +632,24 @@ where
 {
     pub async fn init(&self, config: &mut KernelConfig) -> Result<(), libc::c_int> {
         let _ = config.add_capabilities(fuser::consts::FUSE_DO_READDIRPLUS);
+        if let Some(user_max_background) = std::env::var_os("UNSTABLE_MAX_BACKGROUND") {
+            let max_background = user_max_background
+                .into_string()
+                .ok()
+                .and_then(|v| v.parse::<u16>().ok())
+                .expect("invalid env var max background");
+            let old = config.set_max_background(max_background).expect("unable to set max background");
+            tracing::warn!("set max background to {} from {}", max_background, old)
+        }
+        if let Some(user_congestion_threshold) = std::env::var_os("UNSTABLE_CONGESTION_THRESHOLD") {
+            let congestion_threshold = user_congestion_threshold
+                .into_string()
+                .ok()
+                .and_then(|v| v.parse::<u16>().ok())
+                .expect("invalid env var congestion threshold");
+            let old = config.set_congestion_threshold(congestion_threshold).expect("unable to set congestion threshold");
+            tracing::warn!("set congestion threshold to {} from {}", congestion_threshold, old);
+        }
         if self.config.allow_overwrite {
             // Overwrites require FUSE_ATOMIC_O_TRUNC capability on the host, so we will panic if the
             // host doesn't support it.

--- a/mountpoint-s3/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3/src/prefetch/backpressure_controller.rs
@@ -1,7 +1,7 @@
 use std::{env, ops::Range, sync::LazyLock};
 
 use async_channel::{unbounded, Receiver, Sender};
-use tracing::trace;
+use tracing::{trace,info};
 
 use super::PrefetchReadError;
 
@@ -82,7 +82,7 @@ pub fn new_backpressure_controller(config: BackpressureConfig) -> (BackpressureC
 
 static BACKPRESSURE_FIXED_THRESHOLD: LazyLock<bool> = LazyLock::new(|| {
     let v = env::var("UNSTABLE_BACKPRESSURE_FIXED_THRESHOLD").as_ref().map(|v| v == "1").unwrap_or(false);
-    trace!("Using backpressue override {v}");
+    info!("Using backpressue override {v}");
     v
 });
 

--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -67,6 +67,7 @@ impl<E: std::error::Error + Send + Sync> PartQueue<E> {
             let start = Instant::now();
             let part = self.receiver.recv().await;
             metrics::histogram!("prefetch.part_queue_starved_us").record(start.elapsed().as_micros() as f64);
+            trace!("part queue starved for {} us", start.elapsed().as_micros());
             match part {
                 Err(RecvError) => Err(PrefetchReadError::GetRequestTerminatedUnexpectedly),
                 Ok(part) => part,

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -377,6 +377,7 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
             // Blocks if read window increment if it's not enough to read the next offset
             if let Some(next_read_window_offset) = backpressure_limiter.wait_for_read_window_increment(next_offset).await? {
                 let diff = next_read_window_offset.saturating_sub(request.as_ref().read_window_end_offset()) as usize;
+                trace!("incrementing CRT read window by {} mb", diff / (1024*1024));
                 request.as_mut().increment_read_window(diff);
             }
         }


### PR DESCRIPTION
The CRT memory limit can be performance-impacting and this allows it to be specified on the command-line (default is based on hardware and the target throughput specified, otherwise).

**Note**: This PR is intended for perf-benchmark-working-branch.

## Description of change

Add crt-mem-limit option to the mount-s3 CLI.  Pass this through to the C CRT client.

Use a PR to the branch as a mechanism to get another pair of eyes/knowledge share, but there is at least one TODO before this could be merged to mainline (called out in a comment), and we should make sure directionally we want to expose this parameter directly in this way.

## Does this change impact existing behavior?

No, the default behaviour should be unchanged.  Verified that not passing the argument gives a default assignment of the memory limit.

## Does this change need a changelog entry in any of the crates?

Not until merged to main, then, unsure.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
