### PR TITLE
Remove target_os 'bitrig' in fuser which is unsupported by Rust

### DIFF
--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -61,7 +61,6 @@ impl Drop for Mount {
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd",
-                    target_os = "bitrig",
                     target_os = "netbsd"
                 )))]
                 unsafe {

--- a/src/mnt/fuse2_sys.rs
+++ b/src/mnt/fuse2_sys.rs
@@ -27,7 +27,6 @@ extern "C" {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     )))]
     pub fn fuse_unmount_compat22(mountpoint: *const c_char);

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -178,7 +178,6 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     ))]
     {

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -64,7 +64,6 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     ))]
     let r = unsafe { libc::unmount(mnt.as_ptr(), 0) };
@@ -74,7 +73,6 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     )))]
     let r = unsafe { libc::umount(mnt.as_ptr()) };


### PR DESCRIPTION
## Description of change

Our fuser fork emits a lot of warnings during builds, impacting our pull requests. This change addresses the use of undeclared target operating systems.

Bitrig is no longer developed and most changes were contributed back to its upstream OpenBSD. Bitrig support was removed from Rust in 2019 (https://github.com/rust-lang/rust/pull/60775). This change removes the conditions from Fuser, who's MSRV is 1.74.

This change is a good candidate to be contributed to upstream (https://github.com/cberner/fuser/pull/312). Once contributed, this commit can be removed.

## Does this change impact existing behavior?

`bitrig` will no longer be a supported operating system for fuser (though its unlikely it worked, given MSRV of 1.74).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
