### PR TITLE
Add `get_object_sse` to `GetObjectRequest`, add tests for SSE in express on put/get

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -227,6 +227,12 @@ impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectReques
         self.request.get_object_checksum().await
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -542,6 +542,12 @@ impl GetObjectRequest for MockGetObjectRequest {
         Ok(self.object.checksum.clone())
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
         self.read_window_end_offset += len as u64;
     }

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -78,6 +78,12 @@ impl GetObjectRequest for ThroughputGetObjectRequest {
         Ok(self.request.object.checksum.clone())
     }
 
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        Ok((None, None))
+    }
+
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {
         let this = self.project();
         this.request.increment_read_window(len);

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -572,6 +572,12 @@ pub trait GetObjectRequest:
     /// Get the object's checksum, if uploaded with one
     async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError>;
 
+    /// Get the object's SSE type and KMS Key ARN, as defined in:
+    /// https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError>;
+
     /// Increment the flow-control window, so that response data continues downloading.
     ///
     /// If the client was created with `enable_read_backpressure` set true,

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1134,6 +1134,14 @@ fn parse_checksum(headers: &Headers) -> Result<Checksum, HeadersError> {
     })
 }
 
+/// Extract the SSE-type and SSE-key information from headers
+fn parse_object_sse(headers: &Headers) -> Result<(Option<String>, Option<String>), HeadersError> {
+    let sse_type = headers.get_as_optional_string("x-amz-server-side-encryption")?;
+    let sse_kms_key_id = headers.get_as_optional_string("x-amz-server-side-encryption-aws-kms-key-id")?;
+
+    Ok((sse_type, sse_kms_key_id))
+}
+
 /// Try to parse a modeled error out of a failing meta request
 fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3RequestError> {
     /// Look for a redirect header pointing to a different region for the bucket

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -19,7 +19,8 @@ use crate::object_client::{
     Checksum, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError, ObjectClientResult, ObjectMetadata,
 };
 use crate::s3_crt_client::{
-    parse_checksum, GetObjectRequest, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation, S3RequestError,
+    parse_checksum, parse_object_sse, GetObjectRequest, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation,
+    S3RequestError,
 };
 use crate::types::ChecksumMode;
 
@@ -202,6 +203,14 @@ impl GetObjectRequest for S3GetObjectRequest {
 
         let headers = self.get_object_headers().await?;
         parse_checksum(&headers).map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(Box::new(e))))
+    }
+
+    async fn get_object_sse(
+        &self,
+    ) -> ObjectClientResult<(Option<String>, Option<String>), GetObjectError, Self::ClientError> {
+        let headers = self.get_object_headers().await?;
+        parse_object_sse(&headers)
+            .map_err(|e| ObjectClientError::ClientError(S3RequestError::InternalError(Box::new(e))))
     }
 
     fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -67,6 +67,20 @@ pub fn get_test_bucket() -> String {
     }
 }
 
+/// An S3 Express bucket with SSE-S3 set as the default encryption
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
+}
+
+/// An S3 Express bucket with SSE-KMS set as a default encryption with a key matching the `KMS_TEST_KEY_ID`
+#[cfg(feature = "s3express_tests")]
+pub fn get_express_sse_kms_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS to run integration tests")
+}
+
 pub fn get_test_kms_key_id() -> String {
     std::env::var("KMS_TEST_KEY_ID").expect("Set KMS_TEST_KEY_ID to run integration tests")
 }

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -293,10 +293,10 @@ async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>)
 
 #[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_sse_kms_bucket(), false)]
 #[test_case(Some("aws:kms"), None, get_express_sse_kms_bucket(), false)]
-#[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_bucket(), true)] // this may start working in future, requires server-side changes
-#[test_case(Some("aws:kms"), None, get_express_bucket(), true)] // this may start working in future, requires server-side changes
+#[test_case(Some("aws:kms"), Some(get_test_kms_key_id()), get_express_bucket(), true)]
+#[test_case(Some("aws:kms"), None, get_express_bucket(), true)]
 #[test_case(Some("AES256"), None, get_express_bucket(), false)]
-#[test_case(Some("AES256"), None, get_express_sse_kms_bucket(), true)] // this may start working in future, requires changes in CRT
+#[test_case(Some("AES256"), None, get_express_sse_kms_bucket(), true)]
 #[test_case(None, None, get_express_bucket(), false)]
 #[tokio::test]
 #[cfg(feature = "s3express_tests")]


### PR DESCRIPTION
## Description of change

- New `get_object_sse` method allows accessing SSE configuration returned with GetObject response;
- Tests `test_put_object_sse` reflect the current behaviour of PUT requests when SSE settings are specified in requests to two Express buckets with SSE-S3 and SSE-KMS default encryption; 
- Tests `test_get_object_sse` check that SSE settings are accessible via `GetObjectResult`.

> Some tests are expected to fail until we add `S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS`

Relevant issues: N/A

## Does this change impact existing behavior?

No.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
