### PR TITLE
Return the new object ETag in PutObjectResult

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -731,8 +731,10 @@ impl ObjectClient for MockClient {
 
         let mut object: MockObject = contents.into();
         object.set_storage_class(params.storage_class.clone());
+        let etag = object.etag.clone();
         add_object(&self.objects, key, object);
         Ok(PutObjectResult {
+            etag,
             sse_type: None,
             sse_kms_key_id: None,
         })
@@ -874,8 +876,10 @@ impl MockPutObjectRequest {
         } else {
             object.parts = Some(MockObjectParts::Count(parts.len()));
         }
+        let etag = object.etag.clone();
         add_object(&self.objects, &self.key, object);
         Ok(PutObjectResult {
+            etag,
             sse_type: None,
             sse_kms_key_id: None,
         })

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -64,6 +64,12 @@ impl FromStr for ETag {
     }
 }
 
+impl<S: AsRef<str>> From<S> for ETag {
+    fn from(value: S) -> Self {
+        Self(value.as_ref().to_string())
+    }
+}
+
 /// A generic interface to S3-like object storage services.
 ///
 /// This trait defines the common methods that all object services implement.
@@ -492,10 +498,11 @@ pub trait PutObjectRequest: Send {
 }
 
 /// Result of a [ObjectClient::put_object] request
-// TODO: Populate this struct with return fields from the S3 API, e.g., etag.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct PutObjectResult {
+    /// ETag of the uploaded object
+    pub etag: ETag,
     /// Server-side encryption type that was used to store new object (reported by S3)
     pub sse_type: Option<String>,
     /// Server-side encryption KMS key ID that was used to store new object (reported by S3)

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -1,74 +1,20 @@
-use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
+use std::fmt::{self, Debug};
+use std::ops::Range;
+use std::pin::Pin;
+use std::time::SystemTime;
+
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use futures::Stream;
 use mountpoint_s3_crt::s3::client::BufferPoolUsageStats;
-use std::pin::Pin;
-use std::str::FromStr;
-use std::time::SystemTime;
-use std::{
-    fmt::{self, Debug},
-    ops::Range,
-    string::ParseError,
-};
 use thiserror::Error;
 use time::OffsetDateTime;
 
-/// A single element of a [`get_object`](ObjectClient::get_object) response stream is a pair of
-/// offset within the object and the bytes starting at that offset.
-pub type GetBodyPart = (u64, Box<[u8]>);
+use crate::checksums;
+use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 
-/// An ETag (entity tag) is a unique identifier for a HTTP object.
-///
-/// New ETags can be created with the [`FromStr`] implementation.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ETag(String);
-
-impl ETag {
-    /// Get the ETag as a string
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Unpack the [String] contained by the [ETag] wrapper
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-
-    /// Creating default etag for tests
-    #[doc(hidden)]
-    pub fn for_tests() -> Self {
-        Self("test_etag".to_string())
-    }
-
-    /// Creating unique etag from bytes
-    #[doc(hidden)]
-    #[cfg(feature = "mock")]
-    pub fn from_object_bytes(data: &[u8]) -> Self {
-        use md5::Digest as _;
-
-        let mut hasher = md5::Md5::new();
-        hasher.update(data);
-
-        let hash = hasher.finalize();
-        let result = format!("{:x}", hash);
-        Self(result)
-    }
-}
-
-impl FromStr for ETag {
-    type Err = ParseError;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let etag = value.to_string();
-        Ok(ETag(etag))
-    }
-}
-
-impl<S: AsRef<str>> From<S> for ETag {
-    fn from(value: S) -> Self {
-        Self(value.as_ref().to_string())
-    }
-}
+mod etag;
+pub use etag::ETag;
 
 /// A generic interface to S3-like object storage services.
 ///
@@ -426,7 +372,7 @@ impl PutObjectSingleParams {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum UploadChecksum {
-    Crc32c(crate::checksums::Crc32c),
+    Crc32c(checksums::Crc32c),
 }
 
 impl UploadChecksum {
@@ -469,6 +415,10 @@ pub trait GetObjectRequest:
     /// return data up to this offset *exclusively*.
     fn read_window_end_offset(self: Pin<&Self>) -> u64;
 }
+
+/// A single element of a [`get_object`](ObjectClient::get_object) response stream is a pair of
+/// offset within the object and the bytes starting at that offset.
+pub type GetBodyPart = (u64, Box<[u8]>);
 
 /// A streaming put request which allows callers to asynchronously write the body of the request.
 ///

--- a/mountpoint-s3-client/src/object_client/etag.rs
+++ b/mountpoint-s3-client/src/object_client/etag.rs
@@ -1,0 +1,54 @@
+use std::str::FromStr;
+use std::string::ParseError;
+
+/// An ETag (entity tag) is a unique identifier for a HTTP object.
+///
+/// New ETags can be created with the [`FromStr`] implementation.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ETag(String);
+
+impl ETag {
+    /// Get the ETag as a string
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Unpack the [String] contained by the [ETag] wrapper
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    /// Creating default etag for tests
+    #[doc(hidden)]
+    pub fn for_tests() -> Self {
+        Self("test_etag".to_string())
+    }
+
+    /// Creating unique etag from bytes
+    #[doc(hidden)]
+    #[cfg(feature = "mock")]
+    pub fn from_object_bytes(data: &[u8]) -> Self {
+        use md5::Digest as _;
+
+        let mut hasher = md5::Md5::new();
+        hasher.update(data);
+
+        let hash = hasher.finalize();
+        let result = format!("{:x}", hash);
+        Self(result)
+    }
+}
+
+impl FromStr for ETag {
+    type Err = ParseError;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let etag = value.to_string();
+        Ok(ETag(etag))
+    }
+}
+
+impl<S: AsRef<str>> From<S> for ETag {
+    fn from(value: S) -> Self {
+        Self(value.as_ref().to_string())
+    }
+}

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -39,7 +39,7 @@ async fn test_put_object(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &contents[..]).await;
@@ -65,7 +65,7 @@ async fn test_put_object_empty(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &[]).await;
@@ -100,7 +100,7 @@ async fn test_put_object_multi_part(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object failed");
     check_get_result(result, None, &contents[..]).await;
@@ -137,7 +137,7 @@ async fn test_put_object_large(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object failed");
     check_get_result(result, None, &contents[..]).await;

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -29,7 +29,7 @@ async fn test_put_object_single(
         .expect("put_object should succeed");
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &contents[..]).await;
@@ -53,7 +53,7 @@ async fn test_put_object_single_empty(
         .expect("put_object should succeed");
 
     let result = client
-        .get_object(bucket, key, None, None)
+        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &[]).await;


### PR DESCRIPTION
## Description of change

On success, both `put_object` (MPU) and `put_object_single` return the ETag of the newly uploaded object. 

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

Yes. Changelogs will be updated in a separate change (including changes from #1046).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
