### PR TITLE
Add support for custom headers in PUT requests

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -383,6 +383,8 @@ pub struct PutObjectSingleParams {
     /// If `server_side_encryption` has a valid value of aws:kms or aws:kms:dsse, this value may be used to specify AWS KMS key ID to be used
     /// when creating new S3 object
     pub ssekms_key_id: Option<String>,
+    /// Custom headers to add to the request
+    pub custom_headers: Vec<(String, String)>,
 }
 
 impl PutObjectSingleParams {
@@ -412,6 +414,12 @@ impl PutObjectSingleParams {
     /// Set KMS key ID to be used for server-side encryption.
     pub fn ssekms_key_id(mut self, value: Option<String>) -> Self {
         self.ssekms_key_id = value;
+        self
+    }
+
+    /// Add a custom header to the request.
+    pub fn add_custom_header(mut self, name: String, value: String) -> Self {
+        self.custom_headers.push((name, value));
         self
     }
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -316,6 +316,8 @@ pub struct PutObjectParams {
     /// If `server_side_encryption` has a valid value of aws:kms or aws:kms:dsse, this value may be used to specify AWS KMS key ID to be used
     /// when creating new S3 object
     pub ssekms_key_id: Option<String>,
+    /// Custom headers to add to the request
+    pub custom_headers: Vec<(String, String)>,
 }
 
 impl PutObjectParams {
@@ -345,6 +347,12 @@ impl PutObjectParams {
     /// Set KMS key ID to be used for server-side encryption.
     pub fn ssekms_key_id(mut self, value: Option<String>) -> Self {
         self.ssekms_key_id = value;
+        self
+    }
+
+    /// Add a custom header to the request.
+    pub fn add_custom_header(mut self, name: String, value: String) -> Self {
+        self.custom_headers.push((name, value));
         self
     }
 }

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -128,6 +128,12 @@ impl S3CrtClient {
                     .set_checksum_header(checksum)
                     .map_err(S3RequestError::construction_failure)?;
             }
+            for (name, value) in &params.custom_headers {
+                message
+                    .inner
+                    .add_header(&Header::new(name, value))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
 
             let body_input_stream =
                 InputStream::new_from_slice(&self.inner.allocator, slice).map_err(S3RequestError::CrtError)?;

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -42,6 +42,13 @@ impl S3CrtClient {
         };
         message.set_checksum_config(checksum_config);
 
+        for (name, value) in &params.custom_headers {
+            message
+                .inner
+                .add_header(&Header::new(name, value))
+                .map_err(S3RequestError::construction_failure)?;
+        }
+
         let review_callback = ReviewCallbackBox::default();
         let callback = review_callback.clone();
 


### PR DESCRIPTION
## Description of change

Allows users to add custom headers to requests initiated by `put_object` and `put_object_single`.

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

Yes. Changelogs will be updated in a separate PR (including all related PUT request changes, #1046 and #1057).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
