### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,12 +788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,7 +1382,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "crypto-bigint 0.4.9",
  "der",
  "digest",
@@ -1640,12 +1634,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2366,8 +2354,6 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
- "aws-sdk-sts",
- "base16ct 0.2.0",
  "bincode",
  "bitflags",
  "built",
@@ -2385,7 +2371,6 @@ dependencies = [
  "hex",
  "httpmock",
  "humansize",
- "lazy_static",
  "libc",
  "linked-hash-map",
  "metrics",
@@ -2423,7 +2408,6 @@ dependencies = [
 name = "mountpoint-s3-client"
 version = "0.11.0"
 dependencies = [
- "anyhow",
  "async-io",
  "async-lock",
  "async-trait",
@@ -2431,7 +2415,6 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
- "aws-sdk-sts",
  "aws-smithy-runtime-api",
  "base64ct",
  "built",
@@ -2441,7 +2424,6 @@ dependencies = [
  "ctor",
  "futures",
  "lazy_static",
- "libc",
  "md-5",
  "metrics",
  "mountpoint-s3-client",
@@ -2473,12 +2455,10 @@ name = "mountpoint-s3-crt"
 version = "0.10.0"
 dependencies = [
  "anyhow",
- "async-channel 2.3.1",
  "clap",
  "criterion",
  "ctor",
  "futures",
- "futures-timer",
  "libc",
  "log",
  "mountpoint-s3-crt-sys",
@@ -2486,7 +2466,6 @@ dependencies = [
  "serde_json",
  "smallstr",
  "static_assertions",
- "tempfile",
  "test-case",
  "thiserror",
  "tracing",
@@ -2501,9 +2480,7 @@ dependencies = [
  "cc",
  "cmake",
  "libc",
- "log",
  "rustflags",
- "smallstr",
  "which",
 ]
 
@@ -3335,7 +3312,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -17,7 +17,6 @@ base64ct = { version = "1.6.0", features = ["std"] }
 const_format = "0.2.33"
 futures = "0.3.31"
 lazy_static = "1.5.0"
-libc = "0.2.161"
 metrics = "0.24.0"
 once_cell = "1.20.2"
 percent-encoding = "2.3.1"
@@ -39,11 +38,9 @@ rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
-anyhow = { version = "1.0.91", features = ["backtrace"] }
 aws-config = "1.5.8"
 aws-credential-types = "1.2.1"
 aws-sdk-s3 = "1.57.0"
-aws-sdk-sts = "1.46.0"
 aws-smithy-runtime-api = "1.7.2"
 bytes = "1.8.0"
 clap = { version = "4.5.20", features = ["derive"] }

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -80,8 +80,6 @@ which = "6.0.3"
 
 [dependencies]
 libc = "0.2.161"
-log = "0.4.22"
-smallstr = "0.3.0"
 
 [lib]
 doctest = false

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -9,6 +9,7 @@ description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazo
 
 [dependencies]
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
+
 futures = "0.3.31"
 libc = "0.2.161"
 log = "0.4.22"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -9,8 +9,6 @@ description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazo
 
 [dependencies]
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
-
-async-channel = "2.3.1"
 futures = "0.3.31"
 libc = "0.2.161"
 log = "0.4.22"
@@ -23,10 +21,8 @@ anyhow = { version = "1.0.91", features = ["backtrace"] }
 clap = { version = "4.5.20", features = ["derive"] }
 criterion = "0.5.1"
 ctor = "0.2.8"
-futures-timer = "3.0.3"
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = "1.0.132"
-tempfile = "3.13.0"
 test-case = "3.3.1"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -26,7 +26,6 @@ dashmap = "6.1.0"
 futures = "0.3.31"
 hdrhistogram = { version = "7.5.4", default-features = false }
 hex = "0.4.3"
-lazy_static = "1.5.0"
 libc = "0.2.161"
 linked-hash-map = "0.5.6"
 metrics = "0.24.0"
@@ -59,8 +58,6 @@ assert_fs = "1.1.2"
 aws-config = "1.5.8"
 aws-credential-types = "1.2.1"
 aws-sdk-s3 = "1.57.0"
-aws-sdk-sts = "1.46.0"
-base16ct = { version = "0.2.0", features = ["alloc"] }
 ctor = "0.2.8"
 filetime = "0.2.25"
 futures = { version = "*", features = ["thread-pool"] }


### PR DESCRIPTION
## Description of change

Removes unused dependencies, determined by `cargo shear`: https://github.com/Boshen/cargo-shear

```
❯ cargo shear                                         
Analyzing /Users/djonesoa/devel/mountpoint-s3

mountpoint-s3 -- mountpoint-s3/Cargo.toml:
  base16ct
  lazy_static
  aws-sdk-sts

mountpoint-s3-client -- mountpoint-s3-client/Cargo.toml:
  libc
  anyhow
  aws-sdk-sts

mountpoint-s3-crt -- mountpoint-s3-crt/Cargo.toml:
  futures-timer
  async-channel
  tempfile

mountpoint-s3-crt-sys -- mountpoint-s3-crt-sys/Cargo.toml:
  smallstr
  log


If you believe cargo-shear has detected an unused dependency incorrectly,
you can add the dependency to the list of dependencies to ignore in the
`[package.metadata.cargo-shear]` section of the appropriate Cargo.toml.

For example:

[package.metadata.cargo-shear]
ignored = ["crate-name"]
```

Relevant issues: N/A

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No behavior or breaking changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
