### PR TITLE
Improve support for additional checksum algorithms in mountpoint-s3-client

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -16,6 +16,8 @@
 * `ChecksumAlgorithm` has a new variant `Unknown(String)`,
   to accomodate algorithms not recognized by the client should they be added in future.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+* Allow to specify any of the supported checksum algorithms when uploading objects with `put_object_single`.
+  ([#1157](https://github.com/awslabs/mountpoint-s3/pull/1157))
 
 ### Breaking changes
 

--- a/mountpoint-s3-client/src/checksums.rs
+++ b/mountpoint-s3-client/src/checksums.rs
@@ -1,5 +1,8 @@
-//! Provides base64 encoding/decoding for CRC32C checksums.
+//! Provides base64 encoding/decoding for various checksums.
+pub use mountpoint_s3_crt::checksums::crc32::{self, Crc32};
 pub use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};
+pub use mountpoint_s3_crt::checksums::sha1::{self, Sha1};
+pub use mountpoint_s3_crt::checksums::sha256::{self, Sha256};
 
 use base64ct::Base64;
 use base64ct::Encoding;
@@ -15,6 +18,28 @@ pub fn crc32c_from_base64(base64_str: &str) -> Result<Crc32c, ParseError> {
     let mut dec_buf = [0u8; std::mem::size_of::<u32>()];
     let _ = Base64::decode(base64_str, &mut dec_buf)?;
     Ok(Crc32c::new(u32::from_be_bytes(dec_buf)))
+}
+
+/// The base64 encoding for this CRC32 checksum value.
+pub fn crc32_to_base64(checksum: &Crc32) -> String {
+    Base64::encode_string(&checksum.value().to_be_bytes())
+}
+
+/// Create a CRC32 checksum from a base64 encoding.
+pub fn crc32_from_base64(base64_str: &str) -> Result<Crc32, ParseError> {
+    let mut dec_buf = [0u8; std::mem::size_of::<u32>()];
+    let _ = Base64::decode(base64_str, &mut dec_buf)?;
+    Ok(Crc32::new(u32::from_be_bytes(dec_buf)))
+}
+
+/// The base64 encoding for this SHA1 checksum value.
+pub fn sha1_to_base64(checksum: &Sha1) -> String {
+    Base64::encode_string(checksum.value())
+}
+
+/// The base64 encoding for this SHA256 checksum value.
+pub fn sha256_to_base64(checksum: &Sha256) -> String {
+    Base64::encode_string(checksum.value())
 }
 
 /// Error parsing CRC32C checksums.
@@ -50,5 +75,46 @@ mod tests {
     fn test_crc32c_from_base64_error(invalid_base64: &str) {
         let err = crc32c_from_base64(invalid_base64).expect_err("parsing should fail");
         assert!(matches!(err, ParseError::Base64ParseError(_)));
+    }
+
+    #[test]
+    fn test_crc32_to_base64() {
+        let crc = Crc32::new(1234);
+        let base64 = crc32_to_base64(&crc);
+        assert_eq!(&base64, "AAAE0g==");
+    }
+
+    #[test]
+    fn test_crc32_from_base64() {
+        let base64 = "AAAE0g==";
+        let crc = crc32_from_base64(base64).expect("parsing should succeeed");
+        assert_eq!(crc.value(), 1234);
+    }
+
+    #[test_case("AAA")]
+    #[test_case("AAAE0g")]
+    #[test_case("AAAE0gAA==")]
+    fn test_crc32_from_base64_error(invalid_base64: &str) {
+        let err = crc32_from_base64(invalid_base64).expect_err("parsing should fail");
+        assert!(matches!(err, ParseError::Base64ParseError(_)));
+    }
+
+    #[test]
+    fn test_sha1_to_base64() {
+        let sha1 = Sha1::new([
+            247, 195, 188, 29, 128, 142, 4, 115, 42, 223, 103, 153, 101, 204, 195, 76, 167, 174, 52, 65,
+        ]);
+        let base64 = sha1_to_base64(&sha1);
+        assert_eq!(&base64, "98O8HYCOBHMq32eZZczDTKeuNEE=");
+    }
+
+    #[test]
+    fn test_sha256_to_base64() {
+        let sha256 = Sha256::new([
+            21, 226, 176, 211, 195, 56, 145, 235, 176, 241, 239, 96, 158, 196, 25, 66, 12, 32, 227, 32, 206, 148, 198,
+            95, 188, 140, 51, 18, 68, 142, 178, 37,
+        ]);
+        let base64 = sha256_to_base64(&sha256);
+        assert_eq!(&base64, "FeKw08M4keuw8e9gnsQZQgwg4yDOlMZfvIwzEkSOsiU=");
     }
 }

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -180,7 +180,7 @@ impl MockClient {
     }
 
     /// Mock implementation of PutObject.
-    pub fn mock_put_object<'a>(
+    fn mock_put_object<'a>(
         &self,
         key: &str,
         params: &PutObjectSingleParams,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 use time::OffsetDateTime;
 
-use crate::checksums;
+use crate::checksums::{self, crc32_to_base64, crc32c_to_base64, sha1_to_base64, sha256_to_base64};
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 
 mod etag;
@@ -806,6 +806,20 @@ impl Checksum {
         }
 
         algorithms
+    }
+}
+
+impl From<Option<UploadChecksum>> for Checksum {
+    fn from(value: Option<UploadChecksum>) -> Self {
+        let mut checksum = Checksum::empty();
+        match value.as_ref() {
+            Some(UploadChecksum::Crc32c(crc32c)) => checksum.checksum_crc32c = Some(crc32c_to_base64(crc32c)),
+            Some(UploadChecksum::Crc32(crc32)) => checksum.checksum_crc32 = Some(crc32_to_base64(crc32)),
+            Some(UploadChecksum::Sha1(sha1)) => checksum.checksum_sha1 = Some(sha1_to_base64(sha1)),
+            Some(UploadChecksum::Sha256(sha256)) => checksum.checksum_sha256 = Some(sha256_to_base64(sha256)),
+            None => {}
+        };
+        checksum
     }
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -548,6 +548,9 @@ impl PutObjectSingleParams {
 #[non_exhaustive]
 pub enum UploadChecksum {
     Crc32c(checksums::Crc32c),
+    Crc32(checksums::Crc32),
+    Sha1(checksums::Sha1),
+    Sha256(checksums::Sha256),
 }
 
 impl UploadChecksum {
@@ -555,6 +558,9 @@ impl UploadChecksum {
     pub fn checksum_algorithm(&self) -> ChecksumAlgorithm {
         match self {
             UploadChecksum::Crc32c(_) => ChecksumAlgorithm::Crc32c,
+            UploadChecksum::Crc32(_) => ChecksumAlgorithm::Crc32,
+            UploadChecksum::Sha1(_) => ChecksumAlgorithm::Sha1,
+            UploadChecksum::Sha256(_) => ChecksumAlgorithm::Sha256,
         }
     }
 }
@@ -648,6 +654,12 @@ pub struct PutObjectResult {
 pub enum PutObjectError {
     #[error("The bucket does not exist")]
     NoSuchBucket,
+
+    #[error("The provided checksum does not match the data")]
+    BadChecksum,
+
+    #[error("The server does not support the functionality required to fulfill the request")]
+    NotImplemented,
 }
 
 /// Restoration status for S3 objects in flexible retrieval storage classes.

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -36,7 +36,7 @@ use pin_project::{pin_project, pinned_drop};
 use thiserror::Error;
 use tracing::{debug, error, trace, Span};
 
-use crate::checksums::crc32c_to_base64;
+use crate::checksums::{crc32_to_base64, crc32c_to_base64, sha1_to_base64, sha256_to_base64};
 use crate::endpoint_config::EndpointError;
 use crate::endpoint_config::{self, EndpointConfig};
 use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
@@ -939,6 +939,9 @@ impl<'a> S3Message<'a> {
     ) -> Result<(), mountpoint_s3_crt::common::error::Error> {
         let header = match checksum {
             UploadChecksum::Crc32c(crc32c) => Header::new("x-amz-checksum-crc32c", crc32c_to_base64(crc32c)),
+            UploadChecksum::Crc32(crc32) => Header::new("x-amz-checksum-crc32", crc32_to_base64(crc32)),
+            UploadChecksum::Sha1(sha1) => Header::new("x-amz-checksum-sha1", sha1_to_base64(sha1)),
+            UploadChecksum::Sha256(sha256) => Header::new("x-amz-checksum-sha256", sha256_to_base64(sha256)),
         };
         self.inner.set_header(&header)
     }

--- a/mountpoint-s3-client/tests/put_object_single.rs
+++ b/mountpoint-s3-client/tests/put_object_single.rs
@@ -5,11 +5,11 @@ pub mod common;
 use std::collections::HashMap;
 
 use common::*;
-use mountpoint_s3_client::checksums::{crc32c, crc32c_to_base64};
+use mountpoint_s3_client::checksums::crc32c;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
 use mountpoint_s3_client::types::{
-    ChecksumAlgorithm, GetObjectParams, PutObjectResult, PutObjectSingleParams, UploadChecksum,
+    Checksum, ChecksumAlgorithm, GetObjectParams, PutObjectResult, PutObjectSingleParams, UploadChecksum,
 };
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::checksums::{crc32, sha1, sha256};
@@ -96,7 +96,7 @@ async fn test_put_checksums(checksum_algorithm: Option<ChecksumAlgorithm>) {
     let mut contents = vec![0u8; PART_SIZE * 2];
     rng.fill(&mut contents[..]);
 
-    let checksum = match checksum_algorithm {
+    let upload_checksum = match checksum_algorithm {
         Some(ChecksumAlgorithm::Crc32c) => Some(UploadChecksum::Crc32c(crc32c::checksum(&contents))),
         Some(ChecksumAlgorithm::Crc32) => Some(UploadChecksum::Crc32(crc32::checksum(&contents))),
         Some(ChecksumAlgorithm::Sha1) => Some(UploadChecksum::Sha1(
@@ -109,7 +109,7 @@ async fn test_put_checksums(checksum_algorithm: Option<ChecksumAlgorithm>) {
         None => None,
     };
 
-    let params = PutObjectSingleParams::new().checksum(checksum.clone());
+    let params = PutObjectSingleParams::new().checksum(upload_checksum.clone());
     client
         .put_object_single(&bucket, &key, &params, &contents)
         .await
@@ -125,20 +125,14 @@ async fn test_put_checksums(checksum_algorithm: Option<ChecksumAlgorithm>) {
         .await
         .unwrap();
 
-    match checksum {
-        Some(UploadChecksum::Crc32c(upload_checksum)) => {
-            let checksum = output.checksum_crc32_c().unwrap();
-            let encoded = crc32c_to_base64(&upload_checksum);
-            assert_eq!(checksum, encoded);
-        }
-        Some(_) => unreachable!("unexpected checksum type"),
-        None => {
-            assert!(
-                output.checksum_crc32_c().is_none(),
-                "crc32c should not be present when upload checksums are disabled"
-            );
-        }
-    }
+    let output_checksum = Checksum {
+        checksum_crc32: output.checksum_crc32,
+        checksum_crc32c: output.checksum_crc32_c,
+        checksum_sha1: output.checksum_sha1,
+        checksum_sha256: output.checksum_sha256,
+    };
+    let checksum: Checksum = upload_checksum.into();
+    assert_eq!(output_checksum, checksum);
 }
 
 #[tokio::test]

--- a/mountpoint-s3-crt/src/checksums/sha1.rs
+++ b/mountpoint-s3-crt/src/checksums/sha1.rs
@@ -39,10 +39,13 @@ pub fn checksum(buf: &[u8]) -> Result<Sha1, Error> {
 }
 
 /// SHA1 Hasher
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Sha1Hasher {
     inner: NonNull<aws_hash>,
 }
+
+/// Safety: [Sha1Hasher] is not [Clone] and owns the inner [aws_hash].
+unsafe impl Send for Sha1Hasher {}
 
 impl Sha1Hasher {
     /// Create a new [Sha1Hasher].

--- a/mountpoint-s3-crt/src/checksums/sha256.rs
+++ b/mountpoint-s3-crt/src/checksums/sha256.rs
@@ -39,10 +39,13 @@ pub fn checksum(buf: &[u8]) -> Result<Sha256, Error> {
 }
 
 /// SHA256 Hasher
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Sha256Hasher {
     inner: NonNull<aws_hash>,
 }
+
+/// Safety: [Sha256Hasher] is not [Clone] and owns the inner [aws_hash].
+unsafe impl Send for Sha256Hasher {}
 
 impl Sha256Hasher {
     /// Create a new SHA256 hasher.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -15,7 +15,7 @@ use futures::Future;
 use mountpoint_s3_crt_sys::*;
 
 use std::ffi::{OsStr, OsString};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::marker::PhantomPinned;
 use std::mem::MaybeUninit;
 use std::os::unix::prelude::OsStrExt;
@@ -1472,6 +1472,18 @@ impl ChecksumAlgorithm {
             aws_s3_checksum_algorithm::AWS_SCA_SHA1 => Some(ChecksumAlgorithm::Sha1),
             aws_s3_checksum_algorithm::AWS_SCA_SHA256 => Some(ChecksumAlgorithm::Sha256),
             _ => unreachable!("unknown aws_s3_checksum_algorithm"),
+        }
+    }
+}
+
+impl Display for ChecksumAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChecksumAlgorithm::Crc32c => f.write_str("CRC32C"),
+            ChecksumAlgorithm::Crc32 => f.write_str("CRC32"),
+            ChecksumAlgorithm::Sha1 => f.write_str("SHA1"),
+            ChecksumAlgorithm::Sha256 => f.write_str("SHA256"),
+            ChecksumAlgorithm::Unknown(algorithm) => write!(f, "Unknown algorithm: {:?}", algorithm),
         }
     }
 }

--- a/mountpoint-s3/tests/common/fuse.rs
+++ b/mountpoint-s3/tests/common/fuse.rs
@@ -260,7 +260,7 @@ pub mod mock_session {
             params: PutObjectSingleParams,
         ) -> Result<(), Box<dyn std::error::Error>> {
             let full_key = format!("{}{}", self.prefix, key);
-            _ = self.client.mock_put_object(&full_key, &params, value)?;
+            _ = tokio_block_on(self.client.put_object_single(BUCKET_NAME, &full_key, &params, value))?;
             Ok(())
         }
 

--- a/mountpoint-s3/tests/fuse_tests/read_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/read_test.rs
@@ -8,8 +8,6 @@ use std::time::{Duration, Instant};
 
 use mountpoint_s3::data_cache::InMemoryDataCache;
 use mountpoint_s3::S3FilesystemConfig;
-#[cfg(not(feature = "s3express_tests"))]
-use mountpoint_s3_client::types::PutObjectParams;
 use rand::RngCore;
 use rand::SeedableRng as _;
 use rand_chacha::ChaChaRng;
@@ -135,17 +133,19 @@ fn read_flexible_retrieval_test(
     files: &[&str],
     restore: RestorationOptions,
 ) {
+    use mountpoint_s3_client::types::PutObjectSingleParams;
+
     let test_session = creator_fn(prefix, Default::default());
 
     for file in files {
-        let mut put_params = PutObjectParams::default();
+        let mut put_params = PutObjectSingleParams::default();
         if *file != "STANDARD" {
             put_params.storage_class = Some(file.to_string());
         }
         let key = format!("{file}.txt");
         test_session
             .client()
-            .put_object_params(&key, b"hello world", put_params)
+            .put_object_single(&key, b"hello world", put_params)
             .unwrap();
         match restore {
             RestorationOptions::None => (),

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
+use mountpoint_s3_client::types::Checksum;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use test_case::test_case;
@@ -1214,13 +1215,13 @@ fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksum
         // Express One Zone the list of parts is always present. The important thing is just that
         // the *checksums* aren't present, because we disabled those.
         assert!(
-            object_checksum.is_none_or(|c| c.checksum_crc32c.is_none()),
-            "crc32c should not be present when upload checksums are disabled"
+            object_checksum.is_none_or(|c| c == Checksum::empty()),
+            "checksums should not be present when upload checksums are disabled"
         );
         for part_checksum in part_checksums {
             assert!(
-                part_checksum.is_none_or(|c| c.checksum_crc32c.is_none()),
-                "crc32c should not be present when upload checksums are disabled"
+                part_checksum.is_none_or(|c| c == Checksum::empty()),
+                "checksums should not be present when upload checksums are disabled"
             );
         }
     }

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -1163,7 +1163,6 @@ fn concurrent_open_for_write_test(max_files: usize) {
 
 fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksums: bool) {
     const OBJECT_SIZE: usize = 20 * 1024 * 1024;
-    const PART_SIZE: usize = 8 * 1024 * 1024;
     const KEY: &str = "dir/new.txt";
 
     let config = TestSessionConfig {
@@ -1199,28 +1198,30 @@ fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksum
     drop(f);
 
     // Now it's fsync'ed and closed, it should be present in S3
-    let parts = test_session.client().get_object_parts(KEY).unwrap();
+    let (object_checksum, part_checksums) = test_session.client().get_object_checksums(KEY).unwrap();
     if use_upload_checksums {
-        let parts = parts.expect("parts should be non-empty");
-        assert_eq!(parts.len(), (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE);
-        for part in parts {
-            let checksum = part.checksum.expect("checksum should be present");
-            let _crc32c = checksum.checksum_crc32c.expect("crc32c is used for trailing checksums");
-        }
+        // We should get the correct checksum on the whole object or on the parts.
+        let object_crc32c = object_checksum.is_some_and(|checksum| checksum.checksum_crc32c.is_some());
+        let parts_crc32c = !part_checksums.is_empty()
+            && part_checksums.iter().all(|checksum| {
+                checksum
+                    .as_ref()
+                    .is_some_and(|checksum| checksum.checksum_crc32c.is_some())
+            });
+        assert!(object_crc32c || parts_crc32c, "crc32c is used for trailing checksums");
     } else {
         // For S3 Standard, the list of parts is only present if checksums were used, but for S3
         // Express One Zone the list of parts is always present. The important thing is just that
         // the *checksums* aren't present, because we disabled those.
-        if let Some(parts) = parts {
-            assert_eq!(parts.len(), (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE);
-            for part in parts {
-                if let Some(checksum) = part.checksum {
-                    assert!(
-                        checksum.checksum_crc32c.is_none(),
-                        "crc32c should not be present when upload checksums are disabled"
-                    );
-                }
-            }
+        assert!(
+            object_checksum.is_none_or(|c| c.checksum_crc32c.is_none()),
+            "crc32c should not be present when upload checksums are disabled"
+        );
+        for part_checksum in part_checksums {
+            assert!(
+                part_checksum.is_none_or(|c| c.checksum_crc32c.is_none()),
+                "crc32c should not be present when upload checksums are disabled"
+            );
         }
     }
 }


### PR DESCRIPTION
Allows to specify any of the supported checksum algorithms when uploading objects.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry?

Yes, adding an entry to the `mountpoint-s3-client` changelog.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
