### PR TITLE
Remove 16MiB part size override in FIO read benchmarks

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -143,7 +143,6 @@ read_benchmark () {
       --allow-delete \
       --log-directory=${log_dir} \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
-      --part-size=16777216 \
       ${optional_args}
     mount_status=$?
     set -e

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -169,7 +169,6 @@ cache_benchmark () {
       --cache=${cache_dir} \
       --log-directory=${log_dir} \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
-      --part-size=16777216 \
       ${optional_args}
     mount_status=$?
     set -e


### PR DESCRIPTION
## Description of change

The read benchmarks currently override the part size. It's unclear why this was added (#779), but we think its best to remove the override such that the benchmarks represent the default configuration.

Relevant issues: N/A

## Does this change impact existing behavior?

It changes benchmark configuration. We expect the effect to be minimal.

No impact to Mountpoint itself.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
