### PR TITLE
Update vendored fuser to bc31e4d2

### DIFF
--- a/vendor/fuser/Cargo.toml
+++ b/vendor/fuser/Cargo.toml
@@ -77,7 +77,7 @@ required-features = ["abi-7-12"]
 
 [[example]]
 name = "notify_inval_inode"
-required-features = ["abi-7-12"]
+required-features = ["abi-7-15"]
 
 [[example]]
 name = "ioctl"

--- a/vendor/fuser/deny.toml
+++ b/vendor/fuser/deny.toml
@@ -9,24 +9,6 @@
 # The values provided in this template are the default values that will be used
 # when any section or field is not specified in your own configuration
 
-# If 1 or more target triples (and optionally, target_features) are specified,
-# only the specified targets will be checked when running `cargo deny check`.
-# This means, if a particular package is only ever used as a target specific
-# dependency, such as, for example, the `nix` crate only being used via the
-# `target_family = "unix"` configuration, that only having windows targets in
-# this list would mean the nix crate, as well as any of its exclusive
-# dependencies not shared by any other crates, would be ignored, as the target
-# list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
-
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
@@ -35,16 +17,8 @@ targets = [
 db-path = "~/.cargo/advisory-db"
 # The url of the advisory database to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -64,8 +38,6 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
@@ -74,26 +46,6 @@ allow = [
 #    "BSD-3-Clause",
     "MIT",
 ]
-# List of explictly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
-# Lint level for licenses considered copyleft
-copyleft = "deny"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -105,7 +57,7 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], name = "adler32", version = "*" },
-    { allow = ["Unicode-DFS-2016"], name = "unicode-ident", version = "*" },
+    { allow = ["Unicode-3.0"], name = "unicode-ident", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/vendor/fuser/examples/simple.rs
+++ b/vendor/fuser/examples/simple.rs
@@ -1098,6 +1098,10 @@ impl Filesystem for SimpleFS {
         flags: u32,
         reply: ReplyEmpty,
     ) {
+        debug!(
+            "rename() called with: source {parent:?} {name:?}, \
+            destination {new_parent:?} {new_name:?}, flags {flags:#b}",
+        );
         let mut inode_attrs = match self.lookup_name(parent, name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
@@ -1922,8 +1926,7 @@ fn as_file_kind(mut mode: u32) -> FileKind {
 }
 
 fn get_groups(pid: u32) -> Vec<u32> {
-    #[cfg(not(target_os = "macos"))]
-    {
+    if cfg!(not(target_os = "macos")) {
         let path = format!("/proc/{pid}/task/{pid}/status");
         let file = File::open(path).unwrap();
         for line in BufReader::new(file).lines() {

--- a/vendor/fuser/src/request.rs
+++ b/vendor/fuser/src/request.rs
@@ -617,9 +617,9 @@ impl<'a> Request<'a> {
                 se.filesystem.setvolname(self, x.name(), self.reply());
             }
             #[cfg(target_os = "macos")]
-            ll::Operation::GetXTimes(_) => {
+            ll::Operation::GetXTimes(x) => {
                 se.filesystem
-                    .getxtimes(self, self.request.nodeid().into(), self.reply());
+                    .getxtimes(self, x.nodeid().into(), self.reply());
             }
             #[cfg(target_os = "macos")]
             ll::Operation::Exchange(x) => {

--- a/vendor/fuser/tests/integration_tests.rs
+++ b/vendor/fuser/tests/integration_tests.rs
@@ -1,3 +1,6 @@
+// No integration tests for non-Linux targets, so turn off the module for now.
+#![cfg(target_os = "linux")]
+
 use fuser::{Filesystem, Session};
 use std::rc::Rc;
 use std::thread;
@@ -7,8 +10,10 @@ use tempfile::TempDir;
 #[test]
 #[cfg(target_os = "linux")]
 fn unmount_no_send() {
-    // Rc to make this !Send
-    struct NoSendFS(Rc<()>);
+    struct NoSendFS(
+        // Rc to make this !Send
+        #[allow(dead_code)] Rc<()>,
+    );
 
     impl Filesystem for NoSendFS {}
 


### PR DESCRIPTION
This change pulls in the current state of our fuser fork, recently rebased on the latest commits upstream. Most importantly, we want to tackle build warnings which should be resolved by https://github.com/cberner/fuser/pull/315.

### Does this change impact existing behavior?

No, build warning fixes only.

### Does this change need a changelog entry?

No, no API or behavior change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
