### PR TITLE
Refactor `ObjectClient.get_object` to use an `GetObjectParams` parameter

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -26,6 +26,10 @@
 * Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
   `ChecksumAlgorithm` no longer implements `Copy`.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+* `get_object` method now requires a `GetObjectParams` parameter.
+  Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
+  ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))
+
 
 ## v0.11.0 (October 17, 2024)
 

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -9,7 +9,7 @@ use futures::StreamExt;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::mock_client::throughput_client::ThroughputMockClient;
 use mountpoint_s3_client::mock_client::{MockClientConfig, MockObject};
-use mountpoint_s3_client::types::ETag;
+use mountpoint_s3_client::types::{ETag, GetObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use tracing_subscriber::fmt::Subscriber;
@@ -46,7 +46,7 @@ fn run_benchmark(
                 scope.spawn(|| {
                     futures::executor::block_on(async move {
                         let mut request = client
-                            .get_object(bucket, key, None, None)
+                            .get_object(bucket, key, &GetObjectParams::new())
                             .await
                             .expect("couldn't create get request");
                         let mut request = pin!(request);

--- a/mountpoint-s3-client/examples/download.rs
+++ b/mountpoint-s3-client/examples/download.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use clap::{Arg, Command};
 use futures::StreamExt;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::types::GetObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use regex::Regex;
@@ -58,7 +59,7 @@ fn main() {
     let last_offset_clone = Arc::clone(&last_offset);
     futures::executor::block_on(async move {
         let mut request = client
-            .get_object(bucket, key, range, None)
+            .get_object(bucket, key, &GetObjectParams::new().range(range))
             .await
             .expect("couldn't create get request");
         loop {

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! let client = S3CrtClient::new(Default::default()).expect("client construction failed");
 //!
-//! let response = client.get_object("my-bucket", "my-key", None, None).await.expect("get_object failed");
+//! let response = client.get_object("my-bucket", "my-key", &GetObjectParams::new().await.expect("get_object failed"));
 //! let body = response.map_ok(|(offset, body)| body.to_vec()).try_concat().await.expect("body streaming failed");
 //! # }
 //! ```
@@ -73,9 +73,9 @@ pub mod config {
 pub mod types {
     pub use super::object_client::{
         Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag,
-        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectRequest, HeadObjectParams,
-        HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult, ObjectInfo, ObjectPart,
-        PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
+        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams, GetObjectRequest,
+        HeadObjectParams, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult, ObjectInfo,
+        ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
         UploadChecksum, UploadReview, UploadReviewPart,
     };
 }

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -1,4 +1,3 @@
-use std::ops::Range;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -14,10 +13,11 @@ use crate::mock_client::{
     MockClient, MockClientConfig, MockClientError, MockGetObjectRequest, MockObject, MockPutObjectRequest,
 };
 use crate::object_client::{
-    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, ETag, GetBodyPart,
-    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectRequest, HeadObjectError,
-    HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient,
-    ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams, PutObjectResult, PutObjectSingleParams,
+    CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, GetBodyPart,
+    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest,
+    HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
+    ObjectClient, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams, PutObjectResult,
+    PutObjectSingleParams,
 };
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
@@ -148,10 +148,9 @@ impl ObjectClient for ThroughputMockClient {
         &self,
         bucket: &str,
         key: &str,
-        range: Option<Range<u64>>,
-        if_match: Option<ETag>,
+        params: &GetObjectParams,
     ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
-        let request = self.inner.get_object(bucket, key, range, if_match).await?;
+        let request = self.inner.get_object(bucket, key, params).await?;
         let rate_limiter = self.rate_limiter.clone();
         Ok(ThroughputGetObjectRequest { request, rate_limiter })
     }
@@ -219,6 +218,7 @@ mod tests {
     use futures::StreamExt;
 
     use crate::mock_client::MockObject;
+    use crate::types::ETag;
 
     use super::*;
 
@@ -245,7 +245,10 @@ mod tests {
                 let start = Instant::now();
                 let num_bytes = block_on(async move {
                     let mut num_bytes = 0;
-                    let mut get = client.get_object("test_bucket", "testfile", None, None).await.unwrap();
+                    let mut get = client
+                        .get_object("test_bucket", "testfile", &GetObjectParams::new())
+                        .await
+                        .unwrap();
                     while let Some(part) = get.next().await {
                         let (_offset, part) = part.unwrap();
                         num_bytes += part.len();

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -78,8 +78,7 @@ pub trait ObjectClient {
         &self,
         bucket: &str,
         key: &str,
-        range: Option<Range<u64>>,
-        if_match: Option<ETag>,
+        params: &GetObjectParams,
     ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError>;
 
     /// List the objects in a bucket under a given prefix
@@ -182,6 +181,33 @@ pub enum GetObjectError {
 
     #[error("At least one of the preconditions specified did not hold")]
     PreconditionFailed,
+}
+
+/// Parameters to a [`get_object`](ObjectClient::get_object) request
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct GetObjectParams {
+    pub range: Option<Range<u64>>,
+    pub if_match: Option<ETag>,
+}
+
+impl GetObjectParams {
+    /// Create a default [GetObjectParams].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the range retrieved by the GetObject request
+    pub fn range(mut self, value: Option<Range<u64>>) -> Self {
+        self.range = value;
+        self
+    }
+
+    /// Set the required etag on the object
+    pub fn if_match(mut self, value: Option<ETag>) -> Self {
+        self.if_match = value;
+        self
+    }
 }
 
 /// Result of a [`list_objects`](ObjectClient::list_objects) request

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1281,12 +1281,9 @@ impl ObjectClient for S3CrtClient {
         &self,
         bucket: &str,
         key: &str,
-        range: Option<Range<u64>>,
-        if_match: Option<ETag>,
-        // TODO: If more arguments are added to get object, make a request struct having those arguments
-        // along with bucket and key.
+        params: &GetObjectParams,
     ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
-        self.get_object(bucket, key, range, if_match)
+        self.get_object(bucket, key, params)
     }
 
     async fn list_objects(

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -38,7 +38,7 @@ impl S3CrtClient {
         key: &str,
         params: &GetObjectParams,
     ) -> Result<S3GetObjectRequest, ObjectClientError<GetObjectError, S3RequestError>> {
-        let span = request_span!(self.inner, "get_object", bucket, key, ?params.range, ?params.if_match);
+        let span = request_span!(self.inner, "get_object", bucket, key, range=?params.range, if_match=?params.if_match);
 
         let mut message = self
             .inner

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -15,6 +15,7 @@ use common::*;
 use futures::StreamExt;
 use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
+use mountpoint_s3_client::types::GetObjectParams;
 #[cfg(not(feature = "s3express_tests"))]
 use mountpoint_s3_client::S3RequestError;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
@@ -56,7 +57,7 @@ async fn test_static_provider() {
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -76,7 +77,7 @@ async fn test_static_provider() {
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object request should be sent");
 
@@ -138,7 +139,7 @@ async fn test_profile_provider_static_async() {
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -154,7 +155,7 @@ async fn test_profile_provider_static_async() {
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should be sent");
 
@@ -219,7 +220,7 @@ async fn test_profile_provider_assume_role_async() {
     let client = S3CrtClient::new(config).unwrap();
 
     let mut request = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should be sent");
 
@@ -234,7 +235,7 @@ async fn test_profile_provider_assume_role_async() {
     let client = S3CrtClient::new(config).unwrap();
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;
@@ -430,7 +431,7 @@ async fn test_scoped_credentials() {
 
     // Inside the prefix, things should be fine
     let _result = client
-        .get_object(&bucket, &format!("{prefix}foo/foo.txt"), None, None)
+        .get_object(&bucket, &format!("{prefix}foo/foo.txt"), &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     let _result = client
@@ -440,7 +441,7 @@ async fn test_scoped_credentials() {
 
     // Outside the prefix, requests should fail with permissions errors
     let mut request = client
-        .get_object(&bucket, &format!("{prefix}baz.txt"), None, None)
+        .get_object(&bucket, &format!("{prefix}baz.txt"), &GetObjectParams::new())
         .await
         .expect("request should be sent");
     let err = request

--- a/mountpoint-s3-client/tests/endpoint_config.rs
+++ b/mountpoint-s3-client/tests/endpoint_config.rs
@@ -6,6 +6,7 @@ use aws_sdk_s3::primitives::ByteStream;
 use bytes::Bytes;
 use common::*;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::types::GetObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use test_case::test_case;
 
@@ -28,7 +29,7 @@ async fn run_test(endpoint_config: EndpointConfig, prefix: &str, bucket: String)
     let client = S3CrtClient::new(config).expect("could not create test client");
 
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &body[..]).await;

--- a/mountpoint-s3-client/tests/metrics.rs
+++ b/mountpoint-s3-client/tests/metrics.rs
@@ -20,7 +20,7 @@ use metrics::{
     Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
 };
 use mountpoint_s3_client::error::ObjectClientError;
-use mountpoint_s3_client::types::HeadObjectParams;
+use mountpoint_s3_client::types::{GetObjectParams, HeadObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 use regex::Regex;
 use rusty_fork::rusty_fork_test;
@@ -172,7 +172,7 @@ async fn test_get_object_metrics() {
 
     let client: S3CrtClient = get_test_client();
     let result = client
-        .get_object(&bucket, &key, None, None)
+        .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect("get_object should succeed");
     let result = result

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -11,7 +11,7 @@ use mountpoint_s3_client::checksums::crc32c_to_base64;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
-    ChecksumAlgorithm, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
+    ChecksumAlgorithm, GetObjectParams, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
     PutObjectTrailingChecksums,
 };
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
@@ -41,7 +41,11 @@ async fn test_put_object(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &contents[..]).await;
@@ -67,7 +71,11 @@ async fn test_put_object_empty(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &[]).await;
@@ -102,7 +110,11 @@ async fn test_put_object_multi_part(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object failed");
     check_get_result(result, None, &contents[..]).await;
@@ -139,7 +151,11 @@ async fn test_put_object_large(
     let put_object_result = request.complete().await.unwrap();
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object failed");
     check_get_result(result, None, &contents[..]).await;
@@ -486,7 +502,7 @@ async fn check_get_object<Client: ObjectClient>(
     bucket: &str,
     key: &str,
 ) -> ObjectClientResult<(), GetObjectError, Client::ClientError> {
-    let result = client.get_object(bucket, key, None, None).await?;
+    let result = client.get_object(bucket, key, &GetObjectParams::new()).await?;
     pin_mut!(result);
     result.next().await.unwrap()?;
     Ok(())

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 use common::*;
 use mountpoint_s3_client::checksums::{crc32c, crc32c_to_base64};
 use mountpoint_s3_client::config::S3ClientConfig;
-use mountpoint_s3_client::types::{ChecksumAlgorithm, PutObjectResult, PutObjectSingleParams, UploadChecksum};
+use mountpoint_s3_client::types::{
+    ChecksumAlgorithm, GetObjectParams, PutObjectResult, PutObjectSingleParams, UploadChecksum,
+};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use rand::Rng;
 use test_case::test_case;
@@ -31,7 +33,11 @@ async fn test_put_object_single(
         .expect("put_object should succeed");
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &contents[..]).await;
@@ -55,7 +61,11 @@ async fn test_put_object_single_empty(
         .expect("put_object should succeed");
 
     let result = client
-        .get_object(bucket, key, None, Some(put_object_result.etag.clone()))
+        .get_object(
+            bucket,
+            key,
+            &GetObjectParams::new().if_match(Some(put_object_result.etag.clone())),
+        )
         .await
         .expect("get_object should succeed");
     check_get_result(result, None, &[]).await;

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bytes::BytesMut;
 use futures::{pin_mut, StreamExt};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
-use mountpoint_s3_client::types::{GetObjectRequest, PutObjectParams};
+use mountpoint_s3_client::types::{GetObjectParams, GetObjectRequest, PutObjectParams};
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
 use sha2::{Digest, Sha256};
 use tracing::Instrument;
@@ -71,7 +71,11 @@ where
         }
 
         let object_key = block_key(&self.prefix, cache_key, block_idx);
-        let result = match self.client.get_object(&self.bucket_name, &object_key, None, None).await {
+        let result = match self
+            .client
+            .get_object(&self.bucket_name, &object_key, &GetObjectParams::new())
+            .await
+        {
             Ok(result) => result,
             Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey)) => return Ok(None),
             Err(e) => return Err(e.into()),

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -2,7 +2,7 @@ use async_stream::try_stream;
 use bytes::Bytes;
 use futures::task::{Spawn, SpawnExt};
 use futures::{pin_mut, Stream, StreamExt};
-use mountpoint_s3_client::{types::GetObjectRequest, ObjectClient};
+use mountpoint_s3_client::{types::GetObjectParams, types::GetObjectRequest, ObjectClient};
 use std::marker::{Send, Sync};
 use std::sync::Arc;
 use std::{fmt::Debug, ops::Range};
@@ -360,7 +360,7 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         let request = client
-            .get_object(&bucket, id.key(), Some(request_range.clone()), Some(id.etag().clone()))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(PrefetchReadError::GetRequestFailed)?;

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -15,7 +15,7 @@ use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error_metadata::ClientErrorMetadata;
 use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
 use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, Operation};
-use mountpoint_s3_client::types::{ETag, RestoreStatus};
+use mountpoint_s3_client::types::{ETag, GetObjectParams, RestoreStatus};
 use mountpoint_s3_client::ObjectClient;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3_client::PutObjectRequest;
@@ -600,7 +600,7 @@ async fn test_sequential_write(write_size: usize) {
 
     // Check that the object made it to S3 as we expected
     let get = client
-        .get_object(BUCKET_NAME, "dir1/file2.bin", None, None)
+        .get_object(BUCKET_NAME, "dir1/file2.bin", &GetObjectParams::new())
         .await
         .unwrap();
     let actual = get.collect().await.unwrap();


### PR DESCRIPTION
<!--
    The title and description of pull requests will be used when creating a squash commit to the base branch (usually `main`).
    Please keep them both up-to-date as the code change evolves, to ensure that the commit message is useful for future readers.
-->

## Description of change

Refactor `ObjectClient.get_object` to use an `&GetObjectParams` parameter.

Migrates the two existing parameters, `range` and `if_match` to `GetObjectParams` and changes all call sites.

<!--
    Please describe your contribution here.
    What is the change and why are you making it?
-->

Relevant issues: N/A

## Does this change impact existing behavior?

No

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

## Does this change need a changelog entry in any of the crates?

Yes. Breaking change in mountpoint-s3-client. 

<!--
    Please confirm yes or no.
    If no, add justification. If unsure, ask a reviewer.

    You can find the changelog for each crate here:
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt/CHANGELOG.md
    - https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-crt-sys/CHANGELOG.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
