### PR TITLE
Remove `express_cache` feature flag

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### New features
 
+* Mountpoint now offers a new command-line argument `--cache-express <BUCKET>` which enables caching of object content to the specified bucket on S3 Express One Zone. ([#1145](https://github.com/awslabs/mountpoint-s3/pull/1145))
+
 ### Breaking changes
 
 ### Other changes

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Mountpoint now offers a new command-line argument `--cache-express <BUCKET>` which enables caching of object content to the specified bucket on S3 Express One Zone. ([#1145](https://github.com/awslabs/mountpoint-s3/pull/1145))
+* Mountpoint now offers a new command-line argument `--cache-xz <BUCKET>` which enables caching of object content to the specified bucket on S3 Express One Zone. ([#1145](https://github.com/awslabs/mountpoint-s3/pull/1145))
 
 ### Breaking changes
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -81,7 +81,6 @@ built = { version = "0.7.5", features = ["git2"] }
 
 [features]
 # Unreleased feature flags
-express_cache = ["block_size"]
 block_size = []
 event_log = []
 mem_limiter = []

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -318,7 +318,6 @@ pub struct CliArgs {
     )]
     pub cache_block_size: Option<u64>,
 
-    #[cfg(feature = "express_cache")]
     #[clap(
         long,
         help = "Enable caching of object content to the specified bucket on S3 Express One Zone (same region only)",
@@ -440,7 +439,6 @@ impl CliArgs {
     }
 
     fn cache_express_bucket_name(&self) -> Option<&str> {
-        #[cfg(feature = "express_cache")]
         if let Some(bucket_name) = &self.cache_xz {
             return Some(bucket_name);
         }


### PR DESCRIPTION
## Description of change

- Removes the feature flag so the shared cache may be included in the next build;
- Adds a changelog entry introducing the feature.

(update and merge this after: https://github.com/awslabs/mountpoint-s3/pull/1144)

Relevant issues: N/A

## Does this change impact existing behavior?

No, a new feature added.

## Does this change need a changelog entry in any of the crates?

Yes, adding one in this PR.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
