### PR TITLE
Allow clients to define custom callbacks to handle telemetry

### DIFF
--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -61,7 +61,9 @@ pub mod error_metadata;
 
 pub use object_client::{ObjectClient, PutObjectRequest};
 
-pub use s3_crt_client::{get_object::S3GetObjectResponse, put_object::S3PutObjectRequest, S3CrtClient, S3RequestError};
+pub use s3_crt_client::{
+    get_object::S3GetObjectResponse, put_object::S3PutObjectRequest, OnTelemetry, S3CrtClient, S3RequestError,
+};
 
 /// Configuration for the S3 client
 pub mod config {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -102,6 +102,7 @@ pub struct S3ClientConfig {
     read_backpressure: bool,
     initial_read_window: usize,
     network_interface_names: Vec<String>,
+    telemetry_callback: Option<Arc<dyn OnTelemetry>>,
 }
 
 impl Default for S3ClientConfig {
@@ -120,6 +121,7 @@ impl Default for S3ClientConfig {
             read_backpressure: false,
             initial_read_window: DEFAULT_PART_SIZE,
             network_interface_names: vec![],
+            telemetry_callback: None,
         }
     }
 }
@@ -221,6 +223,13 @@ impl S3ClientConfig {
         self.network_interface_names = network_interface_names;
         self
     }
+
+    /// Set a custom telemetry callback handler
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn telemetry_callback(mut self, telemetry_callback: Arc<dyn OnTelemetry>) -> Self {
+        self.telemetry_callback = Some(telemetry_callback);
+        self
+    }
 }
 
 /// Authentication configuration for the CRT-based S3 client
@@ -288,6 +297,7 @@ struct S3CrtClientInner {
     bucket_owner: Option<String>,
     credentials_provider: Option<CredentialsProvider>,
     host_resolver: HostResolver,
+    telemetry_callback: Option<Arc<dyn OnTelemetry>>,
 }
 
 impl S3CrtClientInner {
@@ -422,6 +432,7 @@ impl S3CrtClientInner {
             bucket_owner: config.bucket_owner,
             credentials_provider: Some(credentials_provider),
             host_resolver,
+            telemetry_callback: config.telemetry_callback,
         })
     }
 
@@ -551,6 +562,7 @@ impl S3CrtClientInner {
         let endpoint = options.get_endpoint().expect("S3Message always has an endpoint");
         let hostname = endpoint.host_name().to_str().unwrap().to_owned();
         let host_resolver = self.host_resolver.clone();
+        let telemetry_callback = self.telemetry_callback.clone();
 
         let start_time = Instant::now();
         let first_body_part = Arc::new(AtomicBool::new(true));
@@ -594,6 +606,10 @@ impl S3CrtClientInner {
                     metrics::counter!("s3.requests.failures", "op" => op, "type" => request_type, "status" => http_status.unwrap_or(-1).to_string()).increment(1);
                 } else if request_canceled {
                     metrics::counter!("s3.requests.canceled", "op" => op, "type" => request_type).increment(1);
+                }
+
+                if let Some(telemetry_callback) = &telemetry_callback {
+                    telemetry_callback.on_telemetry(metrics);
                 }
             })
             .on_headers(move |headers, response_status| {
@@ -1368,6 +1384,11 @@ impl ObjectClient for S3CrtClient {
         self.get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
             .await
     }
+}
+
+/// Custom handling of telemetry events
+pub trait OnTelemetry: std::fmt::Debug + Send + Sync {
+    fn on_telemetry(&self, request_metrics: &RequestMetrics);
 }
 
 #[cfg(test)]

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "s3_tests")]
 
-use aws_config::profile::ProfileFileCredentialsProvider;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::config::Region;

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -90,7 +90,7 @@ pub fn get_test_backpressure_client(initial_read_window: usize, part_size: Optio
 
 pub fn get_test_client_with_custom_telemetry(telemetry_callback: Arc<dyn OnTelemetry>) -> S3CrtClient {
     let config = S3ClientConfig::new()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .telemetry_callback(telemetry_callback);
     S3CrtClient::new(config).expect("could not create test client")
 }


### PR DESCRIPTION
## Description of change
Different users of mountpoint will care about different metrics returned for each requests, so allow them to define their own custom handlers for the on_telemetry callback in addition to the default metrics that mountpoint emits.

This allows users to do things like: 
- emit extended request ids ("x-amz-id-2")
- When some criteria is met, log out additional information

Relevant issues: #1079 

## Does this change impact existing behavior?


No there should be no breaking changes, the only visible change is that there's a new field to the S3ClientConfig which defines the custom telemetry handler

## Does this change need a changelog entry in any of the crates?

Just a note in mountpoint-s3-client letting users know this feature now exists

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
