### PR TITLE
Verify object metadata in Express cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "base64ct",
  "bincode",
  "bitflags",
  "built",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -46,6 +46,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 async-stream = "0.3.6"
 humansize = "2.1.3"
+base64ct = "1.6.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17.0", default-features = false }

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -30,6 +30,8 @@ pub type BlockIndex = u64;
 pub enum DataCacheError {
     #[error("IO error when reading or writing from cache: {0}")]
     IoFailure(#[source] anyhow::Error),
+    #[error("Block header was not valid: {0}")]
+    InvalidBlockHeader(String),
     #[error("Block content was not valid/readable")]
     InvalidBlockContent,
     #[error("Block offset does not match block index")]

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -32,6 +32,8 @@ pub enum DataCacheError {
     IoFailure(#[source] anyhow::Error),
     #[error("Block header was not valid: {0}")]
     InvalidBlockHeader(String),
+    #[error("Block checksum was not present")]
+    BlockChecksumMissing,
     #[error("Block content was not valid/readable")]
     InvalidBlockContent,
     #[error("Block offset does not match block index")]

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -5,7 +5,7 @@ use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheRe
 
 use async_trait::async_trait;
 use base64ct::{Base64, Encoding};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures::{pin_mut, StreamExt};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
@@ -17,8 +17,6 @@ use sha2::{Digest, Sha256};
 use tracing::Instrument;
 
 use mountpoint_s3_client::checksums::crc32c_from_base64;
-#[cfg(test)]
-use proptest_derive::Arbitrary;
 
 const CACHE_VERSION: &str = "V1";
 
@@ -175,19 +173,37 @@ where
     ///
     /// TODO: consider adding some validation of the bucket.
     pub fn new(client: Client, config: ExpressDataCacheConfig, source_bucket_name: &str, bucket_name: &str) -> Self {
-        let prefix = hex::encode(
-            Sha256::new()
-                .chain_update(CACHE_VERSION.as_bytes())
-                .chain_update(config.block_size.to_be_bytes())
-                .chain_update(source_bucket_name.as_bytes())
-                .finalize(),
-        );
         Self {
             client,
-            prefix,
+            prefix: Self::build_prefix(source_description, config.block_size),
             config,
             bucket_name: bucket_name.to_owned(),
         }
+    }
+
+    fn build_prefix(source_description: &str, block_size: u64) -> String {
+        hex::encode(
+            Sha256::new()
+                .chain_update(CACHE_VERSION.as_bytes())
+                .chain_update(block_size.to_be_bytes())
+                .chain_update(source_bucket_name.as_bytes())
+                .finalize(),
+        )
+    }
+
+    fn get_put_block_data(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+    ) -> DataCacheResult<(String, PutObjectSingleParams, Bytes)> {
+        let object_key = get_s3_key(&self.prefix, cache_key, block_idx);
+
+        let (data, checksum) = bytes.into_inner().map_err(|_| DataCacheError::InvalidBlockContent)?;
+        let block_metadata = BlockMetadata::new(block_idx, block_offset, cache_key, &self.bucket_name, checksum);
+
+        Ok((object_key, block_metadata.to_put_object_params(), data))
     }
 }
 
@@ -211,9 +227,7 @@ where
             return Err(DataCacheError::InvalidBlockOffset);
         }
 
-        let headers = BlockHeader::new(block_idx, block_offset, cache_key, &self.bucket_name);
-
-        let object_key = headers.to_s3_key(&self.prefix);
+        let object_key = get_s3_key(&self.prefix, cache_key, block_idx);
         let result = match self
             .client
             .get_object(
@@ -232,14 +246,16 @@ where
             .get_object_metadata()
             .await
             .map_err(|err| DataCacheError::IoFailure(err.into()))?;
-        headers.validate_headers(&object_metadata)?;
 
         let checksum = result
             .get_object_checksum()
             .await
             .map_err(|err| DataCacheError::IoFailure(err.into()))?;
-        let crc32 = crc32c_from_base64(&checksum.checksum_crc32c.ok_or(DataCacheError::BlockChecksumMissing)?)
+        let crc32c = crc32c_from_base64(&checksum.checksum_crc32c.ok_or(DataCacheError::BlockChecksumMissing)?)
             .map_err(|err| DataCacheError::IoFailure(err.into()))?;
+
+        let block_metadata = BlockMetadata::new(block_idx, block_offset, cache_key, &self.bucket_name, crc32c);
+        block_metadata.validate_object_metadata(&object_metadata)?;
 
         pin_mut!(result);
         // Guarantee that the request will start even in case of `initial_read_window == 0`.
@@ -263,7 +279,7 @@ where
             }
         }
         let buffer = buffer.freeze();
-        Ok(Some(ChecksummedBytes::new_from_inner_data(buffer, crc32)))
+        Ok(Some(ChecksummedBytes::new_from_inner_data(buffer, crc32c)))
     }
 
     async fn put_block(
@@ -282,16 +298,10 @@ where
             return Err(DataCacheError::InvalidBlockOffset);
         }
 
-        let headers = BlockHeader::new(block_idx, block_offset, &cache_key, &self.bucket_name);
-        let object_key = headers.to_s3_key(&self.prefix);
+        let (object_key, put_params, data) = self.get_put_block_data(&cache_key, block_idx, block_offset, bytes)?;
 
-        let (data, checksum) = bytes.into_inner().map_err(|_| DataCacheError::InvalidBlockContent)?;
-        let params = PutObjectSingleParams::new()
-            .object_metadata(headers.to_headers())
-            .checksum(Some(UploadChecksum::Crc32c(checksum)));
-        let _req = self
-            .client
-            .put_object_single(&self.bucket_name, &object_key, &params, data)
+        self.client
+            .put_object_single(&self.bucket_name, &object_key, &put_params, data)
             .in_current_span()
             .await?;
 
@@ -301,6 +311,127 @@ where
     fn block_size(&self) -> u64 {
         self.config.block_size
     }
+}
+
+/// Metadata about the cached object to ensure that the object we've retrieved is the one we were
+/// wanting to get (and avoid collisions with the key).
+/// On miss, bypass the cache and go to the main data source.
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[derive(Debug, PartialEq, Eq)]
+struct BlockMetadata {
+    block_idx: BlockIndex,
+    block_offset: u64,
+    etag: String,
+    source_key: String,
+    source_bucket_name: String,
+    data_checksum: u32,
+    header_checksum: u32,
+}
+
+impl BlockMetadata {
+    pub fn new(
+        block_idx: BlockIndex,
+        block_offset: u64,
+        cache_key: &ObjectId,
+        source_bucket_name: &str,
+        data_checksum: Crc32c,
+    ) -> Self {
+        let header_checksum =
+            Self::get_header_checksum(block_idx, block_offset, cache_key, source_bucket_name, data_checksum).value();
+        Self {
+            block_idx,
+            block_offset,
+            etag: cache_key.etag().as_str().to_string(),
+            source_key: cache_key.key().to_string(),
+            source_bucket_name: source_bucket_name.to_string(),
+            data_checksum: data_checksum.value(),
+            header_checksum,
+        }
+    }
+
+    /// Convert to object metadata that is HTTP header safe (ASCII only)
+    pub fn to_put_object_params(&self) -> PutObjectSingleParams {
+        let source_key_encoded = Base64::encode_string(self.source_key.as_bytes());
+        let object_metadata = HashMap::from([
+            ("cache-version".to_string(), CACHE_VERSION.to_string()),
+            ("block-idx".to_string(), format!("{}", self.block_idx)),
+            ("block-offset".to_string(), format!("{}", self.block_offset)),
+            ("etag".to_string(), self.etag.clone()),
+            ("source-key".to_string(), source_key_encoded),
+            ("source-bucket-name".to_string(), self.source_bucket_name.clone()),
+            ("header-checksum".to_string(), format!("{}", self.header_checksum)),
+        ]);
+
+        PutObjectSingleParams::new()
+            .object_metadata(object_metadata)
+            .checksum(Some(UploadChecksum::Crc32c(Crc32c::new(self.data_checksum))))
+    }
+
+    /// Validate the object metadata headers received match this BlockHeader object.
+    pub fn validate_object_metadata(&self, headers: &HashMap<String, String>) -> Result<(), DataCacheError> {
+        self.validate_header(headers, "cache-version", |version| version == CACHE_VERSION)?;
+        self.validate_header(headers, "block-idx", |block_idx| {
+            block_idx.parse() == Ok(self.block_idx)
+        })?;
+        self.validate_header(headers, "block-offset", |block_offset| {
+            block_offset.parse() == Ok(self.block_offset)
+        })?;
+        self.validate_header(headers, "etag", |etag| etag == self.etag)?;
+        self.validate_header(headers, "source-key", |source_key| {
+            source_key == Base64::encode_string(self.source_key.as_bytes())
+        })?;
+        self.validate_header(headers, "source-bucket-name", |source_bucket_name| {
+            source_bucket_name == self.source_bucket_name
+        })?;
+        self.validate_header(headers, "header-checksum", |header_checksum| {
+            header_checksum.parse() == Ok(self.header_checksum)
+        })?;
+
+        Ok(())
+    }
+
+    fn validate_header<F: Fn(&str) -> bool>(
+        &self,
+        headers: &HashMap<String, String>,
+        header: &str,
+        is_valid: F,
+    ) -> Result<(), DataCacheError> {
+        let value = headers
+            .get(header)
+            .ok_or(DataCacheError::InvalidBlockHeader(header.to_string()))?;
+        is_valid(value)
+            .then_some(())
+            .ok_or(DataCacheError::InvalidBlockHeader(header.to_string()))
+    }
+
+    fn get_header_checksum(
+        block_idx: BlockIndex,
+        block_offset: u64,
+        cache_key: &ObjectId,
+        source_bucket_name: &str,
+        data_checksum: Crc32c,
+    ) -> Crc32c {
+        let mut hasher = crc32c::Hasher::new();
+        hasher.update(CACHE_VERSION.as_bytes());
+        hasher.update(&block_idx.to_be_bytes());
+        hasher.update(&block_offset.to_be_bytes());
+        hasher.update(cache_key.etag().as_str().as_bytes());
+        hasher.update(cache_key.key().as_bytes());
+        hasher.update(source_bucket_name.as_bytes());
+        hasher.update(&data_checksum.value().to_be_bytes());
+        hasher.finalize()
+    }
+}
+
+/// Get the S3 key this block should be written to or read from.
+fn get_s3_key(prefix: &str, cache_key: &ObjectId, block_idx: BlockIndex) -> String {
+    let hashed_cache_key = hex::encode(
+        Sha256::new()
+            .chain_update(cache_key.key())
+            .chain_update(cache_key.etag().as_str())
+            .finalize(),
+    );
+    format!("{}/{}/{:010}", prefix, hashed_cache_key, block_idx)
 }
 
 #[cfg(test)]
@@ -447,34 +578,110 @@ mod tests {
         assert_eq!(client.object_count(), 0, "cache must be empty");
     }
 
+    #[tokio::test]
+    async fn test_get_validate_failure() {
+        let bucket = "test-bucket";
+        let part_size = 8 * 1024 * 1024;
+        let block_size = 512 * 1024;
+        let config = MockClientConfig {
+            bucket: bucket.to_string(),
+            part_size,
+            enable_backpressure: true,
+            initial_read_window_size: part_size,
+            ..Default::default()
+        };
+        let client = Arc::new(MockClient::new(config));
+
+        let cache = ExpressDataCache::new(bucket, client.clone(), "unique source description", block_size);
+
+        let data = ChecksummedBytes::new("Foo".into());
+        let data_2 = ChecksummedBytes::new("Bar".into());
+        let cache_key = ObjectId::new("a".into(), ETag::for_tests());
+
+        let (object_key, put_params, data) = cache.get_put_block_data(&cache_key, 0, 0, data).unwrap();
+
+        // Remove the checksum when writing.
+        client
+            .put_object_single(bucket, &object_key, &put_params.clone().checksum(None), data.clone())
+            .in_current_span()
+            .await
+            .unwrap();
+        let err = cache
+            .get_block(&cache_key, 0, 0)
+            .await
+            .expect_err("cache should return error if checksum isn't present");
+        assert!(matches!(err, DataCacheError::BlockChecksumMissing));
+
+        // Remove the object metadata when writing.
+        client
+            .put_object_single(
+                bucket,
+                &object_key,
+                &put_params.clone().object_metadata(HashMap::new()),
+                data.clone(),
+            )
+            .in_current_span()
+            .await
+            .unwrap();
+        let err = cache
+            .get_block(&cache_key, 0, 0)
+            .await
+            .expect_err("cache should return error if object metadata isn't present");
+        assert!(matches!(err, DataCacheError::InvalidBlockHeader(_)));
+
+        let (_, put_params, data) = cache.get_put_block_data(&cache_key, 0, 0, data_2).unwrap();
+
+        // Emulate corrupt data by writing 'incorrect' data.
+        client
+            .put_object_single(
+                bucket,
+                &object_key,
+                &put_params.clone().object_metadata(HashMap::new()),
+                data.clone(),
+            )
+            .in_current_span()
+            .await
+            .unwrap();
+        let err = cache
+            .get_block(&cache_key, 0, 0)
+            .await
+            .expect_err("cache should return error if object headers don't match data");
+        assert!(matches!(err, DataCacheError::InvalidBlockHeader(_)));
+    }
+
     proptest! {
         #[test]
-        fn proptest_block_header_creates_small_s3_keys(block_header: BlockHeader) {
+        fn proptest_creates_small_s3_keys(key: String, etag: String, block_idx: BlockIndex, source_description: String, block_size: u64) {
             // Ensure we can always serialise to S3 keys smaller than 1kb
-            prop_assert!(block_header.to_s3_key("prefix").len() <= 1024);
+            let cache_key = ObjectId::new(key, etag.into());
+            let prefix = ExpressDataCache::<MockClient>::build_prefix(&source_description, block_size);
+            prop_assert!(get_s3_key(&prefix, &cache_key, block_idx).len() <= 1024);
         }
 
         #[test]
-        fn proptest_block_header_to_headers_s3_key_ascii_only(block_header: BlockHeader) {
+        fn proptest_block_metadata_to_headers_s3_key_ascii_only(block_metadata: BlockMetadata) {
             // Validate that even with UTF keys, the source key is always ascii
-            let headers = block_header.to_headers();
-            prop_assert!(headers.get("source-key").unwrap().is_ascii());
+            let params = block_metadata.to_put_object_params();
+            prop_assert!(params.object_metadata.get("source-key").unwrap().is_ascii());
         }
 
         #[test]
-        fn proptest_block_header_validates_headers(block_header: BlockHeader, block_header2: BlockHeader) {
+        fn proptest_block_metadata_validates_headers(block_metadata: BlockMetadata, block_metadata2: BlockMetadata) {
             // `to_headers` should contain enough information that `validate_headers` acts as equality
-            if block_header == block_header2 {
-                prop_assert!(block_header2.validate_headers(&block_header.to_headers()).is_ok());
+            let params = block_metadata.to_put_object_params();
+            if block_metadata == block_metadata2 {
+                prop_assert!(block_metadata2.validate_object_metadata(&params.object_metadata).is_ok());
             } else {
-                prop_assert!(block_header2.validate_headers(&block_header.to_headers()).is_err());
+                prop_assert!(block_metadata2.validate_object_metadata(&params.object_metadata).is_err());
             }
         }
 
         #[test]
-        fn proptest_block_header_validates_headers_is_equal(block_header: BlockHeader) {
+        fn proptest_block_metadata_validates_headers_is_equal(block_metadata: BlockMetadata) {
             // More checks to verify the equals path, as generating lots of equals examples may be hard
-            prop_assert!(block_header.validate_headers(&block_header.to_headers()).is_ok());
+            let params = block_metadata.to_put_object_params();
+            prop_assert!(block_metadata.validate_object_metadata(&params.object_metadata).is_ok());
+            prop_assert!(matches!(params.checksum, Some(UploadChecksum::Crc32c(x)) if x == Crc32c::new(block_metadata.data_checksum)));
         }
     }
 }

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -241,8 +241,9 @@ impl BlockMetadata {
         }
     }
 
-    /// Convert to object metadata that is HTTP header safe (ASCII only)
+    /// Build parameters to be used when running a PutObject for this block
     pub fn to_put_object_params(&self) -> PutObjectSingleParams {
+        // Convert to object metadata that is HTTP header safe (ASCII only)
         let source_key_encoded = Base64::encode_string(self.source_key.as_bytes());
         let object_metadata = HashMap::from([
             ("cache-version".to_string(), CACHE_VERSION.to_string()),
@@ -259,7 +260,7 @@ impl BlockMetadata {
             .checksum(Some(UploadChecksum::Crc32c(Crc32c::new(self.data_checksum))))
     }
 
-    /// Validate the object metadata headers received match this BlockHeader object.
+    /// Validate the object metadata headers received match this BlockMetadata object.
     pub fn validate_object_metadata(&self, headers: &HashMap<String, String>) -> Result<(), DataCacheError> {
         self.validate_header(headers, "cache-version", |version| version == CACHE_VERSION)?;
         self.validate_header(headers, "block-idx", |block_idx| {


### PR DESCRIPTION
## Description of change

- Verify S3 Express cache objects have valid object metadata which matches the keys
- Verifies the CRC32C of the object content post-download from S3
  - If checksum is missing, return `BlockChecksumMissing`.

Relevant issues: N/A

## Does this change impact existing behavior?

Changes S3 Express cache to require object metadata and CRC32C to be present. Old caches will not be used. 

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
