### PR TITLE
Update README example bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ or the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables,
 or from [several other sources](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#aws-credentials).
 
 To mount your bucket, run this command,
-replacing `DOC-EXAMPLE-BUCKET` with the name of your bucket
+replacing `amzn-s3-demo-bucket` with the name of your bucket
 and `/path/to/mount` with the directory you want to mount the bucket to:
 
-    mount-s3 DOC-EXAMPLE-BUCKET /path/to/mount
+    mount-s3 amzn-s3-demo-bucket /path/to/mount
 
 Now you can work with your bucket contents as if they were a local file system:
 


### PR DESCRIPTION
## Description of change

The Mountpoint README currently uses an outdated example bucket name. AWS documentation is using the bucket name prefix `amzn-s3-demo-bucket` across all documentation.

This is a change missed in #1099.

Relevant issues: #1099

## Does this change impact existing behavior?

No, changes documentation and unit test source code only.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
