### PR TITLE
Replace deprecated `PanicInfo` type alias

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 default-run = "mount-s3"
+rust-version = "1.81"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.14.0", features = ["abi-7-28"] }

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -2,7 +2,7 @@ use std::backtrace::Backtrace;
 use std::fs::{DirBuilder, OpenOptions};
 use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::prelude::OpenOptionsExt;
-use std::panic::{self, PanicInfo};
+use std::panic::{self, PanicHookInfo};
 use std::path::{Path, PathBuf};
 use std::thread;
 
@@ -70,7 +70,7 @@ pub fn prepare_log_file_name(log_directory: &Path) -> PathBuf {
     log_directory.join(file_name)
 }
 
-fn tracing_panic_hook(panic_info: &PanicInfo) {
+fn tracing_panic_hook(panic_info: &PanicHookInfo) {
     let location = panic_info
         .location()
         .map(|l| format!("{}", l))


### PR DESCRIPTION
## Description of change

Fixes clippy [failure](https://github.com/awslabs/mountpoint-s3/actions/runs/11390221324/job/31691333810?pr=1071).

Relevant issues: No

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
