### PR TITLE
Remove clone of current span in record_name fn

### DIFF
--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -149,6 +149,6 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn record_name(name: &str) -> Span {
-    Span::current().record("name", name).clone()
+pub fn record_name(name: &str) {
+    Span::current().record("name", name);
 }


### PR DESCRIPTION
## Description of change

Very minor, just noticed clone when we don't even use the returned value.

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
