### PR TITLE
Add debug print for inode number in mknod

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -406,6 +406,10 @@ where
             .superblock
             .create(&self.client, parent, name, InodeKind::File)
             .await?;
+        // Log newly created Inode number
+        let inode_nr = lookup.inode.ino();
+        debug!("mknod: created inode number {inode_nr}");
+
         let attr = self.make_attr(&lookup);
         Ok(Entry {
             ttl: lookup.validity(),

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -406,10 +406,7 @@ where
             .superblock
             .create(&self.client, parent, name, InodeKind::File)
             .await?;
-        // Log newly created Inode number
-        let inode_nr = lookup.inode.ino();
-        debug!("mknod: created inode number {inode_nr}");
-
+        debug!(ino = lookup.inode.ino(), "new inode created");
         let attr = self.make_attr(&lookup);
         Ok(Entry {
             ttl: lookup.validity(),


### PR DESCRIPTION
## Description of change

`mknod` now prints the newly created inode number. This can help with tracing the lifetime of an inode between FUSE requests.

## Does this change impact existing behavior?

No, small debug log addition only.

## Does this change need a changelog entry in any of the crates?

No.

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
