### PR TITLE
Enable metric emission in benchmark runs

### DIFF
--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -159,6 +159,7 @@ run_benchmarks() {
       --log-directory=${log_dir} \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
       $part_size \
+      --log-metrics \
       ${optional_args}
     mount_status=$?
     set -e

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -173,6 +173,7 @@ cache_benchmark () {
       --log-directory=${log_dir} \
       --prefix=${S3_BUCKET_TEST_PREFIX} \
       --part-size=16777216 \
+      --log-metrics \
       ${optional_args}
     mount_status=$?
     set -e

--- a/mountpoint-s3/scripts/fs_latency_bench.sh
+++ b/mountpoint-s3/scripts/fs_latency_bench.sh
@@ -68,6 +68,7 @@ do
         --allow-delete \
         --log-directory=$log_dir \
         --prefix=${S3_BUCKET_TEST_PREFIX} \
+        --log-metrics \
         ${optional_args}
     mount_status=$?
     if [ $mount_status -ne 0 ]; then
@@ -120,7 +121,7 @@ do
 
     # cleanup mount directory
     rm -rf ${mount_dir}
-    
+
     # increase directory size
     dir_size=$(awk "BEGIN {print $dir_size*10}")
 done
@@ -143,6 +144,7 @@ for job_file in "${jobs_dir}"/*.fio; do
     --allow-delete \
     --log-directory=$log_dir \
     --prefix=${S3_BUCKET_TEST_PREFIX} \
+    --log-metrics \
     ${optional_args}
   mount_status=$?
   if [ $mount_status -ne 0 ]; then


### PR DESCRIPTION
## Description of change

We opted to disable debug logging in #1104 as this may impact performance, however it was not known that the memory usage monitoring was dependent on metrics being emitted implicitly due to `--debug`. This change restores metrics in logs to fix the peak memory usage benchmarking.

Relevant issues: #1104

## Does this change impact existing behavior?

No change to Mountpoint.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
