### PR TITLE
Make `mnt::Mount` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use crate::mnt::mount_options::check_option_conflicts;
 use crate::session::MAX_WRITE_SIZE;
 #[cfg(feature = "abi-7-16")]
 pub use ll::fuse_abi::fuse_forget_one;
-pub use mnt::mount_options::MountOption;
+pub use mnt::{Mount, mount_options::MountOption};
 #[cfg(feature = "abi-7-11")]
 pub use notify::{Notifier, PollHandle};
 #[cfg(feature = "abi-7-11")]


### PR DESCRIPTION
## Description of change

fuser v0.15.0 added support for creating sessions from FUSE fd. I'm working on a PR to add this support to Mountpoint. We still need to open the FUSE device and call `mount` syscall in order to test this new behavior, and all this logic is already exists with `mnt::Mount`. 

We could just copy the logic from `mnt::Mount` - but since we already have this fork, making this change seemed fine to me. Maybe we can also consider upstreaming it.

## Does this change impact existing behavior?

No

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
