### PR TITLE
Avoid joining the fuse background thread when dropping test sessions

### DIFF
--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -101,8 +101,8 @@ impl TestSession {
 
 impl Drop for TestSession {
     fn drop(&mut self) {
-        // Explicitly unmount so we know the background thread is gone
-        self.session.take().unwrap().join();
+        // Unmount first by dropping the background session
+        self.session.take();
     }
 }
 


### PR DESCRIPTION
## Description of change

The change #1116 fixed the order in which the file system was unmounted and the temporary mount directory was removed. In order to unmount, we added a call to `join()` on the FUSE session, which also waits for its background thread to join and can occasionally fail with a `ECONNABORTED` (ConnectionAborted, "Software caused connection abort") error.
This change addresses the issue by only dropping the FUSE session, without waiting for the thread to terminate.

## Does this change impact existing behavior?

No. Only affects tests.

## Does this change need a changelog entry in any of the crates?

No. Only affects tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
