### PR TITLE
Lay out files using fio in the benchmark.

### DIFF
--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -42,6 +42,7 @@ You can use the following steps.
         export S3_BUCKET_NAME=bucket_name
         export S3_BUCKET_TEST_PREFIX=prefix_path/
         export S3_ENDPOINT_URL=endpoint_url # optional
+        # these filenames only needed by cache benchmark
         export S3_BUCKET_BENCH_FILE=bench_file_name
         export S3_BUCKET_SMALL_BENCH_FILE=small_bench_file_name
         # to filter by job name; e.g. to only run small jobs

--- a/mountpoint-s3/scripts/fio/read_latency/ttfb.fio
+++ b/mountpoint-s3/scripts/fio/read_latency/ttfb.fio
@@ -1,9 +1,11 @@
 [global]
 name=fs_bench
-bs=1B
+# large write block size not used as part of benchmark, but speeds up file layout
+bs=1B,1M
 
 [time_to_first_byte_read]
-size=1B
+size=1G
+io_limit=1B
 rw=read
 ioengine=sync
 fallocate=none

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -169,6 +169,7 @@ cache_benchmark () {
     cargo run --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
+      --allow-overwrite \
       --cache=${cache_dir} \
       --log-directory=${log_dir} \
       --prefix=${S3_BUCKET_TEST_PREFIX} \


### PR DESCRIPTION
## Description of change

This makes the benchmarks more self-contained, creating the state that they need to run rather than relying on pre-created state (potentially with different/unknown mount options and/or object properties).

It does change behaviour a little: previously the multi-thread tests would use the same object whereas now each thread uses its own object -- arguably this is a more useful test but results in higher S3 usage.

Also note that the cache benchmark is unchanged in this commit, because it makes assumptions about the filename used by the tests.

Removing the assumption that each test will operate on a single file prepares us for future mixed read/write tests, and allows different fio jobs to be run in parallel safely.

## Does this change impact existing behavior?

Yes, see above: previously the multi-thread tests would use the same object whereas now each thread uses its own object -- arguably this is a more useful test but results in higher S3 usage.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
