### PR TITLE
Update macOS unit tests to use latest macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,10 @@ jobs:
 
   macos-test:
     name: Tests (MacOS)
-    runs-on: macos-12
+
+    # We don't strictly support macOS,
+    # checking latest macOS version passes unit tests is enough.
+    runs-on: macos-latest
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Description of change

This change updates the CI to use the latest version of macOS available on GitHub runners (currently macOS 15), updating from macOS 12.

We are seeing GitHub CI failing in some cases. We wanted to update version anyway, and I suspect the issues we are seeing is due to the deprecation (maybe).

I update to latest since we don't strictly support macOS, so just checking that unit tests pass on the latest version is enough for us.

Relevant issues:
- https://github.com/github/roadmap/issues/986

## Does this change impact existing behavior?

CI change only. No behavior change.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
