### PR TITLE
Validate that shared cache bucket is usable

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -896,7 +896,8 @@ where
         (None, Some((config, bucket_name, cache_bucket_name))) => {
             tracing::trace!("using S3 Express One Zone bucket as a cache for object content");
             let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
-            block_on(express_cache.verify_cache_valid())?;
+            block_on(express_cache.verify_cache_valid())
+                .with_context(|| format!("initial PutObject failed for shared cache bucket {cache_bucket_name}"))?;
 
             let prefetcher = caching_prefetch(express_cache, runtime, prefetcher_config);
             let fuse_session = create_filesystem(
@@ -936,7 +937,8 @@ where
             tracing::trace!("using both local disk and S3 Express One Zone bucket as a cache for object content");
             let (managed_cache_dir, disk_cache) = create_disk_cache(cache_dir_path, disk_data_cache_config)?;
             let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
-            block_on(express_cache.verify_cache_valid())?;
+            block_on(express_cache.verify_cache_valid())
+                .with_context(|| format!("initial PutObject failed for shared cache bucket {cache_bucket_name}"))?;
             let cache = MultilevelDataCache::new(Arc::new(disk_cache), express_cache, runtime.clone());
 
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use clap::{value_parser, ArgGroup, Parser, ValueEnum};
 use fuser::{MountOption, Session};
+use futures::executor::block_on;
 use futures::task::Spawn;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
@@ -895,6 +896,7 @@ where
         (None, Some((config, bucket_name, cache_bucket_name))) => {
             tracing::trace!("using S3 Express One Zone bucket as a cache for object content");
             let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
+            block_on(express_cache.verify_cache_valid())?;
 
             let prefetcher = caching_prefetch(express_cache, runtime, prefetcher_config);
             let fuse_session = create_filesystem(
@@ -934,6 +936,7 @@ where
             tracing::trace!("using both local disk and S3 Express One Zone bucket as a cache for object content");
             let (managed_cache_dir, disk_cache) = create_disk_cache(cache_dir_path, disk_data_cache_config)?;
             let express_cache = ExpressDataCache::new(client.clone(), config, bucket_name, cache_bucket_name);
+            block_on(express_cache.verify_cache_valid())?;
             let cache = MultilevelDataCache::new(Arc::new(disk_cache), express_cache, runtime.clone());
 
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -84,6 +84,9 @@ where
             self.bucket_name, self.config.block_size
         );
 
+        // put_object is sufficient for validating cache, as S3 Directory buckets only support
+        // read-only, or read-write. Write implies read access.
+        // Validating we're in a directory bucket by using the `EXPRESS_ONEZONE` storage class.
         self.client
             .put_object_single(
                 &self.bucket_name,


### PR DESCRIPTION
## Description of change

- Validates the shared cache bucket is write-able
- Validates the shared cache bucket supports the `EXPRESS_ONEZONE` storage class

Relevant issues: N/A

## Does this change impact existing behavior?

Yes, the shared cache bucket is now validated that it supports the `EXPRESS_ONEZONE` storage class

## Does this change need a changelog entry in any of the crates?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
