### PR TITLE
Address CRT documentation warnings, add deny statements for bare_urls and broken_intra_doc_links

### DIFF
--- a/mountpoint-s3-crt/src/common/uri.rs
+++ b/mountpoint-s3-crt/src/common/uri.rs
@@ -42,7 +42,7 @@ impl Uri {
         }
     }
 
-    /// Return the authority portion of the URI (host[:port]). If no authority was present, returns
+    /// Return the authority portion of the URI (`host[:port]`). If no authority was present, returns
     /// an empty string.
     pub fn authority(&self) -> &OsStr {
         // SAFETY: `inner` is a valid `aws_uri` since it's owned by this struct, and the lifetime of

--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -275,7 +275,7 @@ impl<'a> Message<'a> {
     }
 
     /// Add a header to this message. If the header already exists in the message, this will add a
-    /// another header instead of overwriting the existing one. Use [set_header] to overwrite
+    /// another header instead of overwriting the existing one. Use [Self::set_header] to overwrite
     /// potentially existing headers.
     pub fn add_header(&mut self, header: &Header<impl AsRef<OsStr>, impl AsRef<OsStr>>) -> Result<(), Error> {
         // SAFETY: `aws_http_message_add_header` makes a copy of the values in `header`.

--- a/mountpoint-s3-crt/src/io/event_loop.rs
+++ b/mountpoint-s3-crt/src/io/event_loop.rs
@@ -100,7 +100,7 @@ unsafe impl Send for EventLoopGroup {}
 unsafe impl Sync for EventLoopGroup {}
 
 impl EventLoopGroup {
-    /// Create a new default EventLoopGroup.
+    /// Create a new default [EventLoopGroup].
     /// max_threads: use None for the CRT default
     /// on_shutdown will be called when the event loop group shuts down.
     pub fn new_default(

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -1,4 +1,10 @@
-#![deny(missing_debug_implementations, missing_docs, clippy::undocumented_unsafe_blocks)]
+#![deny(
+    missing_debug_implementations,
+    missing_docs,
+    clippy::undocumented_unsafe_blocks,
+    rustdoc::bare_urls,
+    rustdoc::broken_intra_doc_links
+)]
 
 //! Rust bindings for the AWS Common Runtime.
 

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -1343,25 +1343,25 @@ impl Debug for RequestMetrics {
 pub enum RequestType {
     /// When the request type is unknown to the CRT. Operation name may have been attached to non-meta CRT requests.
     Unknown,
-    /// HeadObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
+    /// HeadObject: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html>
     HeadObject,
-    /// GetObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
+    /// GetObject: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>
     GetObject,
-    /// ListParts: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+    /// ListParts: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html>
     ListParts,
-    /// CreateMultipartUpload: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+    /// CreateMultipartUpload: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html>
     CreateMultipartUpload,
-    /// UploadPart: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+    /// UploadPart: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html>
     UploadPart,
-    /// AbortMultipartUpload: https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+    /// AbortMultipartUpload: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html>
     AbortMultipartUpload,
-    /// CompleteMultipartUpload: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+    /// CompleteMultipartUpload: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html>
     CompleteMultipartUpload,
-    /// UploadPartCopy: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html
+    /// UploadPartCopy: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html>
     UploadPartCopy,
-    /// CopyObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+    /// CopyObject: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html>
     CopyObject,
-    /// PutObject: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+    /// PutObject: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html>
     PutObject,
 }
 


### PR DESCRIPTION
## Description of change

Since updating our GitHub Actions configuration, we now have a number of warnings directly surfaced in our PRs.

This change takes a quick stab at eliminating some low-hanging fruit. It also will now fail the build if these issues are reintroduced when making changes to the CRT crate.

Relevant issues: N/A

## Does this change impact existing behavior?

No behavior changes. Docs and build process only.

## Does this change need a changelog entry in any of the crates?

No, no behavior or API changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
