### PR TITLE
Update PR template to reflect how PR metadata is used in PR merges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,14 @@
+<!--
+    The title and description of pull requests will be used when creating a squash commit to the base branch (usually `main`).
+    Please keep them both up-to-date as the code change evolves, to ensure that the commit message is useful for future readers.
+-->
+
 ## Description of change
 
-<!-- Please describe your contribution here. What and why? -->
+<!--
+    Please describe your contribution here.
+    What is the change and why are you making it?
+-->
 
 Relevant issues: <!-- Please add issue numbers. -->
 


### PR DESCRIPTION
## Description of change

We have updated pull request settings to use the description of the PR in the commit message rather than the list of individual commits in the pull request.

This change explains the importance of the title and description in how they are used to create the squash commit. We want to encourage PR authors to be aware of this and keep the metadata up-to-date.

Relevant issues: N/A

## Does this change impact existing behavior?

No, PR template change only.

## Does this change need a changelog entry in any of the crates?

No, there are no code changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
