### PR TITLE
Rename the shared cache CLI flag

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -327,7 +327,7 @@ pub struct CliArgs {
         value_parser = parse_bucket_name,
         group = "cache_group",
     )]
-    pub cache_express: Option<String>,
+    pub cache_xz: Option<String>,
 
     #[clap(
         long,
@@ -441,7 +441,7 @@ impl CliArgs {
 
     fn cache_express_bucket_name(&self) -> Option<&str> {
         #[cfg(feature = "express_cache")]
-        if let Some(bucket_name) = &self.cache_express {
+        if let Some(bucket_name) = &self.cache_xz {
             return Some(bucket_name);
         }
         None


### PR DESCRIPTION
## Description of change

Rename the CLI flag for the shared cache. New help message:

```bash
--cache-xz <BUCKET>
    Enable caching of object content to the specified bucket on S3 Express One Zone (same region only)
```

Relevant issues: N/A

## Does this change impact existing behavior?

No, it's behind a feature flag.

## Does this change need a changelog entry in any of the crates?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
