### PR TITLE
Add ability to request checksum in an S3 HeadObject request

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Other changes
 
-* No other changes.
+* Add parameter to request checksum information as part of a `HeadObject` request.
+  If specified, the result should contain the checksum for the object if available in the S3 response.
+  ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 
 ### Breaking changes
 
@@ -12,6 +14,9 @@
   ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
 * `HeadObjectResult` no longer provides the bucket and key used in the original request.
   ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
+* `head_object` method now requires a `HeadObjectParams` parameter.
+  The structure itself is not required to specify anything to achieve the existing behavior.
+  ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 
 ## v0.11.0 (October 17, 2024)
 

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -17,9 +17,9 @@ use pin_project::pin_project;
 use crate::object_client::{
     CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
-    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
-    ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams,
-    UploadReview,
+    HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient,
+    ObjectClientError, ObjectClientResult, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult,
+    PutObjectSingleParams, UploadReview,
 };
 
 // Wrapper for injecting failures into a get stream or a put request
@@ -167,9 +167,10 @@ where
         &self,
         bucket: &str,
         key: &str,
+        params: &HeadObjectParams,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError> {
         (self.head_object_cb)(&mut *self.state.lock().unwrap(), bucket, key)?;
-        self.client.head_object(bucket, key).await
+        self.client.head_object(bucket, key, params).await
     }
 
     async fn put_object(

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -72,11 +72,11 @@ pub mod config {
 /// Types used by all object clients
 pub mod types {
     pub use super::object_client::{
-        Checksum, ChecksumAlgorithm, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag, GetBodyPart,
-        GetObjectAttributesParts, GetObjectAttributesResult, GetObjectRequest, HeadObjectResult, ListObjectsResult,
-        ObjectAttribute, ObjectClientResult, ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult,
-        PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus, UploadChecksum, UploadReview,
-        UploadReviewPart,
+        Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag,
+        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectRequest, HeadObjectParams,
+        HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult, ObjectInfo, ObjectPart,
+        PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
+        UploadChecksum, UploadReview, UploadReviewPart,
     };
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -25,11 +25,11 @@ use tracing::trace;
 use crate::checksums::crc32c_to_base64;
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::{
-    Checksum, ChecksumAlgorithm, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError,
+    Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError,
     DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesParts,
-    GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectResult, ListObjectsError,
-    ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult, ObjectInfo, ObjectPart,
-    PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams,
+    GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError, HeadObjectParams, HeadObjectResult,
+    ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError, ObjectClientResult,
+    ObjectInfo, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams,
     PutObjectTrailingChecksums, RestoreStatus, UploadReview, UploadReviewPart,
 };
 
@@ -376,6 +376,7 @@ pub struct MockObject {
     etag: ETag,
     parts: Option<MockObjectParts>,
     object_metadata: HashMap<String, String>,
+    checksum: Checksum,
 }
 
 impl MockObject {
@@ -395,6 +396,7 @@ impl MockObject {
             etag,
             parts: None,
             object_metadata: HashMap::new(),
+            checksum: Checksum::empty(),
         }
     }
 
@@ -408,6 +410,7 @@ impl MockObject {
             etag,
             parts: None,
             object_metadata: HashMap::new(),
+            checksum: Checksum::empty(),
         }
     }
 
@@ -431,6 +434,7 @@ impl MockObject {
             etag,
             parts: None,
             object_metadata: HashMap::new(),
+            checksum: Checksum::empty(),
         }
     }
 
@@ -448,6 +452,10 @@ impl MockObject {
 
     pub fn set_restored(&mut self, restore_status: Option<RestoreStatus>) {
         self.restore_status = restore_status;
+    }
+
+    pub fn set_checksum(&mut self, checksum: Checksum) {
+        self.checksum = checksum;
     }
 
     pub fn len(&self) -> usize {
@@ -676,6 +684,7 @@ impl ObjectClient for MockClient {
         &self,
         bucket: &str,
         key: &str,
+        params: &HeadObjectParams,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError> {
         trace!(bucket, key, "HeadObject");
         self.inc_op_count(Operation::HeadObject);
@@ -686,12 +695,19 @@ impl ObjectClient for MockClient {
 
         let objects = self.objects.read().unwrap();
         if let Some(object) = objects.get(key) {
+            // Checksum information is opt-in
+            let checksum = match params.checksum_mode {
+                Some(ChecksumMode::Enabled) => object.checksum.clone(),
+                None => Checksum::empty(),
+            };
+
             Ok(HeadObjectResult {
                 size: object.size as u64,
                 last_modified: object.last_modified,
                 etag: object.etag.clone(),
                 storage_class: object.storage_class.clone(),
                 restore_status: object.restore_status,
+                checksum,
             })
         } else {
             Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))
@@ -1676,7 +1692,7 @@ mod tests {
         put_request.complete().await.unwrap();
 
         // head_object returns storage class
-        let head_result = client.head_object(bucket, key).await.unwrap();
+        let head_result = client.head_object(bucket, key, &HeadObjectParams::new()).await.unwrap();
         assert_eq!(head_result.storage_class.as_deref(), storage_class);
 
         // list_objects returns storage class
@@ -1699,14 +1715,14 @@ mod tests {
         let head_counter_1 = client.new_counter(Operation::HeadObject);
         let delete_counter_1 = client.new_counter(Operation::DeleteObject);
 
-        let _result = client.head_object(bucket, "key").await;
+        let _result = client.head_object(bucket, "key", &HeadObjectParams::new()).await;
         assert_eq!(1, head_counter_1.count());
         assert_eq!(0, delete_counter_1.count());
 
         let head_counter_2 = client.new_counter(Operation::HeadObject);
         assert_eq!(0, head_counter_2.count());
 
-        let _result = client.head_object(bucket, "key").await;
+        let _result = client.head_object(bucket, "key", &HeadObjectParams::new()).await;
         let _result = client.delete_object(bucket, "key").await;
         let _result = client.delete_object(bucket, "key").await;
         let _result = client.delete_object(bucket, "key").await;

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -376,6 +376,9 @@ pub struct MockObject {
     etag: ETag,
     parts: Option<MockObjectParts>,
     object_metadata: HashMap<String, String>,
+    /// S3 checksums associated with the object.
+    ///
+    /// Typically, at most one of the checksums should be set.
     checksum: Checksum,
 }
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -16,8 +16,8 @@ use crate::mock_client::{
 use crate::object_client::{
     CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
-    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientResult,
-    PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
+    HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient,
+    ObjectClientResult, PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
 };
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
@@ -168,8 +168,9 @@ impl ObjectClient for ThroughputMockClient {
         &self,
         bucket: &str,
         key: &str,
+        params: &HeadObjectParams,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError> {
-        self.inner.head_object(bucket, key).await
+        self.inner.head_object(bucket, key, params).await
     }
 
     async fn put_object(

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1305,8 +1305,9 @@ impl ObjectClient for S3CrtClient {
         &self,
         bucket: &str,
         key: &str,
+        params: &HeadObjectParams,
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, Self::ClientError> {
-        self.head_object(bucket, key).await
+        self.head_object(bucket, key, params).await
     }
 
     async fn put_object(

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -6,6 +6,7 @@ pub mod common;
 use std::time::{Duration, Instant};
 
 use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::ChecksumAlgorithm;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_s3::types::{GlacierJobParameters, RestoreRequest, Tier};
 use bytes::Bytes;
@@ -13,6 +14,7 @@ use common::*;
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError};
 #[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::types::RestoreStatus;
+use mountpoint_s3_client::types::{ChecksumMode, HeadObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 #[cfg(not(feature = "s3express_tests"))]
 use test_case::test_case;
@@ -34,13 +36,79 @@ async fn test_head_object() {
         .unwrap();
 
     let client: S3CrtClient = get_test_client();
-    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+    let result = client
+        .head_object(&bucket, &key, &HeadObjectParams::new())
+        .await
+        .expect("head_object failed");
 
     assert_eq!(
         result.size as usize,
         body.len(),
         "HeadObject reported size should match uploaded body length",
     );
+}
+
+#[test_case(ChecksumAlgorithm::Crc32)]
+#[test_case(ChecksumAlgorithm::Crc32C)]
+#[test_case(ChecksumAlgorithm::Sha1)]
+#[test_case(ChecksumAlgorithm::Sha256)]
+#[tokio::test]
+async fn test_head_object_checksum(checksum_algorithm: ChecksumAlgorithm) {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_head_object");
+
+    let key = format!("{prefix}hello");
+    let body = b"hello world!";
+    let put_object_output = sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .checksum_algorithm(checksum_algorithm.clone())
+        .send()
+        .await
+        .unwrap();
+
+    let client: S3CrtClient = get_test_client();
+
+    for retrieve_checksum in [true, false] {
+        let mut params = HeadObjectParams::new();
+        if retrieve_checksum {
+            params = params.checksum_mode(Some(ChecksumMode::Enabled));
+        }
+        let result = client
+            .head_object(&bucket, &key, &params)
+            .await
+            .expect("head_object failed");
+
+        let checksum = result.checksum;
+        if retrieve_checksum {
+            match &checksum_algorithm {
+                ChecksumAlgorithm::Crc32 => assert_eq!(
+                    checksum.checksum_crc32,
+                    put_object_output.checksum_crc32().map(|s| s.to_string())
+                ),
+                ChecksumAlgorithm::Crc32C => assert_eq!(
+                    checksum.checksum_crc32c,
+                    put_object_output.checksum_crc32_c().map(|s| s.to_string())
+                ),
+                ChecksumAlgorithm::Sha1 => assert_eq!(
+                    checksum.checksum_sha1,
+                    put_object_output.checksum_sha1().map(|s| s.to_string())
+                ),
+                ChecksumAlgorithm::Sha256 => assert_eq!(
+                    checksum.checksum_sha256,
+                    put_object_output.checksum_sha256().map(|s| s.to_string())
+                ),
+                _ => unimplemented!("This algorithm is not supported"),
+            }
+        } else {
+            assert!(checksum.checksum_crc32.is_none());
+            assert!(checksum.checksum_crc32c.is_none());
+            assert!(checksum.checksum_sha1.is_none());
+            assert!(checksum.checksum_sha256.is_none());
+        }
+    }
 }
 
 #[test_case("INTELLIGENT_TIERING")]
@@ -52,7 +120,7 @@ async fn test_head_object_storage_class(storage_class: &str) {
     let sdk_client = get_test_sdk_client().await;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_head_object");
 
-    let key = format!("{prefix}/hello");
+    let key = format!("{prefix}hello");
     let body = b"hello world!";
     sdk_client
         .put_object()
@@ -65,7 +133,10 @@ async fn test_head_object_storage_class(storage_class: &str) {
         .unwrap();
 
     let client: S3CrtClient = get_test_client();
-    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+    let result = client
+        .head_object(&bucket, &key, &HeadObjectParams::new())
+        .await
+        .expect("head_object failed");
 
     assert_eq!(result.size as usize, body.len());
     assert_eq!(result.storage_class.as_deref(), Some(storage_class));
@@ -80,7 +151,7 @@ async fn test_head_object_404_key() {
 
     let client: S3CrtClient = get_test_client();
 
-    let result = client.head_object(&bucket, &key).await;
+    let result = client.head_object(&bucket, &key, &HeadObjectParams::new()).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))
@@ -95,7 +166,9 @@ async fn test_head_object_404_bucket() {
 
     let client: S3CrtClient = get_test_client();
 
-    let result = client.head_object("DOC-EXAMPLE-BUCKET", &key).await;
+    let result = client
+        .head_object("DOC-EXAMPLE-BUCKET", &key, &HeadObjectParams::new())
+        .await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))
@@ -111,7 +184,7 @@ async fn test_head_object_no_perm() {
 
     let client: S3CrtClient = get_test_client();
 
-    let result = client.head_object(&bucket, &key).await;
+    let result = client.head_object(&bucket, &key, &HeadObjectParams::new()).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ClientError(S3RequestError::Forbidden(_, _)))
@@ -138,7 +211,10 @@ async fn test_head_object_restored() {
         .unwrap();
 
     let client: S3CrtClient = get_test_client();
-    let result = client.head_object(&bucket, &key).await.expect("head_object failed");
+    let result = client
+        .head_object(&bucket, &key, &HeadObjectParams::new())
+        .await
+        .expect("head_object failed");
 
     assert!(
         result.restore_status.is_none(),
@@ -168,7 +244,10 @@ async fn test_head_object_restored() {
     let start = Instant::now();
     let mut timeout_exceeded = true;
     while start.elapsed() < timeout {
-        let response = client.head_object(&bucket, &key).await.expect("head_object failed");
+        let response = client
+            .head_object(&bucket, &key, &HeadObjectParams::new())
+            .await
+            .expect("head_object failed");
         if let Some(RestoreStatus::Restored { expiry: _ }) = response.restore_status {
             timeout_exceeded = false;
             break;

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -16,7 +16,6 @@ use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError};
 use mountpoint_s3_client::types::RestoreStatus;
 use mountpoint_s3_client::types::{ChecksumMode, HeadObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
-#[cfg(not(feature = "s3express_tests"))]
 use test_case::test_case;
 
 #[tokio::test]

--- a/mountpoint-s3-client/tests/metrics.rs
+++ b/mountpoint-s3-client/tests/metrics.rs
@@ -20,6 +20,7 @@ use metrics::{
     Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
 };
 use mountpoint_s3_client::error::ObjectClientError;
+use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 use regex::Regex;
 use rusty_fork::rusty_fork_test;
@@ -233,7 +234,7 @@ async fn test_head_object_403() {
 
     let client: S3CrtClient = get_test_client();
     let err = client
-        .head_object(&bucket, "some-key")
+        .head_object(&bucket, "some-key", &HeadObjectParams::new())
         .await
         .expect_err("head to no-permissions bucket should fail");
     assert!(matches!(

--- a/mountpoint-s3-client/tests/network_interface_config.rs
+++ b/mountpoint-s3-client/tests/network_interface_config.rs
@@ -7,6 +7,7 @@ use test_case::test_case;
 use common::*;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError::ServiceError};
+use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 
 #[tokio::test]
@@ -21,7 +22,7 @@ async fn test_empty_list() {
     let client = S3CrtClient::new(config).expect("client should create OK");
 
     let err = client
-        .head_object(&bucket, &key)
+        .head_object(&bucket, &key, &HeadObjectParams::new())
         .await
         .expect_err("head_object should fail as the key doesn't exist");
     assert!(
@@ -43,7 +44,7 @@ async fn test_one_interface_ok() {
     let client = S3CrtClient::new(config).expect("client should create OK");
 
     let err = client
-        .head_object(&bucket, &key)
+        .head_object(&bucket, &key, &HeadObjectParams::new())
         .await
         .expect_err("head_object should fail as the key doesn't exist");
     assert!(

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -11,7 +11,8 @@ use mountpoint_s3_client::checksums::crc32c_to_base64;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
-    ChecksumAlgorithm, ObjectClientResult, PutObjectParams, PutObjectResult, PutObjectTrailingChecksums,
+    ChecksumAlgorithm, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
+    PutObjectTrailingChecksums,
 };
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
 use mountpoint_s3_crt::checksums::crc32c;
@@ -660,7 +661,7 @@ async fn test_concurrent_put_objects(throughput_target_gbps: f64, max_concurrent
         // Also try to issue an unrelated request (head_object).
         tokio::time::timeout(TIMEOUT, async {
             client
-                .head_object(&bucket, &not_existing_key)
+                .head_object(&bucket, &not_existing_key, &HeadObjectParams::new())
                 .await
                 .expect_err("head object should fail")
         })

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -9,6 +9,7 @@ use mountpoint_s3::mem_limiter::MemoryLimiter;
 use mountpoint_s3::object::ObjectId;
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::types::{ETag, HeadObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use sysinfo::{RefreshKind, System};
@@ -110,7 +111,8 @@ fn main() {
     };
     let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), max_memory_target));
 
-    let head_object_result = block_on(client.head_object(bucket, key)).expect("HeadObject failed");
+    let head_object_result =
+        block_on(client.head_object(bucket, key, &HeadObjectParams::new())).expect("HeadObject failed");
     let size = head_object_result.size;
     let etag = head_object_result.etag;
 

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -9,7 +9,7 @@ use mountpoint_s3::mem_limiter::MemoryLimiter;
 use mountpoint_s3::object::ObjectId;
 use mountpoint_s3::prefetch::{default_prefetch, Prefetch, PrefetchResult};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
-use mountpoint_s3_client::types::{ETag, HeadObjectParams};
+use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use sysinfo::{RefreshKind, System};

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -8,7 +8,7 @@ use tracing::trace;
 #[derive(Debug)]
 pub enum File {
     Local,
-    Remote(MockObject),
+    Remote(Box<MockObject>),
 }
 
 #[derive(Debug)]
@@ -306,7 +306,7 @@ fn build_reference<'a>(flat: impl Iterator<Item = (&'a String, &'a MockObject)>)
     #[derive(Debug)]
     enum RefNode {
         Directory(Rc<RefCell<BTreeMap<String, RefNode>>>),
-        File(MockObject),
+        File(Box<MockObject>),
     }
 
     impl RefNode {
@@ -356,7 +356,7 @@ fn build_reference<'a>(flat: impl Iterator<Item = (&'a String, &'a MockObject)>)
         if valid_inode_name(file_name) && should_create {
             leaf_dir
                 .borrow_mut()
-                .insert(file_name.to_string(), RefNode::File(file.clone()));
+                .insert(file_name.to_string(), RefNode::File(Box::new(file.clone())));
         }
     }
 


### PR DESCRIPTION
## Description of change

For a consumer of the S3 client, we need to return the checksum algorithm used with the object. This change adds the request option to retrieve checksum algorithm as part of a HeadObject request. The result now include the field, which will only be populated when requested and supported by the S3 implementation.

Relevant issues: N/A

## Does this change impact existing behavior?

We now require a `HeadObjectParams` struct when invoking `head_object` with the S3 client. This changes the signature, and so a change log entry will be added for the client crate. There is no behavior change.

## Does this change need a changelog entry in any of the crates?

Yes, a note is added for `mountpoint-s3-client` crate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
