### PR TITLE
Update vendored fuser to daad5673

### DIFF
--- a/vendor/fuser/README.md
+++ b/vendor/fuser/README.md
@@ -1,4 +1,19 @@
+## Fork of fuser for Mountpoint
+
 This is a fork of the excellent [`fuser`](https://github.com/cberner/fuser) Rust crate for FUSE bindings, with some Mountpoint-specific changes to improve performance of concurrent operations. We'll be working to upstream these changes soon.
+
+### Fork Maintenance
+
+This fork should be maintained in the `fuser/fork` branch of the [awslabs/mountpoint-s3 repository on GitHub](https://github.com/awslabs/mountpoint-s3/tree/main/vendor/fuser).
+
+To pull in new changes from upstream, you should fetch and rebase the changes locally and then force push to the `fuser/fork` branch (- not ideal!).
+Once the `fuser/fork` branch is as desired, create a new branch from Mountpoint's `main` branch.
+Run the [`vendor-fuser.sh` script](https://github.com/awslabs/mountpoint-s3/blob/main/vendor-fuser.sh).
+You should open a pull request with the new commit created by the script.
+This pull request is where the changes are reviewed.
+
+If you wish to add new divergent changes to this fork of Fuser,
+open a pull request on the Mountpoint repository branching from the `fuser/fork` branch and use `fuser/fork` as the base branch when creating the pull request.
 
 ---
 

--- a/vendor/fuser/build.rs
+++ b/vendor/fuser/build.rs
@@ -1,18 +1,25 @@
 fn main() {
+    // Register rustc cfg for switching between mount implementations.
+    // When fuser MSRV is updated to v1.77 or above, we should switch from 'cargo:' to 'cargo::' syntax.
+    println!("cargo:rustc-check-cfg=cfg(fuser_mount_impl, values(\"pure-rust\", \"libfuse2\", \"libfuse3\"))");
+
     #[cfg(all(not(feature = "libfuse"), not(target_os = "linux")))]
     unimplemented!("Building without libfuse is only supported on Linux");
 
+    #[cfg(not(feature = "libfuse"))]
+    {
+        println!("cargo:rustc-cfg=fuser_mount_impl=\"pure-rust\"");
+    }
     #[cfg(feature = "libfuse")]
     {
-        #[cfg(target_os = "macos")]
-        {
+        if cfg!(target_os = "macos") {
             if pkg_config::Config::new()
                 .atleast_version("2.6.0")
                 .probe("fuse") // for macFUSE 4.x
                 .map_err(|e| eprintln!("{}", e))
                 .is_ok()
             {
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
                 println!("cargo:rustc-cfg=feature=\"macfuse-4-compat\"");
             } else {
                 pkg_config::Config::new()
@@ -20,11 +27,9 @@ fn main() {
                     .probe("osxfuse") // for osxfuse 3.x
                     .map_err(|e| eprintln!("{}", e))
                     .unwrap();
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
             }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
+        } else {
             // First try to link with libfuse3
             if pkg_config::Config::new()
                 .atleast_version("3.0.0")
@@ -32,7 +37,7 @@ fn main() {
                 .map_err(|e| eprintln!("{e}"))
                 .is_ok()
             {
-                println!("cargo:rustc-cfg=feature=\"libfuse3\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse3\"");
             } else {
                 // Fallback to libfuse
                 pkg_config::Config::new()
@@ -40,7 +45,7 @@ fn main() {
                     .probe("fuse")
                     .map_err(|e| eprintln!("{e}"))
                     .unwrap();
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
             }
         }
     }

--- a/vendor/fuser/src/lib.rs
+++ b/vendor/fuser/src/lib.rs
@@ -26,7 +26,7 @@ use crate::mnt::mount_options::check_option_conflicts;
 use crate::session::MAX_WRITE_SIZE;
 #[cfg(feature = "abi-7-16")]
 pub use ll::fuse_abi::fuse_forget_one;
-pub use mnt::mount_options::MountOption;
+pub use mnt::{Mount, mount_options::MountOption};
 #[cfg(feature = "abi-7-11")]
 pub use notify::{Notifier, PollHandle};
 #[cfg(feature = "abi-7-11")]

--- a/vendor/fuser/src/ll/mod.rs
+++ b/vendor/fuser/src/ll/mod.rs
@@ -10,9 +10,7 @@ mod request;
 use std::{convert::TryInto, num::NonZeroI32, time::SystemTime};
 
 pub use reply::Response;
-pub use request::{
-    AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestError, RequestId, Version,
-};
+pub use request::{AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestId, Version};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 /// Possible input arguments for atime & mtime, which can either be set to a specified time,

--- a/vendor/fuser/src/ll/notify.rs
+++ b/vendor/fuser/src/ll/notify.rs
@@ -17,6 +17,7 @@ pub(crate) enum Notification<'a> {
     Bare(NotificationBuf),
 
     /// For notifications that include a buffer of arbitrary data
+    #[allow(dead_code)]
     WithData(NotificationBuf, &'a [u8]),
 
     /// For notifications that include a NUL-terminated name
@@ -122,6 +123,7 @@ impl<'a> Notification<'a> {
         Self::WithName(buf.as_bytes().into(), name)
     }
 
+    #[allow(dead_code)]
     fn from_struct_with_data<T: IntoBytes + Immutable + ?Sized>(buf: &T, data: &'a [u8]) -> Self {
         Self::WithData(buf.as_bytes().into(), data)
     }

--- a/vendor/fuser/src/ll/request.rs
+++ b/vendor/fuser/src/ll/request.rs
@@ -874,6 +874,7 @@ mod op {
         GetSize(GetXAttrSize),
         /// User is requesting the data stored in the XAttr.  If the data will fit
         /// in this number of bytes it should be returned, otherwise return [Err(Errno::ERANGE)].
+        #[allow(dead_code)]
         Size(NonZeroU32),
     }
     impl<'a> GetXAttr<'a> {
@@ -1517,6 +1518,7 @@ mod op {
     }
 
     /// Copy the specified range from the source inode to the destination inode
+    #[cfg(feature = "abi-7-28")]
     #[derive(Debug, Clone, Copy)]
     pub struct CopyFileRangeFile {
         pub inode: INodeNo,
@@ -1885,6 +1887,7 @@ pub enum Operation<'a> {
     Forget(Forget<'a>),
     GetAttr(GetAttr<'a>),
     SetAttr(SetAttr<'a>),
+    #[allow(dead_code)]
     ReadLink(ReadLink<'a>),
     SymLink(SymLink<'a>),
     MkNod(MkNod<'a>),
@@ -1896,6 +1899,7 @@ pub enum Operation<'a> {
     Open(Open<'a>),
     Read(Read<'a>),
     Write(Write<'a>),
+    #[allow(dead_code)]
     StatFs(StatFs<'a>),
     Release(Release<'a>),
     FSync(FSync<'a>),
@@ -1922,6 +1926,7 @@ pub enum Operation<'a> {
     #[cfg(feature = "abi-7-11")]
     Poll(Poll<'a>),
     #[cfg(feature = "abi-7-15")]
+    #[allow(dead_code)]
     NotifyReply(NotifyReply<'a>),
     #[cfg(feature = "abi-7-16")]
     BatchForget(BatchForget<'a>),
@@ -1944,6 +1949,7 @@ pub enum Operation<'a> {
     Exchange(Exchange<'a>),
 
     #[cfg(feature = "abi-7-12")]
+    #[allow(dead_code)]
     CuseInit(CuseInit<'a>),
 }
 

--- a/vendor/fuser/src/mnt/fuse2.rs
+++ b/vendor/fuser/src/mnt/fuse2.rs
@@ -18,11 +18,17 @@ fn ensure_last_os_error() -> io::Error {
     }
 }
 
+/// An active FUSE mount.
+///
+/// This struct manages the lifecycle of the mount, unmounting when dropped.
 #[derive(Debug)]
 pub struct Mount {
     mountpoint: CString,
 }
 impl Mount {
+    /// Mounts the filesystem at the given path, with the given options.
+    ///
+    /// Returns the mounted FUSE file descriptor along with a [Mount] for handling the mount lifecycle.
     pub fn new(mountpoint: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
         let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
@@ -55,7 +61,6 @@ impl Drop for Mount {
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd",
-                    target_os = "bitrig",
                     target_os = "netbsd"
                 )))]
                 unsafe {

--- a/vendor/fuser/src/mnt/fuse2_sys.rs
+++ b/vendor/fuser/src/mnt/fuse2_sys.rs
@@ -16,7 +16,7 @@ pub struct fuse_args {
     pub allocated: c_int,
 }
 
-#[cfg(feature = "libfuse2")]
+#[cfg(fuser_mount_impl = "libfuse2")]
 extern "C" {
     // *_compat25 functions were introduced in FUSE 2.6 when function signatures changed.
     // Therefore, the minimum version requirement for *_compat25 functions is libfuse-2.6.0.
@@ -27,7 +27,6 @@ extern "C" {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     )))]
     pub fn fuse_unmount_compat22(mountpoint: *const c_char);

--- a/vendor/fuser/src/mnt/fuse3.rs
+++ b/vendor/fuser/src/mnt/fuse3.rs
@@ -22,11 +22,17 @@ fn ensure_last_os_error() -> io::Error {
     }
 }
 
+/// An active FUSE mount.
+///
+/// This struct manages the lifecycle of the mount, unmounting and destroying the session when dropped.
 #[derive(Debug)]
 pub struct Mount {
     fuse_session: *mut c_void,
 }
 impl Mount {
+    /// Mounts the filesystem at the given path, with the given options.
+    ///
+    /// Returns the mounted FUSE file descriptor along with a [Mount] for handling the mount lifecycle.
     pub fn new(mnt: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
         let mnt = CString::new(mnt.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {

--- a/vendor/fuser/src/mnt/fuse_pure.rs
+++ b/vendor/fuser/src/mnt/fuse_pure.rs
@@ -178,7 +178,6 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     ))]
     {


### PR DESCRIPTION
## Description of change

This change updates the vendored fuser version. The changes include an amended README to include information on how to maintain the fork, as well as rebasing our patches on top of the upstream fuser repository.

The main changes we're interested in here is to eliminate many of the build warnings that are currently showing up in pull requests.

Relevant issues: N/A

## Does this change impact existing behavior?

No change in behavior of any crate.

## Does this change need a changelog entry in any of the crates?

No change log needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
