### PR TITLE
Improve error handling and reporting when removing cache blocks

### DIFF
--- a/mountpoint-s3/src/object.rs
+++ b/mountpoint-s3/src/object.rs
@@ -1,12 +1,23 @@
+use std::fmt::Debug;
+
 use mountpoint_s3_client::types::ETag;
 
 use crate::sync::Arc;
 
 /// Identifier for a specific version of an S3 object.
 /// Formed by the object key and etag. Holds its components in an [Arc], so it can be cheaply cloned.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct ObjectId {
     inner: Arc<InnerObjectId>,
+}
+
+impl Debug for ObjectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectId")
+            .field("key", &self.inner.key)
+            .field("etag", &self.inner.etag)
+            .finish()
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]


### PR DESCRIPTION
Minor improvements to how we handle removal of cache blocks: 
* distinguish between eviction and deletion of invalid blocks,
* avoid logging failure to remove if the file was not found,
* remove entry from usage map.

Relevant issues: #1040 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
