### PR TITLE
Bump to stable Rust (1.82)

### DIFF
--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -309,15 +309,11 @@ fn compile_logging_shim(crt_include_dir: impl AsRef<Path>) {
 /// Should be used in `cargo:rustc-link-lib`.
 fn static_link_modifiers_for_lib(library_name: &str) -> &'static str {
     // Up until v1.82, Rust was passing `+whole-archive` linker flag while building the tests.
-    // That's no longer the case with v1.82 and our tests started to fail with undefined references.
-    // To preserve this behaviour, we're passing `+whole-archive` explicitly for `aws-c-common`
-    // if we're doing a debug build.
-    // See https://github.com/rust-lang/rust/pull/128400.
-    // A debug build does not necessarily mean we're building the tests, but there is no way to
-    // detect if we're building the tests in `build.rs` at the moment, and this is the best approximation.
-    // See https://github.com/rust-lang/cargo/issues/1581.
-    let is_debug = get_env("PROFILE").unwrap_or_default() == "debug";
-    if is_debug && library_name == "aws-c-common" {
+    // That's no longer the case with v1.82 and our tests started to fail with undefined references from `aws-c-common`.
+    // To preserve this behaviour, we're passing `+whole-archive` explicitly for `aws-c-common`,
+    // unfortunately we're passing this flag for all builds as there is no way to detect if we're
+    // building the tests currently, see https://github.com/rust-lang/cargo/issues/1581.
+    if library_name == "aws-c-common" {
         "static:+whole-archive"
     } else {
         "static"

--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -2,7 +2,7 @@ use std::backtrace::Backtrace;
 use std::fs::{DirBuilder, OpenOptions};
 use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::prelude::OpenOptionsExt;
-use std::panic::{self, PanicInfo};
+use std::panic::{self, PanicHookInfo};
 use std::path::{Path, PathBuf};
 use std::thread;
 
@@ -70,7 +70,7 @@ pub fn prepare_log_file_name(log_directory: &Path) -> PathBuf {
     log_directory.join(file_name)
 }
 
-fn tracing_panic_hook(panic_info: &PanicInfo) {
+fn tracing_panic_hook(panic_info: &PanicHookInfo) {
     let location = panic_info
         .location()
         .map(|l| format!("{}", l))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "stable"
 components = ["rust-src"]


### PR DESCRIPTION
## Description of change
Our build with Rust 1.82 broken previously due to changes on Rust 1.82. This PR fixes those breakages and bumps Rust version to stable.
- [Always pass +whole-archive modifier for aws-c-common](https://github.com/awslabs/mountpoint-s3/pull/1075/commits/689681af3b8f9ab8a1f8c32d032bfcad1c432e14)
- [Replace deprecated PanicInfo type alias](https://github.com/awslabs/mountpoint-s3/commit/e42ef2edcd2c7d4b621770ec6d6ecf4a8af65900) Cherry-picked from @vladem's original PR https://github.com/awslabs/mountpoint-s3/pull/1072. Since we have `rust-toolchain.toml` now, and we don't vend `mountpoint-s3` as a Rust crate, we're fine to only use `rust-toolchain.toml` and not `rust-version` in `Cargo.toml`. Although they serve to different purposes, having only one place to specify Rust version would be preferable and sufficient in our case.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
