### PR TITLE
Add failure hook for put_object_single

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -543,7 +543,7 @@ impl Stream for MockGetObjectRequest {
     }
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Default, Error, PartialEq, Eq)]
 pub struct MockClientError(pub Cow<'static, str>);
 
 impl std::fmt::Display for MockClientError {

--- a/mountpoint-s3/src/prefetch.rs
+++ b/mountpoint-s3/src/prefetch.rs
@@ -566,7 +566,7 @@ mod tests {
     use super::*;
     use futures::executor::{block_on, ThreadPool};
     use mountpoint_s3_client::error::GetObjectError;
-    use mountpoint_s3_client::failure_client::{countdown_failure_client, RequestFailureMap};
+    use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig, RequestFailureMap};
     use mountpoint_s3_client::mock_client::{ramp_bytes, MockClient, MockClientConfig, MockClientError, MockObject};
     use mountpoint_s3_client::types::ETag;
     use proptest::proptest;
@@ -800,7 +800,7 @@ mod tests {
         size: u64,
         read_size: usize,
         test_config: TestConfig,
-        get_failures: RequestFailureMap<MockClient, GetObjectError>,
+        get_failures: RequestFailureMap<MockClientError, GetObjectError>,
     ) {
         let config = MockClientConfig {
             bucket: "test-bucket".to_string(),
@@ -817,10 +817,10 @@ mod tests {
 
         let client = Arc::new(countdown_failure_client(
             client,
-            get_failures,
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
+            CountdownFailureConfig {
+                get_failures,
+                ..Default::default()
+            },
         ));
         let mem_limiter = MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT);
 
@@ -1126,10 +1126,10 @@ mod tests {
 
         let client = Arc::new(countdown_failure_client(
             client,
-            get_failures,
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
+            CountdownFailureConfig {
+                get_failures,
+                ..Default::default()
+            },
         ));
         let mem_limiter = MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT);
 

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -249,7 +249,7 @@ mod tests {
 
     use super::*;
     use mountpoint_s3_client::{
-        failure_client::countdown_failure_client,
+        failure_client::{countdown_failure_client, CountdownFailureConfig},
         mock_client::{MockClient, MockClientConfig, MockClientError},
     };
     use test_case::test_case;
@@ -337,10 +337,10 @@ mod tests {
 
         let failure_client = Arc::new(countdown_failure_client(
             client.clone(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            put_failures,
+            CountdownFailureConfig {
+                put_failures,
+                ..Default::default()
+            },
         ));
 
         let uploader = Uploader::new(failure_client.clone(), None, ServerSideEncryption::default(), true);

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -13,7 +13,7 @@ use mountpoint_s3::S3FilesystemConfig;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3_client::error_metadata::ClientErrorMetadata;
-use mountpoint_s3_client::failure_client::countdown_failure_client;
+use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
 use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, Operation};
 use mountpoint_s3_client::types::{ETag, RestoreStatus};
 use mountpoint_s3_client::ObjectClient;
@@ -753,10 +753,10 @@ async fn test_upload_aborted_on_write_failure() {
 
     let failure_client = countdown_failure_client(
         client.clone(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        put_failures,
+        CountdownFailureConfig {
+            put_failures,
+            ..Default::default()
+        },
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
@@ -828,10 +828,10 @@ async fn test_upload_aborted_on_fsync_failure() {
 
     let failure_client = countdown_failure_client(
         client.clone(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        put_failures,
+        CountdownFailureConfig {
+            put_failures,
+            ..Default::default()
+        },
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
@@ -888,10 +888,10 @@ async fn test_upload_aborted_on_release_failure() {
 
     let failure_client = countdown_failure_client(
         client.clone(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        put_failures,
+        CountdownFailureConfig {
+            put_failures,
+            ..Default::default()
+        },
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),


### PR DESCRIPTION
## Description of change

Add support for the new single PutObject operation to `FailureClient`, so that tests can inject failures for PutObject requests.

This change also refactors the setup of the failure client by introducing a `Config` struct.

## Does this change impact existing behavior?

Only impacts tests.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
