### PR TITLE
Add missing documentation for fuser Mount structs

### DIFF
--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -18,11 +18,17 @@ fn ensure_last_os_error() -> io::Error {
     }
 }
 
+/// An active FUSE mount.
+///
+/// This struct manages the lifecycle of the mount, unmounting when dropped.
 #[derive(Debug)]
 pub struct Mount {
     mountpoint: CString,
 }
 impl Mount {
+    /// Mounts the filesystem at the given path, with the given options.
+    ///
+    /// Returns the mounted FUSE file descriptor along with a [Mount] for handling the mount lifecycle.
     pub fn new(mountpoint: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
         let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -22,11 +22,17 @@ fn ensure_last_os_error() -> io::Error {
     }
 }
 
+/// An active FUSE mount.
+///
+/// This struct manages the lifecycle of the mount, unmounting and destroying the session when dropped.
 #[derive(Debug)]
 pub struct Mount {
     fuse_session: *mut c_void,
 }
 impl Mount {
+    /// Mounts the filesystem at the given path, with the given options.
+    ///
+    /// Returns the mounted FUSE file descriptor along with a [Mount] for handling the mount lifecycle.
     pub fn new(mnt: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
         let mnt = CString::new(mnt.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {


### PR DESCRIPTION
## Description of change

Our fuser fork emits a lot of warnings during builds, impacting our pull requests. This change addresses missing documentation on one struct in fuser (which was introduced by our change in https://github.com/awslabs/mountpoint-s3/pull/1098).

This change is a good candidate to be contributed to upstream. Once contributed, this commit can be removed.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
