### PR TITLE
Allow enforcing SSE settings for the cache bucket

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -227,6 +227,12 @@ impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectReques
         self.request.get_object_checksum().await
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -542,6 +542,12 @@ impl GetObjectRequest for MockGetObjectRequest {
         Ok(self.object.checksum.clone())
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
         self.read_window_end_offset += len as u64;
     }

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -78,6 +78,12 @@ impl GetObjectRequest for ThroughputGetObjectRequest {
         Ok(self.request.object.checksum.clone())
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -572,6 +572,12 @@ pub trait GetObjectRequest:
     /// Get the object's checksum, if uploaded with one
     async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError>;
 
+    /// Get the object's SSE type and KMS Key ARN, as defined in:
+    /// https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError>;
+
     /// Increment the flow-control window, so that response data continues downloading.
     ///
     /// If the client was created with `enable_read_backpressure` set true,

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1134,6 +1134,14 @@ fn parse_checksum(headers: &Headers) -> Result<Checksum, HeadersError> {
     })
 }
 
+/// Extract the SSE-type and SSE-key information from headers
+fn parse_object_sse(headers: &Headers) -> Result<(Option<String>, Option<String>), HeadersError> {
+    let sse_type = headers.get_as_optional_string("x-amz-server-side-encryption")?;
+    let sse_kms_key_id = headers.get_as_optional_string("x-amz-server-side-encryption-aws-kms-key-id")?;
+
+    Ok((sse_type, sse_kms_key_id))
+}
+
 /// Try to parse a modeled error out of a failing meta request
 fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3RequestError> {
     /// Look for a redirect header pointing to a different region for the bucket

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -19,7 +19,8 @@ use crate::object_client::{
     Checksum, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError, ObjectClientResult, ObjectMetadata,
 };
 use crate::s3_crt_client::{
-    parse_checksum, GetObjectRequest, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation, S3RequestError,
+    parse_checksum, parse_object_sse, GetObjectRequest, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation,
+    S3RequestError,
 };
 use crate::types::ChecksumMode;
 
@@ -202,6 +203,14 @@ impl GetObjectRequest for S3GetObjectRequest {
 
         let headers = self.get_object_headers().await?;
         parse_checksum(&headers).map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(Box::new(e))))
+    }
+
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        let headers = self.get_object_headers().await?;
+        parse_object_sse(&headers)
+            .map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(Box::new(e))))
     }
 
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -67,6 +67,20 @@ pub fn get_test_bucket() -> String {
     }
 }
 
+/// An S3 Express bucket with SSE-S3 set as the default encryption
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+}
+
+/// An S3 Express bucket with SSE-KMS set as a default encryption with a key matching the `KMS_TEST_KEY_ID`
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_sse_kms_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS to run integration tests")
+}
+
 pub fn get_test_kms_key_id() -> String {
     std::env::var("KMS_TEST_KEY_ID").expect("Set KMS_TEST_KEY_ID to run integration tests")
 }

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -293,10 +293,10 @@ async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>)
 
 #[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_sse_kms_bucket(), false)]
 #[test_case(Some("aws:kms"), None, get_express_sse_kms_bucket(), false)]
-#[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_bucket(), true)] // this may start working in future, requires server-side changes
-#[test_case(Some("aws:kms"), None, get_express_bucket(), true)] // this may start working in future, requires server-side changes
+#[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_bucket(), true)]
+#[test_case(Some("aws:kms"), None, get_express_bucket(), true)]
 #[test_case(Some("AES256"), None, get_express_bucket(), false)]
-#[test_case(Some("AES256"), None, get_express_sse_kms_bucket(), true)] // this may start working in future, requires changes in CRT
+#[test_case(Some("AES256"), None, get_express_sse_kms_bucket(), true)]
 #[test_case(None, None, get_express_bucket(), false)]
 #[tokio::test]
 #[cfg(feature = "s3express_tests")]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -894,7 +894,13 @@ where
     match (args.disk_data_cache_config(), args.express_data_cache_config()) {
         (None, Some((config, bucket_name, cache_bucket_name))) => {
             tracing::trace!("using S3 Express One Zone bucket as a cache for object content");
-            let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
+            let express_cache = ExpressDataCache::new(
+                client.clone(),
+                config,
+                bucket_name,
+                cache_bucket_name,
+                filesystem_config.server_side_encryption.clone(),
+            );
 
             let prefetcher = caching_prefetch(express_cache, runtime, prefetcher_config);
             let fuse_session = create_filesystem(
@@ -933,7 +939,13 @@ where
         (Some((disk_data_cache_config, cache_dir_path)), Some((config, bucket_name, cache_bucket_name))) => {
             tracing::trace!("using both local disk and S3 Express One Zone bucket as a cache for object content");
             let (managed_cache_dir, disk_cache) = create_disk_cache(cache_dir_path, disk_data_cache_config)?;
-            let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
+            let express_cache = ExpressDataCache::new(
+                client.clone(),
+                config,
+                bucket_name,
+                cache_bucket_name,
+                filesystem_config.server_side_encryption.clone(),
+            );
             let cache = MultilevelDataCache::new(Arc::new(disk_cache), express_cache, runtime.clone());
 
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -36,8 +36,6 @@ pub enum DataCacheError {
     InvalidBlockOffset,
     #[error("Error while trying to evict cache content")]
     EvictionFailure,
-    #[error("A block stored with wrong SSE settings")]
-    StoredWithWrongSse,
 }
 
 pub type DataCacheResult<Value> = Result<Value, DataCacheError>;

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -36,6 +36,8 @@ pub enum DataCacheError {
     InvalidBlockOffset,
     #[error("Error while trying to evict cache content")]
     EvictionFailure,
+    #[error("A block stored with wrong SSE settings")]
+    StoredWithWrongSse,
 }
 
 pub type DataCacheResult<Value> = Result<Value, DataCacheError>;

--- a/mountpoint-s3/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3/src/data_cache/multilevel_cache.rs
@@ -151,7 +151,13 @@ mod tests {
             ..Default::default()
         };
         let client = MockClient::new(config);
-        let cache = ExpressDataCache::new(client.clone(), Default::default(), "unique source description", bucket);
+        let cache = ExpressDataCache::new(
+            client.clone(),
+            Default::default(),
+            "unique source description",
+            bucket,
+            Default::default(),
+        );
         (client, cache)
     }
 

--- a/mountpoint-s3/tests/common/cache.rs
+++ b/mountpoint-s3/tests/common/cache.rs
@@ -1,0 +1,115 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use mountpoint_s3::{
+    data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult},
+    object::ObjectId,
+};
+
+/// A wrapper around any type implementing [DataCache], which counts operations
+pub struct CacheTestWrapper<Cache> {
+    cache: Arc<Cache>,
+    pub get_block_ok_count: Arc<AtomicU64>,
+    pub get_block_hit_count: Arc<AtomicU64>,
+    pub get_block_failed_count: Arc<AtomicU64>,
+    pub put_block_ok_count: Arc<AtomicU64>,
+    pub put_block_failed_count: Arc<AtomicU64>,
+}
+
+impl<Cache> Clone for CacheTestWrapper<Cache> {
+    fn clone(&self) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            get_block_ok_count: self.get_block_ok_count.clone(),
+            get_block_hit_count: self.get_block_hit_count.clone(),
+            get_block_failed_count: self.get_block_failed_count.clone(),
+            put_block_ok_count: self.put_block_ok_count.clone(),
+            put_block_failed_count: self.put_block_failed_count.clone(),
+        }
+    }
+}
+
+impl<Cache> CacheTestWrapper<Cache> {
+    pub fn new(cache: Arc<Cache>) -> Self {
+        CacheTestWrapper {
+            cache,
+            get_block_ok_count: Arc::new(AtomicU64::new(0)),
+            get_block_hit_count: Arc::new(AtomicU64::new(0)),
+            get_block_failed_count: Arc::new(AtomicU64::new(0)),
+            put_block_ok_count: Arc::new(AtomicU64::new(0)),
+            put_block_failed_count: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn wait_for_put(&self, max_wait_duration: Duration, should_fail: bool) {
+        let st = std::time::Instant::now();
+        loop {
+            if st.elapsed() > max_wait_duration {
+                panic!("timeout on waiting for data being stored to the cache")
+            }
+            if should_fail && self.put_block_failed_count.load(Ordering::SeqCst) > 1 {
+                break;
+            }
+            if !should_fail && self.put_block_ok_count.load(Ordering::SeqCst) > 1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+#[async_trait]
+impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Cache> {
+    async fn get_block(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        object_size: usize,
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        let result = self
+            .cache
+            .get_block(cache_key, block_idx, block_offset, object_size)
+            .await
+            .inspect(|_| {
+                self.get_block_ok_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .inspect_err(|_| {
+                self.get_block_failed_count.fetch_add(1, Ordering::SeqCst);
+            })?
+            .inspect(|_| {
+                self.get_block_hit_count.fetch_add(1, Ordering::SeqCst);
+            });
+
+        Ok(result)
+    }
+
+    async fn put_block(
+        &self,
+        cache_key: ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+        object_size: usize,
+    ) -> DataCacheResult<()> {
+        self.cache
+            .put_block(cache_key, block_idx, block_offset, bytes, object_size)
+            .await
+            .inspect(|_| {
+                self.put_block_ok_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .inspect_err(|_| {
+                self.put_block_failed_count.fetch_add(1, Ordering::SeqCst);
+            })
+    }
+
+    fn block_size(&self) -> u64 {
+        self.cache.block_size()
+    }
+}

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -113,7 +113,7 @@ pub trait TestSessionCreator: FnOnce(&str, TestSessionConfig) -> TestSession {}
 // `FnOnce(...)` in place of `impl TestSessionCreator`.
 impl<T> TestSessionCreator for T where T: FnOnce(&str, TestSessionConfig) -> TestSession {}
 
-fn create_fuse_session<Client, Prefetcher>(
+pub fn create_fuse_session<Client, Prefetcher>(
     client: Client,
     prefetcher: Prefetcher,
     bucket: &str,
@@ -363,12 +363,7 @@ pub mod s3_session {
             let (bucket, prefix) = get_test_bucket_and_prefix(test_name);
             let region = get_test_region();
 
-            let client_config = S3ClientConfig::default()
-                .part_size(test_config.part_size)
-                .endpoint_config(get_test_endpoint_config())
-                .read_backpressure(true)
-                .initial_read_window(test_config.initial_read_window_size);
-            let client = S3CrtClient::new(client_config).unwrap();
+            let client = create_crt_client(test_config.part_size, test_config.initial_read_window_size);
             let runtime = client.event_loop_group();
             let prefetcher = caching_prefetch(cache, runtime, test_config.prefetcher_config);
             let session = create_fuse_session(
@@ -385,7 +380,16 @@ pub mod s3_session {
         }
     }
 
-    fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
+    pub fn create_crt_client(part_size: usize, initial_read_window_size: usize) -> S3CrtClient {
+        let client_config = S3ClientConfig::default()
+            .part_size(part_size)
+            .endpoint_config(get_test_endpoint_config())
+            .read_backpressure(true)
+            .initial_read_window(initial_read_window_size);
+        S3CrtClient::new(client_config).unwrap()
+    }
+
+    pub fn create_test_client(region: &str, bucket: &str, prefix: &str) -> impl TestClient {
         let sdk_client = tokio_block_on(async { get_test_sdk_client(region).await });
         SDKTestClient {
             prefix: prefix.to_owned(),

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -2,6 +2,8 @@
 //! Allow for unused items since this is included independently in each module.
 #![allow(dead_code)]
 
+pub mod cache;
+
 pub mod creds;
 
 #[cfg(feature = "fuse_tests")]

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -8,13 +8,17 @@ use rand_chacha::rand_core::OsRng;
 use crate::common::tokio_block_on;
 
 pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
-    let bucket = if cfg!(feature = "s3express_tests") {
-        std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
-            .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
-    } else {
-        std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
-    };
+    #[cfg(not(feature = "s3express_tests"))]
+    let bucket = get_standard_bucket();
+    #[cfg(feature = "s3express_tests")]
+    let bucket = get_express_bucket();
 
+    let prefix = get_test_prefix(test_name);
+
+    (bucket, prefix)
+}
+
+pub fn get_test_prefix(test_name: &str) -> String {
     // Generate a random nonce to make sure this prefix is truly unique
     let nonce = OsRng.next_u64();
 
@@ -22,9 +26,17 @@ pub fn get_test_bucket_and_prefix(test_name: &str) -> (String, String) {
     let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or(String::from("mountpoint-test/"));
     assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
 
-    let prefix = format!("{prefix}{test_name}/{nonce}/");
+    format!("{prefix}{test_name}/{nonce}/")
+}
 
-    (bucket, prefix)
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+}
+
+pub fn get_standard_bucket() -> String {
+    std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
 }
 
 pub fn get_test_bucket_forbidden() -> String {

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -1,0 +1,197 @@
+use std::{
+    fs,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    thread::sleep,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use mountpoint_s3::{
+    data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult, ExpressDataCache},
+    object::ObjectId,
+    prefetch::caching_prefetch,
+    ServerSideEncryption,
+};
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+use test_case::test_case;
+
+use crate::common::{
+    fuse::{create_fuse_session, s3_session::create_crt_client},
+    s3::{get_express_bucket, get_standard_bucket, get_test_prefix},
+};
+
+const CLIENT_PART_SIZE: usize = 8 * 1024 * 1024;
+
+#[test_case("aws:sse", true; "value does not match the default for the bucket")]
+#[test_case("AES256", false; "value match the default for the bucket")]
+fn express_cache_sse_put(sse: &str, should_fail: bool) {
+    // let region = get_test_region();
+    let bucket_name = get_standard_bucket();
+    let prefix = get_test_prefix("express_cache_bad_sse");
+    let express_bucket_name = get_express_bucket();
+    let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE);
+    let express_cache = ExpressDataCache::new(
+        client.clone(),
+        Default::default(),
+        &bucket_name,
+        &express_bucket_name,
+        ServerSideEncryption::new(Some(sse.to_owned()), None),
+    );
+    let express_cache = CacheTestWrapper::new(Arc::new(express_cache));
+
+    // Mount a bucket
+    let mount_point = tempfile::tempdir().unwrap();
+    let runtime = client.event_loop_group();
+    let prefetcher = caching_prefetch(express_cache.clone(), runtime, Default::default());
+    let _session = create_fuse_session(
+        client,
+        prefetcher,
+        &bucket_name,
+        &prefix,
+        mount_point.path(),
+        Default::default(),
+    );
+
+    // Write an object, no caching happens yet
+    let key = get_object_key(&prefix, "key", 100);
+    let path = mount_point.path().join(&key);
+    let written = random_binary_data(1024 * 1024);
+    fs::write(&path, &written).expect("write should succeed");
+
+    // First read should be from the source bucket and not be cache as the SSE can not be enforced
+    let read = fs::read(&path).expect("read should succeed");
+    assert_eq!(read, written);
+
+    // Cache writes are async, wait for that to happen
+    const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
+    let st = std::time::Instant::now();
+    loop {
+        if st.elapsed() > MAX_WAIT_DURATION {
+            panic!("timeout on waiting for data being stored to the cache")
+        }
+        if should_fail && express_cache.put_block_failed_count.load(Ordering::SeqCst) > 1 {
+            break;
+        }
+        if !should_fail && express_cache.put_block_count.load(Ordering::SeqCst) > 1 {
+            break;
+        }
+        sleep(Duration::from_millis(100));
+    }
+
+    // Depending on the test case check that either or writes failed or all were successful
+    let put_block_count = express_cache.put_block_count.load(Ordering::SeqCst);
+    let put_block_failed_count = express_cache.put_block_failed_count.load(Ordering::SeqCst);
+    if should_fail {
+        assert!(put_block_count == put_block_failed_count)
+    } else {
+        assert!(put_block_failed_count == 0);
+    }
+}
+
+// #[test]
+// fn express_cache_good_sse() {
+//     // put
+//     // get
+// }
+
+// #[test]
+// fn express_cache_expected_bucket_owner() {
+//     // put
+//     // get
+// }
+
+// #[test]
+// fn express_cache_wrong_etag() {}
+
+struct CacheTestWrapper<Cache> {
+    cache: Arc<Cache>,
+    cache_hit_count: Arc<AtomicU64>,
+    put_block_count: Arc<AtomicU64>,
+    put_block_failed_count: Arc<AtomicU64>,
+}
+
+impl<Cache> Clone for CacheTestWrapper<Cache> {
+    fn clone(&self) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            cache_hit_count: self.cache_hit_count.clone(),
+            put_block_count: self.put_block_count.clone(),
+            put_block_failed_count: self.put_block_failed_count.clone(),
+        }
+    }
+}
+
+impl<Cache> CacheTestWrapper<Cache> {
+    fn new(cache: Arc<Cache>) -> Self {
+        CacheTestWrapper {
+            cache,
+            cache_hit_count: Arc::new(AtomicU64::new(0)),
+            put_block_count: Arc::new(AtomicU64::new(0)),
+            put_block_failed_count: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Cache> {
+    async fn get_block(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        object_size: usize,
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        let result = self
+            .cache
+            .get_block(cache_key, block_idx, block_offset, object_size)
+            .await?
+            .inspect(|_| {
+                self.cache_hit_count.fetch_add(1, Ordering::SeqCst);
+            });
+        Ok(result)
+    }
+
+    async fn put_block(
+        &self,
+        cache_key: ObjectId,
+        block_idx: BlockIndex,
+        block_offset: u64,
+        bytes: ChecksummedBytes,
+        object_size: usize,
+    ) -> DataCacheResult<()> {
+        self.put_block_count.fetch_add(1, Ordering::SeqCst);
+        self.cache
+            .put_block(cache_key, block_idx, block_offset, bytes, object_size)
+            .await
+            .inspect_err(|_| {
+                self.put_block_failed_count.fetch_add(1, Ordering::SeqCst);
+            })
+    }
+
+    fn block_size(&self) -> u64 {
+        self.cache.block_size()
+    }
+}
+
+fn random_binary_data(size_in_bytes: usize) -> Vec<u8> {
+    let seed = rand::thread_rng().gen();
+    let mut rng = ChaChaRng::seed_from_u64(seed);
+    let mut data = vec![0; size_in_bytes];
+    rng.fill_bytes(&mut data);
+    data
+}
+
+// Creates a random key which has a size of at least `min_size_in_bytes`
+fn get_object_key(key_prefix: &str, key_suffix: &str, min_size_in_bytes: usize) -> String {
+    let random_suffix: u64 = rand::thread_rng().gen();
+    let last_key_part = format!("{key_suffix}{random_suffix}"); // part of the key after all the "/"
+    let full_key = format!("{key_prefix}{last_key_part}");
+    let full_key_size = full_key.as_bytes().len();
+    let padding_size = min_size_in_bytes.saturating_sub(full_key_size);
+    let padding = "0".repeat(padding_size);
+    format!("{last_key_part}{padding}")
+}

--- a/mountpoint-s3/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3/tests/fuse_tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "s3_tests", feature = "s3express_tests"))]
+mod cache_test;
 mod consistency_test;
 mod fork_test;
 mod lookup_test;


### PR DESCRIPTION
## Description of change

Use `--sse` and `--sse-kms-key-id` to enforce a specific SSE configuration on the shared cache bucket.

https://github.com/awslabs/mountpoint-s3/pull/1071 and https://github.com/awslabs/mountpoint-s3/pull/1132 should be merged before this.

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

Yes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
