### PR TITLE
Add checksum algorithm to ListObjectsV2 response

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -20,6 +20,7 @@
   The structure itself is not required to specify anything to achieve the existing behavior.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 * Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
+  `ChecksumAlgorithm` no longer implements `Copy`.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
 
 ## v0.11.0 (October 17, 2024)

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -7,6 +7,9 @@
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 * Expose checksum algorithm in `ListObjectsResult`'s `ObjectInfo` struct.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+* `ChecksumAlgorithm` has a new variant `Unknown(String)`,
+  to accomodate algorithms not recognized by the client should they be added in future.
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
 
 ### Breaking changes
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add parameter to request checksum information as part of a `HeadObject` request.
   If specified, the result should contain the checksum for the object if available in the S3 response.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
+* Expose checksum algorithm in `ListObjectsResult`'s `ObjectInfo` struct.
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
 
 ### Breaking changes
 
@@ -17,6 +19,8 @@
 * `head_object` method now requires a `HeadObjectParams` parameter.
   The structure itself is not required to specify anything to achieve the existing behavior.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
+* Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
 
 ## v0.11.0 (October 17, 2024)
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -256,7 +256,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum_algorithm(),
+                    checksum_algorithm: object.checksum.checksum_algorithm(),
                 });
             }
         }
@@ -318,7 +318,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum_algorithm(),
+                    checksum_algorithm: object.checksum.checksum_algorithm(),
                 });
             }
             next_continuation_token += 1;
@@ -473,24 +473,6 @@ impl MockObject {
 
     pub fn etag(&self) -> ETag {
         self.etag.clone()
-    }
-
-    pub fn checksum_algorithm(&self) -> Option<ChecksumAlgorithm> {
-        let Checksum {
-            checksum_crc32,
-            checksum_crc32c,
-            checksum_sha1,
-            checksum_sha256,
-        } = &self.checksum;
-
-        match (checksum_crc32, checksum_crc32c, checksum_sha1, checksum_sha256) {
-            (Some(_), None, None, None) => Some(ChecksumAlgorithm::Crc32),
-            (None, Some(_), None, None) => Some(ChecksumAlgorithm::Crc32c),
-            (None, None, Some(_), None) => Some(ChecksumAlgorithm::Sha1),
-            (None, None, None, Some(_)) => Some(ChecksumAlgorithm::Sha256),
-            (None, None, None, None) => None,
-            _ => unreachable!("should not have more than one checksum"),
-        }
     }
 }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -256,7 +256,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum.checksum_algorithm(),
+                    checksum_algorithm: object.checksum.algorithm(),
                 });
             }
         }
@@ -318,7 +318,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum.checksum_algorithm(),
+                    checksum_algorithm: object.checksum.algorithm(),
                 });
             }
             next_continuation_token += 1;

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -812,6 +812,9 @@ mod tests {
             checksum_sha256: None,
         };
         let algorithm = checksum.algorithm().expect("checksum algorithm must be present");
-        assert!([ChecksumAlgorithm::Crc32c, ChecksumAlgorithm::Sha1].contains(&algorithm), "algorithm should match one of the algorithms present in the struct");
+        assert!(
+            [ChecksumAlgorithm::Crc32c, ChecksumAlgorithm::Sha1].contains(&algorithm),
+            "algorithm should match one of the algorithms present in the struct",
+        );
     }
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -715,8 +715,6 @@ impl Checksum {
     /// Provide [ChecksumAlgorithm] for the [Checksum], if set and recognized.
     ///
     /// This method assumes that at most one checksum will be set and will return the first matched.
-    /// This method cannot account for any new checksum algorithms that may be introduced in the future,
-    /// returning [None] when no algorithm is recognized.
     pub fn algorithm(&self) -> Option<ChecksumAlgorithm> {
         let Self {
             checksum_crc32,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -622,6 +622,7 @@ pub enum RestoreStatus {
 /// See [Object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html) in the *Amazon S3
 /// API Reference* for more details.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ObjectInfo {
     /// Key for this object.
     pub key: String,
@@ -643,6 +644,9 @@ pub struct ObjectInfo {
 
     /// Entity tag of this object.
     pub etag: String,
+
+    /// The algorithm that was used to create a checksum of the object.
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
 }
 
 /// All possible object attributes that can be retrived from [ObjectClient::get_object_attributes].

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -717,7 +717,7 @@ impl Checksum {
     /// This method assumes that at most one checksum will be set and will return the first matched.
     /// This method cannot account for any new checksum algorithms that may be introduced in the future,
     /// returning [None] when no algorithm is recognized.
-    pub fn checksum_algorithm(&self) -> Option<ChecksumAlgorithm> {
+    pub fn algorithm(&self) -> Option<ChecksumAlgorithm> {
         let Self {
             checksum_crc32,
             checksum_crc32c,
@@ -788,7 +788,7 @@ mod tests {
             checksum_sha1: Some("checksum_sha1".to_string()),
             checksum_sha256: None,
         };
-        assert_eq!(checksum.checksum_algorithm(), Some(ChecksumAlgorithm::Sha1));
+        assert_eq!(checksum.algorithm(), Some(ChecksumAlgorithm::Sha1));
     }
 
     #[test]
@@ -799,7 +799,7 @@ mod tests {
             checksum_sha1: None,
             checksum_sha256: None,
         };
-        assert_eq!(checksum.checksum_algorithm(), None);
+        assert_eq!(checksum.algorithm(), None);
     }
 
     #[test]
@@ -811,7 +811,7 @@ mod tests {
             checksum_sha1: Some("checksum_sha1".to_string()),
             checksum_sha256: None,
         };
-        let algorithm = checksum.checksum_algorithm().expect("checksum algorithm must be present");
+        let algorithm = checksum.algorithm().expect("checksum algorithm must be present");
         assert!([ChecksumAlgorithm::Crc32c, ChecksumAlgorithm::Sha1].contains(&algorithm), "algorithm should match one of the algorithms present in the struct");
     }
 }

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1458,7 +1458,7 @@ pub enum ChecksumAlgorithm {
     Sha256,
     /// Checksum of a type unknown to this S3 client.
     ///
-    /// This type will be used if Mountpoint ever encounters a checksum algorithm it doesn't recognise.
+    /// This type will be used if Mountpoint ever encounters a checksum algorithm it doesn't recognize.
     /// This should allow Mountpoint to continue with most file operations which don't depend on the checksum algorithm.
     Unknown(String),
 }

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1445,7 +1445,8 @@ impl ChecksumConfig {
 }
 
 /// Checksum algorithm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ChecksumAlgorithm {
     /// Crc32c checksum.
     Crc32c,
@@ -1455,6 +1456,11 @@ pub enum ChecksumAlgorithm {
     Sha1,
     /// Sha256 checksum.
     Sha256,
+    /// Checksum of a type unknown to this S3 client.
+    ///
+    /// This type will be used if Mountpoint ever encounters a checksum algorithm it doesn't recognise.
+    /// This should allow Mountpoint to continue with most file operations which don't depend on the checksum algorithm.
+    Unknown(String),
 }
 
 impl ChecksumAlgorithm {


### PR DESCRIPTION
## Description of change

For a consumer of the S3 client, we need to return the checksum algorithm used with objects.

This change exposes the checksum algorithm that is sometimes returned as part of a ListObjectsV2 request. This functionality is not opt-in, and will now simply be exposed to be used by consumers of Mountpoint S3 client where supported.

This change also updates `ChecksumAlgorithm` to have a new `Unknown` variant. This is a common pattern in AWS SDKs. This will allow clients to recognize where an unknown algorithm is returned (should the S3 service start supporting additional algorithms), and avoid either returning `None` (if optional) or panicking when the error may be recoverable.

Relevant issues: N/A

## Does this change impact existing behavior?

Yes, it changes the `ObjectInfo` and `ChecksumAlgorithm` structs. Specifically, they are now marked `non_exhaustive` meaning that new fields could be added in the future (as has been done in this PR).

## Does this change need a changelog entry in any of the crates?

Yes, relevant change logs for breaking change (`non_exhaustive`) as well as new feature (exposing checksum algorithm) have been added to `mountpoint-s3-client`'s changelog.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
