### PR TITLE
Update user-agent on express cache usage

### DIFF
--- a/mountpoint-s3-client/src/user_agent.rs
+++ b/mountpoint-s3-client/src/user_agent.rs
@@ -57,6 +57,14 @@ impl UserAgent {
         self
     }
 
+    /// Add a key-value metadata field to the header with multiple values
+    pub fn key_values(&mut self, key: &str, values: &[&str]) -> &mut Self {
+        let value = values.join("+");
+        self.fields
+            .push(format!("md/{}#{}", sanitize_string(key), sanitize_string(value)));
+        self
+    }
+
     /// Add a value-only metadata field to the header
     pub fn value(&mut self, value: &str) -> &mut Self {
         self.fields.push(format!("md/{}", sanitize_string(value)));
@@ -163,5 +171,13 @@ mod tests {
             sanitize_string("Java_HotSpot_(TM)_64-Bit_Server_VM"),
             "Java_HotSpot_-TM-_64-Bit_Server_VM"
         );
+    }
+
+    #[test]
+    fn test_multiple_values() {
+        let mut user_agent = UserAgent::new(None);
+        user_agent.key_values("mp-cache", &["shared", "local"]);
+        let user_agent_string = user_agent.build();
+        assert!(user_agent_string.contains("md/mp-cache#shared+local"));
     }
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -745,6 +745,9 @@ pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, EventLoo
     if let Some(interfaces) = &args.bind {
         user_agent.key_value("mp-nw-interfaces", &interfaces.len().to_string());
     }
+    if args.cache_express_bucket_name().is_some() {
+        user_agent.value("mp-cache-express");
+    }
 
     // This is a weird looking number! We really want our first request size to be 1MiB,
     // which is a common IO size. But Linux's readahead will try to read an extra 128k on on


### PR DESCRIPTION
## Description of change

Add `mp-cache-express` to the user agent when caching in express is enabled.

Relevant issues: N/A

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
