### PR TITLE
Add support for single PutObject in mountpoint-s3-client

### DIFF
--- a/mountpoint-s3-client/src/checksums.rs
+++ b/mountpoint-s3-client/src/checksums.rs
@@ -1,5 +1,5 @@
 //! Provides base64 encoding/decoding for CRC32C checksums.
-use mountpoint_s3_crt::checksums::crc32c::Crc32c;
+pub use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};
 
 use base64ct::Base64;
 use base64ct::Encoding;

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -16,10 +16,9 @@ use pin_project::pin_project;
 use crate::object_client::{
     DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
     GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
-    ObjectAttribute, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest,
-    PutObjectResult, UploadReview,
+    ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams,
+    PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
 };
-use crate::ObjectClient;
 
 // Wrapper for injecting failures into a get stream or a put request
 pub struct FailureRequestWrapper<Client: ObjectClient, RequestWrapperState> {
@@ -166,7 +165,7 @@ where
         &self,
         bucket: &str,
         key: &str,
-        params: &PutObjectParams,
+        params: &PutObjectSingleParams,
         contents: impl AsRef<[u8]> + Send + 'a,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         // TODO failure hook for put_object_single

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -162,6 +162,17 @@ where
         })
     }
 
+    async fn put_object_single<'a>(
+        &self,
+        bucket: &str,
+        key: &str,
+        params: &PutObjectParams,
+        contents: impl AsRef<[u8]> + Send + 'a,
+    ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
+        // TODO failure hook for put_object_single
+        self.client.put_object_single(bucket, key, params, contents).await
+    }
+
     async fn get_object_attributes(
         &self,
         bucket: &str,

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -74,8 +74,8 @@ pub mod types {
     pub use super::object_client::{
         Checksum, ChecksumAlgorithm, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts,
         GetObjectAttributesResult, GetObjectRequest, HeadObjectResult, ListObjectsResult, ObjectAttribute,
-        ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectTrailingChecksums,
-        RestoreStatus, UploadReview, UploadReviewPart,
+        ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams,
+        PutObjectTrailingChecksums, RestoreStatus, UploadChecksum, UploadReview, UploadReviewPart,
     };
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -340,6 +340,7 @@ pub enum Operation {
     GetObjectAttributes,
     ListObjectsV2,
     PutObject,
+    PutObjectSingle,
 }
 
 /// Counter for a specific client [Operation].
@@ -707,6 +708,29 @@ impl ObjectClient for MockClient {
             &self.in_progress_uploads,
         );
         Ok(put_request)
+    }
+
+    async fn put_object_single<'a>(
+        &self,
+        bucket: &str,
+        key: &str,
+        params: &PutObjectParams,
+        contents: impl AsRef<[u8]> + Send + 'a,
+    ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
+        trace!(bucket, key, "PutObject");
+        self.inc_op_count(Operation::PutObjectSingle);
+
+        if bucket != self.config.bucket {
+            return Err(ObjectClientError::ServiceError(PutObjectError::NoSuchBucket));
+        }
+
+        let mut object: MockObject = contents.into();
+        object.set_storage_class(params.storage_class.clone());
+        add_object(&self.objects, key, object);
+        Ok(PutObjectResult {
+            sse_type: None,
+            sse_kms_key_id: None,
+        })
     }
 
     async fn get_object_attributes(
@@ -1501,6 +1525,31 @@ mod tests {
             next_offset += body.len() as u64;
             assert_eq!(body, obj.read(offset, body.len()));
         }
+    }
+
+    #[tokio::test]
+    async fn test_put_object_single() {
+        let client = MockClient::new(MockClientConfig {
+            bucket: "test_bucket".to_string(),
+            part_size: 1024,
+            unordered_list_seed: None,
+            ..Default::default()
+        });
+
+        let content = vec![42u8; 512];
+        let _put_result = client
+            .put_object_single("test_bucket", "key1", &Default::default(), &content)
+            .await
+            .expect("put_object failed");
+
+        let get_request = client
+            .get_object("test_bucket", "key1", None, None)
+            .await
+            .expect("get_object failed");
+
+        // Check that the result of get_object is correct.
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(&content, &*actual);
     }
 
     proptest::proptest! {

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -28,7 +28,7 @@ use crate::object_client::{
     GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
     HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
     ObjectClientResult, ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
-    PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
+    PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
 };
 
 mod leaky_bucket;
@@ -714,7 +714,7 @@ impl ObjectClient for MockClient {
         &self,
         bucket: &str,
         key: &str,
-        params: &PutObjectParams,
+        params: &PutObjectSingleParams,
         contents: impl AsRef<[u8]> + Send + 'a,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         trace!(bucket, key, "PutObject");

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -9,15 +9,15 @@ use futures::Stream;
 use pin_project::pin_project;
 
 use crate::mock_client::leaky_bucket::LeakyBucket;
-use crate::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, MockPutObjectRequest};
-use crate::object_client::{
-    DeleteObjectError, DeleteObjectResult, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
-    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
-    ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams,
+use crate::mock_client::{
+    MockClient, MockClientConfig, MockClientError, MockGetObjectRequest, MockObject, MockPutObjectRequest,
 };
-use crate::types::{ETag, PutObjectResult};
-
-use super::MockGetObjectRequest;
+use crate::object_client::{
+    DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
+    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
+    ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult,
+    PutObjectSingleParams,
+};
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
 /// performance without the jitter or service latency of targeting a real service. Note that while
@@ -167,7 +167,7 @@ impl ObjectClient for ThroughputMockClient {
         &self,
         bucket: &str,
         key: &str,
-        params: &PutObjectParams,
+        params: &PutObjectSingleParams,
         contents: impl AsRef<[u8]> + Send + 'a,
     ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
         self.inner.put_object_single(bucket, key, params, contents).await

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -15,7 +15,7 @@ use crate::object_client::{
     GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
     ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams,
 };
-use crate::types::ETag;
+use crate::types::{ETag, PutObjectResult};
 
 use super::MockGetObjectRequest;
 
@@ -161,6 +161,16 @@ impl ObjectClient for ThroughputMockClient {
         params: &PutObjectParams,
     ) -> ObjectClientResult<Self::PutObjectRequest, PutObjectError, Self::ClientError> {
         self.inner.put_object(bucket, key, params).await
+    }
+
+    async fn put_object_single<'a>(
+        &self,
+        bucket: &str,
+        key: &str,
+        params: &PutObjectParams,
+        contents: impl AsRef<[u8]> + Send + 'a,
+    ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
+        self.inner.put_object_single(bucket, key, params, contents).await
     }
 
     async fn get_object_attributes(

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -344,12 +344,12 @@ impl PutObjectParams {
     }
 }
 
-/// How CRC32c checksums are used for parts of a multi-part PutObject request
+/// How CRC32c checksums are used for single PutObject or parts of a multi-part PutObject request
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum PutObjectTrailingChecksums {
-    /// Checksums are computed, passed to upload review, and also sent to S3
+    /// Checksums are computed and sent to S3. Also passed to upload review for multi-part PutObject
     Enabled,
-    /// Checksums are computed, passed to upload review, but not sent to S3
+    /// Only for multi-part PutObject: checksums are computed and passed to upload review, but not sent to S3. Equivalent to [Disabled] for single PutObject
     ReviewOnly,
     /// Checksums are not computed on the client side
     #[default]

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -134,6 +134,15 @@ pub trait ObjectClient {
         params: &PutObjectParams,
     ) -> ObjectClientResult<Self::PutObjectRequest, PutObjectError, Self::ClientError>;
 
+    /// Put an object into the object store.
+    async fn put_object_single<'a>(
+        &self,
+        bucket: &str,
+        key: &str,
+        params: &PutObjectParams,
+        contents: impl AsRef<[u8]> + Send + 'a,
+    ) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError>;
+
     /// Retrieves all the metadata from an object without returning the object contents.
     async fn get_object_attributes(
         &self,

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -808,7 +808,8 @@ impl S3Operation {
         }
     }
 
-    /// The operation name to set when configuring a request, if required.
+    /// The operation name to set when configuring a request. Required for operations that
+    /// have MetaRequestType::Default (see [meta_request_type]). `None` otherwise.
     fn operation_name(&self) -> Option<&'static str> {
         match self {
             S3Operation::DeleteObject => Some("DeleteObject"),

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -235,7 +235,6 @@ macro_rules! object_client_test {
         mod $test_fn_identifier {
             use super::$test_fn_identifier;
             use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
-            use mountpoint_s3_client::types::PutObjectParams;
             use $crate::{get_test_bucket_and_prefix, get_test_client};
 
             #[tokio::test]
@@ -250,7 +249,7 @@ macro_rules! object_client_test {
                 });
 
                 let key = format!("{prefix}hello");
-                $test_fn_identifier(&client, &bucket, &key, PutObjectParams::new()).await;
+                $test_fn_identifier(&client, &bucket, &key, Default::default()).await;
             }
 
             #[tokio::test]
@@ -260,7 +259,7 @@ macro_rules! object_client_test {
                 let client = get_test_client();
 
                 let key = format!("{prefix}hello");
-                $test_fn_identifier(&client, &bucket, &key, PutObjectParams::new()).await;
+                $test_fn_identifier(&client, &bucket, &key, Default::default()).await;
             }
         }
     };

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -1,0 +1,232 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use common::*;
+use mountpoint_s3_client::checksums::crc32c_to_base64;
+use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::types::{PutObjectParams, PutObjectResult, PutObjectTrailingChecksums};
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+use mountpoint_s3_crt::checksums::crc32c;
+use rand::Rng;
+use test_case::test_case;
+
+// Simple test for PUT object. Puts a single, small object as a single part and checks that the
+// contents are correct with a GET.
+async fn test_put_object_single(
+    client: &(impl ObjectClient + Sync),
+    bucket: &str,
+    key: &str,
+    request_params: PutObjectParams,
+) -> PutObjectResult {
+    let mut rng = rand::thread_rng();
+
+    let mut contents = vec![0u8; 32];
+    rng.fill(&mut contents[..]);
+
+    let put_object_result = client
+        .put_object_single(bucket, key, &request_params, &contents)
+        .await
+        .expect("put_object should succeed");
+
+    let result = client
+        .get_object(bucket, key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &contents[..]).await;
+
+    put_object_result
+}
+
+object_client_test!(test_put_object_single);
+
+// Simple test for PUT object. Puts a single, empty object and checks that the (empty)
+// contents are correct with a GET.
+async fn test_put_object_single_empty(
+    client: &(impl ObjectClient + Sync),
+    bucket: &str,
+    key: &str,
+    request_params: PutObjectParams,
+) -> PutObjectResult {
+    let put_object_result = client
+        .put_object_single(bucket, key, &request_params, [])
+        .await
+        .expect("put_object should succeed");
+
+    let result = client
+        .get_object(bucket, key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &[]).await;
+
+    put_object_result
+}
+
+object_client_test!(test_put_object_single_empty);
+
+#[test_case(PutObjectTrailingChecksums::Enabled; "enabled")]
+#[test_case(PutObjectTrailingChecksums::ReviewOnly; "review only")]
+#[test_case(PutObjectTrailingChecksums::Disabled; "disabled")]
+#[tokio::test]
+async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
+    const PART_SIZE: usize = 5 * 1024 * 1024;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
+    let client_config = S3ClientConfig::new()
+        .part_size(PART_SIZE)
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let key = format!("{prefix}hello");
+
+    let mut rng = rand::thread_rng();
+    let mut contents = vec![0u8; PART_SIZE * 2];
+    rng.fill(&mut contents[..]);
+
+    let params = PutObjectParams::new().trailing_checksums(trailing_checksums);
+    client
+        .put_object_single(&bucket, &key, &params, &contents)
+        .await
+        .expect("put_object should succeed");
+
+    let sdk_client = get_test_sdk_client().await;
+    let output = sdk_client
+        .head_object()
+        .bucket(&bucket)
+        .key(key)
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await
+        .unwrap();
+
+    if trailing_checksums == PutObjectTrailingChecksums::Enabled {
+        let checksum = output.checksum_crc32_c().unwrap();
+        let expected_checksum = crc32c::checksum(&contents);
+
+        let encoded = crc32c_to_base64(&expected_checksum);
+        assert_eq!(checksum, encoded);
+    } else {
+        assert!(
+            output.checksum_crc32_c().is_none(),
+            "crc32c should not be present when upload checksums are disabled"
+        );
+    }
+}
+
+#[test_case("INTELLIGENT_TIERING")]
+#[test_case("GLACIER")]
+#[tokio::test]
+// S3 Express One Zone is a distinct storage class and can't be overridden
+#[cfg(not(feature = "s3express_tests"))]
+async fn test_put_object_storage_class(storage_class: &str) {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_object_abort");
+    let client = get_test_client();
+    let key = format!("{prefix}hello");
+
+    let mut rng = rand::thread_rng();
+    let mut contents = vec![0u8; 32];
+    rng.fill(&mut contents[..]);
+
+    let params = PutObjectParams::new().storage_class(storage_class.to_owned());
+    client
+        .put_object_single(&bucket, &key, &params, &contents)
+        .await
+        .expect("put_object should succeed");
+
+    let sdk_client = get_test_sdk_client().await;
+    let attributes = sdk_client
+        .get_object_attributes()
+        .bucket(bucket)
+        .key(key)
+        .object_attributes(aws_sdk_s3::types::ObjectAttributes::StorageClass)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(storage_class, attributes.storage_class.unwrap().as_str());
+}
+
+#[cfg(not(feature = "s3express_tests"))]
+async fn check_sse(
+    bucket: &String,
+    key: &String,
+    expected_sse: Option<&str>,
+    expected_key: &Option<String>,
+    put_object_result: PutObjectResult,
+) {
+    let sdk_client = get_test_sdk_client().await;
+    let head_object_resp = sdk_client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("head object should succeed");
+    let (expected_sse, expected_sdk_sse) = match expected_sse {
+        None => (Some("AES256"), aws_sdk_s3::types::ServerSideEncryption::Aes256),
+        Some("AES256") => (Some("AES256"), aws_sdk_s3::types::ServerSideEncryption::Aes256),
+        Some("aws:kms") => (Some("aws:kms"), aws_sdk_s3::types::ServerSideEncryption::AwsKms),
+        Some("aws:kms:dsse") => (
+            Some("aws:kms:dsse"),
+            aws_sdk_s3::types::ServerSideEncryption::AwsKmsDsse,
+        ),
+        _ => panic!("unexpected sse type was used in a test"),
+    };
+    let actual_sse = head_object_resp
+        .server_side_encryption
+        .expect("SSE field should always have a value for this test");
+    assert_eq!(
+        actual_sse, expected_sdk_sse,
+        "unexpected sse type in HEAD_OBJECT response"
+    );
+    assert_eq!(
+        put_object_result.sse_type.as_deref(),
+        expected_sse,
+        "unexpected sse type in PutObjectResult"
+    );
+    if !matches!(expected_sdk_sse, aws_sdk_s3::types::ServerSideEncryption::Aes256) {
+        assert!(
+            head_object_resp.ssekms_key_id.is_some(),
+            "must have a key for non-default encryption methods",
+        );
+    }
+    if expected_key.is_some() {
+        // do not check the value of AWS managed key
+        assert_eq!(
+            &head_object_resp.ssekms_key_id, expected_key,
+            "unexpected sse key in HEAD_OBJECT response"
+        );
+        assert_eq!(
+            &put_object_result.sse_kms_key_id, expected_key,
+            "unexpected sse key in PutObjectResult"
+        );
+    }
+}
+
+// Test that SSE settings, which were used to create a new object, are reflected in:
+// 1. HEAD_OBJECT response queried via AWS SDK;
+// 2. returned `PutObjectResult`.
+#[test_case(Some("aws:kms"), Some(get_test_kms_key_id()))]
+#[test_case(Some("aws:kms"), None)]
+#[test_case(Some("aws:kms:dsse"), Some(get_test_kms_key_id()))]
+#[test_case(Some("aws:kms:dsse"), None)]
+#[test_case(None, None)]
+#[test_case(Some("AES256"), None)]
+#[tokio::test]
+#[cfg(not(feature = "s3express_tests"))]
+async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {
+    let bucket = get_test_bucket();
+    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let request_params = PutObjectParams::new()
+        .server_side_encryption(sse_type.map(|value| value.to_owned()))
+        .ssekms_key_id(kms_key_id.to_owned());
+
+    let prefix = get_unique_test_prefix("test_put_object_sse");
+    let key = format!("{prefix}hello");
+    let put_object_result = test_put_object_single(&client, &bucket, &key, request_params.clone()).await;
+    check_sse(&bucket, &key, sse_type, &kms_key_id, put_object_result).await;
+
+    let prefix = get_unique_test_prefix("test_put_object_sse");
+    let key = format!("{prefix}hello");
+    let put_object_result = test_put_object_single(&client, &bucket, &key, request_params.clone()).await;
+    check_sse(&bucket, &key, sse_type, &kms_key_id, put_object_result).await;
+}

--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::http::http_library_init;
+use crate::io::stream::InputStream;
 use crate::{aws_byte_cursor_as_slice, CrtError, ToAwsByteCursor};
 
 /// An HTTP header.
@@ -250,12 +251,15 @@ impl<'a> Iterator for HeadersIterator<'a> {
 
 /// A single HTTP message, initialized to be empty (i.e., no headers, no body).
 #[derive(Debug)]
-pub struct Message {
+pub struct Message<'a> {
     /// The pointer to the inner `aws_http_message`.
     pub(crate) inner: NonNull<aws_http_message>,
+
+    /// Input stream for the body of the http message, if present.
+    body_input_stream: Option<InputStream<'a>>,
 }
 
-impl Message {
+impl<'a> Message<'a> {
     /// Creates a new HTTP/1.1 request message.
     pub fn new_request(allocator: &Allocator) -> Result<Self, Error> {
         // TODO: figure out a better place to call this
@@ -264,7 +268,10 @@ impl Message {
         // SAFETY: `allocator.inner` is a valid `aws_allocator`.
         let inner = unsafe { aws_http_message_new_request(allocator.inner.as_ptr()).ok_or_last_error()? };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            body_input_stream: None,
+        })
     }
 
     /// Add a header to this message. If the header already exists in the message, this will add a
@@ -315,9 +322,31 @@ impl Message {
         let headers = unsafe { Headers::from_crt(header_ptr) };
         Ok(headers)
     }
+
+    /// Sets the body input stream for this message, and returns any previously set input stream.
+    /// If input_stream is None, unsets the body.
+    pub fn set_body_stream(&mut self, input_stream: Option<InputStream<'a>>) -> Option<InputStream<'a>> {
+        let old_input_stream = std::mem::replace(&mut self.body_input_stream, input_stream);
+
+        let new_input_stream_ptr = self
+            .body_input_stream
+            .as_ref()
+            .map(|s| s.inner.as_ptr())
+            .unwrap_or(std::ptr::null_mut());
+
+        // SAFETY: `aws_http_message_set_request_method` does _not_ take ownership of the underlying
+        // input stream. We take ownership of the input stream to make sure it doesn't get dropped
+        // while the CRT has a pointer to it. We also use lifetime parameters to enforce that this
+        // message does not outlive any data borrowed by the input stream.
+        unsafe {
+            aws_http_message_set_body_stream(self.inner.as_ptr(), new_input_stream_ptr);
+        }
+
+        old_input_stream
+    }
 }
 
-impl Drop for Message {
+impl Drop for Message<'_> {
     fn drop(&mut self) {
         // SAFETY: `self.inner` is a valid `aws_http_message`, and on Drop it's safe to decrement
         // the reference count since we won't use it again through `self.`

--- a/mountpoint-s3-crt/src/io.rs
+++ b/mountpoint-s3-crt/src/io.rs
@@ -11,6 +11,7 @@ pub mod event_loop;
 pub mod futures;
 pub mod host_resolver;
 pub mod retry_strategy;
+pub mod stream;
 
 static IO_LIBRARY_INIT: Once = Once::new();
 

--- a/mountpoint-s3-crt/src/io/stream.rs
+++ b/mountpoint-s3-crt/src/io/stream.rs
@@ -1,0 +1,192 @@
+//! AWS input streams.
+
+use crate::common::{allocator::Allocator, error::Error};
+use crate::CrtError;
+use mountpoint_s3_crt_sys::*;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+/// Status of an [InputStream].
+#[derive(Debug)]
+pub struct StreamStatus {
+    is_valid: bool,
+    is_end_of_stream: bool,
+}
+
+impl From<aws_stream_status> for StreamStatus {
+    fn from(status: aws_stream_status) -> Self {
+        Self {
+            is_valid: status.is_valid,
+            is_end_of_stream: status.is_end_of_stream,
+        }
+    }
+}
+
+impl From<StreamStatus> for aws_stream_status {
+    fn from(status: StreamStatus) -> Self {
+        Self {
+            is_valid: status.is_valid,
+            is_end_of_stream: status.is_end_of_stream,
+        }
+    }
+}
+
+/// Specifies where to seek from in an [InputStream].
+#[derive(Debug)]
+pub enum SeekBasis {
+    /// Seek from the beginning of the stream.
+    Begin,
+    /// Seek from the end of the stream.
+    End,
+}
+
+impl From<aws_stream_seek_basis> for SeekBasis {
+    fn from(value: aws_stream_seek_basis) -> Self {
+        match value {
+            aws_stream_seek_basis::AWS_SSB_BEGIN => Self::Begin,
+            aws_stream_seek_basis::AWS_SSB_END => Self::End,
+            _ => panic!("invalid stream seek basis: {value:?}"),
+        }
+    }
+}
+
+impl From<SeekBasis> for aws_stream_seek_basis {
+    fn from(value: SeekBasis) -> Self {
+        match value {
+            SeekBasis::Begin => aws_stream_seek_basis::AWS_SSB_BEGIN,
+            SeekBasis::End => aws_stream_seek_basis::AWS_SSB_END,
+        }
+    }
+}
+
+/// An [InputStream] is a way to read bytes. They can be obtained either from CRT functions,
+/// or by creating a new one based on a Rust type that implements the [GenericInputStream] trait.
+#[derive(Debug)]
+pub struct InputStream<'a> {
+    /// The inner aws_input_stream
+    pub(crate) inner: NonNull<aws_input_stream>,
+
+    /// Phantom data to keep the lifetimes correct, for example, if this stream is created from an
+    /// aws_byte_cursor that has some lifetime.
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> InputStream<'a> {
+    /// Create a new [InputStream] from a slice. The slice is not copied, and so the resulting
+    /// [InputStream] cannot outlive the slice (enforced by a lifetime restriction on the [InputStream].
+    pub fn new_from_slice(allocator: &Allocator, buffer: &'a [u8]) -> Result<Self, Error> {
+        let cursor = aws_byte_cursor {
+            len: buffer.len(),
+            ptr: buffer.as_ptr() as *mut u8,
+        };
+
+        // SAFETY: allocator is a valid aws_allocator. `Self` has a lifetime of 'a, so Rust
+        // will ensure that the return value from this function doesn't out live the buffer.
+        // We need to make sure in things that consume InputStream that we don't accidentally
+        // cause it to live longer than expected. (Or just kill this function...)
+        let inner = unsafe { aws_input_stream_new_from_cursor(allocator.inner.as_ptr(), &cursor).ok_or_last_error()? };
+
+        Ok(Self {
+            inner,
+            _phantom: Default::default(),
+        })
+    }
+}
+
+impl<'a> Drop for InputStream<'a> {
+    fn drop(&mut self) {
+        // SAFETY: self.inner is a valid `aws_input_stream`.
+        unsafe {
+            aws_input_stream_release(self.inner.as_ptr());
+        }
+    }
+}
+
+impl<'a> InputStream<'a> {
+    /// Seek to the given offset. Basis is either BEGIN or END, and describes where to seek from.
+    pub fn seek(&self, offset: i64, basis: SeekBasis) -> Result<(), Error> {
+        // SAFETY: self.inner is a valid input stream.
+        unsafe { aws_input_stream_seek(self.inner.as_ptr(), offset, basis.into()).ok_or_last_error() }
+    }
+
+    /// Read some data into `buffer`, and return how many bytes were read.
+    pub fn read(&self, buffer: &mut [u8]) -> Result<usize, Error> {
+        let mut byte_buf = aws_byte_buf {
+            len: 0,
+            buffer: buffer.as_mut_ptr(),
+            capacity: buffer.len(),
+            allocator: std::ptr::null_mut(),
+        };
+
+        // SAFETY: we know that the aws_byte_buf we just made points to a valid buffer, and trust
+        // the CRT function not to write outside that buffer's capacity. Also, self.inner is a
+        // valid input stream.
+        unsafe {
+            aws_input_stream_read(self.inner.as_ptr(), &mut byte_buf).ok_or_last_error()?;
+        };
+
+        assert_eq!(byte_buf.capacity, buffer.len(), "capacity should not change");
+
+        assert!(
+            byte_buf.len <= buffer.len(),
+            "should not have written more than available"
+        );
+        Ok(byte_buf.len)
+    }
+
+    /// Get the status of this stream. Can be used to indicate if stream is at the EOF.
+    pub fn get_status(&self) -> Result<StreamStatus, Error> {
+        let mut status: aws_stream_status = Default::default();
+
+        // SAFETY: self.inner is a valid input stream and status is a local variable.
+        unsafe {
+            aws_input_stream_get_status(self.inner.as_ptr(), &mut status).ok_or_last_error()?;
+        }
+
+        Ok(status.into())
+    }
+
+    /// Get the length of this input stream, in bytes. If a length cannot be determined, return Err.
+    pub fn get_length(&self) -> Result<usize, Error> {
+        let mut out_length: i64 = 0;
+
+        // SAFETY: self.inner is a valid input stream and out_length is a pointer to a local variable.
+        unsafe {
+            aws_input_stream_get_length(self.inner.as_ptr(), &mut out_length).ok_or_last_error()?;
+        }
+
+        Ok(out_length.try_into().expect("failed to convert i64 to usize"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::allocator::Allocator;
+
+    #[test]
+    fn test_slice_cursor() {
+        let allocator = Allocator::default();
+
+        let bytes = b"Hello world!".to_vec();
+
+        // Create a new CRT input stream from this slice.
+        let stream =
+            InputStream::new_from_slice(&allocator, &bytes[..]).expect("failed to make input stream from slice");
+
+        let mut buffer = vec![0u8; 40];
+
+        let nread = stream.read(&mut buffer).expect("read failed");
+
+        assert_eq!(nread, bytes.len());
+        assert_eq!(&buffer[..nread], &bytes[..]);
+
+        let status = stream.get_status().expect("get_status failed");
+
+        assert!(status.is_end_of_stream);
+
+        let length = stream.get_length().expect("get_length failed");
+
+        assert_eq!(length, bytes.len());
+    }
+}

--- a/mountpoint-s3-crt/src/io/stream.rs
+++ b/mountpoint-s3-crt/src/io/stream.rs
@@ -6,6 +6,47 @@ use mountpoint_s3_crt_sys::*;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
+/// Wrapper for [aws_input_stream].
+#[derive(Debug)]
+pub struct InputStream<'a> {
+    /// The inner `aws_input_stream`. Consumers should always hold the containing `InputStream<'a>` to ensure
+    /// `inner` points to a valid buffer.
+    pub(crate) inner: NonNull<aws_input_stream>,
+
+    /// Phantom data to keep the lifetimes correct, for example, if this stream is created from an
+    /// aws_byte_cursor that has some lifetime.
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> InputStream<'a> {
+    /// Create a new [InputStream] from a slice. The slice is not copied, and so the resulting
+    /// [InputStream] cannot outlive the slice (enforced by a lifetime restriction on the [InputStream]).
+    pub fn new_from_slice(allocator: &Allocator, buffer: &'a [u8]) -> Result<Self, Error> {
+        let cursor = aws_byte_cursor {
+            len: buffer.len(),
+            ptr: buffer.as_ptr() as *mut u8,
+        };
+
+        // SAFETY: allocator is a valid aws_allocator. `Self` has a lifetime of 'a, so Rust
+        // will ensure that the return value from this function doesn't out live the buffer.
+        let inner = unsafe { aws_input_stream_new_from_cursor(allocator.inner.as_ptr(), &cursor).ok_or_last_error()? };
+
+        Ok(Self {
+            inner,
+            _phantom: Default::default(),
+        })
+    }
+}
+
+impl<'a> Drop for InputStream<'a> {
+    fn drop(&mut self) {
+        // SAFETY: self.inner is a valid `aws_input_stream`.
+        unsafe {
+            aws_input_stream_release(self.inner.as_ptr());
+        }
+    }
+}
+
 /// Status of an [InputStream].
 #[derive(Debug)]
 pub struct StreamStatus {
@@ -55,49 +96,6 @@ impl From<SeekBasis> for aws_stream_seek_basis {
         match value {
             SeekBasis::Begin => aws_stream_seek_basis::AWS_SSB_BEGIN,
             SeekBasis::End => aws_stream_seek_basis::AWS_SSB_END,
-        }
-    }
-}
-
-/// An [InputStream] is a way to read bytes. They can be obtained either from CRT functions,
-/// or by creating a new one based on a Rust type that implements the [GenericInputStream] trait.
-#[derive(Debug)]
-pub struct InputStream<'a> {
-    /// The inner aws_input_stream
-    pub(crate) inner: NonNull<aws_input_stream>,
-
-    /// Phantom data to keep the lifetimes correct, for example, if this stream is created from an
-    /// aws_byte_cursor that has some lifetime.
-    _phantom: PhantomData<&'a [u8]>,
-}
-
-impl<'a> InputStream<'a> {
-    /// Create a new [InputStream] from a slice. The slice is not copied, and so the resulting
-    /// [InputStream] cannot outlive the slice (enforced by a lifetime restriction on the [InputStream].
-    pub fn new_from_slice(allocator: &Allocator, buffer: &'a [u8]) -> Result<Self, Error> {
-        let cursor = aws_byte_cursor {
-            len: buffer.len(),
-            ptr: buffer.as_ptr() as *mut u8,
-        };
-
-        // SAFETY: allocator is a valid aws_allocator. `Self` has a lifetime of 'a, so Rust
-        // will ensure that the return value from this function doesn't out live the buffer.
-        // We need to make sure in things that consume InputStream that we don't accidentally
-        // cause it to live longer than expected. (Or just kill this function...)
-        let inner = unsafe { aws_input_stream_new_from_cursor(allocator.inner.as_ptr(), &cursor).ok_or_last_error()? };
-
-        Ok(Self {
-            inner,
-            _phantom: Default::default(),
-        })
-    }
-}
-
-impl<'a> Drop for InputStream<'a> {
-    fn drop(&mut self) {
-        // SAFETY: self.inner is a valid `aws_input_stream`.
-        unsafe {
-            aws_input_stream_release(self.inner.as_ptr());
         }
     }
 }
@@ -177,16 +175,27 @@ mod test {
         let mut buffer = vec![0u8; 40];
 
         let nread = stream.read(&mut buffer).expect("read failed");
-
         assert_eq!(nread, bytes.len());
         assert_eq!(&buffer[..nread], &bytes[..]);
 
         let status = stream.get_status().expect("get_status failed");
-
         assert!(status.is_end_of_stream);
 
         let length = stream.get_length().expect("get_length failed");
-
         assert_eq!(length, bytes.len());
+
+        // Partial reads
+        let mut small_buffer = vec![0u8; 5];
+        stream.seek(0, SeekBasis::Begin).expect("seek to the start failed");
+
+        let nread = stream.read(&mut small_buffer).expect("read prefix failed");
+        assert_eq!(nread, 5);
+        assert_eq!(&small_buffer[..], &bytes[..5]);
+
+        stream.seek(-5, SeekBasis::End).expect("seek -5 from the end failed");
+
+        let nread = stream.read(&mut small_buffer).expect("read suffix failed");
+        assert_eq!(nread, 5);
+        assert_eq!(&small_buffer[..], &bytes[(length - 5)..]);
     }
 }


### PR DESCRIPTION
## Description of change

Re-introduce support for a single PutObject request in `mountpoint-s3-client`. The request is exposed with the name `put_object_single`, while the existing `put_object` method performs a multi-part upload. 

## Does this change impact existing behavior?

No, it adds a new method.

## Does this change need a changelog entry in any of the crates?

Yes, it will require an entry for `mountpoint-s3-client` and possibly for `mountpoint-s3-crt`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
