### PR TITLE
Add failing reference test

### DIFF
--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -1290,4 +1290,24 @@ mod mutations {
             0,
         )
     }
+
+    #[test]
+    fn regression_put_nested_over_open_file() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([])),
+            vec![
+                Op::CreateFile(
+                    ValidName("a".into()),
+                    DirectoryIndex(0),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+                Op::PutObject(
+                    DirectoryIndex(0),
+                    Name("a/-".into()),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+            ],
+            0,
+        )
+    }
 }


### PR DESCRIPTION
## Description of change

One of the property-based tests found a new case where the reference model and Mountpoint implementation diverge. This change adds the case as a failing test:

```
---- reftests::harness::mutations::regression_put_nested_over_open_file stdout ----
thread 'reftests::harness::mutations::regression_put_nested_over_open_file' panicked at mountpoint-s3/tests/reftests/harness.rs:640:29:
assertion `left == right` failed: for file "a" expecting RegularFile found Directory
  left: Directory
 right: RegularFile
```

The issue seems to be around the shadowing behavior when a "local" file is open (i.e. not uploaded yet) and a prefix with the same name is created on the bucket. **To be further investigated.**

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
