### PR TITLE
Fix ANSI escape codes being included in log files on macOS

### DIFF
--- a/mountpoint-s3/src/logging.rs
+++ b/mountpoint-s3/src/logging.rs
@@ -159,8 +159,8 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
 
     let registry = tracing_subscriber::registry()
         .with(syslog_layer)
-        .with(console_layer)
         .with(file_layer)
+        .with(console_layer)
         .with(metrics_tracing_span_layer());
 
     registry.init();


### PR DESCRIPTION
<!--
    The title and description of pull requests will be used when creating a squash commit to the base branch (usually `main`).
    Please keep them both up-to-date as the code change evolves, to ensure that the commit message is useful for future readers.
-->

## Description of change

Before this change, log files written on macOS would include ANSI escape codes (#1050). It's unclear why this is not reproducible on Linux.

This change reorders the logging layers such that the console layer (with ANSI) is evaluated last, and so the mutations to add ANSI escapes is not applied when writing log files. This issue appears related: https://github.com/tokio-rs/tracing/issues/658.

Relevant issues: #1050 

## Does this change impact existing behavior?

This fixes log files written on macOS (which is an unsupported platform).

## Does this change need a changelog entry in any of the crates?

This is a minor bug fix on an unsupported platform, so no changelog entry needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
