### PR TITLE
Add support for writing object metadata with PutObject

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -964,7 +964,6 @@ mod tests {
     use futures::{pin_mut, StreamExt};
     use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
-    use std::default::Default;
     use test_case::test_case;
 
     use super::*;

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -373,6 +373,7 @@ pub struct MockObject {
     last_modified: OffsetDateTime,
     etag: ETag,
     parts: Option<MockObjectParts>,
+    object_metadata: HashMap<String, String>,
 }
 
 impl MockObject {
@@ -391,6 +392,7 @@ impl MockObject {
             last_modified: OffsetDateTime::now_utc(),
             etag,
             parts: None,
+            object_metadata: HashMap::new(),
         }
     }
 
@@ -403,6 +405,7 @@ impl MockObject {
             last_modified: OffsetDateTime::now_utc(),
             etag,
             parts: None,
+            object_metadata: HashMap::new(),
         }
     }
 
@@ -425,6 +428,7 @@ impl MockObject {
             last_modified: OffsetDateTime::now_utc(),
             etag,
             parts: None,
+            object_metadata: HashMap::new(),
         }
     }
 
@@ -434,6 +438,10 @@ impl MockObject {
 
     pub fn set_storage_class(&mut self, storage_class: Option<String>) {
         self.storage_class = storage_class;
+    }
+
+    pub fn set_object_metadata(&mut self, object_metadata: HashMap<String, String>) {
+        self.object_metadata = object_metadata;
     }
 
     pub fn set_restored(&mut self, restore_status: Option<RestoreStatus>) {
@@ -731,6 +739,7 @@ impl ObjectClient for MockClient {
 
         let mut object: MockObject = contents.into();
         object.set_storage_class(params.storage_class.clone());
+        object.set_object_metadata(params.object_metadata.clone());
         let etag = object.etag.clone();
         add_object(&self.objects, key, object);
         Ok(PutObjectResult {
@@ -870,6 +879,7 @@ impl MockPutObjectRequest {
         let buffer = std::mem::take(&mut self.buffer);
         let mut object: MockObject = buffer.into();
         object.set_storage_class(self.params.storage_class.clone());
+        object.set_object_metadata(self.params.object_metadata.clone());
         // For S3 Standard, part attributes are only available when additional checksums are used
         if self.params.trailing_checksums == PutObjectTrailingChecksums::Enabled {
             object.parts = Some(MockObjectParts::Parts(parts));
@@ -954,6 +964,7 @@ mod tests {
     use futures::{pin_mut, StreamExt};
     use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
+    use std::default::Default;
     use test_case::test_case;
 
     use super::*;
@@ -1505,8 +1516,10 @@ mod tests {
             ..Default::default()
         });
 
+        let object_metadata = HashMap::from([("foo".to_string(), "bar".to_string())]);
+        let put_object_params = PutObjectParams::new().object_metadata(object_metadata.clone());
         let mut put_request = client
-            .put_object("test_bucket", "key1", &Default::default())
+            .put_object("test_bucket", "key1", &put_object_params)
             .await
             .expect("put_object failed");
 
@@ -1534,6 +1547,7 @@ mod tests {
             next_offset += body.len() as u64;
             assert_eq!(body, obj.read(offset, body.len()));
         }
+        assert_eq!(object_metadata, get_request.object.object_metadata);
     }
 
     #[tokio::test]
@@ -1546,8 +1560,10 @@ mod tests {
         });
 
         let content = vec![42u8; 512];
+        let object_metadata = HashMap::from([("foo".to_string(), "bar".to_string())]);
+        let put_object_params = PutObjectSingleParams::new().object_metadata(object_metadata.clone());
         let _put_result = client
-            .put_object_single("test_bucket", "key1", &Default::default(), &content)
+            .put_object_single("test_bucket", "key1", &put_object_params, &content)
             .await
             .expect("put_object failed");
 
@@ -1556,6 +1572,7 @@ mod tests {
             .await
             .expect("get_object failed");
 
+        assert_eq!(object_metadata, get_request.object.object_metadata);
         // Check that the result of get_object is correct.
         let actual = get_request.collect().await.expect("failed to collect body");
         assert_eq!(&content, &*actual);

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -8,15 +8,6 @@ use auto_impl::auto_impl;
 use futures::Stream;
 use mountpoint_s3_crt::s3::client::BufferPoolUsageStats;
 use std::collections::HashMap;
-use std::hash::Hash;
-use std::pin::Pin;
-use std::str::FromStr;
-use std::time::SystemTime;
-use std::{
-    fmt::{self, Debug},
-    ops::Range,
-    string::ParseError,
-};
 use thiserror::Error;
 use time::OffsetDateTime;
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -280,7 +280,7 @@ pub struct PutObjectParams {
     pub ssekms_key_id: Option<String>,
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
-    /// Object metadata to be uploaded with objects.
+    /// User-defined object metadata
     pub object_metadata: HashMap<String, String>,
 }
 
@@ -363,7 +363,7 @@ pub struct PutObjectSingleParams {
     pub ssekms_key_id: Option<String>,
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
-    /// Object metadata to be uploaded with objects.
+    /// User-defined object metadata
     pub object_metadata: HashMap<String, String>,
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -7,6 +7,16 @@ use async_trait::async_trait;
 use auto_impl::auto_impl;
 use futures::Stream;
 use mountpoint_s3_crt::s3::client::BufferPoolUsageStats;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::str::FromStr;
+use std::time::SystemTime;
+use std::{
+    fmt::{self, Debug},
+    ops::Range,
+    string::ParseError,
+};
 use thiserror::Error;
 use time::OffsetDateTime;
 
@@ -270,6 +280,8 @@ pub struct PutObjectParams {
     pub ssekms_key_id: Option<String>,
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
+    /// Object metadata to be uploaded with objects.
+    pub object_metadata: HashMap<String, String>,
 }
 
 impl PutObjectParams {
@@ -305,6 +317,12 @@ impl PutObjectParams {
     /// Add a custom header to the request.
     pub fn add_custom_header(mut self, name: String, value: String) -> Self {
         self.custom_headers.push((name, value));
+        self
+    }
+
+    /// Set user defined object metadata.
+    pub fn object_metadata(mut self, value: HashMap<String, String>) -> Self {
+        self.object_metadata = value;
         self
     }
 }
@@ -345,6 +363,8 @@ pub struct PutObjectSingleParams {
     pub ssekms_key_id: Option<String>,
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
+    /// Object metadata to be uploaded with objects.
+    pub object_metadata: HashMap<String, String>,
 }
 
 impl PutObjectSingleParams {
@@ -380,6 +400,12 @@ impl PutObjectSingleParams {
     /// Add a custom header to the request.
     pub fn add_custom_header(mut self, name: String, value: String) -> Self {
         self.custom_headers.push((name, value));
+        self
+    }
+
+    /// Set user defined object metadata.
+    pub fn object_metadata(mut self, value: HashMap<String, String>) -> Self {
+        self.object_metadata = value;
         self
     }
 }

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -45,6 +45,11 @@ impl S3CrtClient {
         };
         message.set_checksum_config(checksum_config);
 
+        for (name, value) in &params.object_metadata {
+            message
+                .set_header(&Header::new(format!("x-amz-meta-{}", name), value))
+                .map_err(S3RequestError::construction_failure)?
+        }
         for (name, value) in &params.custom_headers {
             message
                 .inner
@@ -129,6 +134,11 @@ impl S3CrtClient {
                 message
                     .set_checksum_header(checksum)
                     .map_err(S3RequestError::construction_failure)?;
+            }
+            for (name, value) in &params.object_metadata {
+                message
+                    .set_header(&Header::new(format!("x-amz-meta-{}", name), value))
+                    .map_err(S3RequestError::construction_failure)?
             }
             for (name, value) in &params.custom_headers {
                 message

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -15,6 +15,7 @@ use mountpoint_s3_client::types::{
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
 use mountpoint_s3_crt::checksums::crc32c;
 use rand::Rng;
+use std::collections::HashMap;
 use test_case::test_case;
 
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
@@ -375,6 +376,66 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
     }
 }
 
+#[test_case(HashMap::new(); "Empty")]
+#[test_case(HashMap::from([("foo".to_string(), "bar".to_string()), ("a".to_string(), "b".to_string())]); "ASCII")]
+#[tokio::test]
+async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, String>) {
+    const PART_SIZE: usize = 5 * 1024 * 1024;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_happy");
+    let client_config = S3ClientConfig::new()
+        .part_size(PART_SIZE)
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let key = format!("{prefix}hello");
+
+    let mut rng = rand::thread_rng();
+    let mut contents = vec![0u8; PART_SIZE * 2];
+    rng.fill(&mut contents[..]);
+
+    let params = PutObjectParams::new().object_metadata(object_metadata.clone());
+
+    let mut request = client
+        .put_object(&bucket, &key, &params)
+        .await
+        .expect("put_object should succeed");
+
+    request.write(&contents).await.unwrap();
+    request.complete().await.unwrap();
+
+    let sdk_client = get_test_sdk_client().await;
+    let output = sdk_client.head_object().bucket(&bucket).key(key).send().await.unwrap();
+
+    match output.metadata() {
+        Some(returned_object_metadata) => {
+            assert_eq!(&object_metadata, returned_object_metadata);
+        }
+        None => {
+            assert!(object_metadata.is_empty());
+        }
+    }
+}
+
+#[test_case(HashMap::from([("£".to_string(), "£".to_string())]); "UTF-8")]
+#[tokio::test]
+async fn test_put_user_object_metadata_bad_header(object_metadata: HashMap<String, String>) {
+    const PART_SIZE: usize = 5 * 1024 * 1024;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_bad_header");
+    let client_config = S3ClientConfig::new()
+        .part_size(PART_SIZE)
+        .endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let key = format!("{prefix}hello");
+
+    let mut rng = rand::thread_rng();
+    let mut contents = vec![0u8; PART_SIZE * 2];
+    rng.fill(&mut contents[..]);
+
+    let params = PutObjectParams::new().object_metadata(object_metadata.clone());
+
+    let mut request = client.put_object(&bucket, &key, &params).await.unwrap();
+    request.write(&contents).await.expect_err("header parsing should fail");
+}
+
 #[test_case(true; "pass review")]
 #[test_case(false; "fail review")]
 #[tokio::test]
@@ -450,7 +511,7 @@ async fn check_get_object<Client: ObjectClient>(
 // S3 Express One Zone is a distinct storage class and can't be overridden
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_storage_class(storage_class: &str) {
-    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_object_abort");
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_object_storage_class");
     let client = get_test_client();
     let key = format!("{prefix}hello");
 


### PR DESCRIPTION
## Description of change

<!-- Please describe your contribution here. What and why? -->

Adds a new parameter to `PutObjectParams` and `PutObjectSingleParams`: `object_metadata`.

`object_metadata` is a hashmap of user supplied metadata for the object being written to. 

See the [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata) for details

Relevant issues: NA

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No.

## Does this change need a changelog entry in any of the crates?

Yes, it will require an entry for `mountpoint-s3-client`.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
