### PR TITLE
Fix issue with fstat after upload

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### New features
+
+### Breaking changes
+
+### Other changes
+
+* Fix an issue where `fstat` would fail and return `ESTALE` when invoked on a file descriptor after a successful `fsync`. ([#1085](https://github.com/awslabs/mountpoint-s3/pull/1085))
+
 ## v1.10.0 (October 15, 2024)
 
 ### New features

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -1964,7 +1964,7 @@ mod tests {
 
         // Invoke [finish_writing], without actually adding the
         // object to the client
-        writehandle.finish().unwrap();
+        writehandle.finish(None).unwrap();
 
         // All nested dirs disappear
         let dirname = nested_dirs.first().unwrap();
@@ -2149,7 +2149,7 @@ mod tests {
         assert_eq!(stat.mtime, mtime);
 
         // Invoke [finish_writing] to make the file remote
-        writehandle.finish().unwrap();
+        writehandle.finish(Some(ETag::for_tests())).unwrap();
 
         // Should get an error back when calling setattr
         let result = superblock

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -374,14 +374,12 @@ where
 }
 
 #[cfg(feature = "s3_tests")]
-#[ignore = "file upload replaces inode breaking fstat due to returning ESTALE"]
 #[test_case(true; "with fsync")]
 #[test_case(true; "without fsync")]
 fn fstat_after_writing_s3(with_fsync: bool) {
     fstat_after_writing(fuse::s3_session::new, with_fsync);
 }
 
-#[ignore = "file upload replaces inode breaking fstat due to returning ESTALE"]
 #[test_case(true; "with fsync")]
 #[test_case(true; "without fsync")]
 fn fstat_after_writing_mock(with_fsync: bool) {


### PR DESCRIPTION
## Description of change

As covered in #1044, Mountpoint would previously invalidate the inode for a file open for writing once it completed the upload, which resulted in calls to `fstat` to return `ESTALE`.

This change addresses the issue by updating the etag in the existing inode with the one returned from a successful upload. 

## Does this change impact existing behavior?

Fixes the issue in #1044.

## Does this change need a changelog entry in any of the crates?

Added an entry in `mountpoint-s3` changelog.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
