### PR TITLE
Fix compilation error on macOS/arm

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Other changes
 
-* Implement statfs to report non-zero synthetic values. This may unblock applications which rely on verifying there is available space before creating new files.([#1118](https://github.com/awslabs/mountpoint-s3/pull/1118)).
+* Implement statfs to report non-zero synthetic values. This may unblock applications which rely on verifying there is available space before creating new files. ([#1118](https://github.com/awslabs/mountpoint-s3/pull/1118))
 
 ## v1.11.0 (November 21, 2024)
 

--- a/mountpoint-s3/tests/fuse_tests/statfs_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/statfs_test.rs
@@ -11,8 +11,8 @@ fn statfs_test_static_values(creator_fn: impl TestSessionCreator, prefix: &str) 
     assert_ne!(stats.blocks_free(), 0);
     assert_ne!(stats.blocks_available(), 0);
     // These two are values set by us
-    assert_eq!(stats.files(), u64::MAX / 1024);
-    assert_eq!(stats.files_available(), u64::MAX / 1024);
+    assert_eq!(stats.files() as u64, u64::MAX / 1024);
+    assert_eq!(stats.files_available() as u64, u64::MAX / 1024);
     // These are default values from the Default implementation
     assert_eq!(stats.block_size(), 512);
     assert_eq!(stats.name_max(), 255);


### PR DESCRIPTION
Add a cast in the new `statfs` test: `libc::fsfilcnt_t` is not `u64` on all platforms.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
