### PR TITLE
Update bucket name examples to use recommended 'amzn-s3-demo-bucket'

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -1,8 +1,8 @@
 # Configuring Mountpoint for Amazon S3
 
-In most scenarios, you can use Mountpoint by running the following command, where you should replace `DOC-EXAMPLE-BUCKET` with the name of your Amazon S3 bucket, and `/path/to/mount` with the directory you want to mount your bucket into:
+In most scenarios, you can use Mountpoint by running the following command, where you should replace `amzn-s3-demo-bucket` with the name of your Amazon S3 bucket, and `/path/to/mount` with the directory you want to mount your bucket into:
 
-    mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount
+    mount-s3 amzn-s3-demo-bucket /path/to/mount
 
 We've tried hard to make this simple command adopt good defaults for most scenarios. However, some scenarios may need additional configuration. This document shows how to configure these elements of Mountpoint:
 * [AWS credentials](#aws-credentials)
@@ -51,7 +51,7 @@ More details on permissions required when using SSE-KMS can be found in the [SSE
 
 If you only [mount a prefix of your S3 bucket](#mounting-a-bucket-prefix) rather than the entire bucket, you need these IAM permissions only for the prefix you mount. You can scope down your IAM permissions to a prefix using the `Resource` element of the policy statement for most of these permissions, but for `s3:ListBucket` you must use the `s3:prefix` condition key instead.
 
-Here is an example least-privilege policy document to add to an IAM user or role that allows full access to your S3 bucket for Mountpoint. Replace `DOC-EXAMPLE-BUCKET` with the name of your bucket. Alternatively, you can use the [`AmazonS3FullAccess`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-iam-awsmanpol.html) managed policy, but the managed policy grants more permissions than needed for Mountpoint.
+Here is an example least-privilege policy document to add to an IAM user or role that allows full access to your S3 bucket for Mountpoint. Replace `amzn-s3-demo-bucket` with the name of your bucket. Alternatively, you can use the [`AmazonS3FullAccess`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-iam-awsmanpol.html) managed policy, but the managed policy grants more permissions than needed for Mountpoint.
 
 ```
 {
@@ -64,7 +64,7 @@ Here is an example least-privilege policy document to add to an IAM user or role
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::DOC-EXAMPLE-BUCKET"
+                "arn:aws:s3:::amzn-s3-demo-bucket"
             ]
         },
         {
@@ -77,7 +77,7 @@ Here is an example least-privilege policy document to add to an IAM user or role
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::DOC-EXAMPLE-BUCKET/*"
+                "arn:aws:s3:::amzn-s3-demo-bucket/*"
             ]
         }
    ]
@@ -93,7 +93,7 @@ Directory buckets, introduced with the S3 Express One Zone storage class, use a 
         {
             "Effect": "Allow",
             "Action": "s3express:CreateSession",
-            "Resource": "arn:aws:s3express:REGION:ACCOUNT-ID:bucket/DOC-EXAMPLE-BUCKET--az_id--x-s3"
+            "Resource": "arn:aws:s3express:REGION:ACCOUNT-ID:bucket/amzn-s3-demo-bucket--az_id--x-s3"
         }
     ]
 }
@@ -250,7 +250,7 @@ A tracking issue is open for `fstab` support: [#44](https://github.com/awslabs/m
 
 Until this support is implemented, we recommend using a service manager like systemd to manage the mount process and mount during boot.
 Below is an example of a systemd unit that launches Mountpoint at boot time.
-Replace `/home/ec2-user/s3-bucket-mount` and `DOC-EXAMPLE-BUCKET` with your mount directory and S3 bucket.
+Replace `/home/ec2-user/s3-bucket-mount` and `amzn-s3-demo-bucket` with your mount directory and S3 bucket.
 
 ```ini
 [Unit]
@@ -262,7 +262,7 @@ AssertPathIsDirectory=/home/ec2-user/s3-bucket-mount
 Type=forking
 User=ec2-user
 Group=ec2-user
-ExecStart=/usr/bin/mount-s3 DOC-EXAMPLE-BUCKET /home/ec2-user/s3-bucket-mount
+ExecStart=/usr/bin/mount-s3 amzn-s3-demo-bucket /home/ec2-user/s3-bucket-mount
 ExecStop=/usr/bin/fusermount -u /home/ec2-user/s3-bucket-mount
 
 [Install]
@@ -305,7 +305,7 @@ and we recommend setting the permissions on the file system to not allow reads b
 You can then start Mountpoint using the cache directory you mounted:
 
 ```
-mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount --cache /mnt/mp-cache
+mount-s3 amzn-s3-demo-bucket /path/to/mount --cache /mnt/mp-cache
 ```
 
 ### Caching object content to memory
@@ -326,7 +326,7 @@ The size is configurable using the `size` option.
 You can then start Mountpoint using the directory where the RAM disk was mounted.
 
 ```
-mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount --cache /mnt/mp-cache-tmpfs
+mount-s3 amzn-s3-demo-bucket /path/to/mount --cache /mnt/mp-cache-tmpfs
 ```
 
 ### Using multiple Mountpoint processes on a host
@@ -345,7 +345,7 @@ This argument can be specified multiple times to allow requests to be fanned-out
 As an example, this command binds to two network interfaces and Mountpoint traffic will be distributed over them both:
 
 ```
-mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount --bind ens0 --bind ens1
+mount-s3 amzn-s3-demo-bucket /path/to/mount --bind ens0 --bind ens1
 ```
 
 This feature is a work-in-progress.

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,9 +34,9 @@ To launch Mountpoint in an interactive container, run this command:
     docker run -ti --cap-add SYS_ADMIN --device /dev/fuse --entrypoint bash mountpoint-s3
 
 Within the container you can run this command to mount a bucket to the `/mnt` directory,
-replacing `DOC-EXAMPLE-BUCKET` with the name of your S3 bucket:
+replacing `amzn-s3-demo-bucket` with the name of your S3 bucket:
 
-    mount-s3 DOC-EXAMPLE-BUCKET /mnt
+    mount-s3 amzn-s3-demo-bucket /mnt
 
 ### Running as a service
 
@@ -44,13 +44,13 @@ You can also run the Docker container as a service,
 and access the mounted directory from your host or other Docker containers.
 To do so, first create a directory `/path/to/mount` in your host filesystem,
 and a subdirectory `/path/to/mount/bucket` to be the target of the mount.
-Then run this command, replacing DOC-EXAMPLE-BUCKET with the name of your S3 bucket,
+Then run this command, replacing amzn-s3-demo-bucket with the name of your S3 bucket,
 and `/path/to/mount` with the directory you created:
 
     docker run -d --cap-add SYS_ADMIN --device /dev/fuse \
         --mount type=bind,source=/path/to/mount,target=/mountpoint,bind-propagation=shared \
         mountpoint-s3 \
-        DOC-EXAMPLE-BUCKET /mountpoint/bucket
+        amzn-s3-demo-bucket /mountpoint/bucket
 
 Your bucket is now mounted in the `/path/to/mount/bucket` directory on the host.
 By default, only the user used by the container (likely `root`) will have access to the mount.

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -18,13 +18,13 @@ Now install Mountpoint if you don't already have it:
 
 To generate and upload the training shards to an S3 bucket, run:
 
-    python resnet.py make s3://DOC-EXAMPLE-BUCKET/shard-data/ --num-images 50000
+    python resnet.py make s3://amzn-s3-demo-bucket/shard-data/ --num-images 50000
 
 This will upload about 5GB worth of shards to your bucket.
 
 Now to run the training loop:
 
-    python resnet.py train s3://DOC-EXAMPLE-BUCKET/shard-data/ --source-kind mountpoint --batch-size 256 --max-epochs 3
+    python resnet.py train s3://amzn-s3-demo-bucket/shard-data/ --source-kind mountpoint --batch-size 256 --max-epochs 3
 
 The `--source-kind` argument controls how the data is loaded from S3:
 * `mountpoint` spawns a Mountpoint instance and accesses it as a local file system with the [`FileOpener`](https://pytorch.org/data/beta/generated/torchdata.datapipes.iter.FileOpener.html#torchdata.datapipes.iter.FileOpener) datapipe from torchdata

--- a/examples/pytorch/resnet.py
+++ b/examples/pytorch/resnet.py
@@ -5,11 +5,11 @@ images.
 
 Run it like this to upload the training shards to an S3 bucket:
 
-    python resnet.py make s3://DOC-EXAMPLE-BUCKET/shard-data/ --num-images 10000
+    python resnet.py make s3://amzn-s3-demo-bucket/shard-data/ --num-images 10000
 
 And then run it like this to run the training loop:
 
-    python resnet.py train s3://DOC-EXAMPLE-BUCKET/shard-data/ --source-kind mountpoint --batch-size 256
+    python resnet.py train s3://amzn-s3-demo-bucket/shard-data/ --source-kind mountpoint --batch-size 256
 
 The --source-kind argument controls how the data is loaded from S3:
 * `mountpoint` spawns a Mountpoint instance and accesses it as a local file system

--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -275,12 +275,12 @@ mod test {
     fn test_virtual_addr() {
         let endpoint_config = EndpointConfig::new("eu-west-1").addressing_style(AddressingStyle::Automatic);
         let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
+            .resolve_for_bucket("amzn-s3-demo-bucket")
             .unwrap()
             .uri()
             .unwrap();
         assert_eq!(
-            "https://doc-example-bucket.s3.eu-west-1.amazonaws.com",
+            "https://amzn-s3-demo-bucket.s3.eu-west-1.amazonaws.com",
             endpoint_uri.as_os_str()
         );
     }
@@ -291,22 +291,22 @@ mod test {
             .addressing_style(AddressingStyle::Path)
             .endpoint(Uri::new_from_str(&Allocator::default(), "https://example.com").unwrap());
         let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
+            .resolve_for_bucket("amzn-s3-demo-bucket")
             .unwrap()
             .uri()
             .unwrap();
-        assert_eq!("https://example.com/doc-example-bucket", endpoint_uri.as_os_str());
+        assert_eq!("https://example.com/amzn-s3-demo-bucket", endpoint_uri.as_os_str());
     }
 
     #[test]
     fn test_endpoint_arg_with_region() {
         let endpoint_config = EndpointConfig::new("us-east-1")
             .endpoint(Uri::new_from_str(&Allocator::default(), "https://s3.eu-west-1.amazonaws.com").unwrap());
-        let resolved_endpoint = endpoint_config.resolve_for_bucket("doc-example-bucket").unwrap();
+        let resolved_endpoint = endpoint_config.resolve_for_bucket("amzn-s3-demo-bucket").unwrap();
         let endpoint_uri = resolved_endpoint.uri().unwrap();
         // region is ignored when endpoint_url is specified
         assert_eq!(
-            "https://doc-example-bucket.s3.eu-west-1.amazonaws.com",
+            "https://amzn-s3-demo-bucket.s3.eu-west-1.amazonaws.com",
             endpoint_uri.as_os_str()
         );
         let endpoint_auth_scheme = resolved_endpoint.auth_scheme().unwrap();
@@ -319,12 +319,12 @@ mod test {
     fn test_fips_dual_stack() {
         let endpoint_config = EndpointConfig::new("eu-west-1").use_fips(true).use_dual_stack(true);
         let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
+            .resolve_for_bucket("amzn-s3-demo-bucket")
             .unwrap()
             .uri()
             .unwrap();
         assert_eq!(
-            "https://doc-example-bucket.s3-fips.dualstack.eu-west-1.amazonaws.com",
+            "https://amzn-s3-demo-bucket.s3-fips.dualstack.eu-west-1.amazonaws.com",
             endpoint_uri.as_os_str()
         );
     }
@@ -335,12 +335,12 @@ mod test {
             .use_accelerate(true)
             .use_dual_stack(true);
         let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
+            .resolve_for_bucket("amzn-s3-demo-bucket")
             .unwrap()
             .uri()
             .unwrap();
         assert_eq!(
-            "https://doc-example-bucket.s3-accelerate.dualstack.amazonaws.com",
+            "https://amzn-s3-demo-bucket.s3-accelerate.dualstack.amazonaws.com",
             endpoint_uri.as_os_str()
         );
     }
@@ -351,12 +351,12 @@ mod test {
             .use_dual_stack(true)
             .addressing_style(AddressingStyle::Path);
         let endpoint_uri = endpoint_config
-            .resolve_for_bucket("doc-example-bucket")
+            .resolve_for_bucket("amzn-s3-demo-bucket")
             .unwrap()
             .uri()
             .unwrap();
         assert_eq!(
-            "https://s3.dualstack.eu-west-1.amazonaws.com/doc-example-bucket",
+            "https://s3.dualstack.eu-west-1.amazonaws.com/amzn-s3-demo-bucket",
             endpoint_uri.as_os_str()
         );
     }

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1396,7 +1396,7 @@ mod tests {
 
         let mut message = client
             .inner
-            .new_request_template("GET", "doc-example-bucket")
+            .new_request_template("GET", "amzn-s3-demo-bucket")
             .expect("new request template expected");
 
         let headers = message.inner.get_headers().expect("Expected a block of HTTP headers");
@@ -1479,7 +1479,7 @@ mod tests {
 
         let mut message = client
             .inner
-            .new_request_template("GET", "doc-example-bucket")
+            .new_request_template("GET", "amzn-s3-demo-bucket")
             .expect("new request template expected");
 
         let headers = message.inner.get_headers().expect("Expected a block of HTTP headers");
@@ -1517,7 +1517,7 @@ mod tests {
 
         let mut message = client
             .inner
-            .new_request_template("GET", "doc-example-bucket")
+            .new_request_template("GET", "amzn-s3-demo-bucket")
             .expect("new request template expected");
 
         let headers = message.inner.get_headers().expect("Expected a block of HTTP headers");
@@ -1552,7 +1552,7 @@ mod tests {
 
     #[test]
     fn parse_301_redirect() {
-        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Endpoint>DOC-EXAMPLE-BUCKET.s3-us-west-2.amazonaws.com</Endpoint><Bucket>DOC-EXAMPLE-BUCKET</Bucket><RequestId>CM0Z9YFABRVSWXDJ</RequestId><HostId>HHmbUixasrJ02DlkOSCvJId897Jm0ERHuE2XMkSn2Oax1J/ad2+AU9nFrODN1ay13cWFgIAYBnI=</HostId></Error>"#;
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Endpoint>amzn-s3-demo-bucket.s3-us-west-2.amazonaws.com</Endpoint><Bucket>amzn-s3-demo-bucket</Bucket><RequestId>CM0Z9YFABRVSWXDJ</RequestId><HostId>HHmbUixasrJ02DlkOSCvJId897Jm0ERHuE2XMkSn2Oax1J/ad2+AU9nFrODN1ay13cWFgIAYBnI=</HostId></Error>"#;
         let result = make_result(301, OsStr::from_bytes(&body[..]), Some("us-west-2"));
         let result = try_parse_generic_error(&result);
         let Some(S3RequestError::IncorrectRegion(region)) = result else {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn parse_404_no_such_bucket() {
-        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>DOC-EXAMPLE-BUCKET</BucketName><RequestId>4VAGDP5HMYTDNB3Y</RequestId><HostId>JMgGqpVKIaaTieG68IODiV2piWw/q9VCTowGvWP36BEz6oIVEXiesn8cDE5ph7if0gpY5WU1Wc8=</HostId></Error>"#;
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>amzn-s3-demo-bucket</BucketName><RequestId>4VAGDP5HMYTDNB3Y</RequestId><HostId>JMgGqpVKIaaTieG68IODiV2piWw/q9VCTowGvWP36BEz6oIVEXiesn8cDE5ph7if0gpY5WU1Wc8=</HostId></Error>"#;
         let result = make_result(404, OsStr::from_bytes(&body[..]));
         let result = parse_get_object_error(&result);
         assert_eq!(result, Some(GetObjectError::NoSuchBucket));

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn parse_404_no_such_bucket() {
-        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>DOC-EXAMPLE-BUCKET</BucketName><RequestId>4VAGDP5HMYTDNB3Y</RequestId></Error>"#;
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>amzn-s3-demo-bucket</BucketName><RequestId>4VAGDP5HMYTDNB3Y</RequestId></Error>"#;
         let result = make_result(404, OsStr::from_bytes(&body[..]));
         let result = parse_get_object_attributes_error(&result);
         assert_eq!(result, Some(GetObjectAttributesError::NoSuchBucket));

--- a/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn parse_404_no_such_bucket() {
-        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>DOC-EXAMPLE-BUCKET</BucketName><RequestId>4YAYHJ0E82DDDNF0</RequestId><HostId>Ajn9+i3d3VWQi339YrGqBbJqQlj5HaX2vplXp9IlDPAxsJ4vsIAsje0P2gJ0of/mTKKz/fv9pNy9RqhbLUBc/g==</HostId></Error>"#;
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>amzn-s3-demo-bucket</BucketName><RequestId>4YAYHJ0E82DDDNF0</RequestId><HostId>Ajn9+i3d3VWQi339YrGqBbJqQlj5HaX2vplXp9IlDPAxsJ4vsIAsje0P2gJ0of/mTKKz/fv9pNy9RqhbLUBc/g==</HostId></Error>"#;
         let result = make_result(404, OsStr::from_bytes(&body[..]));
         let result = parse_list_objects_error(&result);
         assert_eq!(result, Some(ListObjectsError::NoSuchBucket));

--- a/mountpoint-s3-client/tests/delete_object.rs
+++ b/mountpoint-s3-client/tests/delete_object.rs
@@ -73,7 +73,7 @@ async fn test_delete_object_404_bucket() {
 
     let client: S3CrtClient = get_test_client();
 
-    let result = client.delete_object("DOC-EXAMPLE-BUCKET", &key).await;
+    let result = client.delete_object("amzn-s3-demo-bucket", &key).await;
     assert!(matches!(
         result,
         Err(ObjectClientError::ServiceError(DeleteObjectError::NoSuchBucket))

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -222,7 +222,7 @@ async fn test_get_object_404_bucket() {
     let client: S3CrtClient = get_test_client();
 
     let mut result = client
-        .get_object("DOC-EXAMPLE-BUCKET", &key, None, None)
+        .get_object("amzn-s3-demo-bucket", &key, None, None)
         .await
         .expect("get_object failed");
     let next = StreamExt::next(&mut result).await.expect("stream needs to return Err");

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -54,7 +54,7 @@ async fn test_head_bucket_forbidden() {
 async fn test_head_bucket_not_found() {
     let client = get_test_client();
     // Buckets are case sensitive. This bucket will use path-style access and 404.
-    let bucket = "DOC-EXAMPLE-BUCKET";
+    let bucket = "amzn-s3-demo-bucket";
 
     let result = client.head_bucket(bucket).await;
 

--- a/mountpoint-s3-client/tests/head_object.rs
+++ b/mountpoint-s3-client/tests/head_object.rs
@@ -166,7 +166,7 @@ async fn test_head_object_404_bucket() {
     let client: S3CrtClient = get_test_client();
 
     let result = client
-        .head_object("DOC-EXAMPLE-BUCKET", &key, &HeadObjectParams::new())
+        .head_object("amzn-s3-demo-bucket", &key, &HeadObjectParams::new())
         .await;
     assert!(matches!(
         result,

--- a/mountpoint-s3-client/tests/list_objects.rs
+++ b/mountpoint-s3-client/tests/list_objects.rs
@@ -116,7 +116,7 @@ async fn test_list_objects_404_bucket() {
     let client: S3CrtClient = get_test_client();
 
     let result = client
-        .list_objects("DOC-EXAMPLE-BUCKET", None, "/", 1000, &prefix)
+        .list_objects("amzn-s3-demo-bucket", None, "/", 1000, &prefix)
         .await;
     assert!(matches!(
         result,

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1165,7 +1165,7 @@ mod tests {
     #[test_case("s3://test-bucket", false; "not providing bare bucket name")]
     #[test_case("~/mnt", false; "directory name in place of bucket")]
     #[test_case("arn:aws:s3::00000000:accesspoint/s3-bucket-test.mrap", true; "multiregion accesspoint ARN")]
-    #[test_case("arn:aws:s3:::doc-example-bucket", true; "bucket ARN(maybe rejected by endpoint resolver with error message)")]
+    #[test_case("arn:aws:s3:::amzn-s3-demo-bucket", true; "bucket ARN(maybe rejected by endpoint resolver with error message)")]
     #[test_case("arn:aws-cn:s3:cn-north-2:555555555555:accesspoint/china-region-ap", true; "standard accesspoint ARN in China")]
     #[test_case("arn:aws-us-gov:s3-object-lambda:us-gov-west-1:555555555555:accesspoint/example-olap", true; "S3 object lambda accesspoint in US Gov")]
     #[test_case("arn:aws:s3-outposts:us-east-1:555555555555:outpost/outpost-id/accesspoint/accesspoint-name", true; "S3 outpost accesspoint ARN")]

--- a/mountpoint-s3/src/fs/error.rs
+++ b/mountpoint-s3/src/fs/error.rs
@@ -23,7 +23,7 @@ use crate::upload::UploadWriteError;
 /// include its source. For example:
 ///
 /// ```ignore
-/// let err = client.head_object("DOC-EXAMPLE-BUCKET", "mykey").await.expect_err("failed");
+/// let err = client.head_object("amzn-s3-demo-bucket", "mykey").await.expect_err("failed");
 /// return Err(err!(libc::ENOENT, source:err, "file does not exist"));
 /// ```
 /// will print "file does not exist: service error: ...".


### PR DESCRIPTION
## Description of change

Mountpoint currently uses an outdated example bucket name. AWS documentation is using the bucket name prefix `amzn-s3-demo-bucket` across all documentation.

We plan to update for consistency with AWS documentation (such as the Amazon S3 User Guide).

When reviewing AWS documentation, it is typically ([1](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html), [2](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html)) presented lowercase but as a code highlight. We also use that same format now in our documentation.

Relevant issues: N/A

## Does this change impact existing behavior?

No, changes documentation and unit test source code only.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
