### PR TITLE
Add GetObject support for object metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,12 +265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
 name = "async-process"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +367,12 @@ dependencies = [
  "quote",
  "syn 2.0.85",
 ]
+
+[[package]]
+name = "async_cell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
 
 [[package]]
 name = "atomic-waker"
@@ -2426,8 +2426,8 @@ version = "0.11.0"
 dependencies = [
  "async-io",
  "async-lock",
- "async-once-cell",
  "async-trait",
+ "async_cell",
  "auto_impl",
  "aws-config",
  "aws-credential-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-process"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2426,7 @@ version = "0.11.0"
 dependencies = [
  "async-io",
  "async-lock",
+ "async-once-cell",
  "async-trait",
  "auto_impl",
  "aws-config",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -11,7 +11,7 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.10.0" }
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
 
-async-once-cell = "0.5.4"
+async_cell = "0.2.2"
 async-trait = "0.1.83"
 auto_impl = "1.2.0"
 base64ct = { version = "1.6.0", features = ["std"] }

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -11,6 +11,7 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.10.0" }
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
 
+async-once-cell = "0.5.4"
 async-trait = "0.1.83"
 auto_impl = "1.2.0"
 base64ct = { version = "1.6.0", features = ["std"] }

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -18,8 +18,8 @@ use crate::object_client::{
     CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
     HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient,
-    ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
-    PutObjectSingleParams, UploadReview,
+    ObjectClientError, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams, PutObjectRequest,
+    PutObjectResult, PutObjectSingleParams, UploadReview,
 };
 
 // Wrapper for injecting failures into a get stream or a put request
@@ -223,11 +223,13 @@ pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
 }
 
 #[cfg_attr(not(docsrs), async_trait)]
-impl<Client: ObjectClient, FailState: Send> GetObjectRequest for FailureGetRequest<Client, FailState> {
+impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectRequest
+    for FailureGetRequest<Client, FailState>
+{
     type ClientError = Client::ClientError;
 
-    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError> {
-        self.request.get_object_metadata().await
+    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
+        self.project_ref().request.get_object_metadata().await
     }
 
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -222,7 +222,7 @@ pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
     request: Client::GetObjectRequest,
 }
 
-#[cfg_attr(not(docsrs), async_trait)]
+#[async_trait]
 impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectRequest
     for FailureGetRequest<Client, FailState>
 {

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -222,8 +222,13 @@ pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
     request: Client::GetObjectRequest,
 }
 
+#[cfg_attr(not(docsrs), async_trait)]
 impl<Client: ObjectClient, FailState: Send> GetObjectRequest for FailureGetRequest<Client, FailState> {
     type ClientError = Client::ClientError;
+
+    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError> {
+        self.request.get_object_metadata().await
+    }
 
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -228,7 +228,7 @@ impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectReques
 {
     type ClientError = Client::ClientError;
 
-    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
+    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
         self.request.get_object_metadata().await
     }
 

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -222,14 +222,14 @@ pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
     request: Client::GetObjectRequest,
 }
 
-#[async_trait]
+#[cfg_attr(not(docsrs), async_trait)]
 impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectRequest
     for FailureGetRequest<Client, FailState>
 {
     type ClientError = Client::ClientError;
 
-    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
-        self.project_ref().request.get_object_metadata().await
+    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
+        self.request.get_object_metadata().await
     }
 
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -534,7 +534,7 @@ impl MockGetObjectRequest {
 impl GetObjectRequest for MockGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
+    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
         Ok(self.object.object_metadata.clone())
     }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -530,7 +530,7 @@ impl MockGetObjectRequest {
     }
 }
 
-#[cfg_attr(not(docsrs), async_trait)]
+#[async_trait]
 impl GetObjectRequest for MockGetObjectRequest {
     type ClientError = MockClientError;
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -530,11 +530,11 @@ impl MockGetObjectRequest {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(docsrs), async_trait)]
 impl GetObjectRequest for MockGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
+    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
         Ok(self.object.object_metadata.clone())
     }
 
@@ -1105,8 +1105,7 @@ mod tests {
         let expected_range = expected_range.start as usize..expected_range.end as usize;
         assert_eq!(&accum[..], &body[expected_range], "body does not match");
 
-        pin_mut!(get_request);
-        assert_eq!(get_request.as_ref().get_object_metadata().await, Ok(object_metadata));
+        assert_eq!(get_request.get_object_metadata().await, Ok(object_metadata));
     }
 
     #[tokio::test]

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -66,7 +66,7 @@ pub struct ThroughputGetObjectRequest {
     rate_limiter: LeakyBucket,
 }
 
-#[cfg_attr(not(docsrs), async_trait)]
+#[async_trait]
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -70,7 +70,7 @@ pub struct ThroughputGetObjectRequest {
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
+    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
         Ok(self.request.object.object_metadata.clone())
     }
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -66,11 +66,11 @@ pub struct ThroughputGetObjectRequest {
     rate_limiter: LeakyBucket,
 }
 
-#[async_trait]
+#[cfg_attr(not(docsrs), async_trait)]
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
+    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError> {
         Ok(self.request.object.object_metadata.clone())
     }
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ops::Range;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -18,7 +17,7 @@ use crate::object_client::{
     CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
     HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient,
-    ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
+    ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
 };
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
@@ -71,7 +70,7 @@ pub struct ThroughputGetObjectRequest {
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError> {
+    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
         Ok(self.request.object.object_metadata.clone())
     }
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ops::Range;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -66,8 +67,13 @@ pub struct ThroughputGetObjectRequest {
     rate_limiter: LeakyBucket,
 }
 
+#[cfg_attr(not(docsrs), async_trait)]
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
+
+    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError> {
+        Ok(self.request.object.object_metadata.clone())
+    }
 
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -525,7 +525,7 @@ impl UploadChecksum {
 /// This struct implements [`futures::Stream`], which you can use to read the body of the object.
 /// Each item of the stream is a part of the object body together with the part's offset within the
 /// object.
-#[cfg_attr(not(docsrs), async_trait)]
+#[async_trait]
 pub trait GetObjectRequest:
     Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send + Sync
 {

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -529,6 +529,11 @@ pub trait GetObjectRequest:
 {
     type ClientError: std::error::Error + Send + Sync + 'static;
 
+    /// Get the object's user defined metadata.
+    /// If the metadata has already been read, return immediately. Otherwise, resolve the future
+    /// when they're read.
+    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError>;
+
     /// Increment the flow-control window, so that response data continues downloading.
     ///
     /// If the client was created with `enable_read_backpressure` set true,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -525,7 +525,7 @@ impl UploadChecksum {
 /// This struct implements [`futures::Stream`], which you can use to read the body of the object.
 /// Each item of the stream is a part of the object body together with the part's offset within the
 /// object.
-#[async_trait]
+#[cfg_attr(not(docsrs), async_trait)]
 pub trait GetObjectRequest:
     Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send + Sync
 {
@@ -534,7 +534,7 @@ pub trait GetObjectRequest:
     /// Get the object's user defined metadata.
     /// If the metadata has already been read, return immediately. Otherwise, resolve the future
     /// when they're read.
-    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError>;
+    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError>;
 
     /// Increment the flow-control window, so that response data continues downloading.
     ///

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -143,7 +143,7 @@ pub trait ObjectClient {
 ///
 /// [`ServiceError`]: ObjectClientError::ServiceError
 /// [`ClientError`]: ObjectClientError::ClientError
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ObjectClientError<S, C> {
     /// An error returned by the service itself
     #[error("Service error")]
@@ -534,7 +534,7 @@ pub trait GetObjectRequest:
     /// Get the object's user defined metadata.
     /// If the metadata has already been read, return immediately. Otherwise, resolve the future
     /// when they're read.
-    async fn get_object_metadata(&self) -> Result<ObjectMetadata, Self::ClientError>;
+    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError>;
 
     /// Increment the flow-control window, so that response data continues downloading.
     ///

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -357,6 +357,8 @@ pub enum GetObjectAttributesError {
     NoSuchKey,
 }
 
+pub type ObjectMetadata = HashMap<String, String>;
+
 /// Parameters to a [`put_object`](ObjectClient::put_object) request
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
@@ -373,7 +375,7 @@ pub struct PutObjectParams {
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
     /// User-defined object metadata
-    pub object_metadata: HashMap<String, String>,
+    pub object_metadata: ObjectMetadata,
 }
 
 impl PutObjectParams {
@@ -413,7 +415,7 @@ impl PutObjectParams {
     }
 
     /// Set user defined object metadata.
-    pub fn object_metadata(mut self, value: HashMap<String, String>) -> Self {
+    pub fn object_metadata(mut self, value: ObjectMetadata) -> Self {
         self.object_metadata = value;
         self
     }
@@ -456,7 +458,7 @@ pub struct PutObjectSingleParams {
     /// Custom headers to add to the request
     pub custom_headers: Vec<(String, String)>,
     /// User-defined object metadata
-    pub object_metadata: HashMap<String, String>,
+    pub object_metadata: ObjectMetadata,
 }
 
 impl PutObjectSingleParams {
@@ -496,7 +498,7 @@ impl PutObjectSingleParams {
     }
 
     /// Set user defined object metadata.
-    pub fn object_metadata(mut self, value: HashMap<String, String>) -> Self {
+    pub fn object_metadata(mut self, value: ObjectMetadata) -> Self {
         self.object_metadata = value;
         self
     }
@@ -525,14 +527,14 @@ impl UploadChecksum {
 /// object.
 #[cfg_attr(not(docsrs), async_trait)]
 pub trait GetObjectRequest:
-    Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send
+    Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send + Sync
 {
     type ClientError: std::error::Error + Send + Sync + 'static;
 
     /// Get the object's user defined metadata.
     /// If the metadata has already been read, return immediately. Otherwise, resolve the future
     /// when they're read.
-    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError>;
+    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError>;
 
     /// Increment the flow-control window, so that response data continues downloading.
     ///

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -17,7 +17,7 @@ use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::s3::client::MetaRequestResult;
 use pin_project::pin_project;
 
-use crate::object_client::{ETag, GetBodyPart, GetObjectError, ObjectClientError, ObjectClientResult};
+use crate::object_client::{ETag, GetBodyPart, GetObjectError, ObjectClientError, ObjectClientResult, ObjectMetadata};
 use crate::s3_crt_client::{
     GetObjectRequest, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation, S3RequestError,
 };
@@ -123,8 +123,6 @@ impl S3CrtClient {
     }
 }
 
-type ObjectMetadata = HashMap<String, String>;
-
 /// A streaming response to a GetObject request.
 ///
 /// This struct implements [`futures::Stream`], which you can use to read the body of the object.
@@ -151,7 +149,7 @@ pub struct S3GetObjectRequest {
 impl GetObjectRequest for S3GetObjectRequest {
     type ClientError = S3RequestError;
 
-    async fn get_object_metadata(&mut self) -> Result<HashMap<String, String>, Self::ClientError> {
+    async fn get_object_metadata(self: Pin<&Self>) -> Result<ObjectMetadata, Self::ClientError> {
         let empty_read_window = self.read_window_end_offset <= self.next_offset;
         let request_required = self.object_metadata_cb.try_get().is_none();
         if self.enable_backpressure && empty_read_window && request_required {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -145,7 +145,7 @@ pub struct S3GetObjectRequest {
     read_window_end_offset: u64,
 }
 
-#[cfg_attr(not(docsrs), async_trait)]
+#[async_trait]
 impl GetObjectRequest for S3GetObjectRequest {
     type ClientError = S3RequestError;
 

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -27,6 +27,7 @@ pub enum ObjectMetadataError {
     #[error("error occurred fetching object metadata")]
     ObjectMetadataError,
 }
+
 impl S3CrtClient {
     /// Create and begin a new GetObject request. The returned [GetObjectRequest] is a [Stream] of
     /// body parts of the object, which will be delivered in order.

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -87,12 +87,9 @@ impl S3CrtClient {
                     let object_metadata = headers
                         .iter()
                         .filter_map(|(key, value)| {
-                            // Headers will always be UTF-8 when received from S3, so this is safe
-                            key.to_string_lossy()
-                                .strip_prefix("x-amz-meta-")
-                                .map(|metadata_header| {
-                                    (metadata_header.to_string(), value.to_string_lossy().to_string())
-                                })
+                            let metadata_header = key.to_str()?.strip_prefix("x-amz-meta-")?;
+                            let value = value.to_str()?;
+                            Some((metadata_header.to_string(), value.to_string()))
                         })
                         .collect();
                     // Doesn't matter if receiver's gone away. Either way we don't need to do anything.

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -366,18 +366,13 @@ async fn test_get_object_user_metadata(size: usize, metadata: HashMap<String, St
         .get_object(&bucket, &key, None, None)
         .await
         .expect("get_object should succeed");
-    pin_mut!(result);
-    let actual_metadata = result
-        .as_ref()
-        .get_object_metadata()
-        .await
-        .expect("should return metadata");
+    let actual_metadata = result.get_object_metadata().await.expect("should return metadata");
     let actual_metadata_2 = result
-        .as_ref()
         .get_object_metadata()
         .await
         .expect("should return metadata multiple times");
 
+    pin_mut!(result);
     let expected = &body;
     check_get_result(result, None, expected).await;
     assert_eq!(actual_metadata, metadata);
@@ -408,10 +403,65 @@ async fn test_get_object_user_metadata_with_zero_backpressure(size: usize, metad
         .get_object(&bucket, &key, Some(1..5), None)
         .await
         .expect("get_object should succeed");
-    pin_mut!(result);
     result
-        .as_ref()
         .get_object_metadata()
         .await
         .expect_err("should not return metadata for empty read window");
+}
+
+#[tokio::test]
+async fn test_get_object_metadata_404() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_metadata_404");
+
+    let key = format!("{prefix}/test");
+
+    let client: S3CrtClient = get_test_client();
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    result
+        .get_object_metadata()
+        .await
+        .expect_err("should not return metadata");
+}
+
+#[test_case(1, HashMap::from([("foo".to_string(), "bar".to_string())]); "1-byte object with metadata")]
+#[test_case(10, HashMap::from([("foo".to_string(), "bar".to_string())]); "small object with metadata")]
+#[test_case(30000000, HashMap::from([("foo".to_string(), "bar".to_string())]); "large object with metadata")]
+#[tokio::test]
+async fn test_get_object_user_metadata_after_stream(size: usize, metadata: HashMap<String, String>) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_user_metadata");
+
+    let key = format!("{prefix}/test");
+    let body = vec![0x42; size];
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .set_metadata(Some(metadata.clone()))
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+
+    pin_mut!(result);
+    while let Some(r) = result.next().await {
+        let _ = r.expect("get_object body part failed");
+    }
+    let actual_metadata = result
+        .as_ref()
+        .get_object_metadata()
+        .await
+        .expect("should return metadata");
+    assert_eq!(actual_metadata, metadata);
 }

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -2,6 +2,7 @@
 
 pub mod common;
 
+use std::collections::HashMap;
 use std::ops::Range;
 use std::option::Option::None;
 use std::str::FromStr;
@@ -337,4 +338,69 @@ async fn test_get_object_cancel(read: bool) {
     // Explicitly cancel the request. We don't have a good way to test that any inflight requests
     // were actually cancelled, but we can at least check that the drop doesn't panic/deadlock.
     drop(request);
+}
+
+#[test_case(1, HashMap::from([("foo".to_string(), "bar".to_string())]); "1-byte object with metadata")]
+#[test_case(10, HashMap::from([("foo".to_string(), "bar".to_string())]); "small object with metadata")]
+#[test_case(30000000, HashMap::from([("foo".to_string(), "bar".to_string())]); "large object with metadata")]
+#[tokio::test]
+async fn test_get_object_user_metadata(size: usize, metadata: HashMap<String, String>) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_user_metadata");
+
+    let key = format!("{prefix}/test");
+    let body = vec![0x42; size];
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .set_metadata(Some(metadata.clone()))
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    let mut result = client
+        .get_object(&bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    let actual_metadata = result.get_object_metadata().await.expect("should return metadata");
+    let actual_metadata_2 = result
+        .get_object_metadata()
+        .await
+        .expect("should return metadata multiple times");
+
+    let expected = &body;
+    check_get_result(result, None, expected).await;
+    assert_eq!(actual_metadata, metadata);
+    assert_eq!(actual_metadata_2, metadata);
+}
+
+#[test_case(50, HashMap::from([("foo".to_string(), "bar".to_string())]); "50-byte object with metadata")]
+#[tokio::test]
+async fn test_get_object_user_metadata_with_zero_backpressure(size: usize, metadata: HashMap<String, String>) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_user_metadata_with_zero_backpressure");
+
+    let key = format!("{prefix}/test");
+    let body = vec![0x42; size];
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .set_metadata(Some(metadata.clone()))
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_backpressure_client(0, None);
+
+    let mut result = client
+        .get_object(&bucket, &key, Some(1..5), None)
+        .await
+        .expect("get_object should succeed");
+    result.get_object_metadata().await.expect_err("should not return metadata for empty read window");
 }


### PR DESCRIPTION
## Description of change

<!-- Please describe your contribution here. What and why? -->

Adds support for fetching user defined object metadata in GetObject calls.

Relevant issues: N/A

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

No

## Does this change need a changelog entry in any of the crates?

Yes, for mountpoint-s3-client.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
