### PR TITLE
Support running integration test against custom endpoints

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,6 +23,8 @@ env:
   S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
+  # Optional endpoint url, can be empty
+  S3_ENDPOINT_URL: ${{ vars.S3_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
 
 jobs:

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -23,6 +23,8 @@ env:
   S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
+  # Optional endpoint url, can be empty
+  S3_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,9 @@ env:
   CARGO_INCREMENTAL: 0
   S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME }}
+  # Optional endpoint urls, can be empty
+  S3_ENDPOINT_URL: ${{ vars.S3_ENDPOINT_URL }}
+  S3_EXPRESS_ONE_ZONE_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_REGION }}
   S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_TEST_PREFIX || 'github-actions-tmp/' }}run-${{ github.run_id }}/attempt-${{ github.run_attempt }}/
   # A bucket our IAM role has no access to, but is in the right region, for permissions tests

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -13,7 +13,7 @@ use common::creds::get_scoped_down_credentials;
 use common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
 use common::*;
 use futures::StreamExt;
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
 #[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::S3RequestError;
@@ -52,7 +52,7 @@ async fn test_static_provider() {
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
@@ -72,7 +72,7 @@ async fn test_static_provider() {
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
@@ -134,7 +134,7 @@ async fn test_profile_provider_static_async() {
     // Build a S3CrtClient that uses the config file
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
@@ -150,7 +150,7 @@ async fn test_profile_provider_static_async() {
 
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
@@ -169,7 +169,7 @@ async fn test_profile_provider_static_async() {
     // be constructed.
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
 }
 
@@ -215,7 +215,7 @@ async fn test_profile_provider_assume_role_async() {
     // we did not configure which arn to assume yet.
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
@@ -230,7 +230,7 @@ async fn test_profile_provider_assume_role_async() {
     writeln!(config_file, "source_profile = {}", source_profile).unwrap();
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
@@ -344,7 +344,7 @@ async fn test_credential_process_behind_source_profile_async() {
     // With correct profile, things should be fine
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(correct_profile.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
     let _result = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}foo/"))
@@ -354,7 +354,7 @@ async fn test_credential_process_behind_source_profile_async() {
     // With incorrect profile, requests should fail with a client error
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(incorrect_profile.to_owned()))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
     let err = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}/"))
@@ -425,7 +425,7 @@ async fn test_scoped_credentials() {
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(config).unwrap();
 
     // Inside the prefix, things should be fine

--- a/mountpoint-s3-client/tests/network_interface_config.rs
+++ b/mountpoint-s3-client/tests/network_interface_config.rs
@@ -5,7 +5,7 @@ pub mod common;
 use test_case::test_case;
 
 use common::*;
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError::ServiceError};
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
@@ -17,7 +17,7 @@ async fn test_empty_list() {
 
     let interface_names = Vec::new();
     let config = S3ClientConfig::new()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
     let client = S3CrtClient::new(config).expect("client should create OK");
 
@@ -39,7 +39,7 @@ async fn test_one_interface_ok() {
     let primary_interface = get_primary_interface_name();
     let interface_names = vec![primary_interface];
     let config = S3ClientConfig::new()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
     let client = S3CrtClient::new(config).expect("client should create OK");
 
@@ -66,7 +66,7 @@ async fn test_nonexistent(with_valid_interface: bool) {
         vec![non_existent_interface]
     };
     let config = S3ClientConfig::new()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
     S3CrtClient::new(config).expect_err(
         "CRT should return an error during client creation if provided with non-existent network interface",

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use common::*;
 use futures::{pin_mut, FutureExt, StreamExt};
 use mountpoint_s3_client::checksums::crc32c_to_base64;
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
     ChecksumAlgorithm, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
@@ -315,7 +315,7 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
     let client_config = S3ClientConfig::new()
         .part_size(PART_SIZE)
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -382,7 +382,7 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
 #[tokio::test]
 async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_happy");
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -413,7 +413,7 @@ async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, St
 #[tokio::test]
 async fn test_put_user_object_metadata_bad_header(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_bad_header");
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -431,7 +431,7 @@ async fn test_put_review(pass_review: bool) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_review");
     let client_config = S3ClientConfig::new()
         .part_size(PART_SIZE)
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -598,7 +598,7 @@ async fn check_sse(
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {
     let bucket = get_test_bucket();
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let request_params = PutObjectParams::new()
         .server_side_encryption(sse_type.map(|value| value.to_owned()))
@@ -633,7 +633,7 @@ async fn test_concurrent_put_objects(throughput_target_gbps: f64, max_concurrent
     let bucket = get_test_bucket();
     let prefix = get_unique_test_prefix("test_concurrent_put_objects");
     let client_config = S3ClientConfig::new()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .throughput_target_gbps(throughput_target_gbps);
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let not_existing_key = format!("{}not-there", prefix);

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use common::*;
 use mountpoint_s3_client::checksums::{crc32c, crc32c_to_base64};
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::types::{ChecksumAlgorithm, PutObjectResult, PutObjectSingleParams, UploadChecksum};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use rand::Rng;
@@ -73,7 +73,7 @@ async fn test_put_checksums(checksum_algorithm: Option<ChecksumAlgorithm>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
     let client_config = S3ClientConfig::new()
         .part_size(PART_SIZE)
-        .endpoint_config(EndpointConfig::new(&get_test_region()));
+        .endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -124,7 +124,7 @@ async fn test_put_checksums(checksum_algorithm: Option<ChecksumAlgorithm>) {
 #[tokio::test]
 async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_happy");
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -151,7 +151,7 @@ async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, St
 #[tokio::test]
 async fn test_put_user_object_metadata_bad_header(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_bad_header");
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let key = format!("{prefix}hello");
 
@@ -265,7 +265,7 @@ async fn check_sse(
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {
     let bucket = get_test_bucket();
-    let client_config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&get_test_region()));
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
     let client = S3CrtClient::new(client_config).expect("could not create test client");
     let request_params = PutObjectSingleParams::new()
         .server_side_encryption(sse_type.map(|value| value.to_owned()))

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -275,11 +275,13 @@ pub mod s3_session {
     use aws_sdk_s3::types::{ChecksumAlgorithm, GlacierJobParameters, RestoreRequest, Tier};
     use aws_sdk_s3::Client;
     use mountpoint_s3::prefetch::{caching_prefetch, default_prefetch};
-    use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+    use mountpoint_s3_client::config::S3ClientConfig;
     use mountpoint_s3_client::types::{Checksum, PutObjectTrailingChecksums};
     use mountpoint_s3_client::S3CrtClient;
 
-    use crate::common::s3::{get_test_bucket_and_prefix, get_test_region, get_test_sdk_client};
+    use crate::common::s3::{
+        get_test_bucket_and_prefix, get_test_endpoint_config, get_test_region, get_test_sdk_client,
+    };
 
     /// Create a FUSE mount backed by a real S3 client
     pub fn new(test_name: &str, test_config: TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox) {
@@ -290,7 +292,7 @@ pub mod s3_session {
 
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
-            .endpoint_config(EndpointConfig::new(&region))
+            .endpoint_config(get_test_endpoint_config())
             .auth_config(test_config.auth_config)
             .read_backpressure(true)
             .initial_read_window(test_config.initial_read_window_size);
@@ -325,7 +327,7 @@ pub mod s3_session {
 
             let client_config = S3ClientConfig::default()
                 .part_size(test_config.part_size)
-                .endpoint_config(EndpointConfig::new(&region))
+                .endpoint_config(get_test_endpoint_config())
                 .read_backpressure(true)
                 .initial_read_window(test_config.initial_read_window_size);
             let client = S3CrtClient::new(client_config).unwrap();

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -10,7 +10,7 @@ use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::s3::S3Personality;
 use mountpoint_s3::S3FilesystemConfig;
 #[cfg(feature = "s3_tests")]
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3_client::error_metadata::ClientErrorMetadata;
 use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
@@ -40,7 +40,7 @@ use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client
 use common::{get_crt_client_auth_config, s3::deny_single_object_access_policy};
 
 #[cfg(feature = "s3_tests")]
-use crate::common::s3::{get_test_bucket_and_prefix, get_test_region};
+use crate::common::s3::{get_test_bucket_and_prefix, get_test_endpoint_config};
 
 #[test_case(""; "unprefixed")]
 #[test_case("test_prefix/"; "prefixed")]
@@ -1487,7 +1487,7 @@ async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let client_config = S3ClientConfig::default()
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true);
     let client = S3CrtClient::new(client_config).expect("must be able to create a CRT client");
     let fs = make_test_filesystem_with_client(
@@ -1522,7 +1522,7 @@ async fn test_lookup_forbidden() {
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
-        .endpoint_config(EndpointConfig::new(&get_test_region()))
+        .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true);
     let client = S3CrtClient::new(client_config).expect("must be able to create a CRT client");
 


### PR DESCRIPTION
## Description of change

This allows contributors to run mountpoint integration tests against custom S3 compatible endpoints.

## Does this change impact existing behavior?

No, test only

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
