### PR TITLE
Copy object operation

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Other changes
 
+* Support for copy object operation. ([#1052](https://github.com/awslabs/mountpoint-s3/pull/1052))
 * Address a threading issue in the s2n-tls library that could result in premature cleanup and `NULL pointer` errors. ([aws/s2n-tls#4584](https://github.com/aws/s2n-tls/pull/4584))
 * Inaccurate reporting of `s3.client.buffer_pool.primary_allocated` CRT statistic is fixed. ([awslabs/aws-c-s3#453](https://github.com/awslabs/aws-c-s3/pull/453))
 * Expose `s3.client.buffer_pool.forced_used` metric which account for buffer allocations that could exceed memory limit in the CRT buffer pool. ([#1025](https://github.com/awslabs/mountpoint-s3/pull/1025))

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Other changes
 
-* Support for copy object operation. ([#1052](https://github.com/awslabs/mountpoint-s3/pull/1052))
+* Add support for copy object operation. ([#1052](https://github.com/awslabs/mountpoint-s3/pull/1052))
 * Address a threading issue in the s2n-tls library that could result in premature cleanup and `NULL pointer` errors. ([aws/s2n-tls#4584](https://github.com/aws/s2n-tls/pull/4584))
 * Inaccurate reporting of `s3.client.buffer_pool.primary_allocated` CRT statistic is fixed. ([awslabs/aws-c-s3#453](https://github.com/awslabs/aws-c-s3/pull/453))
 * Expose `s3.client.buffer_pool.forced_used` metric which account for buffer allocations that could exceed memory limit in the CRT buffer pool. ([#1025](https://github.com/awslabs/mountpoint-s3/pull/1025))

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -15,10 +15,11 @@ use mountpoint_s3_crt::s3::client::BufferPoolUsageStats;
 use pin_project::pin_project;
 
 use crate::object_client::{
-    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
-    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
-    ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams,
-    PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
+    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
+    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
+    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
+    ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams,
+    UploadReview,
 };
 
 // Wrapper for injecting failures into a get stream or a put request

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -15,7 +15,7 @@ use mountpoint_s3_crt::s3::client::BufferPoolUsageStats;
 use pin_project::pin_project;
 
 use crate::object_client::{
-    DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
+    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
     GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
     ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams,
     PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
@@ -96,6 +96,19 @@ where
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError> {
         // TODO failure hook for delete_object
         self.client.delete_object(bucket, key).await
+    }
+
+    async fn copy_object(
+        &self,
+        source_bucket: &str,
+        source_key: &str,
+        destination_bucket: &str,
+        destination_key: &str,
+        params: &CopyObjectParams,
+    ) -> ObjectClientResult<CopyObjectResult, CopyObjectError, Self::ClientError> {
+        self.client
+            .copy_object(source_bucket, source_key, destination_bucket, destination_key, params)
+            .await
     }
 
     async fn get_object(

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -72,10 +72,11 @@ pub mod config {
 /// Types used by all object clients
 pub mod types {
     pub use super::object_client::{
-        Checksum, ChecksumAlgorithm, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts,
-        GetObjectAttributesResult, GetObjectRequest, HeadObjectResult, ListObjectsResult, ObjectAttribute,
-        ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams,
-        PutObjectTrailingChecksums, RestoreStatus, UploadChecksum, UploadReview, UploadReviewPart,
+        Checksum, ChecksumAlgorithm, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag, GetBodyPart,
+        GetObjectAttributesParts, GetObjectAttributesResult, GetObjectRequest, HeadObjectResult, ListObjectsResult,
+        ObjectAttribute, ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult,
+        PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus, UploadChecksum, UploadReview,
+        UploadReviewPart,
     };
 }
 
@@ -86,8 +87,8 @@ pub mod types {
 /// client errors. See its documentation for more details.
 pub mod error {
     pub use super::object_client::{
-        DeleteObjectError, GetObjectAttributesError, GetObjectError, HeadObjectError, ListObjectsError,
-        ObjectClientError, PutObjectError,
+        CopyObjectError, DeleteObjectError, GetObjectAttributesError, GetObjectError, HeadObjectError,
+        ListObjectsError, ObjectClientError, PutObjectError,
     };
     #[doc(hidden)]
     pub use super::s3_crt_client::HeadBucketError;

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -25,11 +25,12 @@ use tracing::trace;
 use crate::checksums::crc32c_to_base64;
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::{
-    CopyObjectError, CopyObjectParams, CopyObjectResult, Checksum, ChecksumAlgorithm, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError,
-    GetObjectAttributesParts, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
-    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
-    ObjectClientResult, ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
-    PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
+    Checksum, ChecksumAlgorithm, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError,
+    DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesParts,
+    GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError,
+    ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult, ObjectInfo, ObjectPart,
+    PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams,
+    PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
 };
 
 mod leaky_bucket;

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -14,10 +14,10 @@ use crate::mock_client::{
     MockClient, MockClientConfig, MockClientError, MockGetObjectRequest, MockObject, MockPutObjectRequest,
 };
 use crate::object_client::{
-    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
-    GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
-    ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult,
-    PutObjectSingleParams,
+    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
+    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
+    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientResult,
+    PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
 };
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -14,7 +14,7 @@ use crate::mock_client::{
     MockClient, MockClientConfig, MockClientError, MockGetObjectRequest, MockObject, MockPutObjectRequest,
 };
 use crate::object_client::{
-    DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
+    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesResult,
     GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError, ListObjectsResult,
     ObjectAttribute, ObjectClient, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult,
     PutObjectSingleParams,
@@ -124,6 +124,19 @@ impl ObjectClient for ThroughputMockClient {
         key: &str,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError> {
         self.inner.delete_object(bucket, key).await
+    }
+
+    async fn copy_object(
+        &self,
+        source_bucket: &str,
+        source_key: &str,
+        destination_bucket: &str,
+        destination_key: &str,
+        params: &CopyObjectParams,
+    ) -> ObjectClientResult<CopyObjectResult, CopyObjectError, Self::ClientError> {
+        self.inner
+            .copy_object(source_bucket, source_key, destination_bucket, destination_key, params)
+            .await
     }
 
     async fn get_object(

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -56,6 +56,20 @@ pub trait ObjectClient {
         key: &str,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError>;
 
+    /// Create a copy of an existing object. Currently, this functionality has the following limitations:
+    /// - supported only for standard s3 buckets.
+    /// - host header must use virtual host addressing style (path style is not supported) and both source and dest buckets must have dns compliant name.
+    /// - only {bucket}/{key} format is supported for source and passing arn as source will not work.
+    /// - source bucket is assumed to be in the same region as destination bucket.
+    async fn copy_object(
+        &self,
+        source_bucket: &str,
+        source_key: &str,
+        destination_bucket: &str,
+        destination_key: &str,
+        params: &CopyObjectParams,
+    ) -> ObjectClientResult<CopyObjectResult, CopyObjectError, Self::ClientError>;
+
     /// Get an object from the object store. Returns a stream of body parts of the object. Parts are
     /// guaranteed to be returned by the stream in order and contiguously.
     async fn get_object(
@@ -224,6 +238,39 @@ pub struct DeleteObjectResult {}
 pub enum DeleteObjectError {
     #[error("The bucket does not exist")]
     NoSuchBucket,
+}
+
+/// Result of a [`copy_object`](ObjectClient::copy_object) request
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct CopyObjectResult {
+    // TODO: Populate this struct with return fields from the S3 API, e.g., etag.
+}
+
+/// Errors returned by a [`copy_object`](ObjectClient::copy_object) request
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CopyObjectError {
+    /// Note that CopyObject cannot distinguish between NoSuchBucket and NoSuchKey errors
+    #[error("The object was not found")]
+    NotFound,
+
+    #[error("The source object of the COPY action is not in the active tier and is only stored in Amazon S3 Glacier.")]
+    ObjectNotInActiveTierError,
+}
+
+/// Parameters to a [`copy_object`](ObjectClient::copy_object) request
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct CopyObjectParams {
+    // TODO: Populate this struct with fields as and when required to satisfy various use cases.
+}
+
+impl CopyObjectParams {
+    /// Create a default [CopyObjectParams].
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 /// Result of a [`get_object_attributes`](ObjectClient::get_object_attributes) request

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -57,10 +57,12 @@ pub trait ObjectClient {
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError>;
 
     /// Create a copy of an existing object. Currently, this functionality has the following limitations:
-    /// - supported only for standard s3 buckets.
-    /// - host header must use virtual host addressing style (path style is not supported) and both source and dest buckets must have dns compliant name.
-    /// - only {bucket}/{key} format is supported for source and passing arn as source will not work.
-    /// - source bucket is assumed to be in the same region as destination bucket.
+    /// - Supported only for copying between matching bucket types:
+    ///     - Standard S3 to Standard S3 buckets.
+    ///     - S3 Express to S3 Express buckets.
+    /// - Host header must use virtual host addressing style (path style is not supported) and both source and dest buckets must have dns compliant name.
+    /// - Only {bucket}/{key} format is supported for source and passing arn as source will not work.
+    /// - Source bucket is assumed to be in the same region as destination bucket.
     async fn copy_object(
         &self,
         source_bucket: &str,

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -42,7 +42,6 @@ use crate::endpoint_config::{self, EndpointConfig};
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::*;
 use crate::user_agent::UserAgent;
-use crate::{S3GetObjectRequest, S3PutObjectRequest};
 
 macro_rules! request_span {
     ($self:expr, $method:expr, $($field:tt)*) => {{
@@ -60,6 +59,8 @@ macro_rules! request_span {
 pub(crate) mod copy_object;
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
+
+pub(crate) use get_object::S3GetObjectRequest;
 pub(crate) mod get_object_attributes;
 
 pub(crate) mod head_object;
@@ -68,6 +69,7 @@ pub(crate) mod list_objects;
 pub(crate) mod head_bucket;
 pub(crate) mod put_object;
 pub use head_bucket::HeadBucketError;
+pub(crate) use put_object::S3PutObjectRequest;
 
 /// `tracing` doesn't allow dynamic levels but we want to dynamically choose the log level for
 /// requests based on their response status. https://github.com/tokio-rs/tracing/issues/372

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -42,7 +42,7 @@ use crate::endpoint_config::{self, EndpointConfig};
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::*;
 use crate::user_agent::UserAgent;
-use crate::{object_client::*, S3GetObjectRequest, S3PutObjectRequest};
+use crate::{S3GetObjectRequest, S3PutObjectRequest};
 
 macro_rules! request_span {
     ($self:expr, $method:expr, $($field:tt)*) => {{
@@ -60,17 +60,13 @@ macro_rules! request_span {
 pub(crate) mod copy_object;
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
-
-pub(crate) use get_object::S3GetObjectRequest;
 pub(crate) mod get_object_attributes;
 
 pub(crate) mod head_object;
 pub(crate) mod list_objects;
 
-pub(crate) mod put_object;
-pub(crate) use put_object::S3PutObjectRequest;
-
 pub(crate) mod head_bucket;
+pub(crate) mod put_object;
 pub use head_bucket::HeadBucketError;
 
 /// `tracing` doesn't allow dynamic levels but we want to dynamically choose the log level for

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -42,6 +42,7 @@ use crate::endpoint_config::{self, EndpointConfig};
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::*;
 use crate::user_agent::UserAgent;
+use crate::{object_client::*, S3GetObjectRequest, S3PutObjectRequest};
 
 macro_rules! request_span {
     ($self:expr, $method:expr, $($field:tt)*) => {{
@@ -56,6 +57,7 @@ macro_rules! request_span {
     ($self:expr, $method:expr) => { request_span!($self, $method,) };
 }
 
+pub(crate) mod copy_object;
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
 
@@ -527,7 +529,6 @@ impl S3CrtClientInner {
         let options = Self::new_meta_request_options(message, operation);
         self.make_meta_request_from_options(options, request_span, |_| {}, on_headers, on_body, on_finish)
     }
-
     /// Make an HTTP request using this S3 client that invokes the given callbacks as the request
     /// makes progress. See [make_meta_request] for arguments.
     fn make_meta_request_from_options<T: Send + 'static, E: std::error::Error + Send + 'static>(
@@ -803,6 +804,7 @@ enum S3Operation {
     HeadObject,
     ListObjects,
     PutObject,
+    CopyObject,
     PutObjectSingle,
 }
 
@@ -812,6 +814,7 @@ impl S3Operation {
         match self {
             S3Operation::GetObject => MetaRequestType::GetObject,
             S3Operation::PutObject => MetaRequestType::PutObject,
+            S3Operation::CopyObject => MetaRequestType::CopyObject,
             _ => MetaRequestType::Default,
         }
     }
@@ -827,6 +830,7 @@ impl S3Operation {
             S3Operation::HeadObject => Some("HeadObject"),
             S3Operation::ListObjects => Some("ListObjectsV2"),
             S3Operation::PutObject => None,
+            S3Operation::CopyObject => None,
             S3Operation::PutObjectSingle => Some("PutObject"),
         }
     }
@@ -1092,6 +1096,7 @@ fn request_type_to_metrics_string(request_type: RequestType) -> &'static str {
         RequestType::AbortMultipartUpload => "AbortMultipartUpload",
         RequestType::CompleteMultipartUpload => "CompleteMultipartUpload",
         RequestType::UploadPartCopy => "UploadPartCopy",
+        RequestType::CopyObject => "CopyObject",
         RequestType::PutObject => "PutObject",
     }
 }
@@ -1260,6 +1265,18 @@ impl ObjectClient for S3CrtClient {
         key: &str,
     ) -> ObjectClientResult<DeleteObjectResult, DeleteObjectError, Self::ClientError> {
         self.delete_object(bucket, key).await
+    }
+
+    async fn copy_object(
+        &self,
+        source_bucket: &str,
+        source_key: &str,
+        destination_bucket: &str,
+        destination_key: &str,
+        params: &CopyObjectParams,
+    ) -> ObjectClientResult<CopyObjectResult, CopyObjectError, S3RequestError> {
+        self.copy_object(source_bucket, source_key, destination_bucket, destination_key, params)
+            .await
     }
 
     async fn get_object(

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -1,0 +1,97 @@
+use std::ops::Deref;
+use std::os::unix::prelude::OsStrExt;
+
+use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
+
+use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
+use crate::s3_crt_client::{S3CrtClient, S3Operation, S3RequestError};
+
+impl S3CrtClient {
+    /// Create and begin a new CopyObject request.
+    pub(super) async fn copy_object(
+        &self,
+        source_bucket: &str,
+        source_key: &str,
+        destination_bucket: &str,
+        destination_key: &str,
+        _params: &CopyObjectParams,
+    ) -> ObjectClientResult<CopyObjectResult, CopyObjectError, S3RequestError> {
+        let request = {
+            let mut message = self
+                .inner
+                .new_request_template("PUT", destination_bucket)
+                .map_err(S3RequestError::construction_failure)?;
+            message
+                .set_request_path(format!("/{destination_key}"))
+                .map_err(S3RequestError::construction_failure)?;
+            message
+                .set_header(&Header::new(
+                    "x-amz-copy-source",
+                    format!("/{source_bucket}/{source_key}"),
+                ))
+                .map_err(S3RequestError::construction_failure)?;
+
+            let span = request_span!(
+                self.inner,
+                "copy_object",
+                source_bucket,
+                source_key,
+                destination_bucket,
+                destination_key
+            );
+
+            self.inner
+                .make_simple_http_request(message, S3Operation::CopyObject, span, parse_copy_object_error)?
+        };
+
+        let _body = request.await?;
+
+        Ok(CopyObjectResult {})
+    }
+}
+fn parse_copy_object_error(result: &MetaRequestResult) -> Option<CopyObjectError> {
+    match result.response_status {
+        403 => {
+            let body = result.error_response_body.as_ref()?;
+            let root = xmltree::Element::parse(body.as_bytes()).ok()?;
+            let error_code = root.get_child("Code")?;
+            let error_str = error_code.get_text()?;
+
+            match error_str.deref() {
+                "ObjectNotInActiveTierError" => Some(CopyObjectError::ObjectNotInActiveTierError),
+                _ => None,
+            }
+        }
+        404 => Some(CopyObjectError::NotFound),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::{OsStr, OsString};
+
+    fn make_result(response_status: i32, body: impl Into<OsString>) -> MetaRequestResult {
+        MetaRequestResult {
+            response_status,
+            crt_error: 1i32.into(),
+            error_response_headers: None,
+            error_response_body: Some(body.into()),
+        }
+    }
+    #[test]
+    fn parse_403_object_not_in_active_tier_error() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>ObjectNotInActiveTierError</Code><Message>The source object of the COPY action is not in the active tier and is only stored in Amazon S3 Glacier</Message><BucketName>test-bucket</BucketName><RequestId>BHCQ0FTYY0HKMV43</RequestId><HostId>ntCK1jQfPxY7sSNL/GB13RttgJLjSETfIuOiuRnwImO0dQP2ttj2Qqpn5S/jSLt3Ql0TgHWuYF0=</HostId></Error>"#;
+        let result = make_result(403, OsStr::from_bytes(&body[..]));
+        let result = parse_copy_object_error(&result);
+        assert_eq!(result, Some(CopyObjectError::ObjectNotInActiveTierError));
+    }
+    #[test]
+    fn parse_404_error() {
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code></Code><Message></Message><BucketName>test-bucket</BucketName><RequestId>BHCQ0FTYY0HKMV43</RequestId><HostId>ntCK1jQfPxY7sSNL/GB13RttgJLjSETfIuOiuRnwImO0dQP2ttj2Qqpn5S/jSLt3Ql0TgHWuYF0=</HostId></Error>"#;
+        let result = make_result(404, OsStr::from_bytes(&body[..]));
+        let result = parse_copy_object_error(&result);
+        assert_eq!(result, Some(CopyObjectError::NotFound));
+    }
+}

--- a/mountpoint-s3-client/tests/copy_object.rs
+++ b/mountpoint-s3-client/tests/copy_object.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+use aws_sdk_s3::primitives::ByteStream;
+use bytes::Bytes;
+use common::*;
+use mountpoint_s3_client::error::ObjectClientError;
+use mountpoint_s3_client::S3RequestError;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+#[tokio::test]
+async fn test_copy_objects() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_copy_objects");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+    let copy_key = format!("{prefix}/hello2");
+
+    let _result = client
+        .copy_object(&bucket, &key, &bucket, &copy_key, &Default::default())
+        .await
+        .expect("copy_object operation should succeed");
+
+    sdk_client
+        .head_object()
+        .bucket(&bucket)
+        .key(&copy_key)
+        .send()
+        .await
+        .expect("copied object should exist");
+}
+#[tokio::test]
+async fn test_copy_object_no_permission() {
+    let (_bucket, prefix) = get_test_bucket_and_prefix("test_copy_object_no_permission");
+    let bucket = get_test_bucket_without_permissions();
+    let key = format!("{prefix}/hello");
+    let copy_key = format!("{prefix}/hello2");
+
+    let client: S3CrtClient = get_test_client();
+    let result = client
+        .copy_object(&bucket, &key, &bucket, &copy_key, &Default::default())
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_, _)))
+    ));
+}
+
+// TODO: Add integration test for cross bucket copy but before that need to set up a new environment variable for a new bucket.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1359,6 +1359,8 @@ pub enum RequestType {
     CompleteMultipartUpload,
     /// UploadPartCopy: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html
     UploadPartCopy,
+    /// CopyObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+    CopyObject,
     /// PutObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     PutObject,
 }
@@ -1375,6 +1377,7 @@ impl From<aws_s3_request_type> for RequestType {
             aws_s3_request_type::AWS_S3_REQUEST_TYPE_ABORT_MULTIPART_UPLOAD => RequestType::AbortMultipartUpload,
             aws_s3_request_type::AWS_S3_REQUEST_TYPE_COMPLETE_MULTIPART_UPLOAD => RequestType::CompleteMultipartUpload,
             aws_s3_request_type::AWS_S3_REQUEST_TYPE_UPLOAD_PART_COPY => RequestType::UploadPartCopy,
+            aws_s3_request_type::AWS_S3_REQUEST_TYPE_COPY_OBJECT => RequestType::CopyObject,
             aws_s3_request_type::AWS_S3_REQUEST_TYPE_PUT_OBJECT => RequestType::PutObject,
             _ => panic!("unknown request type {:?}", value),
         }


### PR DESCRIPTION
## Description of change

These changes enable copy object operation. Need this operation in mountpoint to support distributed checkpointing functionality in pytorch.

Relevant issues: <!-- NA-->

## Does this change impact existing behavior?
No

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
No breaking changes

## Does this change need a changelog entry in any of the crates?

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
