### PR TITLE
Remove use of ObjectInfo in S3 client HeadObject response

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Other changes
+
+* No other changes.
+
+### Breaking changes
+
+* `HeadObjectResult` no longer contains an `ObjectInfo` struct.
+  Instead, it returns the object attributes as individual fields on the `HeadObjectResult`.
+  `HeadObjectResult` no longer provides the bucket and key used in the original request.
+  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
+
 ## v0.11.0 (October 17, 2024)
 
 ### Breaking changes

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 * `HeadObjectResult` no longer contains an `ObjectInfo` struct.
   Instead, it returns the object attributes as individual fields on the `HeadObjectResult`.
-  `HeadObjectResult` no longer provides the bucket and key used in the original request.
+  The entity tag field has also changed and is now of type `ETag` rather than `String`.
+  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
+* `HeadObjectResult` no longer provides the bucket and key used in the original request.
   ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
 
 ## v0.11.0 (October 17, 2024)

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -689,7 +689,7 @@ impl ObjectClient for MockClient {
             Ok(HeadObjectResult {
                 size: object.size as u64,
                 last_modified: object.last_modified,
-                etag: object.etag.as_str().to_string(),
+                etag: object.etag.clone(),
                 storage_class: object.storage_class.clone(),
                 restore_status: object.restore_status,
             })

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -687,15 +687,11 @@ impl ObjectClient for MockClient {
         let objects = self.objects.read().unwrap();
         if let Some(object) = objects.get(key) {
             Ok(HeadObjectResult {
-                bucket: bucket.to_string(),
-                object: ObjectInfo {
-                    key: key.to_string(),
-                    size: object.size as u64,
-                    last_modified: object.last_modified,
-                    etag: object.etag.as_str().to_string(),
-                    storage_class: object.storage_class.clone(),
-                    restore_status: object.restore_status,
-                },
+                size: object.size as u64,
+                last_modified: object.last_modified,
+                etag: object.etag.as_str().to_string(),
+                storage_class: object.storage_class.clone(),
+                restore_status: object.restore_status,
             })
         } else {
             Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))
@@ -1681,7 +1677,7 @@ mod tests {
 
         // head_object returns storage class
         let head_result = client.head_object(bucket, key).await.unwrap();
-        assert_eq!(head_result.object.storage_class.as_deref(), storage_class);
+        assert_eq!(head_result.storage_class.as_deref(), storage_class);
 
         // list_objects returns storage class
         let list_result = client.list_objects(bucket, None, "/", 1, "").await.unwrap();

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -219,7 +219,7 @@ pub struct HeadObjectResult {
     pub last_modified: OffsetDateTime,
 
     /// Entity tag of this object.
-    pub etag: String,
+    pub etag: ETag,
 
     /// Storage class for this object.
     ///

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -210,11 +210,28 @@ pub enum ListObjectsError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct HeadObjectResult {
-    /// The name of the bcuket
-    pub bucket: String,
+    /// Size of the object in bytes.
+    ///
+    /// Refers to the `Content-Length` HTTP header for HeadObject.
+    pub size: u64,
 
-    /// Object metadata
-    pub object: ObjectInfo,
+    /// The time this object was last modified.
+    pub last_modified: OffsetDateTime,
+
+    /// Entity tag of this object.
+    pub etag: String,
+
+    /// Storage class for this object.
+    ///
+    /// The value is optional because HeadObject does not return the storage class in its response
+    /// for objects in the S3 Standard storage class.
+    /// See examples in the
+    /// [Amazon S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_Examples).
+    pub storage_class: Option<String>,
+
+    /// Objects in flexible retrieval storage classes (such as GLACIER and DEEP_ARCHIVE) are only
+    /// accessible after restoration
+    pub restore_status: Option<RestoreStatus>,
 }
 
 /// Errors returned by a [`head_object`](ObjectClient::head_object) request

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -97,7 +97,7 @@ impl HeadObjectResult {
             last_modified,
             storage_class,
             restore_status,
-            etag,
+            etag: etag.into(),
         };
         Ok(result)
     }

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -11,9 +11,7 @@ use time::format_description::well_known::Rfc2822;
 use time::OffsetDateTime;
 use tracing::error;
 
-use crate::object_client::{
-    HeadObjectError, HeadObjectResult, ObjectClientError, ObjectClientResult, ObjectInfo, RestoreStatus,
-};
+use crate::object_client::{HeadObjectError, HeadObjectResult, ObjectClientError, ObjectClientResult, RestoreStatus};
 use crate::s3_crt_client::{S3CrtClient, S3Operation, S3RequestError};
 
 #[derive(Error, Debug)]
@@ -85,7 +83,8 @@ impl HeadObjectResult {
         Ok(Some(RestoreStatus::Restored { expiry: expiry.into() }))
     }
 
-    fn parse_from_hdr(bucket: String, key: String, headers: &Headers) -> Result<Self, ParseError> {
+    /// Parse from HeadObject headers
+    fn parse_from_hdr(headers: &Headers) -> Result<Self, ParseError> {
         let last_modified = OffsetDateTime::parse(&get_field(headers, "Last-Modified")?, &Rfc2822)
             .map_err(|e| ParseError::OffsetDateTime(e, "LastModified".into()))?;
         let size = u64::from_str(&get_field(headers, "Content-Length")?)
@@ -93,15 +92,14 @@ impl HeadObjectResult {
         let etag = get_field(headers, "Etag")?;
         let storage_class = get_optional_field(headers, "x-amz-storage-class")?;
         let restore_status = Self::parse_restore_status(headers)?;
-        let object = ObjectInfo {
-            key,
+        let result = HeadObjectResult {
             size,
             last_modified,
             storage_class,
             restore_status,
             etag,
         };
-        Ok(HeadObjectResult { bucket, object })
+        Ok(result)
     }
 }
 
@@ -137,11 +135,7 @@ impl S3CrtClient {
                 span,
                 move |headers, _status| {
                     let mut header = header1.lock().unwrap();
-                    *header = Some(HeadObjectResult::parse_from_hdr(
-                        bucket.to_string(),
-                        key.to_string(),
-                        headers,
-                    ));
+                    *header = Some(HeadObjectResult::parse_from_hdr(headers));
                 },
                 |_, _| (),
                 move |result| {

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -10,7 +9,6 @@ use mountpoint_s3::mem_limiter::MemoryLimiter;
 use mountpoint_s3::object::ObjectId;
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
-use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use sysinfo::{RefreshKind, System};
@@ -114,7 +112,7 @@ fn main() {
 
     let head_object_result = block_on(client.head_object(bucket, key)).expect("HeadObject failed");
     let size = head_object_result.size;
-    let etag = ETag::from_str(&head_object_result.etag).unwrap();
+    let etag = head_object_result.etag;
 
     for i in 0..iterations.unwrap_or(1) {
         let runtime = client.event_loop_group();

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -113,8 +113,8 @@ fn main() {
     let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), max_memory_target));
 
     let head_object_result = block_on(client.head_object(bucket, key)).expect("HeadObject failed");
-    let size = head_object_result.object.size;
-    let etag = ETag::from_str(&head_object_result.object.etag).unwrap();
+    let size = head_object_result.size;
+    let etag = ETag::from_str(&head_object_result.etag).unwrap();
 
     for i in 0..iterations.unwrap_or(1) {
         let runtime = client.event_loop_group();

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -699,8 +699,8 @@ impl SuperblockInner {
             select_biased! {
                 result = file_lookup => {
                     match result {
-                        Ok(HeadObjectResult { object, .. }) => {
-                            let stat = InodeStat::for_file(object.size as usize, object.last_modified, Some(object.etag.clone()), object.storage_class, object.restore_status, self.config.cache_config.file_ttl);
+                        Ok(HeadObjectResult { size, last_modified, restore_status ,etag, storage_class, .. }) => {
+                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag), storage_class, restore_status, self.config.cache_config.file_ttl);
                             file_state = Some(stat);
                         }
                         // If the object is not found, might be a directory, so keep going
@@ -1276,7 +1276,6 @@ mod tests {
                         .head_object(bucket, file.inode.full_key())
                         .await
                         .expect("object should exist")
-                        .object
                         .last_modified;
                     assert_inode_stat!(file, InodeKind::File, modified_time, object_size);
                     assert_eq!(

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -700,7 +700,7 @@ impl SuperblockInner {
                 result = file_lookup => {
                     match result {
                         Ok(HeadObjectResult { size, last_modified, restore_status ,etag, storage_class, .. }) => {
-                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag), storage_class, restore_status, self.config.cache_config.file_ttl);
+                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag.as_str().to_string()), storage_class, restore_status, self.config.cache_config.file_ttl);
                             file_state = Some(stat);
                         }
                         // If the object is not found, might be a directory, so keep going


### PR DESCRIPTION
## Description of change

Before this change, `head_object` and `list_objects` shared the same struct `ObjectInfo`. The data we returned from these two operations was common, and so it worked well. Now we want to add information that is specific to the two operations.

This change leaves `ObjectInfo` in place for `list_objects`, aligning with the [Object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html) structure in the Rest XML API.

This change is in preparation to surfacing checksum algorithm from ListObjectsV2 requests as well as surfacing checksum values in HeadObject requests.

Relevant issues: N/A

## Does this change impact existing behavior?

There is no breaking changes to Mountpoint's file system semantics.

This is a breaking change to direct consumers of Mountpoint's S3 client. The `head_object` return type `HeadObjectResult` will no longer have an `object` field of type `ObjectInfo`. Accesses to those fields should now be on the `HeadObjectResult` struct itself.

## Does this change need a changelog entry in any of the crates?

Yes. A change log entry is added to the `mountpoint-s3-client` crate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
