### PR TITLE
Add a type-safe wrapper for open flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "aws-sdk-sts",
  "base16ct",
  "bincode",
+ "bitflags 2.5.0",
  "built",
  "bytes",
  "clap",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -16,6 +16,7 @@ async-channel = "2.1.1"
 async-lock = "3.3.0"
 async-trait = "0.1.57"
 bincode = "1.3.3"
+bitflags = "2.5.0"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
 const_format = "0.2.30"

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -285,12 +285,12 @@ where
     }
 
     pub async fn open(&self, ino: InodeNo, flags: OpenFlags, pid: u32) -> Result<Opened, Error> {
-        trace!("fs:open with ino {:?} flags {:#b} pid {:?}", ino, flags, pid);
+        trace!("fs:open with ino {:?} flags {} pid {:?}", ino, flags, pid);
 
         #[cfg(not(target_os = "linux"))]
         let direct_io = false;
         #[cfg(target_os = "linux")]
-        let direct_io = flags & libc::O_DIRECT != 0;
+        let direct_io = flags.contains(OpenFlags::O_DIRECT);
 
         // We can't support O_SYNC writes because they require the data to go to stable storage
         // at `write` time, but we only commit a PUT at `close` time.

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -33,6 +33,9 @@ pub use error::{Error, ToErrno};
 pub mod error_metadata;
 use error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_LOOKUP_NONEXISTENT};
 
+mod flags;
+pub use flags::OpenFlags;
+
 mod handles;
 use handles::{DirHandle, FileHandle, FileHandleState, UploadState};
 
@@ -281,7 +284,7 @@ where
         self.superblock.forget(ino, n);
     }
 
-    pub async fn open(&self, ino: InodeNo, flags: i32, pid: u32) -> Result<Opened, Error> {
+    pub async fn open(&self, ino: InodeNo, flags: OpenFlags, pid: u32) -> Result<Opened, Error> {
         trace!("fs:open with ino {:?} flags {:#b} pid {:?}", ino, flags, pid);
 
         #[cfg(not(target_os = "linux"))]
@@ -291,7 +294,7 @@ where
 
         // We can't support O_SYNC writes because they require the data to go to stable storage
         // at `write` time, but we only commit a PUT at `close` time.
-        if flags & (libc::O_SYNC | libc::O_DSYNC) != 0 {
+        if flags.intersects(OpenFlags::O_SYNC | OpenFlags::O_DSYNC) {
             return Err(err!(libc::EINVAL, "O_SYNC and O_DSYNC are not supported"));
         }
 
@@ -309,12 +312,12 @@ where
 
         // Open with O_APPEND is ok for new files because it's same as creating a new one.
         // but we can't support it on existing files and we should explicitly say we don't allow that.
-        if remote_file && (flags & libc::O_APPEND != 0) {
+        if remote_file && flags.contains(OpenFlags::O_APPEND) {
             return Err(err!(libc::EINVAL, "O_APPEND is not supported on existing files"));
         }
 
-        let state = if flags & libc::O_RDWR != 0 {
-            let is_truncate = flags & libc::O_TRUNC != 0;
+        let state = if flags.contains(OpenFlags::O_RDWR) {
+            let is_truncate = flags.contains(OpenFlags::O_TRUNC);
             if !remote_file || (self.config.allow_overwrite && is_truncate) {
                 // If the file is new or opened in truncate mode, we know it must be a write handle.
                 debug!("fs:open choosing write handle for O_RDWR");
@@ -324,7 +327,7 @@ where
                 debug!("fs:open choosing read handle for O_RDWR");
                 FileHandleState::new_read_handle(&lookup, self).await?
             }
-        } else if flags & libc::O_WRONLY != 0 {
+        } else if flags.contains(OpenFlags::O_WRONLY) {
             FileHandleState::new_write_handle(&lookup, lookup.inode.ino(), flags, pid, self).await?
         } else {
             FileHandleState::new_read_handle(&lookup, self).await?
@@ -832,7 +835,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(dentry.attr.size, 0);
-        fs.open(dentry.attr.ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
+        fs.open(dentry.attr.ino, OpenFlags::O_WRONLY, 0)
             .await
             .expect("open before the corruption should succeed");
 
@@ -845,7 +848,7 @@ mod tests {
             .unwrap();
         assert_eq!(dentry.attr.size, 0);
         let err = fs
-            .open(dentry.attr.ino, libc::S_IFREG as i32 | libc::O_WRONLY, 0)
+            .open(dentry.attr.ino, OpenFlags::O_WRONLY, 0)
             .await
             .expect_err("open after the corruption should fail");
         assert_eq!(err.errno, libc::EIO);

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -55,15 +55,21 @@ macro_rules! libc_flags {
 }
 
 /// Flags used in [`open`](super::S3Filesystem::open).
+///
+/// Note that the "access mode" constants are not mapped as values because they do not behave
+/// like normal bit flags (and will not be shown in `Debug`/`Display`):
+/// * `libc::O_ACCMODE = 0b11` is a mask for the access mode,
+/// * `libc::O_RDONLY = 0b00` is also the default value.
+///
+/// The other access mode constants, `libc::O_WRONLY = 0b01` and `libc::O_RDWR = 0b10`, are
+/// valid bit flags and mapped respectively to `OpenFlags::O_WRONLY` and `OpenFlags::O_RDWR`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct OpenFlags(i32);
 
 libc_flags! {
     OpenFlags : i32 {
-        O_RDONLY,
         O_WRONLY,
         O_RDWR,
-        O_ACCMODE,
         O_APPEND,
         O_SYNC,
         O_TRUNC,
@@ -88,6 +94,13 @@ mod tests {
         let raw = libc::O_WRONLY | libc::O_APPEND;
         let flags: OpenFlags = raw.into();
         assert_eq!(flags, OpenFlags::O_WRONLY | OpenFlags::O_APPEND);
+    }
+
+    #[test]
+    fn unknown_test() {
+        let raw = libc::O_ACCMODE; // Not defined as a value in `OpenFlags`.
+        let flags: OpenFlags = raw.into();
+        assert_eq!(flags.bits(), raw, "Unknown value should be preserved");
     }
 
     #[test]

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -18,13 +18,15 @@ macro_rules! libc_flags {
     (
         $struct_name:ident : $raw_type:ty {
         $(
-        $flag_name:ident
+            $(#[$flag_attr:ident $($flag_meta_args:tt)*])*
+            $flag_name:ident
         ),*$(,)+
     }
     ) => {
         bitflags::bitflags! {
             impl $struct_name : $raw_type {
                 $(
+                    $(#[$flag_attr $($flag_meta_args)*])*
                     const $flag_name = libc::$flag_name;
                 )*
 
@@ -66,10 +68,12 @@ libc_flags! {
         O_SYNC,
         O_TRUNC,
         O_DSYNC,
-        O_DIRECT,
         O_NONBLOCK,
         O_NOCTTY,
         O_CREAT,
+
+        #[cfg(target_os = "linux")]
+        O_DIRECT,
 
         // Incomplete list. To be integrated if/when required.
     }
@@ -89,6 +93,10 @@ mod tests {
     #[test]
     fn debug_test() {
         let flags = OpenFlags::O_WRONLY | OpenFlags::O_APPEND;
-        assert_eq!(format!("{:?}", flags), "OpenFlags(0x9 = O_WRONLY | O_APPEND)");
+        let expected = format!(
+            "OpenFlags({:#x} = O_WRONLY | O_APPEND)",
+            libc::O_WRONLY | libc::O_APPEND
+        );
+        assert_eq!(format!("{:?}", flags), expected);
     }
 }

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -1,0 +1,49 @@
+macro_rules! libc_flags {
+    ($name:ident {
+        $(
+        $flag_name:ident
+        ),*$(,)+
+    }
+    ) => {
+            bitflags::bitflags! {
+                impl $name : i32 {
+                    $(
+                        const $flag_name = libc::$flag_name;
+                    )*
+
+                    const _ = !0;
+                }
+            }
+
+            impl std::fmt::Display for $name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    bitflags::parser::to_writer(self, f)
+                }
+            }
+    }
+}
+
+/// Flags used in [`open`](super::S3Filesystem::open).
+#[derive(Debug, Clone, Copy)]
+pub struct OpenFlags(i32);
+
+libc_flags! {
+    OpenFlags {
+        O_RDONLY,
+        O_WRONLY,
+        O_RDWR,
+        O_ACCMODE,
+        O_APPEND,
+        O_SYNC,
+        O_TRUNC,
+        O_DSYNC,
+
+        // Incomplete list. To be integrated if/when required.
+    }
+}
+
+impl From<i32> for OpenFlags {
+    fn from(value: i32) -> Self {
+        Self::from_bits_retain(value)
+    }
+}

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -66,6 +66,10 @@ libc_flags! {
         O_SYNC,
         O_TRUNC,
         O_DSYNC,
+        O_DIRECT,
+        O_NONBLOCK,
+        O_NOCTTY,
+        O_CREAT,
 
         // Incomplete list. To be integrated if/when required.
     }
@@ -77,7 +81,7 @@ mod tests {
 
     #[test]
     fn conversion_test() {
-        let raw = 0x9;
+        let raw = libc::O_WRONLY | libc::O_APPEND;
         let flags: OpenFlags = raw.into();
         assert_eq!(flags, OpenFlags::O_WRONLY | OpenFlags::O_APPEND);
     }

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -1,34 +1,63 @@
+/// Helper to define type-safe flags from `libc` constants.
+/// Usage:
+///
+/// ```
+/// struct MyFlags(u32);
+///
+/// libc_flags! {
+///     MyFlags : u32 {
+///         A,
+///         B,
+///         C,
+///     }
+/// }    
+/// ```
+///
+/// See [`OpenFlags`] for an example.
 macro_rules! libc_flags {
-    ($name:ident {
+    (
+        $struct_name:ident : $raw_type:ty {
         $(
         $flag_name:ident
         ),*$(,)+
     }
     ) => {
-            bitflags::bitflags! {
-                impl $name : i32 {
-                    $(
-                        const $flag_name = libc::$flag_name;
-                    )*
+        bitflags::bitflags! {
+            impl $struct_name : $raw_type {
+                $(
+                    const $flag_name = libc::$flag_name;
+                )*
 
-                    const _ = !0;
-                }
+                const _ = !0;
             }
+        }
 
-            impl std::fmt::Display for $name {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    bitflags::parser::to_writer(self, f)
-                }
+        impl std::fmt::Display for $struct_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                bitflags::parser::to_writer(self, f)
             }
+        }
+
+        impl std::fmt::Debug for $struct_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}({:#x} = {})", stringify!($struct_name), self.0, self.to_string())
+            }
+        }
+
+        impl From<$raw_type> for $struct_name {
+            fn from(value: $raw_type) -> Self {
+                Self::from_bits_retain(value)
+            }
+        }
     }
 }
 
 /// Flags used in [`open`](super::S3Filesystem::open).
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct OpenFlags(i32);
 
 libc_flags! {
-    OpenFlags {
+    OpenFlags : i32 {
         O_RDONLY,
         O_WRONLY,
         O_RDWR,
@@ -42,8 +71,20 @@ libc_flags! {
     }
 }
 
-impl From<i32> for OpenFlags {
-    fn from(value: i32) -> Self {
-        Self::from_bits_retain(value)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_test() {
+        let raw = 0x9;
+        let flags: OpenFlags = raw.into();
+        assert_eq!(flags, OpenFlags::O_WRONLY | OpenFlags::O_APPEND);
+    }
+
+    #[test]
+    fn debug_test() {
+        let flags = OpenFlags::O_WRONLY | OpenFlags::O_APPEND;
+        assert_eq!(format!("{:?}", flags), "OpenFlags(0x9 = O_WRONLY | O_APPEND)");
     }
 }

--- a/mountpoint-s3/src/fs/flags.rs
+++ b/mountpoint-s3/src/fs/flags.rs
@@ -1,7 +1,7 @@
 /// Helper to define type-safe flags from `libc` constants.
 /// Usage:
 ///
-/// ```
+/// ```ignore
 /// struct MyFlags(u32);
 ///
 /// libc_flags! {

--- a/mountpoint-s3/src/fs/handles.rs
+++ b/mountpoint-s3/src/fs/handles.rs
@@ -11,7 +11,7 @@ use crate::sync::atomic::{AtomicI64, Ordering};
 use crate::sync::AsyncMutex;
 use crate::upload::UploadRequest;
 
-use super::{DirectoryEntry, Error, InodeNo, S3Filesystem, ToErrno};
+use super::{DirectoryEntry, Error, InodeNo, OpenFlags, S3Filesystem, ToErrno};
 
 #[derive(Debug)]
 pub struct DirHandle {
@@ -90,11 +90,11 @@ where
     pub async fn new_write_handle(
         lookup: &LookedUp,
         ino: InodeNo,
-        flags: i32,
+        flags: OpenFlags,
         pid: u32,
         fs: &S3Filesystem<Client, Prefetcher>,
     ) -> Result<FileHandleState<Client, Prefetcher>, Error> {
-        let is_truncate = flags & libc::O_TRUNC != 0;
+        let is_truncate = flags.contains(OpenFlags::O_TRUNC);
         let handle = fs
             .superblock
             .write(&fs.client, ino, fs.config.allow_overwrite, is_truncate)

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -122,7 +122,7 @@ where
 
     #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, pid=req.pid(), name=field::Empty))]
     fn open(&self, req: &Request<'_>, ino: InodeNo, flags: i32, reply: ReplyOpen) {
-        match block_on(self.fs.open(ino, flags, req.pid()).in_current_span()) {
+        match block_on(self.fs.open(ino, flags.into(), req.pid()).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
             Err(e) => fuse_error!("open", reply, e),
         }

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -93,7 +93,7 @@ async fn test_read_dir_root(prefix: &str) {
         assert_eq!(attr.attr.ino, reply.ino);
         assert_attr(attr.attr, FileType::RegularFile, 15, uid, gid, file_perm);
 
-        let fh = fs.open(reply.ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+        let fh = fs.open(reply.ino, OpenFlags::empty(), 0).await.unwrap().fh;
         let bytes_read = fs
             .read(reply.ino, fh, 0, 4096, 0, None)
             .await
@@ -169,7 +169,7 @@ async fn test_read_dir_nested(prefix: &str) {
         assert_eq!(attr.attr.ino, reply.ino);
         assert_attr(attr.attr, FileType::RegularFile, 15, uid, gid, file_perm);
 
-        let fh = fs.open(reply.ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+        let fh = fs.open(reply.ino, OpenFlags::empty(), 0).await.unwrap().fh;
         let bytes_read = fs
             .read(reply.ino, fh, 0, 4096, 0, None)
             .await
@@ -283,12 +283,12 @@ async fn test_lookup_then_open_cached() {
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
 
-    let fh = fs.open(ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(ino, OpenFlags::empty(), 0).await.unwrap().fh;
     fs.release(ino, fh, 0, None, true).await.unwrap();
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
 
-    let fh = fs.open(entry.attr.ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(entry.attr.ino, OpenFlags::empty(), 0).await.unwrap().fh;
     fs.release(ino, fh, 0, None, true).await.unwrap();
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
@@ -315,12 +315,12 @@ async fn test_lookup_then_open_no_cache() {
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
 
-    let fh = fs.open(ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(ino, OpenFlags::empty(), 0).await.unwrap().fh;
     fs.release(ino, fh, 0, None, true).await.unwrap();
     assert_eq!(head_counter.count(), 2);
     assert_eq!(list_counter.count(), 2);
 
-    let fh = fs.open(entry.attr.ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(entry.attr.ino, OpenFlags::empty(), 0).await.unwrap().fh;
     fs.release(ino, fh, 0, None, true).await.unwrap();
     assert_eq!(head_counter.count(), 3);
     assert_eq!(list_counter.count(), 3);
@@ -365,7 +365,7 @@ async fn test_readdir_then_open_cached() {
         assert_eq!(head_counter.count(), 0);
         assert_eq!(list_counter.count(), 1);
 
-        let fh = fs.open(entry.ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+        let fh = fs.open(entry.ino, OpenFlags::empty(), 0).await.unwrap().fh;
 
         assert_eq!(head_counter.count(), 0);
         assert_eq!(list_counter.count(), 1);
@@ -489,7 +489,7 @@ async fn test_random_read(object_size: usize) {
     assert_eq!(reply.entries[2].name, "file");
     let ino = reply.entries[2].ino;
 
-    let fh = fs.open(ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(ino, OpenFlags::empty(), 0).await.unwrap().fh;
 
     let mut rng = ChaCha20Rng::seed_from_u64(0x12345678);
     for _ in 0..10 {
@@ -544,7 +544,7 @@ async fn test_implicit_directory_shadow(prefix: &str) {
     assert_eq!(reply.entries[2].name, "file2.txt");
     assert_eq!(reply.entries[2].attr.kind, FileType::RegularFile);
 
-    let fh = fs.open(reply.entries[2].ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(reply.entries[2].ino, OpenFlags::empty(), 0).await.unwrap().fh;
     let bytes_read = fs
         .read(reply.entries[2].ino, fh, 0, 4096, 0, None)
         .await
@@ -633,7 +633,7 @@ async fn test_sequential_write(write_size: usize) {
     assert_eq!(result, libc::EPERM);
 
     // But read-only should work
-    let fh = fs.open(file_ino, OpenFlags::O_RDONLY, 0).await.unwrap().fh;
+    let fh = fs.open(file_ino, OpenFlags::empty(), 0).await.unwrap().fh;
 
     let mut offset = 0;
     while offset < size {
@@ -1250,7 +1250,7 @@ async fn test_flexible_retrieval_objects() {
         let getattr = fs.getattr(entry.ino).await.unwrap();
         assert_eq!(flexible_retrieval, getattr.attr.perm == 0);
 
-        let open = fs.open(entry.ino, OpenFlags::O_RDONLY, 0).await;
+        let open = fs.open(entry.ino, OpenFlags::empty(), 0).await;
         if flexible_retrieval {
             let err = open.expect_err("can't open flexible retrieval objects");
             assert_eq!(err.to_errno(), libc::EACCES);
@@ -1281,7 +1281,7 @@ async fn test_flexible_retrieval_objects() {
         let getattr = fs.getattr(lookup.attr.ino).await.unwrap();
         assert_eq!(flexible_retrieval, getattr.attr.perm == 0);
 
-        let open = fs.open(lookup.attr.ino, OpenFlags::O_RDONLY, 0).await;
+        let open = fs.open(lookup.attr.ino, OpenFlags::empty(), 0).await;
         if flexible_retrieval {
             let err = open.expect_err("can't open flexible retrieval objects");
             assert_eq!(err.to_errno(), libc::EACCES);

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -677,7 +677,7 @@ impl Harness {
     }
 
     async fn compare_file<'a>(&'a self, fs_file: InodeNo, ref_file: &'a MockObject) {
-        let fh = match self.fs.open(fs_file, OpenFlags::O_RDONLY, 0).await {
+        let fh = match self.fs.open(fs_file, OpenFlags::empty(), 0).await {
             Ok(ret) => ret.fh,
             Err(e) => panic!("failed to open {fs_file}: {e:?}"),
         };
@@ -702,7 +702,7 @@ impl Harness {
     /// readable (open should fail).
     async fn check_local_file(&self, inode: InodeNo) {
         let _stat = self.fs.getattr(inode).await.expect("stat should succeed");
-        let open = self.fs.open(inode, OpenFlags::O_RDONLY, 0).await;
+        let open = self.fs.open(inode, OpenFlags::empty(), 0).await;
         assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
     }
 }

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use fuser::FileType;
 use futures::future::{BoxFuture, FutureExt};
-use mountpoint_s3::fs::{CacheConfig, InodeNo, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{CacheConfig, InodeNo, OpenFlags, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::mock_client::{MockClient, MockObject};
@@ -347,7 +347,7 @@ impl Harness {
             return;
         };
 
-        let open = self.fs.open(inflight_write.inode, libc::O_WRONLY, 0).await;
+        let open = self.fs.open(inflight_write.inode, OpenFlags::O_WRONLY, 0).await;
         if inflight_write.file_handle.is_some() {
             // Shouldn't be able to reopen a file that's already open for writing
             assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
@@ -677,7 +677,7 @@ impl Harness {
     }
 
     async fn compare_file<'a>(&'a self, fs_file: InodeNo, ref_file: &'a MockObject) {
-        let fh = match self.fs.open(fs_file, 0x8000, 0).await {
+        let fh = match self.fs.open(fs_file, OpenFlags::O_RDONLY, 0).await {
             Ok(ret) => ret.fh,
             Err(e) => panic!("failed to open {fs_file}: {e:?}"),
         };
@@ -702,7 +702,7 @@ impl Harness {
     /// readable (open should fail).
     async fn check_local_file(&self, inode: InodeNo) {
         let _stat = self.fs.getattr(inode).await.expect("stat should succeed");
-        let open = self.fs.open(inode, libc::O_RDONLY, 0).await;
+        let open = self.fs.open(inode, OpenFlags::O_RDONLY, 0).await;
         assert!(matches!(open, Err(e) if e.to_errno() == libc::EPERM));
     }
 }


### PR DESCRIPTION
## Description of change

Introduce `OpenFlags`, a type-safe wrapper for the flags provided to the `open` FUSE request. The new type is for internal use in `S3FileSystem` and replaces `i32` and `libc` constants.

Note that the set of allowed flags is not exhaustive (some flags are platform-dependent) and intended to be extended as required.

The `flags` module also provides the `libc_flags` helper macro, which should be handy when we wrap other flags types.

## Does this change impact existing behavior?

No functional changed.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
