### PR TITLE
Use separate endpoint URLs for benchmark CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,7 @@ env:
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
-  S3_ENDPOINT_URL: ${{ vars.S3_ENDPOINT_URL }}
+  S3_ENDPOINT_URL: ${{ vars.S3_BENCH_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
 
 jobs:

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -24,7 +24,7 @@ env:
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
-  S3_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_ENDPOINT_URL }}
+  S3_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
 
 jobs:


### PR DESCRIPTION
## Description of change

This allows integration test workflows and benchmark workflows to run against different endpoint URLs.

## Does this change impact existing behavior?

No, only CI change.

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
