### PR TITLE
Do not flush on read file handles

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -335,10 +335,10 @@ where
         };
 
         let is_read_filehandle = match state {
-            FileHandleState::Read{..} => true,
-            _                        => false
+            FileHandleState::Read { .. } => true,
+            _ => false,
         };
-        debug!("{}", if is_read_filehandle {"opening for read"} else {"not opening for read"});
+
         let fh = self.next_handle();
         let handle = FileHandle {
             inode,
@@ -348,8 +348,8 @@ where
         debug!(fh, ino, "new file handle created");
         self.file_handles.write().await.insert(fh, Arc::new(handle));
 
-        let reply_flags = (if direct_io { FOPEN_DIRECT_IO } else { 0 }) | (if is_read_filehandle {1 << 5} else {0});
-        debug!("Set flags as {reply_flags}");
+        let reply_flags = (if direct_io { FOPEN_DIRECT_IO } else { 0 }) | (if is_read_filehandle { 1 << 5 } else { 0 });
+        debug!("Set read file flags as {reply_flags}");
         Ok(Opened { fh, flags: reply_flags })
     }
 
@@ -717,7 +717,6 @@ where
                 None => return Err(err!(libc::EBADF, "invalid file handle")),
             }
         };
-        debug!("Called flush on {_ino}");
         logging::record_name(file_handle.inode.name());
         let mut state = file_handle.state.lock().await;
         match &mut *state {


### PR DESCRIPTION
## Do not flush on read file handles

Currently, even when we open a file just for reading, the flush handler is called on closing the file; however it is currently empty. This PR would allow using the **FOPEN_NOFLUSH** flag (https://github.com/torvalds/linux/blob/master/include/uapi/linux/fuse.h#L188) to skip this for read-files. 
This flag is only available with ABI 7.3.5. It may need a check for this, however this does not seem possible currently (as FUSER does not expose the ABI version directly, but only through feature flags).


Change _most likely_ does not impact existing behaviour. Fuse with lower ABI versions, seems to just ignore the set flag and call the handler. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
