### PR TITLE
Release new crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-io 2.3.2",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-channel 2.2.1",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v0.11.0 (October 17, 2024)
+
+### Breaking changes
+
+* No breaking changes.
+
+### Other changes
+
 * Add support for copy object operation. ([#1052](https://github.com/awslabs/mountpoint-s3/pull/1052))
 * Introduce a new API (`put_object_single`) to perform single PutObject requests rather than multi-part uploads. ([#1046](https://github.com/awslabs/mountpoint-s3/pull/1046))
 * Return the new object ETag after a successful PUT request. ([#1057](https://github.com/awslabs/mountpoint-s3/pull/1057))

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.9.0" }
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.9.0" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.10.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
 
 async-trait = "0.1.57"
 auto_impl = "1.1.2"

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Update to latest CRT dependencies
 
+## v0.10.0 (October 17, 2024)
+
+* Update to latest CRT dependencies
+
 ## v0.9.0 (September 12, 2024)
 
 * Update to latest CRT dependencies

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## v0.10.0 (October 17, 2024)
 
+* Add `RequestType::CopyObject` for copy object operation. ([#1052](https://github.com/awslabs/mountpoint-s3/pull/1052))
+* Add `RequestType::PutObject` for put object operation. ([#1046](https://github.com/awslabs/mountpoint-s3/pull/1046))
+* Add `InputStream` as an option for the `Message` body. ([#1046](https://github.com/awslabs/mountpoint-s3/pull/1046))
 * Update to latest CRT dependencies
 
 ## v0.9.0 (September 12, 2024)

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Update to latest CRT dependencies
 
+## v0.10.0 (October 17, 2024)
+
+* Update to latest CRT dependencies
+
 ## v0.9.0 (September 12, 2024)
 
 * Allow specifying a list of network interfaces to be used by an S3 client. ([#943](https://github.com/awslabs/mountpoint-s3/pull/943))

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.9.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
 
 async-channel = "2.1.1"
 futures = "0.3.24"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,8 +8,8 @@ default-run = "mount-s3"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.10.0" }
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.9.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.11.0" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.10.0" }
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "2.1.1"


### PR DESCRIPTION
## Description of change

Releasing `v0.11.0 mountpoint-s3-client` and it's dependencies `v0.10.0 mountpoint-s3-crt` and `v0.10.0 mountpoint-s3-crt-sys`

## Does this change impact existing behavior?

No breaking changes, see CHANGELOGs for each crate.

## Does this change need a changelog entry in any of the crates?

CHANGELOGs are updated for each crate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
