### PR TITLE
Update documentation to fix installation on Ubuntu 24.04

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -60,7 +60,7 @@ To download and install Mountpoint for Amazon S3 on DEB-based distributions, fol
 
    Then see [Verifying the signature of the Mountpoint for Amazon S3 package](#optional-verifying-the-signature-of-the-mountpoint-for-amazon-s3-package) below.
 
-3. Ensure that package index files are up to date (so that on Ubuntu 24.04 and later, package ``libfuse2t64`` is used to satisfy the libfuse dependency) by running the following command:
+3. Ensure that package index files are up to date (so that on Ubuntu 24.04 and later, package ``libfuse2t64`` is used to satisfy the ``fuse2`` dependency) by running the following command:
    ```
    sudo apt-get update
    ```

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -59,11 +59,16 @@ To download and install Mountpoint for Amazon S3 on DEB-based distributions, fol
     * ARM64 (Graviton) architecture: `https://s3.amazonaws.com/mountpoint-s3-release/latest/arm64/mount-s3.deb.asc`
 
    Then see [Verifying the signature of the Mountpoint for Amazon S3 package](#optional-verifying-the-signature-of-the-mountpoint-for-amazon-s3-package) below.
-3. Install the package by entering the following command:
+
+3. Ensure that package index files are up to date (so that on Ubuntu 24.04 and later, package ``libfuse2t64`` is used to satisfy the libfuse dependency) by running the following command:
+   ```
+   sudo apt-get update
+   ```
+4. Install the package by entering the following command:
    ```
    sudo apt-get install ./mount-s3.deb
    ```
-4. Verify that Mountpoint for Amazon S3 is successfully installed by entering the following command:
+5. Verify that Mountpoint for Amazon S3 is successfully installed by entering the following command:
    ```
    mount-s3 --version
    ```

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -60,7 +60,7 @@ To download and install Mountpoint for Amazon S3 on DEB-based distributions, fol
 
    Then see [Verifying the signature of the Mountpoint for Amazon S3 package](#optional-verifying-the-signature-of-the-mountpoint-for-amazon-s3-package) below.
 
-3. Ensure that package index files are up to date (so that on Ubuntu 24.04 and later, package ``libfuse2t64`` is used to satisfy the ``fuse2`` dependency) by running the following command:
+3. Ensure that package index files are up to date by running the following command:
    ```
    sudo apt-get update
    ```


### PR DESCRIPTION
On Ubuntu 24.04, installation was failing with the following error: "mount-s3 : Depends: libfuse2 but it is not installable".

This change tells users to update the package index, such that the needed package `libfuse2t64` can be found, fixing installation errors in Ubuntu 24.04.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
