### PR TITLE
Add tests for fstat during writing covering breaking cases

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -327,7 +327,7 @@ where
     let file_ttl = Duration::from_millis(50); // keep short for fast tests...
     let filesystem_config = S3FilesystemConfig {
         cache_config: CacheConfig {
-            file_ttl: file_ttl.clone(),
+            file_ttl,
             ..Default::default()
         },
         ..Default::default()
@@ -344,7 +344,6 @@ where
 
     let stat = f.metadata().expect("fstat should succeed before writing");
     assert_eq!(stat.len(), 0);
-    let ino = stat.ino();
 
     let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
     let mut body = vec![0u8; OBJECT_SIZE];


### PR DESCRIPTION
## Description of change

In a recent support case, we saw that `fstat` (stat given some file descriptor) cannot tolerate `ESTALE` being returned by Mountpoint. The `fstat` call will fail outright, rather than being able to tolerate it and perform a new lookup like `stat` does.

These tests document the behavior, such that we can enable them once we know its addressed.

For now, we're not actively working on a fix.

Relevant issues: N/A

## Does this change impact existing behavior?

Nope, just adds ignored tests.

## Does this change need a changelog entry in any of the crates?

No, tests only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
