### PR TITLE
Encapsulate test resources in `TestSession` struct

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/mkdir_test.rs
@@ -1,16 +1,13 @@
 use std::fs::{self, metadata, DirBuilder, File};
 
-use fuser::BackgroundSession;
-use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
+use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionCreator};
 
-fn mkdir_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+fn mkdir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Create local directory
     let dirname = "local_dir";

--- a/mountpoint-s3/tests/fuse_tests/perm_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/perm_test.rs
@@ -4,18 +4,19 @@ use std::{
     os::unix::prelude::{MetadataExt, PermissionsExt},
 };
 
-use fuser::BackgroundSession;
 use mountpoint_s3::S3FilesystemConfig;
 use nix::unistd::{getgid, getuid};
-use tempfile::TempDir;
 use test_case::test_case;
 
-use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
+use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionConfig, TestSessionCreator};
 
-fn perm_test<F>(creator_fn: F, uid: Option<u32>, gid: Option<u32>, dir_mode: Option<u16>, file_mode: Option<u16>)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn perm_test(
+    creator_fn: impl TestSessionCreator,
+    uid: Option<u32>,
+    gid: Option<u32>,
+    dir_mode: Option<u16>,
+    file_mode: Option<u16>,
+) {
     let mut config = S3FilesystemConfig::default();
     if let Some(id) = uid {
         config.uid = id;
@@ -30,13 +31,15 @@ where
         config.file_mode = mode;
     }
 
-    let (mount_point, _session, mut test_client) = creator_fn(
+    let test_session = creator_fn(
         "",
         TestSessionConfig {
             filesystem_config: config,
             ..Default::default()
         },
     );
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // expected values
     let uid = uid.unwrap_or_else(|| getuid().into());
@@ -84,15 +87,13 @@ where
     assert_eq!(file_content, "hello world");
 }
 
-fn perm_test_negative<F>(
-    creator_fn: F,
+fn perm_test_negative(
+    creator_fn: impl TestSessionCreator,
     uid: Option<u32>,
     gid: Option<u32>,
     dir_mode: Option<u16>,
     file_mode: Option<u16>,
-) where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+) {
     let mut config = S3FilesystemConfig::default();
     if let Some(id) = uid {
         config.uid = id;
@@ -107,13 +108,15 @@ fn perm_test_negative<F>(
         config.file_mode = mode;
     }
 
-    let (mount_point, _session, mut test_client) = creator_fn(
+    let test_session = creator_fn(
         "",
         TestSessionConfig {
             filesystem_config: config,
             ..Default::default()
         },
     );
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // expected values
     let uid = uid.unwrap_or_else(|| getuid().into());

--- a/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
@@ -6,7 +6,6 @@ use test_case::test_case;
 fn rmdir_local_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let test_session = creator_fn(prefix, Default::default());
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     // Create local directory
     let main_dirname = "test_dir";
@@ -139,7 +138,6 @@ fn rmdir_remote_dir_test_s3(prefix: &str) {
 fn create_after_rmdir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let test_session = creator_fn(prefix, Default::default());
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     // Create local directory
     let main_dirname = "test_dir";

--- a/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
@@ -1,15 +1,12 @@
-use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
-use fuser::BackgroundSession;
+use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionCreator};
 use std::fs::{self, DirBuilder, File};
 use std::io::Write;
-use tempfile::TempDir;
 use test_case::test_case;
 
-fn rmdir_local_dir_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
-    let (mount_point, _session, _test_client) = creator_fn(prefix, Default::default());
+fn rmdir_local_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
 
     // Create local directory
     let main_dirname = "test_dir";
@@ -79,11 +76,10 @@ fn rmdir_local_dir_test_s3(prefix: &str) {
     rmdir_local_dir_test(fuse::s3_session::new, prefix);
 }
 
-fn rmdir_remote_dir_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+fn rmdir_remote_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     let main_dirname = "test_dir";
     let main_path = mount_point.path().join(main_dirname);
@@ -140,11 +136,11 @@ fn rmdir_remote_dir_test_s3(prefix: &str) {
     rmdir_remote_dir_test(fuse::s3_session::new, prefix);
 }
 
-fn create_after_rmdir_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
-    let (mount_point, _session, _test_client) = creator_fn(prefix, Default::default());
+fn create_after_rmdir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
+
     // Create local directory
     let main_dirname = "test_dir";
     let main_path = mount_point.path().join(main_dirname);

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -6,10 +6,8 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
-use fuser::BackgroundSession;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use tempfile::TempDir;
 use test_case::test_case;
 
 use mountpoint_s3::fs::CacheConfig;
@@ -17,7 +15,7 @@ use mountpoint_s3::S3FilesystemConfig;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3::ServerSideEncryption;
 
-use crate::common::fuse::{self, read_dir_to_entry_names, TestClientBox, TestSessionConfig};
+use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionConfig, TestSessionCreator};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use crate::common::{creds::get_scoped_down_credentials, s3::get_test_kms_key_id};
 
@@ -35,14 +33,13 @@ fn open_for_write(path: impl AsRef<Path>, append: bool, write_only: bool) -> std
     options.create(true).open(path)
 }
 
-fn sequential_write_test<F>(creator_fn: F, prefix: &str, append: bool, write_only: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn sequential_write_test(creator_fn: impl TestSessionCreator, prefix: &str, append: bool, write_only: bool) {
     const OBJECT_SIZE: usize = 50 * 1024;
     const WRITE_SIZE: usize = 1024;
 
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -114,11 +111,10 @@ fn sequential_write_test_mock(prefix: &str, append: bool, write_only: bool) {
     sequential_write_test(fuse::mock_session::new, prefix, append, write_only);
 }
 
-fn write_errors_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, Default::default());
+fn write_errors_test(creator_fn: impl TestSessionCreator, prefix: &str) {
+    let test_session = creator_fn(prefix, Default::default());
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
 
@@ -191,13 +187,12 @@ fn write_errors_test_mock(prefix: &str) {
     write_errors_test(fuse::mock_session::new, prefix);
 }
 
-fn sequential_write_streaming_test<F>(creator_fn: F, object_size: usize, write_chunk_size: usize)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn sequential_write_streaming_test(creator_fn: impl TestSessionCreator, object_size: usize, write_chunk_size: usize) {
     const KEY: &str = "dir/new.txt";
 
-    let (mount_point, _session, mut test_client) = creator_fn("sequential_write_streaming_test", Default::default());
+    let test_session = creator_fn("sequential_write_streaming_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -261,14 +256,13 @@ fn sequential_write_streaming_test_mock(object_size: usize, write_chunk_size: us
     sequential_write_streaming_test(fuse::mock_session::new, object_size, write_chunk_size);
 }
 
-fn fsync_test<F>(creator_fn: F, write_only: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn fsync_test(creator_fn: impl TestSessionCreator, write_only: bool) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
-    let (mount_point, _session, test_client) = creator_fn("fsync_test", Default::default());
+    let test_session = creator_fn("fsync_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -317,10 +311,7 @@ fn fsync_test_mock(write_only: bool) {
     fsync_test(fuse::mock_session::new, write_only);
 }
 
-fn fstat_after_writing<F>(creator_fn: F, with_fsync: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
@@ -336,7 +327,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, _test_client) = creator_fn("fstat_after_writing", session_config);
+    let test_session = creator_fn("fstat_after_writing", session_config);
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -386,10 +379,7 @@ fn fstat_after_writing_mock(with_fsync: bool) {
     fstat_after_writing(fuse::mock_session::new, with_fsync);
 }
 
-fn write_too_big_test<F>(creator_fn: F, write_size: usize)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn write_too_big_test(creator_fn: impl TestSessionCreator, write_size: usize) {
     const KEY: &str = "new.txt";
     const PART_SIZE: usize = 64;
     const MAX_S3_MULTIPART_UPLOAD_PARTS: usize = 10000;
@@ -398,7 +388,9 @@ where
         part_size: PART_SIZE,
         ..Default::default()
     };
-    let (mount_point, _session, _test_client) = creator_fn("write_too_big_test", config);
+    let test_session = creator_fn("write_too_big_test", config);
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -436,14 +428,13 @@ fn write_too_big_test_mock(write_size: usize) {
     write_too_big_test(fuse::mock_session::new, write_size);
 }
 
-fn out_of_order_write_test<F>(creator_fn: F, offset: i64)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn out_of_order_write_test(creator_fn: impl TestSessionCreator, offset: i64) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
-    let (mount_point, _session, _test_client) = creator_fn("out_of_order_write_test", Default::default());
+    let test_session = creator_fn("out_of_order_write_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -489,10 +480,7 @@ fn out_of_order_write_test_mock(offset: i64) {
 }
 
 #[cfg(not(feature = "s3express_tests"))]
-fn write_with_storage_class_test<F>(creator_fn: F, storage_class: Option<&str>)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn write_with_storage_class_test(creator_fn: impl TestSessionCreator, storage_class: Option<&str>) {
     const KEY: &str = "new.txt";
 
     let config = TestSessionConfig {
@@ -502,7 +490,9 @@ where
         },
         ..Default::default()
     };
-    let (mount_point, _session, test_client) = creator_fn("write_with_storage_class_test", config);
+    let test_session = creator_fn("write_with_storage_class_test", config);
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -532,10 +522,7 @@ fn write_with_storage_class_test_s3_mock(storage_class: Option<&str>) {
 }
 
 #[cfg_attr(not(feature = "s3_tests"), allow(unused))] // Mock client doesn't validate storage classes
-fn write_with_invalid_storage_class_test<F>(creator_fn: F, storage_class: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn write_with_invalid_storage_class_test(creator_fn: impl TestSessionCreator, storage_class: &str) {
     const KEY: &str = "new.txt";
 
     let config = TestSessionConfig {
@@ -545,7 +532,9 @@ where
         },
         ..Default::default()
     };
-    let (mount_point, _session, _test_client) = creator_fn("write_with_storage_class_test", config);
+    let test_session = creator_fn("write_with_storage_class_test", config);
+    let mount_point = test_session.mount_dir;
+    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
     write_file(path).expect_err("write with invalid storage class should fail");
@@ -565,15 +554,14 @@ fn write_with_invalid_storage_class_test_s3(storage_class: &str) {
     write_with_invalid_storage_class_test(fuse::s3_session::new, storage_class);
 }
 
-fn flush_test<F>(creator_fn: F, append: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn flush_test(creator_fn: impl TestSessionCreator, append: bool) {
     const OBJECT_SIZE: usize = 50 * 1024;
     const WRITE_SIZE: usize = 1024;
     const KEY: &str = "new.txt";
 
-    let (mount_point, _session, test_client) = creator_fn("flush_test", Default::default());
+    let test_session = creator_fn("flush_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -615,13 +603,12 @@ fn flush_test_mock(append: bool) {
     flush_test(fuse::mock_session::new, append);
 }
 
-fn touch_test<F>(creator_fn: F)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn touch_test(creator_fn: impl TestSessionCreator) {
     const KEY: &str = "new.txt";
 
-    let (mount_point, _session, test_client) = creator_fn("touch_test", Default::default());
+    let test_session = creator_fn("touch_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -659,14 +646,13 @@ fn touch_test_mock() {
     touch_test(fuse::mock_session::new);
 }
 
-fn dd_test<F>(creator_fn: F)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn dd_test(creator_fn: impl TestSessionCreator) {
     const KEY: &str = "new.txt";
     const SIZE: u64 = 128;
 
-    let (mount_point, _session, test_client) = creator_fn("dd_test", Default::default());
+    let test_session = creator_fn("dd_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -700,7 +686,8 @@ fn dd_test_mock() {
 #[test]
 fn spawn_test() {
     const KEY: &str = "new.txt";
-    let (mount_point, _session, _test_client) = fuse::mock_session::new("spawn_test", Default::default());
+    let test_session = fuse::mock_session::new("spawn_test", Default::default());
+    let mount_point = test_session.mount_dir;
 
     let path = mount_point.path().join(KEY);
     let mut f = open_for_write(&path, false, true).unwrap();
@@ -722,7 +709,9 @@ fn spawn_test() {
 #[test]
 fn multi_thread_test() {
     const KEY: &str = "new.txt";
-    let (mount_point, _session, test_client) = fuse::mock_session::new("spawn_test", Default::default());
+    let test_session = fuse::mock_session::new("spawn_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
     let mut f = open_for_write(&path, false, true).unwrap();
@@ -744,10 +733,7 @@ fn multi_thread_test() {
     .unwrap();
 }
 
-fn overwrite_test<F>(creator_fn: F, prefix: &str, write_only: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn overwrite_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -756,7 +742,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -796,10 +784,7 @@ fn overwrite_test_mock(write_only: bool) {
     overwrite_test(fuse::mock_session::new, "overwrite_test", write_only);
 }
 
-fn overwrite_disallowed_on_concurrent_read_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn overwrite_disallowed_on_concurrent_read_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -808,7 +793,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -854,10 +841,7 @@ fn overwrite_disallowed_on_concurrent_read_test_mock() {
     );
 }
 
-fn overwrite_fail_on_write_without_truncate_test<F>(creator_fn: F, prefix: &str, write_only: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn overwrite_fail_on_write_without_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -866,7 +850,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -916,10 +902,7 @@ fn overwrite_fail_on_write_without_truncate_test_mock(write_only: bool) {
     );
 }
 
-fn overwrite_truncate_test<F>(creator_fn: F, prefix: &str, write_only: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn overwrite_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -928,7 +911,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -968,10 +953,7 @@ fn overwrite_truncate_test_mock(write_only: bool) {
     overwrite_truncate_test(fuse::mock_session::new, "overwrite_truncate_test", write_only);
 }
 
-fn overwrite_after_read_test<F>(creator_fn: F, prefix: &str)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn overwrite_after_read_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -980,7 +962,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();
@@ -1018,10 +1002,11 @@ fn overwrite_after_read_test_mock(prefix: &str) {
     overwrite_after_read_test(fuse::mock_session::new, prefix);
 }
 
-fn write_handle_no_update_existing_empty_file<F>(creator_fn: F, prefix: &str, allow_overwrite: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn write_handle_no_update_existing_empty_file(
+    creator_fn: impl TestSessionCreator,
+    prefix: &str,
+    allow_overwrite: bool,
+) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite,
         ..Default::default()
@@ -1030,7 +1015,9 @@ where
         filesystem_config,
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn(prefix, test_config);
+    let test_session = creator_fn(prefix, test_config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory and a file
     test_client.put_object("dir/hello.txt", b"").unwrap();
@@ -1124,7 +1111,9 @@ fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_
     let mut test_config =
         TestSessionConfig::default().with_credentials(tokio_block_on(get_scoped_down_credentials(&policy)));
     test_config.filesystem_config.server_side_encryption = sse;
-    let (mount_point, _session, test_client) = fuse::s3_session::new("sse_with_policy_test", test_config);
+    let test_session = fuse::s3_session::new("sse_with_policy_test", test_config);
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
     let file_name = "hello";
     let path = mount_point.path().join(file_name);
     let mut f = open_for_write(&path, false, true).unwrap();
@@ -1152,8 +1141,9 @@ fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_
 #[cfg(feature = "s3_tests")]
 #[test_case(200)]
 fn concurrent_open_for_write_test(max_files: usize) {
-    let (mount_point, _session, test_client) =
-        fuse::s3_session::new("concurrent_open_for_write_test", Default::default());
+    let test_session = fuse::s3_session::new("concurrent_open_for_write_test", Default::default());
+    let mount_point = test_session.mount_dir;
+    let test_client = test_session.test_client;
 
     let file_names: Vec<_> = (0..max_files).map(|i| format!("file-{i}")).collect();
 
@@ -1181,10 +1171,7 @@ fn concurrent_open_for_write_test(max_files: usize) {
     }
 }
 
-fn write_checksums_test<F>(creator_fn: F, use_upload_checksums: bool)
-where
-    F: FnOnce(&str, TestSessionConfig) -> (TempDir, BackgroundSession, TestClientBox),
-{
+fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksums: bool) {
     const OBJECT_SIZE: usize = 20 * 1024 * 1024;
     const PART_SIZE: usize = 8 * 1024 * 1024;
     const KEY: &str = "dir/new.txt";
@@ -1196,7 +1183,9 @@ where
         },
         ..Default::default()
     };
-    let (mount_point, _session, mut test_client) = creator_fn("write_checksums_test", config);
+    let test_session = creator_fn("write_checksums_test", config);
+    let mount_point = test_session.mount_dir;
+    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory
     test_client.put_object("dir/hello.txt", b"hello world").unwrap();

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -329,7 +329,6 @@ fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
     };
     let test_session = creator_fn("fstat_after_writing", session_config);
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -390,7 +389,6 @@ fn write_too_big_test(creator_fn: impl TestSessionCreator, write_size: usize) {
     };
     let test_session = creator_fn("write_too_big_test", config);
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -434,7 +432,6 @@ fn out_of_order_write_test(creator_fn: impl TestSessionCreator, offset: i64) {
 
     let test_session = creator_fn("out_of_order_write_test", Default::default());
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
 
@@ -534,7 +531,6 @@ fn write_with_invalid_storage_class_test(creator_fn: impl TestSessionCreator, st
     };
     let test_session = creator_fn("write_with_storage_class_test", config);
     let mount_point = test_session.mount_dir;
-    let _test_client = test_session.test_client;
 
     let path = mount_point.path().join(KEY);
     write_file(path).expect_err("write with invalid storage class should fail");

--- a/mountpoint-s3/tests/reftests/fuse.rs
+++ b/mountpoint-s3/tests/reftests/fuse.rs
@@ -20,7 +20,7 @@ use proptest_derive::Arbitrary;
 use tempfile::TempDir;
 use tracing::{info, info_span};
 
-use crate::common::fuse::{mock_session, TestClient, TestSessionConfig};
+use crate::common::fuse::{mock_session, TestClient, TestSession, TestSessionConfig};
 
 const MAX_NUM_FILES: usize = 10;
 const MAX_FILE_SIZE: usize = 1024 * 1024;
@@ -73,7 +73,11 @@ impl MountpointFileSystem {
             filesystem_config: config,
             ..Default::default()
         };
-        let (mountpoint, session, client) = mock_session::new("", test_config);
+        let TestSession {
+            mount_dir: mountpoint,
+            session,
+            test_client: client,
+        } = mock_session::new("", test_config);
         Ok(Self {
             mountpoint,
             session: Some(session),


### PR DESCRIPTION
## Description of change

Currently we return tuples from session constructor functions. This makes adding new resources to testing session challenging. Wrapping all testing resources in `TestSession` will help us to add new resources easily and it will also simply the type signatures of the functions using the test session.

## Does this change impact existing behavior?

No, just tests.

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
