### PR TITLE
Decouple S3FileSystem and S3FuseFileSystem constructors

### DIFF
--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -2,7 +2,7 @@ use clap::{Arg, ArgAction, Command};
 use fuser::{BackgroundSession, MountOption, Session};
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::prefetch::default_prefetch;
-use mountpoint_s3::S3FilesystemConfig;
+use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
@@ -169,12 +169,9 @@ fn mount_file_system(
         mountpoint.to_str().unwrap()
     );
     let prefetcher = default_prefetch(runtime, Default::default());
-    let session = Session::new(
-        S3FuseFilesystem::new(client, prefetcher, bucket_name, &Default::default(), filesystem_config),
-        mountpoint,
-        &options,
-    )
-    .expect("Should have created FUSE session successfully");
+    let fs = S3Filesystem::new(client, prefetcher, bucket_name, &Default::default(), filesystem_config);
+    let session = Session::new(S3FuseFilesystem::new(fs), mountpoint, &options)
+        .expect("Should have created FUSE session successfully");
 
     BackgroundSession::new(session).expect("Should have started FUSE session successfully")
 }

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -8,9 +8,8 @@ use std::time::SystemTime;
 use time::OffsetDateTime;
 use tracing::{field, instrument, Instrument};
 
-use crate::fs::{DirectoryEntry, DirectoryReplier, InodeNo, S3Filesystem, S3FilesystemConfig, ToErrno};
+use crate::fs::{DirectoryEntry, DirectoryReplier, InodeNo, S3Filesystem, ToErrno};
 use crate::prefetch::Prefetch;
-use crate::prefix::Prefix;
 #[cfg(target_os = "macos")]
 use fuser::ReplyXTimes;
 use fuser::{
@@ -76,15 +75,7 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
     Prefetcher: Prefetch,
 {
-    pub fn new(
-        client: Client,
-        prefetcher: Prefetcher,
-        bucket: &str,
-        prefix: &Prefix,
-        config: S3FilesystemConfig,
-    ) -> Self {
-        let fs = S3Filesystem::new(client, prefetcher, bucket, prefix, config);
-
+    pub fn new(fs: S3Filesystem<Client, Prefetcher>) -> Self {
         Self { fs }
     }
 }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -8,7 +8,7 @@ use mountpoint_s3::data_cache::DataCache;
 use mountpoint_s3::fuse::S3FuseFilesystem;
 use mountpoint_s3::prefetch::{Prefetch, PrefetcherConfig};
 use mountpoint_s3::prefix::Prefix;
-use mountpoint_s3::S3FilesystemConfig;
+use mountpoint_s3::{S3Filesystem, S3FilesystemConfig};
 use mountpoint_s3_client::config::S3ClientAuthConfig;
 use mountpoint_s3_client::types::{ObjectPart, PutObjectParams};
 use mountpoint_s3_client::ObjectClient;
@@ -110,7 +110,13 @@ where
 
     let prefix = Prefix::new(prefix).expect("valid prefix");
     let session = Session::new(
-        S3FuseFilesystem::new(client, prefetcher, bucket, &prefix, filesystem_config),
+        S3FuseFilesystem::new(S3Filesystem::new(
+            client,
+            prefetcher,
+            bucket,
+            &prefix,
+            filesystem_config,
+        )),
         mount_dir,
         &options,
     )


### PR DESCRIPTION
<!--
    The title and description of pull requests will be used when creating a squash commit to the base branch (usually `main`).
    Please keep them both up-to-date as the code change evolves, to ensure that the commit message is useful for future readers.
-->

## Description of change

Refactor `S3FuseFileSystem::new` to accept an `S3FileSystem` instance rather than creating a new one. The change highlights that `S3FuseFileSystem` is only a wrapper for `S3FileSystem` and will make it easier to modify `S3FileSystem` construction in future changes.

## Does this change impact existing behavior?

No, it's only a minor internal refactor.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
