### PR TITLE
Ensure that the file system in tests is unmounted before removing the temp dir

### DIFF
--- a/mountpoint-s3/tests/fuse_tests/consistency_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/consistency_test.rs
@@ -11,24 +11,22 @@ fn page_cache_sharing_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     const OBJECT_SIZE: usize = 512 * 1024;
 
     let test_session = creator_fn(prefix, Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
     // Create the first version of the file
     let old_contents = vec![0xaau8; OBJECT_SIZE];
-    test_client.put_object("file.bin", &old_contents).unwrap();
+    test_session.client().put_object("file.bin", &old_contents).unwrap();
 
     // Open the file before updating it remotely
-    let old_file = File::open(mount_point.path().join("file.bin")).unwrap();
+    let old_file = File::open(test_session.mount_path().join("file.bin")).unwrap();
     let mut buf = vec![0u8; 128];
     old_file.read_exact_at(&mut buf, 0).unwrap();
     assert_eq!(buf, &old_contents[..buf.len()]);
 
     let new_contents = vec![0xbbu8; OBJECT_SIZE];
-    test_client.put_object("file.bin", &new_contents).unwrap();
+    test_session.client().put_object("file.bin", &new_contents).unwrap();
 
     // Open the file again, should see the new contents this time
-    let new_file = File::open(mount_point.path().join("file.bin")).unwrap();
+    let new_file = File::open(test_session.mount_path().join("file.bin")).unwrap();
     new_file.read_exact_at(&mut buf, 0).unwrap();
     assert_eq!(buf, &new_contents[..buf.len()]);
 

--- a/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/rmdir_test.rs
@@ -5,11 +5,10 @@ use test_case::test_case;
 
 fn rmdir_local_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let test_session = creator_fn(prefix, Default::default());
-    let mount_point = test_session.mount_dir;
 
     // Create local directory
     let main_dirname = "test_dir";
-    let main_path = mount_point.path().join(main_dirname);
+    let main_path = test_session.mount_path().join(main_dirname);
     let empty_dirname = "local_empty_dir";
     let non_empty_dirname = "local_non_empty_dir";
     let empty_dirpath = main_path.join(empty_dirname);
@@ -77,14 +76,13 @@ fn rmdir_local_dir_test_s3(prefix: &str) {
 
 fn rmdir_remote_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let test_session = creator_fn(prefix, Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
     let main_dirname = "test_dir";
-    let main_path = mount_point.path().join(main_dirname);
+    let main_path = test_session.mount_path().join(main_dirname);
     // explicitly testing remote directories not getting removed
     let remote_dirname = "remote_dir";
-    test_client
+    test_session
+        .client()
         .put_object(&format!("{main_dirname}/{remote_dirname}/hello.txt"), b"hello world")
         .unwrap();
     let remote_path = main_path.join(remote_dirname);
@@ -98,7 +96,8 @@ fn rmdir_remote_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
 
     let empty_remote_dirname = "empty_remote_dir";
     // adding zero byte directory marker
-    test_client
+    test_session
+        .client()
         .put_object(&format!("{main_dirname}/{empty_remote_dirname}/"), b"")
         .unwrap();
     let empty_remote_path = main_path.join(empty_remote_dirname);
@@ -106,7 +105,8 @@ fn rmdir_remote_dir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     assert_eq!(err.raw_os_error(), Some(libc::EPERM));
 
     let remote_filename = "remote_file";
-    test_client
+    test_session
+        .client()
         .put_object(&format!("{main_dirname}/{remote_filename}"), b"Hello World")
         .unwrap();
     let remote_file_path = main_path.join(remote_filename);
@@ -137,11 +137,10 @@ fn rmdir_remote_dir_test_s3(prefix: &str) {
 
 fn create_after_rmdir_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let test_session = creator_fn(prefix, Default::default());
-    let mount_point = test_session.mount_dir;
 
     // Create local directory
     let main_dirname = "test_dir";
-    let main_path = mount_point.path().join(main_dirname);
+    let main_path = test_session.mount_path().join(main_dirname);
     let empty_dirname = "local_empty_dir";
     let empty_dirpath = main_path.join(empty_dirname);
 

--- a/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/semantics_doc_test.rs
@@ -50,20 +50,27 @@ fn list_dir_recursive(path: impl AsRef<Path>, files: bool) -> Result<Vec<String>
 ///     * `list.txt` (file)
 fn basic_directory_structure(creator_fn: impl TestSessionCreator) {
     let test_session = creator_fn("basic_directory_structure", Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
-    test_client.put_object("colors/blue/image.jpg", b"hello world").unwrap();
-    test_client.put_object("colors/red/image.jpg", b"hello world").unwrap();
-    test_client.put_object("colors/list.txt", b"hello world").unwrap();
+    test_session
+        .client()
+        .put_object("colors/blue/image.jpg", b"hello world")
+        .unwrap();
+    test_session
+        .client()
+        .put_object("colors/red/image.jpg", b"hello world")
+        .unwrap();
+    test_session
+        .client()
+        .put_object("colors/list.txt", b"hello world")
+        .unwrap();
 
-    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    let files = list_dir_recursive(test_session.mount_path(), true).unwrap();
     assert_eq!(
         &files[..],
         &["colors/blue/image.jpg", "colors/list.txt", "colors/red/image.jpg"]
     );
 
-    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    let dirs = list_dir_recursive(test_session.mount_path(), false).unwrap();
     assert_eq!(&dirs[..], &["colors", "colors/blue", "colors/red"]);
 }
 
@@ -91,17 +98,18 @@ fn basic_directory_structure_s3() {
 /// creating directories in a bucket, and so these directories will work as expected.
 fn keys_ending_in_delimiter(creator_fn: impl TestSessionCreator) {
     let test_session = creator_fn("keys_ending_in_delimiter", Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
-    test_client.put_object("blue/", b"hello world").unwrap();
-    test_client.put_object("blue/image.jpg", b"hello world").unwrap();
-    test_client.put_object("red/", b"hello world").unwrap();
+    test_session.client().put_object("blue/", b"hello world").unwrap();
+    test_session
+        .client()
+        .put_object("blue/image.jpg", b"hello world")
+        .unwrap();
+    test_session.client().put_object("red/", b"hello world").unwrap();
 
-    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    let files = list_dir_recursive(test_session.mount_path(), true).unwrap();
     assert_eq!(&files[..], &["blue/image.jpg"]);
 
-    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    let dirs = list_dir_recursive(test_session.mount_path(), false).unwrap();
     assert_eq!(&dirs[..], &["blue", "red"]);
 }
 
@@ -127,16 +135,17 @@ fn keys_ending_in_delimiter_s3() {
 /// remove the `blue` directory, and cause the `blue` file to become visible.
 fn files_shadowed_by_directories(creator_fn: impl TestSessionCreator) {
     let test_session = creator_fn("files_shadowed_by_directories", Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
-    test_client.put_object("blue", b"hello world").unwrap();
-    test_client.put_object("blue/image.jpg", b"hello world").unwrap();
+    test_session.client().put_object("blue", b"hello world").unwrap();
+    test_session
+        .client()
+        .put_object("blue/image.jpg", b"hello world")
+        .unwrap();
 
-    let files = list_dir_recursive(mount_point.path(), true).unwrap();
+    let files = list_dir_recursive(test_session.mount_path(), true).unwrap();
     assert_eq!(&files[..], &["blue/image.jpg"]);
 
-    let dirs = list_dir_recursive(mount_point.path(), false).unwrap();
+    let dirs = list_dir_recursive(test_session.mount_path(), false).unwrap();
     assert_eq!(&dirs[..], &["blue"]);
 }
 

--- a/mountpoint-s3/tests/fuse_tests/setattr_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/setattr_test.rs
@@ -20,13 +20,14 @@ fn open_for_write(path: impl AsRef<Path>, append: bool) -> std::io::Result<File>
 
 fn setattr_test(creator_fn: impl TestSessionCreator, prefix: &str, append: bool) {
     let test_session = creator_fn(prefix, Default::default());
-    let mount_point = test_session.mount_dir;
-    let mut test_client = test_session.test_client;
 
     // Make sure there's an existing directory
-    test_client.put_object("dir/hello.txt", b"hello world").unwrap();
+    test_session
+        .client()
+        .put_object("dir/hello.txt", b"hello world")
+        .unwrap();
 
-    let path = mount_point.path().join("dir/new.txt");
+    let path = test_session.mount_path().join("dir/new.txt");
 
     let f = open_for_write(&path, append).unwrap();
 


### PR DESCRIPTION
## Description of change

Ensure that the file system in integration tests is unmounted before removing the temporary directory. The introduction of `TestSession` in #1096 inadvertently changed the order in which the temporary directory and the FUSE session are dropped. Previously it was hidden in the declaration order. This change makes it explicit in `drop`.

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
