### PR TITLE
Refactor MemoryLimiter to specify tracked 'area' when reserving memory

### DIFF
--- a/mountpoint-s3/src/prefetch/part_queue.rs
+++ b/mountpoint-s3/src/prefetch/part_queue.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
-use crate::mem_limiter::MemoryLimiter;
+use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::prefetch::part::Part;
 use crate::prefetch::PrefetchReadError;
 use crate::sync::async_channel::{unbounded, Receiver, RecvError, Sender};
@@ -104,7 +104,7 @@ impl<Client: ObjectClient> PartQueue<Client> {
         metrics::gauge!("prefetch.bytes_in_queue").increment(part.len() as f64);
         // The backpressure controller is not aware of the parts from backwards seek,
         // so we have to reserve memory for them here.
-        self.mem_limiter.reserve(part.len() as u64);
+        self.mem_limiter.reserve(BufferArea::Prefetch, part.len() as u64);
         self.front_queue.push(part);
         Ok(())
     }


### PR DESCRIPTION
The memory limiter currently tracks the amount of memory reserved for prefetching. We plan to extend this as part of supporting appends in S3 Express One Zone (#1160).

This change (originally authored by @monthonk) refactors the memory limiter API to allow specifying the "area" we'd like to reserve in, for the purpose of metrics for now.

### Does this change impact existing behavior?

No change to existing behavior.

### Does this change need a changelog entry?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
