### PR TITLE
Add `Headers.get_as_optional_string` and `get_as_string`

### DIFF
--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -72,6 +72,10 @@ pub enum HeadersError {
     /// Internal CRT error
     #[error("CRT error: {0}")]
     CrtError(#[source] Error),
+
+    /// Header value could not be converted to String
+    #[error("Header string was not valid: {0:?}")]
+    Invalid(OsString),
 }
 
 // Convert CRT error into HeadersError, mapping the HEADER_NOT_FOUND to HeadersError::HeaderNotFound.
@@ -195,6 +199,26 @@ impl Headers {
         let value = unsafe { OsStr::from_bytes(aws_byte_cursor_as_slice(&value)).to_owned() };
 
         Ok(Header::new(name, value))
+    }
+
+    /// Get a single header by name as a string.
+    pub fn get_as_string<H: AsRef<OsStr>>(&self, name: H) -> Result<String, HeadersError> {
+        let header = self.get(name)?;
+        let value = header.value();
+        if let Some(s) = value.to_str() {
+            Ok(s.to_string())
+        } else {
+            Err(HeadersError::Invalid(value.clone()))
+        }
+    }
+
+    /// Get an optional header by name as a string.
+    pub fn get_as_optional_string<H: AsRef<OsStr>>(&self, name: H) -> Result<Option<String>, HeadersError> {
+        Ok(if self.has_header(&name) {
+            Some(self.get_as_string(name)?)
+        } else {
+            None
+        })
     }
 
     /// Iterate over the headers as (name, value) pairs.
@@ -380,6 +404,9 @@ mod test {
         assert_eq!(headers.get("a").unwrap().name(), "a");
         assert_eq!(headers.get("a").unwrap().value(), "1");
 
+        assert_eq!(headers.get_as_string("a"), Ok("1".to_string()));
+        assert_eq!(headers.get_as_optional_string("a"), Ok(Some("1".to_string())));
+
         let map: HashMap<OsString, OsString> = headers.iter().collect();
 
         assert_eq!(map.len(), 3);
@@ -393,6 +420,16 @@ mod test {
         assert!(!headers.has_header("a"));
         let error = headers.get("a").expect_err("should fail because header is not present");
         assert_eq!(error, HeadersError::HeaderNotFound, "should fail with HeaderNotFound");
+
+        let error = headers
+            .get_as_string("a")
+            .expect_err("should fail because header is not present");
+        assert_eq!(error, HeadersError::HeaderNotFound, "should fail with HeaderNotFound");
+
+        let header = headers
+            .get_as_optional_string("a")
+            .expect("Should not fail as optional is expected here");
+        assert_eq!(header, None, "should return None");
     }
 
     /// Test setting the same header twice, which should overwrite with the second value.

--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -201,7 +201,7 @@ impl Headers {
         Ok(Header::new(name, value))
     }
 
-    /// Get a single header by name as a string.
+    /// Get a single header by name as a [String].
     pub fn get_as_string<H: AsRef<OsStr>>(&self, name: H) -> Result<String, HeadersError> {
         let header = self.get(name)?;
         let value = header.value();
@@ -212,7 +212,7 @@ impl Headers {
         }
     }
 
-    /// Get an optional header by name as a string.
+    /// Get an optional header by name as a [String].
     pub fn get_as_optional_string<H: AsRef<OsStr>>(&self, name: H) -> Result<Option<String>, HeadersError> {
         Ok(if self.has_header(&name) {
             Some(self.get_as_string(name)?)


### PR DESCRIPTION
<!--
    The title and description of pull requests will be used when creating a squash commit to the base branch (usually `main`).
    Please keep them both up-to-date as the code change evolves, to ensure that the commit message is useful for future readers.
-->

## Description of change

Refactors `Headers` to have two new public methods: `get_as_optional_string` and `get_as_string`.

Refactor `head_object` and `put_object` to use new header methods rather than custom implementations

<!--
    Please describe your contribution here.
    What is the change and why are you making it?
-->

Relevant issues: N/A

## Does this change impact existing behavior?

Changes log format slightly by making "Header string was not valid" text part of HeadersError.

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

## Does this change need a changelog entry in any of the crates?

No

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
