### PR TITLE
Add support for passing FUSE file descriptors as mount point

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -298,6 +298,25 @@ ExecStop=/usr/bin/fusermount -u /home/ec2-user/s3-bucket-mount
 WantedBy=remote-fs.target
 ```
 
+### Configuring mount point
+
+Mountpoint supports mounting S3 buckets to a directory or a FUSE file descriptor (only on Linux).
+
+For directory mount points, the passed path must be an existing directory.
+
+For FUSE file descriptors on Linux, you can specify an open FUSE file descriptor as a mount point with '/dev/fd/N' syntax.
+This is useful in container environments to achieve unprivileged mounts.
+In this case, it's callers responsibility to:
+1. Opening FUSE device (/dev/fuse) in read-write mode to obtain a file descriptor
+2. Performing 'mount' syscall with desired mount point, the file descriptor and mount options.
+   Mountpoint by default uses and recommends enabling `nodev`, `nosuid`, `default_permissions` and `noatime` mount options,
+   see [Linux kernel documentation](https://man7.org/linux/man-pages/man8/mount.fuse3.8.html#OPTIONS) about more details on mount options.
+3. Spawning Mountpoint with the file descriptor using '/dev/fd/N' syntax as mount point
+4. Closing the file descriptor in the parent process
+5. Performing 'unmount' syscall on the mount point once its desired and/or Mountpoint process terminates
+
+See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
+
 ## Caching configuration
 
 Mountpoint can optionally cache object metadata and content to reduce cost and improve performance for repeated reads to the same file.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -304,16 +304,16 @@ Mountpoint supports mounting S3 buckets to a directory or a FUSE file descriptor
 
 For directory mount points, the passed path must be an existing directory.
 
-For FUSE file descriptors on Linux, you can specify an open FUSE file descriptor as a mount point with '/dev/fd/N' syntax.
+For FUSE file descriptors on Linux, you can specify an open FUSE file descriptor as a mount point with `/dev/fd/N` syntax.
 This is useful in container environments to achieve unprivileged mounts.
 In this case, it's callers responsibility to:
-1. Opening FUSE device (/dev/fuse) in read-write mode to obtain a file descriptor
-2. Performing 'mount' syscall with desired mount point, the file descriptor and mount options.
+1. Opening FUSE device (`/dev/fuse`) in read-write mode to obtain a file descriptor
+2. Performing `mount` syscall with desired mount point, the file descriptor and mount options.
    Mountpoint by default uses and recommends enabling `nodev`, `nosuid`, `default_permissions` and `noatime` mount options,
    see [Linux kernel documentation](https://man7.org/linux/man-pages/man8/mount.fuse3.8.html#OPTIONS) about more details on mount options.
-3. Spawning Mountpoint with the file descriptor using '/dev/fd/N' syntax as mount point
+3. Spawning Mountpoint with the file descriptor using `/dev/fd/N` syntax as mount point
 4. Closing the file descriptor in the parent process
-5. Performing 'unmount' syscall on the mount point once its desired and/or Mountpoint process terminates
+5. Performing `unmount` syscall on the mount point once its desired and/or Mountpoint process terminates
 
 See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -298,22 +298,22 @@ ExecStop=/usr/bin/fusermount -u /home/ec2-user/s3-bucket-mount
 WantedBy=remote-fs.target
 ```
 
-### Configuring mount point
+### Providing a FUSE file descriptor for mounting
 
-Mountpoint supports mounting S3 buckets to a directory or a FUSE file descriptor (only on Linux).
+Mountpoint supports mounting S3 buckets at a given path, or using a provided FUSE file descriptor (only on Linux).
 
 For directory mount points, the passed path must be an existing directory.
 
 For FUSE file descriptors on Linux, you can specify an open FUSE file descriptor as a mount point with `/dev/fd/N` syntax.
 This is useful in container environments to achieve unprivileged mounts.
-In this case, it's callers responsibility to:
-1. Opening FUSE device (`/dev/fuse`) in read-write mode to obtain a file descriptor
-2. Performing `mount` syscall with desired mount point, the file descriptor and mount options.
-   Mountpoint by default uses and recommends enabling `nodev`, `nosuid`, `default_permissions` and `noatime` mount options,
-   see [Linux kernel documentation](https://man7.org/linux/man-pages/man8/mount.fuse3.8.html#OPTIONS) about more details on mount options.
-3. Spawning Mountpoint with the file descriptor using `/dev/fd/N` syntax as mount point
-4. Closing the file descriptor in the parent process
-5. Performing `unmount` syscall on the mount point once its desired and/or Mountpoint process terminates
+In this case, the caller is responsible for the following:
+1. Opening the FUSE device (`/dev/fuse`) in read-write mode to obtain a file descriptor.
+2. Performing the `mount` syscall with the desired mount point, the file descriptor, and any mount options.
+   Mountpoint by default uses and recommends enabling `nodev`, `nosuid`, `default_permissions`, and `noatime` mount options.
+   See the [Linux kernel documentation](https://man7.org/linux/man-pages/man8/mount.fuse3.8.html#OPTIONS) for more details on mount options.
+3. Spawning Mountpoint with the file descriptor using `/dev/fd/N` syntax as the mount point argument.
+4. Closing the file descriptor in the parent process.
+5. Performing the `unmount` syscall on the mount point when unmounting is desired or when the Mountpoint process terminates.
 
 See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
 

--- a/examples/fuse-fd-mount-point/mounthelper.go
+++ b/examples/fuse-fd-mount-point/mounthelper.go
@@ -1,0 +1,86 @@
+// An example script showing usage of FUSE file descriptor as a mount point.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+var mountPoint = flag.String("mountpoint", "", "Path to mount the filesystem at")
+var bucket = flag.String("bucket", "", "S3 Bucket to mount")
+
+func main() {
+	flag.Parse()
+
+	if err := os.MkdirAll(*mountPoint, 0644); err != nil && !errors.Is(err, fs.ErrExist) {
+		log.Panicf("Failed to create target mount point %s: %v\n", *mountPoint, err)
+	}
+
+	// 1. Open FUSE device
+	fd, err := syscall.Open("/dev/fuse", os.O_RDWR, 0)
+	if err != nil {
+		log.Panicf("Failed to open /dev/fuse: %v\n", err)
+	}
+	defer syscall.Close(fd)
+
+	var stat syscall.Stat_t
+	err = syscall.Stat(*mountPoint, &stat)
+	if err != nil {
+		log.Panicf("Failed to stat mount point %s: %v\n", *mountPoint, err)
+	}
+
+	// 2. Perform `mount` syscall
+	options := []string{
+		fmt.Sprintf("fd=%d", fd),
+		fmt.Sprintf("rootmode=%o", stat.Mode),
+		fmt.Sprintf("user_id=%d", os.Geteuid()),
+		fmt.Sprintf("group_id=%d", os.Getegid()),
+	}
+	err = syscall.Mount("mountpoint-s3", *mountPoint, "fuse", syscall.MS_NOSUID | syscall.MS_NODEV, strings.Join(options, ","))
+	if err != nil {
+		log.Panicf("Failed to call mount syscall: %v\n", err)
+	}
+
+	// 5. Perform `unmount` syscall once Mountpoint terminates
+	defer func() {
+		err := syscall.Unmount(*mountPoint, 0)
+		if err != nil {
+			log.Printf("Failed to unmount %s: %v\n", *mountPoint, err)
+		}
+		log.Printf("Succesfully unmounted %s\n", *mountPoint)
+	}()
+
+	// 3. Spawn Mountpoint with the fd
+	mountpointCmd := exec.Command("./target/release/mount-s3",
+		*bucket,
+		fmt.Sprintf("/dev/fd/%d", fd),
+		"--allow-delete")
+	mountpointCmd.Stdout = os.Stdout
+	mountpointCmd.Stderr = os.Stderr
+	err = mountpointCmd.Run()
+	if err != nil {
+		log.Panicf("Failed to start Mountpoint: %v\n", err)
+	}
+
+	// 4. Close fd on parent
+	err = syscall.Close(fd)
+	if err != nil {
+		log.Panicf("Failed to close fd on parent: %v\n", err)
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+
+	log.Print("Filesystem mounted, waiting for ctrl+c signal to terminate")
+	<-done
+
+	// 5. Will run here due to `defer`
+}

--- a/examples/fuse-fd-mount-point/mounthelper.go
+++ b/examples/fuse-fd-mount-point/mounthelper.go
@@ -1,4 +1,10 @@
 // An example script showing usage of FUSE file descriptor as a mount point.
+//
+// Example usage:
+// 	$ go build mounthelper.go
+// 	$ sudo /sbin/setcap 'cap_sys_admin=ep' ./mounthelper # `mount` syscall requires `CAP_SYS_ADMIN`, alternatively, `mounthelper` can be run as root
+//  $ ./mounthelper -mountpoint /tmp/mountpoint -bucket bucketname
+//  $ # Mountpoint mounted at /tmp/mountpoint until `mounthelper` is terminated with ctrl+c.
 package main
 
 import (

--- a/examples/fuse-fd-mount-point/mounthelper.go
+++ b/examples/fuse-fd-mount-point/mounthelper.go
@@ -55,7 +55,11 @@ func main() {
 	}
 
 	// 2. Perform `mount` syscall
-	// Mountpoint enables and recommends these mount options and flags by default
+    // These mount options and flags match those typically set when using Mountpoint.
+    // Some are set by the underlying FUSE library.
+    // Mountpoint sets (correct at the time of authoring this comment):
+    // * `noatime` to avoid unsupported access time updates.
+    // * `default_permissions` to tell the Kernel to evaluate permissions itself, since Mountpoint does not currently provide any handler for FUSE `access`.
 	options := []string{
 		fmt.Sprintf("fd=%d", fd),
 		fmt.Sprintf("rootmode=%o", stat.Mode),

--- a/examples/fuse-fd-mount-point/mounthelper.go
+++ b/examples/fuse-fd-mount-point/mounthelper.go
@@ -55,13 +55,16 @@ func main() {
 	}
 
 	// 2. Perform `mount` syscall
+	// Mountpoint enables and recommends these mount options and flags by default
 	options := []string{
 		fmt.Sprintf("fd=%d", fd),
 		fmt.Sprintf("rootmode=%o", stat.Mode),
 		fmt.Sprintf("user_id=%d", os.Geteuid()),
 		fmt.Sprintf("group_id=%d", os.Getegid()),
+		"default_permissions",
 	}
-	err = syscall.Mount("mountpoint-s3", *mountPoint, "fuse", syscall.MS_NOSUID|syscall.MS_NODEV, strings.Join(options, ","))
+	var flags uintptr = syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOATIME
+	err = syscall.Mount("mountpoint-s3", *mountPoint, "fuse", flags, strings.Join(options, ","))
 	if err != nil {
 		log.Panicf("Failed to call mount syscall: %v\n", err)
 	}

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### New features
 
 * Mountpoint now supports specifying an open FUSE file descriptor in place of the mount path by using the syntax `/dev/fd/N`.
-  See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
+  See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage and see
+  [Configuring mount point](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-mount-point) about more details on configuring this feature.
   ([#1103](https://github.com/awslabs/mountpoint-s3/pull/1103))
 
 ### Other changes

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Mountpoint now supports specifying open FUSE file descriptors as mount points with `/dev/fd/N` syntax.
+* Mountpoint now supports specifying an open FUSE file descriptor in place of the mount path by using the syntax `/dev/fd/N`.
   See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
   ([#1103](https://github.com/awslabs/mountpoint-s3/pull/1103))
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### New features
+
+* Mountpoint now supports specifying open FUSE file descriptors as mount points with `/dev/fd/N` syntax.
+  See [mounthelper.go](https://github.com/awslabs/mountpoint-s3/tree/main/examples/fuse-fd-mount-point/mounthelper.go) as an example usage of this feature.
+  ([#1103](https://github.com/awslabs/mountpoint-s3/pull/1103))
+
 ### Other changes
 
 * Fix an issue where an interrupt during `readdir` syscall leads to an error. ([#965](https://github.com/awslabs/mountpoint-s3/pull/965))

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1081,7 +1081,7 @@ impl MountPoint {
 
     #[cfg(target_os = "linux")]
     fn new_fd(fd: RawFd) -> anyhow::Result<Self> {
-        const FUSE_DEV: &'static str = "/dev/fuse";
+        const FUSE_DEV: &str = "/dev/fuse";
 
         use procfs::process::{FDPermissions, FDTarget, Process};
         use std::os::fd::{FromRawFd, OwnedFd};

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -66,21 +66,14 @@ pub struct CliArgs {
     pub bucket_name: String,
 
     #[clap(
-        help = "Directory to mount the bucket at",
+        help = "Directory or FUSE file descriptor to mount the bucket at",
         long_help = "\
 Directory or FUSE file descriptor to mount the bucket at.
 
 For directory mount points, the passed path must be an existing directory.
 
-You can specify an open FUSE file descriptor as a mount point on Linux using '/dev/fd/N' syntax.
-This is useful in container environments to achieve unprivileged mounts.
-In this case, it's callers responsibility to:
-    1) Opening FUSE device (/dev/fuse) in read-write mode to obtain a file descriptor
-    2) Performing 'mount' syscall with desired mount point and the file descriptor
-    3) Spawning Mountpoint with the file descriptor using '/dev/fd/N' syntax as mount point
-    4) Closing the file descriptor in the parent process
-    5) Performing 'unmount' syscall on the mount point once its desired and/or Mountpoint process terminates
-See examples/fuse-fd-mount-point/mounthelper.go as an example.
+For FUSE file descriptors (Linux-only), it should be of the format `/dev/fd/N`.
+Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         ",
         value_name = "DIRECTORY"
     )]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -569,11 +569,11 @@ impl CliArgs {
             .collect::<Vec<_>>();
 
             if !passed_mount_options.is_empty() {
-                tracing::warn!(
+                return Err(anyhow!(
                     "Mount options: {} are ignored with FUSE fd mount point.\
                     Mount options should be passed while performing `mount` syscall in the caller process.",
                     passed_mount_options.join(", ")
-                );
+                ));
             }
         }
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1085,18 +1085,18 @@ enum MountPoint {
 impl MountPoint {
     fn new(mount_point: impl AsRef<Path>) -> anyhow::Result<Self> {
         match parse_fd_from_mount_point(&mount_point) {
-            Some(fd) => MountPoint::new_fd(fd),
-            None => MountPoint::new_directory(mount_point),
+            Some(fd) => MountPoint::from_fd(fd),
+            None => MountPoint::from_directory(mount_point),
         }
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn new_fd(_: RawFd) -> anyhow::Result<Self> {
+    fn from_fd(_: RawFd) -> anyhow::Result<Self> {
         Err(anyhow!("Passing a FUSE file descriptor only supported on Linux"))
     }
 
     #[cfg(target_os = "linux")]
-    fn new_fd(fd: RawFd) -> anyhow::Result<Self> {
+    fn from_fd(fd: RawFd) -> anyhow::Result<Self> {
         const FUSE_DEV: &str = "/dev/fuse";
 
         use procfs::process::{FDPermissions, FDTarget, Process};
@@ -1133,7 +1133,7 @@ impl MountPoint {
         Ok(MountPoint::FileDescriptor(owned_fd))
     }
 
-    fn new_directory(mount_point: impl AsRef<Path>) -> anyhow::Result<Self> {
+    fn from_directory(mount_point: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = mount_point.as_ref();
 
         if !path.exists() {

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1113,7 +1113,7 @@ impl MountPoint {
             // some reason.
             match Process::myself().and_then(|me| me.mountinfo()) {
                 Ok(mounts) => {
-                    if mounts.0.iter().any(|mount| &mount.mount_point == path) {
+                    if mounts.0.iter().any(|mount| mount.mount_point == path) {
                         return Err(anyhow!("mount point {} is already mounted", path.display()));
                     }
                 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -65,7 +65,24 @@ pub struct CliArgs {
     #[clap(help = "Name of bucket to mount", value_parser = parse_bucket_name)]
     pub bucket_name: String,
 
-    #[clap(help = "Directory to mount the bucket at", value_name = "DIRECTORY")]
+    #[clap(
+        help = "Directory to mount the bucket at",
+        long_help = "\
+Directory or FUSE file descriptor to mount the bucket at.
+
+For directory mount points, the passed path must be an existing directory.
+
+You can specify an open FUSE file descriptor as a mount point on Linux using '/dev/fd/N' syntax.
+This is useful in container environments to achieve unprivileged mounts.
+In this case, it's callers responsibility to:
+    1) Opening FUSE device (/dev/fuse) in read-write mode to obtain a file descriptor
+    2) Performing 'mount' syscall with desired mount point and the file descriptor
+    3) Spawning Mountpoint with the file descriptor using '/dev/fd/N' syntax as mount point
+    4) Closing the file descriptor in the parent process
+    5) Perform 'unmount' syscall with the file descriptor once Mountpoint process terminates
+        ",
+        value_name = "DIRECTORY"
+    )]
     pub mount_point: PathBuf,
 
     #[clap(

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -80,6 +80,8 @@ In this case, it's callers responsibility to:
     3) Spawning Mountpoint with the file descriptor using '/dev/fd/N' syntax as mount point
     4) Closing the file descriptor in the parent process
     5) Performing 'unmount' syscall on the mount point once its desired and/or Mountpoint process terminates
+See examples/fuse-fd-mount-point/mounthelper.go as an example.
+
         ",
         value_name = "DIRECTORY"
     )]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context as _};
 use clap::{value_parser, ArgGroup, Parser, ValueEnum};
-use fuser::{MountOption, Session, SessionACL};
+use fuser::{MountOption, Session};
 use futures::executor::block_on;
 use futures::task::Spawn;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientAuthConfig, S3ClientConfig};

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -557,16 +557,11 @@ impl CliArgs {
 
         #[cfg(target_os = "linux")]
         if matches!(mount_point, MountPoint::FileDescriptor(_)) {
-            let passed_mount_options = &[
-                (self.read_only, "--read-only"),
-                (self.auto_unmount, "--auto-unmount"),
-                (self.allow_root, "--allow-root"),
-                (self.allow_other, "--allow-other"),
-            ]
-            .iter()
-            .filter(|o| o.0)
-            .map(|o| o.1)
-            .collect::<Vec<_>>();
+            let passed_mount_options = &[(self.read_only, "--read-only"), (self.auto_unmount, "--auto-unmount")]
+                .iter()
+                .filter(|o| o.0)
+                .map(|o| o.1)
+                .collect::<Vec<_>>();
 
             if !passed_mount_options.is_empty() {
                 return Err(anyhow!(

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1078,10 +1078,13 @@ struct FuseSessionConfig {
     pub max_threads: usize,
 }
 
-/// A Mount point to mount, can be a directory or a FUSE file descriptor (only on Linux).
+/// OS mount point where S3 file system should be mounted.
+/// This is typically a [Directory], but may be a different variant for more advanced use cases.
 #[derive(Debug)]
 enum MountPoint {
+    /// Directory to mount the new S3 filesystem at.
     Directory(PathBuf),
+    /// Use a FUSE file descriptor that has already been opened and mounted.
     #[cfg(target_os = "linux")]
     FileDescriptor(std::os::fd::OwnedFd),
 }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -133,7 +133,7 @@ impl Drop for TestSession {
     fn drop(&mut self) {
         // If the session created with a pre-existing mount (e.g., with `pass_fuse_fd`),
         // this will unmount it explicitly...
-        let _ = self.mount.take();
+        drop(self.mount.take());
         // ...if not, the background session will have a mount here, and dropping it will unmount it.
         self.session.take();
     }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -78,7 +78,7 @@ impl Default for TestSessionConfig {
             filesystem_config: Default::default(),
             prefetcher_config: Default::default(),
             auth_config: Default::default(),
-            pass_fuse_fd: Default::default(),
+            pass_fuse_fd: false,
         }
     }
 }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -131,7 +131,10 @@ impl TestSession {
 
 impl Drop for TestSession {
     fn drop(&mut self) {
-        // Unmount first by dropping the background session
+        // If the session created with a pre-existing mount (e.g., with `pass_fuse_fd`),
+        // this will unmount it explicitly...
+        let _ = self.mount.take();
+        // ...if not, the background session will have a mount here, and dropping it will unmount it.
         self.session.take();
     }
 }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -167,6 +167,8 @@ where
         MountOption::NoAtime,
         MountOption::AllowOther,
     ];
+    // `MountOption::AllowOther` corresponds to `SessionACL::All`;
+    let session_acl = fuser::SessionACL::All;
 
     let prefix = Prefix::new(prefix).expect("valid prefix");
     let fs = S3FuseFilesystem::new(S3Filesystem::new(
@@ -180,7 +182,7 @@ where
     let (session, mount) = if pass_fuse_fd {
         let (fd, mount) = mount_for_passing_fuse_fd(mount_dir, &options);
         let owned_fd = fd.as_fd().try_clone_to_owned().unwrap();
-        (Session::from_fd(fs, owned_fd, fuser::SessionACL::All), Some(mount))
+        (Session::from_fd(fs, owned_fd, session_acl), Some(mount))
     } else {
         (Session::new(fs, mount_dir, &options).unwrap(), None)
     };

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -188,8 +188,9 @@ where
     (BackgroundSession::new(session).unwrap(), mount)
 }
 
-// Opens `/dev/fuse` and calls `mount` syscall with given `mount_point`.
-// The mount gets automatically unmounted once `Mount` drops.
+/// Open `/dev/fuse` and call `mount` syscall with given `mount_point`.
+///
+/// The mount is automatically unmounted when the returned [Mount] is dropped.
 pub fn mount_for_passing_fuse_fd(mount_point: &Path, options: &[MountOption]) -> (Arc<File>, Mount) {
     let (file, mount) = Mount::new(mount_point, options).unwrap();
 

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -146,6 +146,7 @@ pub trait TestSessionCreator: FnOnce(&str, TestSessionConfig) -> TestSession {}
 // `FnOnce(...)` in place of `impl TestSessionCreator`.
 impl<T> TestSessionCreator for T where T: FnOnce(&str, TestSessionConfig) -> TestSession {}
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_fuse_session<Client, Prefetcher, Runtime>(
     client: Client,
     prefetcher: Prefetcher,

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -316,7 +316,7 @@ where
     let mount_point = tempfile::tempdir().unwrap();
     let runtime = client.event_loop_group();
     let prefetcher = caching_prefetch(cache, runtime.clone(), Default::default());
-    let session = create_fuse_session(
+    let (session, _mount) = create_fuse_session(
         client,
         prefetcher,
         runtime,
@@ -324,6 +324,7 @@ where
         prefix,
         mount_point.path(),
         Default::default(),
+        false,
     );
     (mount_point, session)
 }

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -350,7 +350,7 @@ fn run_fail_on_non_existent_fd() -> Result<(), Box<dyn std::error::Error>> {
     let (bucket, prefix) = get_test_bucket_and_prefix("run_fail_on_non_existent_fd");
     let region = get_test_region();
 
-    let mount_point = "/dev/fd/42";
+    let mount_point = "/dev/fd/1025";
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let child = cmd

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -209,9 +209,8 @@ fn run_in_foreground_with_passed_fuse_fd() -> Result<(), Box<dyn std::error::Err
 
     wait_for_mount("mountpoint-s3-fd", mount_point.path().to_str().unwrap());
 
-    // verify that process is still alive
-    let child_status = child.try_wait().unwrap();
-    assert_eq!(None, child_status);
+    let child_exit_status = child.try_wait().unwrap();
+    assert_eq!(None, child_exit_status, "child exit status should be None as it should still be running");
 
     assert!(mount_exists("mountpoint-s3-fd", mount_point.path().to_str().unwrap()));
 

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -28,10 +28,10 @@ use crate::common::tokio_block_on;
 #[cfg(not(feature = "s3express_tests"))]
 use crate::common::{creds::get_scoped_down_credentials, s3::get_non_test_region, s3::get_test_kms_key_id};
 
-const MOUNT_OPTION_READ_ONLY: &'static str = "--read-only";
-const MOUNT_OPTION_AUTO_UNMOUNT: &'static str = "--auto-unmount";
-const MOUNT_OPTION_ALLOW_ROOT: &'static str = "--allow-root";
-const MOUNT_OPTION_ALLOW_OTHER: &'static str = "--allow-other";
+const MOUNT_OPTION_READ_ONLY: &str = "--read-only";
+const MOUNT_OPTION_AUTO_UNMOUNT: &str = "--auto-unmount";
+const MOUNT_OPTION_ALLOW_ROOT: &str = "--allow-root";
+const MOUNT_OPTION_ALLOW_OTHER: &str = "--allow-other";
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -4,7 +4,7 @@
 use assert_cmd::prelude::*;
 #[cfg(not(feature = "s3express_tests"))]
 use aws_sdk_s3::primitives::ByteStream;
-use fuser::{Mount, MountOption};
+use fuser::MountOption;
 use std::fs::{self, File};
 #[cfg(not(feature = "s3express_tests"))]
 use std::io::Read;
@@ -18,7 +18,7 @@ use tempfile::NamedTempFile;
 use test_case::test_case;
 
 use crate::common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
-use crate::common::fuse::read_dir_to_entry_names;
+use crate::common::fuse::{mount_for_passing_fuse_fd, read_dir_to_entry_names};
 use crate::common::s3::{
     create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_endpoint_url, get_test_region,
     get_test_sdk_client,
@@ -65,11 +65,10 @@ fn run_in_background_with_passed_fuse_fd() -> Result<(), Box<dyn std::error::Err
     let region = get_test_region();
     let mount_point = assert_fs::TempDir::new()?;
 
-    let (fd, _mount) = Mount::new(
+    let (fd, _mount) = mount_for_passing_fuse_fd(
         mount_point.path(),
         &[MountOption::FSName("mountpoint-s3-fd".to_string())],
-    )
-    .unwrap();
+    );
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let child = cmd
@@ -193,11 +192,10 @@ fn run_in_foreground_with_passed_fuse_fd() -> Result<(), Box<dyn std::error::Err
     let region = get_test_region();
     let mount_point = assert_fs::TempDir::new()?;
 
-    let (fd, _mount) = Mount::new(
+    let (fd, _mount) = mount_for_passing_fuse_fd(
         mount_point.path(),
         &[MountOption::FSName("mountpoint-s3-fd".to_string())],
-    )
-    .unwrap();
+    );
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let mut child = cmd
@@ -230,11 +228,10 @@ fn run_in_background_with_passed_fuse_fd_fail_on_mount() -> Result<(), Box<dyn s
     let bucket = get_test_bucket_forbidden();
     let mount_point = assert_fs::TempDir::new()?;
 
-    let (fd, mount) = Mount::new(
+    let (fd, mount) = mount_for_passing_fuse_fd(
         mount_point.path(),
         &[MountOption::FSName("mountpoint-s3-fd".to_string())],
-    )
-    .unwrap();
+    );
 
     let mut cmd = Command::cargo_bin("mount-s3")?;
     let child = cmd

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -30,8 +30,6 @@ use crate::common::{creds::get_scoped_down_credentials, s3::get_non_test_region,
 
 const MOUNT_OPTION_READ_ONLY: &str = "--read-only";
 const MOUNT_OPTION_AUTO_UNMOUNT: &str = "--auto-unmount";
-const MOUNT_OPTION_ALLOW_ROOT: &str = "--allow-root";
-const MOUNT_OPTION_ALLOW_OTHER: &str = "--allow-other";
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -412,9 +410,7 @@ fn run_fail_on_non_fuse_fd() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test_case(&[MOUNT_OPTION_READ_ONLY])]
 #[test_case(&[MOUNT_OPTION_AUTO_UNMOUNT])]
-#[test_case(&[MOUNT_OPTION_ALLOW_ROOT])]
-#[test_case(&[MOUNT_OPTION_ALLOW_OTHER])]
-#[test_case(&[MOUNT_OPTION_READ_ONLY, MOUNT_OPTION_ALLOW_OTHER])]
+#[test_case(&[MOUNT_OPTION_READ_ONLY, MOUNT_OPTION_AUTO_UNMOUNT])]
 fn run_fail_on_non_fuse_fd_if_mount_options_passed(mount_options: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
     let (bucket, prefix) = get_test_bucket_and_prefix("run_fail_on_non_fuse_fd_if_mount_options_passed");
     let region = get_test_region();

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -23,10 +23,10 @@ fn open_for_read(path: impl AsRef<Path>, read_only: bool) -> std::io::Result<Fil
     options.read(true).open(path)
 }
 
-fn basic_read_test(creator_fn: impl TestSessionCreator, prefix: &str, read_only: bool) {
+fn basic_read_test(creator_fn: impl TestSessionCreator, prefix: &str, read_only: bool, pass_fuse_fd: bool) {
     let mut rng = ChaChaRng::seed_from_u64(0x87654321);
 
-    let test_session = creator_fn(prefix, Default::default());
+    let test_session = creator_fn(prefix, TestSessionConfig::default().with_pass_fuse_fd(pass_fuse_fd));
 
     test_session.client().put_object("hello.txt", b"hello world").unwrap();
     let mut two_mib_body = vec![0; 2 * 1024 * 1024];
@@ -76,40 +76,50 @@ fn basic_read_test(creator_fn: impl TestSessionCreator, prefix: &str, read_only:
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "read only")]
-#[test_case(false; "readwrite")]
-fn basic_read_test_s3(read_only: bool) {
-    basic_read_test(fuse::s3_session::new, "basic_read_test", read_only);
+#[test_case(true, false; "read only")]
+#[test_case(false, false; "readwrite")]
+#[test_case(true, true; "read only (pass FUSE fd)")]
+#[test_case(false, true; "readwrite (pass FUSE fd)")]
+fn basic_read_test_s3(read_only: bool, pass_fuse_fd: bool) {
+    basic_read_test(fuse::s3_session::new, "basic_read_test", read_only, pass_fuse_fd);
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "read only")]
-#[test_case(false; "readwrite")]
-fn basic_read_test_s3_with_cache(read_only: bool) {
+#[test_case(true, false; "read only")]
+#[test_case(false, false; "readwrite")]
+#[test_case(true, true; "read only (pass FUSE fd)")]
+#[test_case(false, true; "readwrite (pass FUSE fd)")]
+fn basic_read_test_s3_with_cache(read_only: bool, pass_fuse_fd: bool) {
     basic_read_test(
         fuse::s3_session::new_with_cache(InMemoryDataCache::new(1024 * 1024)),
         "basic_read_test_with_cache",
         read_only,
+        pass_fuse_fd,
     );
 }
 
-#[test_case("", true; "no prefix read only")]
-#[test_case("", false; "no prefix readwrite")]
-#[test_case("basic_read_test", true; "prefix read only")]
-#[test_case("basic_read_test", false; "prefix readwrite")]
-fn basic_read_test_mock(prefix: &str, read_only: bool) {
-    basic_read_test(fuse::mock_session::new, prefix, read_only);
+#[test_case("", true, false; "no prefix read only")]
+#[test_case("", false, false; "no prefix readwrite")]
+#[test_case("", false, true; "no prefix readwrite (pass FUSE fd)")]
+#[test_case("basic_read_test", true, false; "prefix read only")]
+#[test_case("basic_read_test", true, true; "prefix read only (pass FUSE fd)")]
+#[test_case("basic_read_test", false, false; "prefix readwrite")]
+fn basic_read_test_mock(prefix: &str, read_only: bool, pass_fuse_fd: bool) {
+    basic_read_test(fuse::mock_session::new, prefix, read_only, pass_fuse_fd);
 }
 
-#[test_case("", true; "no prefix read only")]
-#[test_case("", false; "no prefix readwrite")]
-#[test_case("basic_read_test_with_cache", true; "prefix read only")]
-#[test_case("basic_read_test_with_cache", false; "prefix readwrite")]
-fn basic_read_test_mock_with_cache(prefix: &str, read_only: bool) {
+#[test_case("", true, false; "no prefix read only")]
+#[test_case("", true, true; "no prefix read only (pass FUSE fd)")]
+#[test_case("", false, false; "no prefix readwrite")]
+#[test_case("basic_read_test_with_cache", true, false; "prefix read only")]
+#[test_case("basic_read_test_with_cache", false, false; "prefix readwrite")]
+#[test_case("basic_read_test_with_cache", false, true; "prefix readwrite (pass FUSE fd)")]
+fn basic_read_test_mock_with_cache(prefix: &str, read_only: bool, pass_fuse_fd: bool) {
     basic_read_test(
         fuse::mock_session::new_with_cache(InMemoryDataCache::new(1024 * 1024)),
         prefix,
         read_only,
+        pass_fuse_fd,
     );
 }
 

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -21,6 +21,7 @@ const READ_WRITE: bool = false;
 const FUSE_PASS_FD: bool = true;
 const FUSE_SELF_MOUNT: bool = false;
 
+/// Test wrapper to support generate of test names when used with [test_case].
 enum BucketPrefix {
     None,
     Some(&'static str),

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -21,7 +21,7 @@ const READ_WRITE: bool = false;
 const FUSE_PASS_FD: bool = true;
 const FUSE_SELF_MOUNT: bool = false;
 
-/// Test wrapper to support generate of test names when used with [test_case].
+/// Test wrapper to support generation of test names when used with [test_case].
 enum BucketPrefix {
     None,
     Some(&'static str),


### PR DESCRIPTION
## Description of change

fuser v0.15.0 added support for creating a `Session` from existing FUSE file descriptor (via `Session::from_fd`). This PR adds this support to Mountpoint. It allows passing FUSE file descriptor as mount point in the form of `/dev/fd/{fd}`. 

An example usage of this feature can be seen with a helper Go script, [mounthelper.go](https://github.com/awslabs/mountpoint-s3/blob/86bdefa5147a7edc533a6be5d2724fec74ba91fb/examples/fuse-fd-mount-point/mounthelper.go):

```bash
$ go build mounthelper.go
$ sudo /sbin/setcap 'cap_sys_admin=ep' ./mounthelper # `mount` syscall requires `CAP_SYS_ADMIN`, alternatively, `mounthelper` can be run as root
$ ./mounthelper -mountpoint /tmp/mountpoint -bucket bucketname
bucket bucketname is mounted at /dev/fd/3
2024/11/07 17:23:42 Filesystem mounted, waiting for ctrl+c signal to terminate 

$ # in a different terminal session
$ echo "Hello at `date`" > /tmp/mountpoint/helloworld
$ cat /tmp/mountpoint/helloworld
Hello at Thu Nov  7 17:32:33 UTC 2024
$ rm /tmp/mountpoint/helloworld
$ cat /tmp/mountpoint/helloworld
cat: /tmp/mountpoint/helloworld: No such file or directory
```

Relevant issues: This PR resurrects a previous PR to add this feature: https://github.com/awslabs/mountpoint-s3/pull/537 

## Does this change impact existing behavior?

Shouldn't affect any existing behavior as we had an “is directory?” check for passed mount points before, and it shouldn't have been possible to pass a file descriptor as a mount point prior to this change.

## Does this change need a changelog entry in any of the crates?

Updated CHANGELOG for `mountpoint-s3`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
