### PR TITLE
Add an integration test for the shared cache

### DIFF
--- a/mountpoint-s3/tests/common/cache.rs
+++ b/mountpoint-s3/tests/common/cache.rs
@@ -1,0 +1,118 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use mountpoint_s3::{
+    data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult},
+    object::ObjectId,
+};
+
+/// A wrapper around any type implementing [DataCache], which counts operations
+pub struct CacheTestWrapper<Cache> {
+    cache: Arc<Cache>,
+    get_block_ok_count: Arc<AtomicU64>,
+    get_block_hit_count: Arc<AtomicU64>,
+    get_block_failed_count: Arc<AtomicU64>,
+    put_block_ok_count: Arc<AtomicU64>,
+    put_block_failed_count: Arc<AtomicU64>,
+}
+
+impl<Cache> Clone for CacheTestWrapper<Cache> {
+    fn clone(&self) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            get_block_ok_count: self.get_block_ok_count.clone(),
+            get_block_hit_count: self.get_block_hit_count.clone(),
+            get_block_failed_count: self.get_block_failed_count.clone(),
+            put_block_ok_count: self.put_block_ok_count.clone(),
+            put_block_failed_count: self.put_block_failed_count.clone(),
+        }
+    }
+}
+
+impl<Cache> CacheTestWrapper<Cache> {
+    pub fn new(cache: Arc<Cache>) -> Self {
+        CacheTestWrapper {
+            cache,
+            get_block_ok_count: Arc::new(AtomicU64::new(0)),
+            get_block_hit_count: Arc::new(AtomicU64::new(0)),
+            get_block_failed_count: Arc::new(AtomicU64::new(0)),
+            put_block_ok_count: Arc::new(AtomicU64::new(0)),
+            put_block_failed_count: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn wait_for_put(&self, max_wait_duration: Duration) {
+        let st = std::time::Instant::now();
+        loop {
+            if st.elapsed() > max_wait_duration {
+                panic!("timeout on waiting for a write to the cache to happen")
+            }
+            if self.put_block_failed_count.load(Ordering::SeqCst) > 0
+                || self.put_block_ok_count.load(Ordering::SeqCst) > 0
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    pub fn get_block_hit_count(&self) -> u64 {
+        self.get_block_hit_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Cache> {
+    async fn get_block(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        object_size: usize,
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        let result = self
+            .cache
+            .get_block(cache_key, block_idx, block_offset, object_size)
+            .await
+            .inspect(|_| {
+                self.get_block_ok_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .inspect_err(|_| {
+                self.get_block_failed_count.fetch_add(1, Ordering::SeqCst);
+            })?
+            .inspect(|_| {
+                self.get_block_hit_count.fetch_add(1, Ordering::SeqCst);
+            });
+
+        Ok(result)
+    }
+
+    async fn put_block(
+        &self,
+        cache_key: ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+        object_size: usize,
+    ) -> DataCacheResult<()> {
+        self.cache
+            .put_block(cache_key, block_idx, block_offset, bytes, object_size)
+            .await
+            .inspect(|_| {
+                self.put_block_ok_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .inspect_err(|_| {
+                self.put_block_failed_count.fetch_add(1, Ordering::SeqCst);
+            })
+    }
+
+    fn block_size(&self) -> u64 {
+        self.cache.block_size()
+    }
+}

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -113,7 +113,7 @@ pub trait TestSessionCreator: FnOnce(&str, TestSessionConfig) -> TestSession {}
 // `FnOnce(...)` in place of `impl TestSessionCreator`.
 impl<T> TestSessionCreator for T where T: FnOnce(&str, TestSessionConfig) -> TestSession {}
 
-fn create_fuse_session<Client, Prefetcher>(
+pub fn create_fuse_session<Client, Prefetcher>(
     client: Client,
     prefetcher: Prefetcher,
     bucket: &str,
@@ -363,12 +363,7 @@ pub mod s3_session {
             let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
             let region = get_test_region();
 
-            let client_config = S3ClientConfig::default()
-                .part_size(test_config.part_size)
-                .endpoint_config(get_test_endpoint_config())
-                .read_backpressure(true)
-                .initial_read_window(test_config.initial_read_window_size);
-            let client = S3CrtClient::new(client_config).unwrap();
+            let client = create_crt_client(test_config.part_size, test_config.initial_read_window_size);
             let runtime = client.event_loop_group();
             let prefetcher = caching_prefetch(cache, runtime, test_config.prefetcher_config);
             let session = create_fuse_session(
@@ -385,7 +380,16 @@ pub mod s3_session {
         }
     }
 
-    fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
+    pub fn create_crt_client(part_size: usize, initial_read_window_size: usize) -> S3CrtClient {
+        let client_config = S3ClientConfig::default()
+            .part_size(part_size)
+            .endpoint_config(get_test_endpoint_config())
+            .read_backpressure(true)
+            .initial_read_window(initial_read_window_size);
+        S3CrtClient::new(client_config).unwrap()
+    }
+
+    pub fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
         let sdk_client = tokio_block_on(async { get_test_sdk_client(region).await });
         SDKTestClient {
             prefix: prefix.to_owned(),

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -389,7 +389,7 @@ pub mod s3_session {
         S3CrtClient::new(client_config).unwrap()
     }
 
-    pub fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
+    fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
         let sdk_client = tokio_block_on(async { get_test_sdk_client(region).await });
         SDKTestClient {
             prefix: prefix.to_owned(),

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -2,6 +2,8 @@
 //! Allow for unused items since this is included independently in each module.
 #![allow(dead_code)]
 
+pub mod cache;
+
 pub mod creds;
 
 #[cfg(feature = "fuse_tests")]

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -11,7 +11,7 @@ pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
     #[cfg(not(feature = "s3express_tests"))]
     let bucket = get_standard_bucket();
     #[cfg(feature = "s3express_tests")]
-    let bucket = get_express_cache_bucket();
+    let bucket = get_express_bucket();
 
     let prefix = get_test_prefix(test_name);
 
@@ -30,7 +30,7 @@ pub fn get_test_prefix(test_name: &str) -> String {
 }
 
 #[cfg(feature = "s3express_tests")]
-pub fn get_express_cache_bucket() -> String {
+pub fn get_express_bucket() -> String {
     std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
         .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
 }

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -8,13 +8,17 @@ use rand_chacha::rand_core::OsRng;
 use crate::common::tokio_block_on;
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = if cfg!(feature = "s3express_tests") {
-        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
-            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
-    } else {
-        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
-    };
+    #[cfg(not(feature = "s3express_tests"))]
+    let bucket = get_standard_bucket();
+    #[cfg(feature = "s3express_tests")]
+    let bucket = get_express_cache_bucket();
 
+    let prefix = get_test_prefix(test_name);
+
+    (bucket, prefix)
+}
+
+pub fn get_test_prefix(test_name: &str) -> String {
     // Generate a random nonce to make sure this prefix is truly unique
     let nonce = OsRng.next_u64();
 
@@ -22,9 +26,17 @@ pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
     let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
     assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
 
-    let prefix = format!("{prefix}{test_name}/{nonce}/");
+    format!("{prefix}{test_name}/{nonce}/")
+}
 
-    (bucket, prefix)
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_cache_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+}
+
+pub fn get_standard_bucket() -> String {
+    std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
 }
 
 pub fn get_test_bucket_forbidden() -> String {

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -1,0 +1,162 @@
+use crate::common::fuse::s3_session::{create_crt_client, create_test_client};
+use crate::common::fuse::{create_fuse_session, TestClient};
+use crate::common::s3::{get_express_cache_bucket, get_standard_bucket, get_test_prefix, get_test_region};
+use fuser::BackgroundSession;
+use mountpoint_s3::data_cache::{DataCache, DiskDataCache, DiskDataCacheConfig, ExpressDataCache};
+use mountpoint_s3::fs::CacheConfig;
+use mountpoint_s3::prefetch::caching_prefetch;
+use mountpoint_s3::S3FilesystemConfig;
+use mountpoint_s3_client::S3CrtClient;
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+use std::fs;
+use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
+use tempfile::TempDir;
+use test_case::test_case;
+
+const CACHE_BLOCK_SIZE: u64 = 1024 * 1024;
+const CLIENT_PART_SIZE: usize = 8 * 1024 * 1024;
+
+#[test_case("key", 100, 1024; "simple")]
+#[test_case("£", 100, 1024; "non-ascii key")]
+#[test_case("key", 1024, 1024; "long key")]
+#[test_case("key", 100, 1024 * 1024; "big file")]
+fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
+    cache_write_read_base(
+        key_suffix,
+        key_size,
+        object_size,
+        express_cache_factory,
+        "express_cache_write_read",
+    )
+}
+
+#[test_case("key", 100, 1024; "simple")]
+#[test_case("£", 100, 1024; "non-ascii key")]
+#[test_case("key", 1024, 1024; "long key")]
+#[test_case("key", 100, 1024 * 1024; "big file")]
+fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
+    let cache_dir = tempfile::tempdir().unwrap();
+    cache_write_read_base(
+        key_suffix,
+        key_size,
+        object_size,
+        disk_cache_factory(cache_dir.path().to_owned()),
+        "disk_cache_write_read",
+    );
+}
+
+fn cache_write_read_base<Cache, CacheFactory>(
+    key_suffix: &str,
+    key_size: usize,
+    object_size: usize,
+    cache_factory: CacheFactory,
+    test_name: &str,
+) where
+    Cache: DataCache + Send + Sync + 'static,
+    CacheFactory: FnOnce(S3CrtClient) -> Cache,
+{
+    let region = get_test_region();
+    let bucket = get_standard_bucket();
+    let prefix = get_test_prefix(test_name);
+
+    // Mount a bucket
+    let filesystem_config = S3FilesystemConfig {
+        cache_config: CacheConfig {
+            serve_lookup_from_cache: true,
+            file_ttl: Duration::from_secs(3600),
+            dir_ttl: Duration::from_secs(3600),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let (mount_point, _session) = new_fuse_session_with_cache(&bucket, &prefix, cache_factory, filesystem_config);
+
+    // Write an object, no caching happens yet
+    let key = get_object_key(&prefix, key_suffix, key_size);
+    let path = mount_point.path().join(&key);
+    let written = random_binary_data(object_size);
+    fs::write(&path, &written).expect("write should succeed");
+
+    // First read should be from the source bucket and be cached
+    let read = fs::read(&path).expect("read should succeed");
+    assert_eq!(read, written);
+
+    // Cache population is async, 3 seconds should be enough for it to finish
+    sleep(Duration::from_secs(3));
+
+    // Ensure data may not be served from the source bucket.
+    //
+    // NOTE, that we assume that the metadata cache will hold an entry for the removed object
+    // at the point of the next read. This assumption must be valid since there are no other
+    // FS operations done before the read. Currently, an entry in the metadata cache may be
+    // invalidated by TTL expiry or a READDIR(PLUS) call.
+    let client = create_test_client(&region, &bucket, &prefix);
+    client.remove_object(&key).expect("remove must succeed");
+    assert!(
+        !client.contains_key(&key).expect("head object must succeed"),
+        "object should not exist in the source bucket"
+    );
+
+    // Second read should be from the cache
+    let read = fs::read(&path).expect("read from the cache should succeed");
+    assert_eq!(read, written);
+}
+
+fn express_cache_factory(client: S3CrtClient) -> ExpressDataCache<S3CrtClient> {
+    let express_bucket_name = get_express_cache_bucket();
+    ExpressDataCache::new(&express_bucket_name, client, &express_bucket_name, CACHE_BLOCK_SIZE)
+}
+
+fn disk_cache_factory(cache_dir: PathBuf) -> impl FnOnce(S3CrtClient) -> DiskDataCache {
+    move |_| {
+        let cache_config = DiskDataCacheConfig {
+            block_size: CACHE_BLOCK_SIZE,
+            limit: Default::default(),
+        };
+        DiskDataCache::new(cache_dir, cache_config)
+    }
+}
+
+fn random_binary_data(size_in_bytes: usize) -> Vec<u8> {
+    let seed = rand::thread_rng().gen();
+    let mut rng = ChaChaRng::seed_from_u64(seed);
+    let mut data = vec![0; size_in_bytes];
+    rng.fill_bytes(&mut data);
+    data
+}
+
+// Creates a random key which has a size of at least `min_size_in_bytes`
+fn get_object_key(key_prefix: &str, key_suffix: &str, min_size_in_bytes: usize) -> String {
+    let random_suffix: u64 = rand::thread_rng().gen();
+    let last_key_part = format!("{key_suffix}{random_suffix}"); // part of the key after all the "/"
+    let full_key = format!("{key_prefix}{last_key_part}");
+    let full_key_size = full_key.as_bytes().len();
+    let padding_size = min_size_in_bytes.saturating_sub(full_key_size);
+    let padding = "0".repeat(padding_size);
+    format!("{last_key_part}{padding}")
+}
+
+/// Create a FUSE mount backed by a real S3 client with a cache.
+/// Note, that the mount uses S3 Standard as a source bucket.
+fn new_fuse_session_with_cache<Cache, CacheFactory>(
+    bucket: &str,
+    prefix: &str,
+    cache_factory: CacheFactory,
+    filesystem_config: S3FilesystemConfig,
+) -> (TempDir, BackgroundSession)
+where
+    Cache: DataCache + Send + Sync + 'static,
+    CacheFactory: FnOnce(S3CrtClient) -> Cache,
+{
+    let mount_dir = tempfile::tempdir().unwrap();
+    let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE);
+    let cache = cache_factory(client.clone());
+    let runtime = client.event_loop_group();
+    let prefetcher = caching_prefetch(cache, runtime, Default::default());
+    let session = create_fuse_session(client, prefetcher, bucket, prefix, mount_dir.path(), filesystem_config);
+
+    (mount_dir, session)
+}

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -1,7 +1,6 @@
 use crate::common::fuse::s3_session::{create_crt_client, create_test_client};
 use crate::common::fuse::{create_fuse_session, TestClient};
-use crate::common::s3::{get_express_cache_bucket, get_standard_bucket, get_test_prefix, get_test_region};
-use fuser::BackgroundSession;
+use crate::common::s3::{get_express_bucket, get_standard_bucket, get_test_prefix, get_test_region};
 use mountpoint_s3::data_cache::{DataCache, DiskDataCache, DiskDataCacheConfig, ExpressDataCache};
 use mountpoint_s3::fs::CacheConfig;
 use mountpoint_s3::prefetch::caching_prefetch;
@@ -10,10 +9,8 @@ use mountpoint_s3_client::S3CrtClient;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::fs;
-use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
-use tempfile::TempDir;
 use test_case::test_case;
 
 const CACHE_BLOCK_SIZE: u64 = 1024 * 1024;
@@ -25,12 +22,16 @@ const CLIENT_PART_SIZE: usize = 8 * 1024 * 1024;
 #[test_case("key", 100, 1024 * 1024; "big file")]
 fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE);
+    let bucket_name = get_standard_bucket();
+    let express_bucket_name = get_express_bucket();
+    let cache = ExpressDataCache::new(&express_bucket_name, client.clone(), &bucket_name, CACHE_BLOCK_SIZE);
+
     cache_write_read_base(
-        client.clone(),
+        client,
         key_suffix,
         key_size,
         object_size,
-        express_cache_factory(client),
+        cache,
         "express_cache_write_read",
     )
 }
@@ -41,27 +42,33 @@ fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usiz
 #[test_case("key", 100, 1024 * 1024; "big file")]
 fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
     let cache_dir = tempfile::tempdir().unwrap();
+    let cache_config = DiskDataCacheConfig {
+        block_size: CACHE_BLOCK_SIZE,
+        limit: Default::default(),
+    };
+    let cache = DiskDataCache::new(cache_dir.path().to_path_buf(), cache_config);
+
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE);
+
     cache_write_read_base(
         client,
         key_suffix,
         key_size,
         object_size,
-        disk_cache_factory(cache_dir.path().to_owned()),
+        cache,
         "disk_cache_write_read",
     );
 }
 
-fn cache_write_read_base<Cache, CacheFactory>(
+fn cache_write_read_base<Cache>(
     client: S3CrtClient,
     key_suffix: &str,
     key_size: usize,
     object_size: usize,
-    cache_factory: CacheFactory,
+    cache: Cache,
     test_name: &str,
 ) where
     Cache: DataCache + Send + Sync + 'static,
-    CacheFactory: FnOnce() -> Cache,
 {
     let region = get_test_region();
     let bucket = get_standard_bucket();
@@ -77,8 +84,17 @@ fn cache_write_read_base<Cache, CacheFactory>(
         },
         ..Default::default()
     };
-    let (mount_point, _session) =
-        new_fuse_session_with_cache(client, &bucket, &prefix, cache_factory, filesystem_config);
+    let mount_point = tempfile::tempdir().unwrap();
+    let runtime = client.event_loop_group();
+    let prefetcher = caching_prefetch(cache, runtime, Default::default());
+    let _session = create_fuse_session(
+        client,
+        prefetcher,
+        &bucket,
+        &prefix,
+        mount_point.path(),
+        filesystem_config,
+    );
 
     // Write an object, no caching happens yet
     let key = get_object_key(&prefix, key_suffix, key_size);
@@ -111,23 +127,6 @@ fn cache_write_read_base<Cache, CacheFactory>(
     assert_eq!(read, written);
 }
 
-fn express_cache_factory(client: S3CrtClient) -> impl FnOnce() -> ExpressDataCache<S3CrtClient> {
-    move || {
-        let express_bucket_name = get_express_cache_bucket();
-        ExpressDataCache::new(&express_bucket_name, client, &express_bucket_name, CACHE_BLOCK_SIZE)
-    }
-}
-
-fn disk_cache_factory(cache_dir: PathBuf) -> impl FnOnce() -> DiskDataCache {
-    move || {
-        let cache_config = DiskDataCacheConfig {
-            block_size: CACHE_BLOCK_SIZE,
-            limit: Default::default(),
-        };
-        DiskDataCache::new(cache_dir, cache_config)
-    }
-}
-
 fn random_binary_data(size_in_bytes: usize) -> Vec<u8> {
     let seed = rand::thread_rng().gen();
     let mut rng = ChaChaRng::seed_from_u64(seed);
@@ -145,26 +144,4 @@ fn get_object_key(key_prefix: &str, key_suffix: &str, min_size_in_bytes: usize) 
     let padding_size = min_size_in_bytes.saturating_sub(full_key_size);
     let padding = "0".repeat(padding_size);
     format!("{last_key_part}{padding}")
-}
-
-/// Create a FUSE mount backed by a real S3 client with a cache.
-/// Note, that the mount uses S3 Standard as a source bucket.
-fn new_fuse_session_with_cache<Cache, CacheFactory>(
-    client: S3CrtClient,
-    bucket: &str,
-    prefix: &str,
-    cache_factory: CacheFactory,
-    filesystem_config: S3FilesystemConfig,
-) -> (TempDir, BackgroundSession)
-where
-    Cache: DataCache + Send + Sync + 'static,
-    CacheFactory: FnOnce() -> Cache,
-{
-    let mount_dir = tempfile::tempdir().unwrap();
-    let cache = cache_factory();
-    let runtime = client.event_loop_group();
-    let prefetcher = caching_prefetch(cache, runtime, Default::default());
-    let session = create_fuse_session(client, prefetcher, bucket, prefix, mount_dir.path(), filesystem_config);
-
-    (mount_dir, session)
 }

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "s3_tests", feature = "s3express_tests"))]
+mod cache_test;
 mod consistency_test;
 mod fork_test;
 mod lookup_test;


### PR DESCRIPTION
## Description of change

Add an integration test for the shared cache. It uses `S3_EXPRESS_ONE_ZONE_BUCKET_NAME` as a cache bucket and `S3_BUCKET_NAME` as a regular bucket.

Relevant issues: No

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
