### PR TITLE
Bypass the shared cache for large objects

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -29,6 +29,7 @@ use sysinfo::{RefreshKind, System};
 
 use crate::data_cache::{
     CacheLimit, DiskDataCache, DiskDataCacheConfig, ExpressDataCache, ManagedCacheDir, MultilevelDataCache,
+    EXPRESS_CACHE_MAX_OBJECT_SIZE,
 };
 use crate::fs::{CacheConfig, ServerSideEncryption, TimeToLive};
 use crate::fuse::session::FuseSession;
@@ -888,6 +889,7 @@ where
                 client.clone(),
                 &args.bucket_name,
                 args.cache_block_size_in_bytes(),
+                EXPRESS_CACHE_MAX_OBJECT_SIZE,
             );
 
             let prefetcher = caching_prefetch(express_cache, runtime, prefetcher_config);
@@ -932,6 +934,7 @@ where
                 client.clone(),
                 &args.bucket_name,
                 args.cache_block_size_in_bytes(),
+                EXPRESS_CACHE_MAX_OBJECT_SIZE,
             );
             let cache = MultilevelDataCache::new(Arc::new(disk_cache), express_cache, runtime.clone());
 

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
-pub use crate::data_cache::express_data_cache::ExpressDataCache;
+pub use crate::data_cache::express_data_cache::{ExpressDataCache, EXPRESS_CACHE_MAX_OBJECT_SIZE};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 
@@ -54,6 +54,7 @@ pub trait DataCache {
         cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
+        object_size: usize,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].
@@ -63,6 +64,7 @@ pub trait DataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         bytes: ChecksummedBytes,
+        object_size: usize,
     ) -> DataCacheResult<()>;
 
     /// Returns the block size for the data cache.

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -16,7 +16,9 @@ use thiserror::Error;
 pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
-pub use crate::data_cache::express_data_cache::{ExpressDataCache, EXPRESS_CACHE_MAX_OBJECT_SIZE};
+pub use crate::data_cache::express_data_cache::{
+    ExpressDataCache, ExpressDataCacheConfig, EXPRESS_CACHE_MAX_OBJECT_SIZE,
+};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -16,9 +16,7 @@ use thiserror::Error;
 pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
-pub use crate::data_cache::express_data_cache::{
-    ExpressDataCache, ExpressDataCacheConfig, EXPRESS_CACHE_MAX_OBJECT_SIZE,
-};
+pub use crate::data_cache::express_data_cache::{ExpressDataCache, ExpressDataCacheConfig};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 

--- a/mountpoint-s3/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3/src/data_cache/multilevel_cache.rs
@@ -118,10 +118,7 @@ where
 mod tests {
     use super::*;
     use crate::checksums::ChecksummedBytes;
-    use crate::data_cache::{
-        CacheLimit, DiskDataCache, DiskDataCacheConfig, ExpressDataCache, ExpressDataCacheConfig,
-        EXPRESS_CACHE_MAX_OBJECT_SIZE,
-    };
+    use crate::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig, ExpressDataCache};
 
     use futures::executor::ThreadPool;
     use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
@@ -154,13 +151,8 @@ mod tests {
             ..Default::default()
         };
         let client = MockClient::new(config);
-        let config = ExpressDataCacheConfig {
-            bucket_name: bucket.to_owned(),
-            source_bucket_name: "unique source description".to_owned(),
-            block_size: BLOCK_SIZE,
-            max_object_size: EXPRESS_CACHE_MAX_OBJECT_SIZE,
-        };
-        (client.clone(), ExpressDataCache::new(client, config))
+        let cache = ExpressDataCache::new(client.clone(), Default::default(), "unique source description", bucket);
+        (client, cache)
     }
 
     #[test_case(false, true; "get from local")]


### PR DESCRIPTION
## Description of change

This change makes `get_block` and `put_block` for objects larger than `1MiB` be a no-op in the shared cache. 

Relevant issues: N/A

## Does this change impact existing behavior?

No, it is under the feature flag.

## Does this change need a changelog entry in any of the crates?

Yes, in the following PRs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
