### PR TITLE
Update ChecksumAlgorithm field of client's ObjectInfo struct to be Vec over single element

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -6,7 +6,8 @@
   If specified, the result should contain the checksum for the object if available in the S3 response.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 * Expose checksum algorithm in `ListObjectsResult`'s `ObjectInfo` struct.
-  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086)),
+  ([#1093](https://github.com/awslabs/mountpoint-s3/pull/1093))
 * `ChecksumAlgorithm` has a new variant `Unknown(String)`,
   to accomodate algorithms not recognized by the client should they be added in future.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -6,8 +6,8 @@
   If specified, the result should contain the checksum for the object if available in the S3 response.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
 * Expose checksum algorithm in `ListObjectsResult`'s `ObjectInfo` struct.
-  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086)),
-  ([#1093](https://github.com/awslabs/mountpoint-s3/pull/1093))
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086),
+  [#1093](https://github.com/awslabs/mountpoint-s3/pull/1093))
 * `ChecksumAlgorithm` has a new variant `Unknown(String)`,
   to accomodate algorithms not recognized by the client should they be added in future.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -256,7 +256,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum.algorithm(),
+                    checksum_algorithms: object.checksum.algorithms(),
                 });
             }
         }
@@ -318,7 +318,7 @@ impl MockClient {
                     etag: object.etag.as_str().to_string(),
                     storage_class: object.storage_class.clone(),
                     restore_status: object.restore_status,
-                    checksum_algorithm: object.checksum.algorithm(),
+                    checksum_algorithms: object.checksum.algorithms(),
                 });
             }
             next_continuation_token += 1;
@@ -1608,8 +1608,8 @@ mod tests {
             .list_objects("test_bucket", None, "/", 1000, "")
             .await
             .expect("should not fail");
-        assert_eq!(result.objects[0].checksum_algorithm, None);
-        assert_eq!(result.objects[1].checksum_algorithm, Some(ChecksumAlgorithm::Sha1));
+        assert_eq!(result.objects[0].checksum_algorithms, vec![]);
+        assert_eq!(result.objects[1].checksum_algorithms, vec![ChecksumAlgorithm::Sha1]);
     }
 
     #[tokio::test]

--- a/mountpoint-s3-client/tests/list_objects.rs
+++ b/mountpoint-s3-client/tests/list_objects.rs
@@ -218,5 +218,5 @@ async fn test_checksum_attribute(upload_checksum_algorithm: ChecksumAlgorithm) {
         _ => todo!("update with new checksum algorithm should one come available"),
     };
 
-    assert_eq!(Some(expected_checksum_algorithm), object.checksum_algorithm);
+    assert_eq!(vec![expected_checksum_algorithm], object.checksum_algorithms);
 }


### PR DESCRIPTION
## Description of change

On reviewing the S3 API documentation, the checksum algorithm field is a list of algorithms. Additionally, when reviewing other SDKs such as the [Rust SDK, we see that they are presenting this field as `Option<Vec<String>>`](https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/types/struct.Object.html) rather than a single optional element. (Note, we do drop the `Option` still.

We'd prefer to align with the SDK interface. Our tenet here is to ensure our S3 client is consistent with the official SDKs where there's no significant effort required. This is making a breaking change while we're already planning to make a number of breaking changes to the client.

Relevant issues:

- Follow up on #1086, which added checksum algorithms to the list objects response.

## Does this change impact existing behavior?

Yes, it changes the S3 client behavior to return a different type. We are however merging this before a new crate release, so this will not be an additional breaking change.

There's no behavior change to Mountpoint file system.

## Does this change need a changelog entry in any of the crates?

There is already an existing entry in `mountpoint-s3-client`'s changelog. This PR has been added to the list of PRs for that entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
