### PR TITLE
Introduce incremental upload mode and support for append

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -204,9 +204,11 @@ Mountpoint automatically configures reasonable defaults for file system settings
 
 By default, Mountpoint allows creating new files but does not allow deleting or overwriting existing objects.
 
-Writes to existing files are allowed if `--allow-overwrite` flag is set at mount time, but only when the `O_TRUNC` flag is used at open time to truncate the existing file. All writes must start from the beginning of the file and must be made sequentially.
-
 If you want to allow file deletion, use the `--allow-delete` flag at mount time. Delete operations immediately delete the object from S3, even if the file is being read from.
+
+If you want to allow overwriting existing files, use the `--allow-overwrite` flag at mount time. The file must be opened with the `O_TRUNC` flag which will truncate the existing file. All writes must start from the beginning of the file and must be made sequentially.
+
+You can also allow appending to existing files in directory buckets in S3 Express One Zone, by setting the `--incremental-upload` flag at mount time. In this mode, writes to existing files opened without the `O_TRUNC` flag are allowed, provided they start at the end of the file and are made sequentially. For more details, see [Reading and writing files](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#reading-and-writing-files).
 
 If you want to forbid all mutating actions on your S3 bucket via Mountpoint, use the `--read-only` command-line flag.
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New features
+
+* Mountpoint now offers a new command-line flag `--incremental-upload`, available when mounting directory buckets in S3 Express One Zone. When set, Mountpoint will perform all uploads incrementally and support appending to existing objects. ([#1165](https://github.com/awslabs/mountpoint-s3/pull/1165))
+
 ### Other changes
 
 * Implement statfs to report non-zero synthetic values. This may unblock applications which rely on verifying there is available space before creating new files. ([#1118](https://github.com/awslabs/mountpoint-s3/pull/1118))

--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -168,8 +168,15 @@ fn mount_file_system(
         bucket_name,
         mountpoint.to_str().unwrap()
     );
-    let prefetcher = default_prefetch(runtime, Default::default());
-    let fs = S3Filesystem::new(client, prefetcher, bucket_name, &Default::default(), filesystem_config);
+    let prefetcher = default_prefetch(runtime.clone(), Default::default());
+    let fs = S3Filesystem::new(
+        client,
+        prefetcher,
+        runtime,
+        bucket_name,
+        &Default::default(),
+        filesystem_config,
+    );
     let session = Session::new(S3FuseFilesystem::new(fs), mountpoint, &options)
         .expect("Should have created FUSE session successfully");
 

--- a/mountpoint-s3/examples/upload_benchmark.rs
+++ b/mountpoint-s3/examples/upload_benchmark.rs
@@ -1,0 +1,233 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::Parser;
+use futures::task::Spawn;
+use mountpoint_s3::mem_limiter::MemoryLimiter;
+use mountpoint_s3::upload::{AppendUploader, Uploader};
+use mountpoint_s3::ServerSideEncryption;
+use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::types::ChecksumAlgorithm;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient};
+use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
+use mountpoint_s3_crt::common::uri::Uri;
+use sysinfo::{RefreshKind, System};
+use tracing_subscriber::fmt::Subscriber;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+/// Like `tracing_subscriber::fmt::init` but sends logs to stderr
+fn init_tracing_subscriber() {
+    RustLogAdapter::try_init().expect("unable to install CRT log adapter");
+
+    let env_filter = EnvFilter::from_default_env();
+    let subscriber = Subscriber::builder()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .finish();
+
+    subscriber.try_init().expect("unable to install global subscriber");
+}
+
+#[derive(Parser, Debug)]
+struct UploadBenchmarkArgs {
+    #[clap(help = "Name of bucket to upload")]
+    pub bucket: String,
+
+    #[clap(help = "Object key to upload")]
+    pub key: String,
+
+    #[clap(long, help = "Object size to upload in bytes")]
+    pub object_size: usize,
+
+    #[clap(long, help = "Number of benchmark iterations", default_value = "1")]
+    pub iterations: usize,
+
+    #[clap(long, help = "Desired throughput in Gbps", default_value = "10")]
+    pub throughput_target_gbps: usize,
+
+    #[clap(long, help = "AWS region of the bucket", default_value = "us-east-1")]
+    pub region: String,
+
+    #[clap(long, help = "S3 endpoint URL [default: auto-detect endpoint]")]
+    pub endpoint_url: Option<String>,
+
+    #[clap(long, help = "Run benchmark using incremental uploads")]
+    pub incremental_upload: bool,
+
+    #[clap(long, help = "Size of each write in bytes", default_value = "131072")]
+    pub write_size: usize,
+
+    #[clap(
+        long,
+        help = "Maximum memory usage target [default: 95% of total system memory]",
+        value_name = "MiB"
+    )]
+    pub max_memory_target: Option<u64>,
+
+    #[clap(long, help = "Write part size for the upload", default_value = "8388608")]
+    pub write_part_size: usize,
+
+    #[clap(long, help = "Server-side encryption algorithm to use when uploading")]
+    pub sse: Option<String>,
+
+    #[clap(
+        long,
+        help = "KMS key ARN to use with KMS server-side encryption when uploading.",
+        requires = "sse"
+    )]
+    pub sse_kms_key_id: Option<String>,
+
+    #[clap(
+        long,
+        help = "Checksum algorithm to use for S3 uploads",
+        value_name = "off|crc32c|crc32|sha1|sha256",
+        default_value = "crc32c"
+    )]
+    pub checksum_algorithm: String,
+}
+
+fn main() {
+    init_tracing_subscriber();
+
+    let args = UploadBenchmarkArgs::parse();
+    println!("starting upload benchmark with {:?}", &args);
+
+    let mut endpoint_config = EndpointConfig::new(&args.region);
+    if let Some(url) = &args.endpoint_url {
+        let endpoint_uri = Uri::new_from_str(&Allocator::default(), url).expect("Failed to parse endpoint URL");
+        endpoint_config = endpoint_config.endpoint(endpoint_uri);
+    }
+    let config = S3ClientConfig::new()
+        .endpoint_config(endpoint_config)
+        .throughput_target_gbps(args.throughput_target_gbps as f64)
+        .write_part_size(args.write_part_size);
+    let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
+    let runtime = client.event_loop_group();
+
+    for i in 0..args.iterations {
+        let start = Instant::now();
+        if args.incremental_upload {
+            futures::executor::block_on(run_append_uploader(client.clone(), runtime.clone(), &args, i));
+        } else {
+            futures::executor::block_on(run_mpu_uploader(client.clone(), &args, i));
+        }
+        let elapsed = start.elapsed();
+        let uploaded_size_mib = (args.object_size as f64) / (1024 * 1024) as f64;
+        println!(
+            "iteration {}: uploaded {:.2} MiB in {:.2}s: {:.2}MiB/s",
+            i,
+            uploaded_size_mib,
+            elapsed.as_secs_f64(),
+            uploaded_size_mib / elapsed.as_secs_f64(),
+        );
+
+        // clean up
+        futures::executor::block_on(client.delete_object(&args.bucket, &args.key)).unwrap();
+    }
+}
+
+async fn run_mpu_uploader<Client: ObjectClient>(client: Arc<Client>, args: &UploadBenchmarkArgs, iteration: usize) {
+    let start = Instant::now();
+    let server_side_encryption = ServerSideEncryption::new(args.sse.clone(), args.sse_kms_key_id.clone());
+
+    let use_additional_checksum = match args.checksum_algorithm.as_str() {
+        "off" => false,
+        "crc32c" => true,
+        other => todo!("MPU uploader does not support {other} checksum algorithm"),
+    };
+    let uploader = Uploader::new(client.clone(), None, server_side_encryption, use_additional_checksum);
+
+    let bucket = args.bucket.clone();
+    let key = args.key.clone();
+    let mut upload_request = uploader.put(&bucket, &key).await.unwrap();
+
+    let mut total_bytes_written = 0;
+    let target_size = args.object_size;
+
+    let contents = vec![0xab; args.write_size];
+    while total_bytes_written < target_size {
+        let len = upload_request
+            .write(total_bytes_written as i64, &contents)
+            .await
+            .unwrap();
+        total_bytes_written += len;
+    }
+    let elapsed = start.elapsed();
+    let total_mib_written = (total_bytes_written as f64) / (1024 * 1024) as f64;
+    println!(
+        "iteration {}: written {:.2} MiB without commit in {:.2}s: {:.2}MiB/s",
+        iteration,
+        total_mib_written,
+        elapsed.as_secs_f64(),
+        total_mib_written / elapsed.as_secs_f64(),
+    );
+    upload_request.complete().await.unwrap();
+}
+
+async fn run_append_uploader<Client, Runtime>(
+    client: Arc<Client>,
+    runtime: Runtime,
+    args: &UploadBenchmarkArgs,
+    iteration: usize,
+) where
+    Client: ObjectClient + Send + Sync + 'static,
+    Runtime: Spawn + Send + Sync + 'static,
+{
+    let start = Instant::now();
+    let max_memory_target = if let Some(target) = args.max_memory_target {
+        target * 1024 * 1024
+    } else {
+        // Default to 95% of total system memory
+        let sys = System::new_with_specifics(RefreshKind::everything());
+        (sys.total_memory() as f64 * 0.95) as u64
+    };
+    let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), max_memory_target));
+
+    let buffer_size = args.write_part_size;
+    let server_side_encryption = ServerSideEncryption::new(args.sse.clone(), args.sse_kms_key_id.clone());
+
+    let checksum_algorithm = match args.checksum_algorithm.as_str() {
+        "off" => None,
+        "crc32c" => Some(ChecksumAlgorithm::Crc32c),
+        "crc32" => Some(ChecksumAlgorithm::Crc32),
+        "sha1" => Some(ChecksumAlgorithm::Sha1),
+        "sha256" => Some(ChecksumAlgorithm::Sha256),
+        other => Some(ChecksumAlgorithm::Unknown(other.to_string())),
+    };
+    let uploader = AppendUploader::new(
+        client.clone(),
+        runtime,
+        mem_limiter,
+        buffer_size,
+        server_side_encryption,
+        checksum_algorithm,
+    );
+
+    let bucket = args.bucket.clone();
+    let key = args.key.clone();
+    let mut upload_request = uploader.start_upload(bucket.clone(), key.clone(), 0, None);
+
+    let mut total_bytes_written = 0;
+    let target_size = args.object_size;
+
+    let contents = vec![0xab; args.write_size];
+    while total_bytes_written < target_size {
+        upload_request
+            .write(total_bytes_written as u64, &contents)
+            .await
+            .unwrap();
+        total_bytes_written += contents.len();
+    }
+    let elapsed = start.elapsed();
+    let total_mib_written = (total_bytes_written as f64) / (1024 * 1024) as f64;
+    println!(
+        "iteration {}: written {:.2} MiB in {:.2}s: {:.2}MiB/s without commit",
+        iteration,
+        total_mib_written,
+        elapsed.as_secs_f64(),
+        total_mib_written / elapsed.as_secs_f64(),
+    );
+    upload_request.complete().await.unwrap();
+}

--- a/mountpoint-s3/src/fs/config.rs
+++ b/mountpoint-s3/src/fs/config.rs
@@ -4,6 +4,7 @@ use nix::unistd::{getgid, getuid};
 
 use crate::mem_limiter::MINIMUM_MEM_LIMIT;
 use crate::s3::S3Personality;
+use crate::superblock::WriteMode;
 
 use super::{ServerSideEncryption, TimeToLive};
 
@@ -25,6 +26,8 @@ pub struct S3FilesystemConfig {
     pub allow_delete: bool,
     /// Allow overwrite
     pub allow_overwrite: bool,
+    /// Enable incremental uploads
+    pub incremental_upload: bool,
     /// Storage class to be used for new object uploads
     pub storage_class: Option<String>,
     /// S3 personality (for different S3 semantics)
@@ -51,11 +54,21 @@ impl Default for S3FilesystemConfig {
             file_mode: 0o644,
             allow_delete: false,
             allow_overwrite: false,
+            incremental_upload: false,
             storage_class: None,
             s3_personality: S3Personality::default(),
             server_side_encryption: Default::default(),
             use_upload_checksums: true,
             mem_limit: MINIMUM_MEM_LIMIT,
+        }
+    }
+}
+
+impl S3FilesystemConfig {
+    pub fn write_mode(&self) -> WriteMode {
+        WriteMode {
+            allow_overwrite: self.allow_overwrite,
+            incremental_upload: self.incremental_upload,
         }
     }
 }

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -14,7 +14,7 @@ pub mod prefix;
 pub mod s3;
 mod superblock;
 mod sync;
-mod upload;
+pub mod upload;
 
 pub use fs::{S3Filesystem, S3FilesystemConfig, ServerSideEncryption};
 

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -50,7 +50,7 @@ use expiry::Expiry;
 mod inode;
 use inode::{valid_inode_name, InodeErrorInfo, InodeKindData, InodeStat, InodeState, WriteStatus};
 
-pub use inode::{Inode, InodeKind, InodeNo, ReadHandle, WriteHandle};
+pub use inode::{Inode, InodeKind, InodeNo, ReadHandle, WriteHandle, WriteMode};
 
 mod negative_cache;
 use negative_cache::NegativeCache;
@@ -262,12 +262,12 @@ impl Superblock {
         &self,
         _client: &OC,
         ino: InodeNo,
-        allow_overwrite: bool,
+        mode: &WriteMode,
         is_truncate: bool,
     ) -> Result<WriteHandle, InodeError> {
         trace!(?ino, "write");
         let inode = self.inner.get(ino)?;
-        WriteHandle::new(self.inner.clone(), inode, allow_overwrite, is_truncate)
+        WriteHandle::new(self.inner.clone(), inode, mode, is_truncate)
     }
 
     /// Create a new handle for a file being read. The handle can be used to update the state of
@@ -1522,7 +1522,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), false, false)
+                .write(&client, new_inode.inode.ino(), &WriteMode::default(), false)
                 .await
                 .expect("should be able to start writing");
             expected_list.push(filename);
@@ -1574,7 +1574,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), false, false)
+                .write(&client, new_inode.inode.ino(), &WriteMode::default(), false)
                 .await
                 .expect("should be able to start writing");
             expected_list.push(filename);
@@ -1728,7 +1728,7 @@ mod tests {
                 .await
                 .unwrap();
             superblock
-                .write(&client, new_inode.inode.ino(), false, false)
+                .write(&client, new_inode.inode.ino(), &WriteMode::default(), false)
                 .await
                 .expect("should be able to start writing");
         }
@@ -1958,7 +1958,7 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), false, false)
+            .write(&client, new_inode.inode.ino(), &WriteMode::default(), false)
             .await
             .expect("should be able to start writing");
 
@@ -2124,7 +2124,7 @@ mod tests {
             .unwrap();
 
         let writehandle = superblock
-            .write(&client, new_inode.inode.ino(), false, false)
+            .write(&client, new_inode.inode.ino(), &WriteMode::default(), false)
             .await
             .expect("should be able to start writing");
 

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -1,29 +1,33 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+use std::future::Future;
 
-use mountpoint_s3_client::checksums::crc32c_from_base64;
-use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
-use mountpoint_s3_client::types::{PutObjectParams, PutObjectResult, PutObjectTrailingChecksums, UploadReview};
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
+use futures::future::RemoteHandle;
+use futures::task::{Spawn, SpawnError, SpawnExt};
 
-use mountpoint_s3_crt::checksums::crc32c::{Crc32c, Hasher};
+use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError, PutObjectError};
+use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag};
+use mountpoint_s3_client::ObjectClient;
+
 use thiserror::Error;
 use tracing::error;
 
-use crate::checksums::combine_checksums;
 use crate::fs::{ServerSideEncryption, SseCorruptedError};
+use crate::mem_limiter::MemoryLimiter;
+use crate::sync::Arc;
 
-type PutRequestError<Client> = ObjectClientError<PutObjectError, <Client as ObjectClient>::ClientError>;
+mod atomic;
+pub use atomic::UploadRequest;
 
-const MAX_S3_MULTIPART_UPLOAD_PARTS: usize = 10000;
+mod hasher;
+pub use hasher::ChecksumHasherError;
+
+mod incremental;
+use incremental::AppendUploadQueueParams;
+pub use incremental::AppendUploadRequest;
 
 /// An [Uploader] creates and manages streaming PutObject requests.
 #[derive(Debug)]
 pub struct Uploader<Client> {
-    inner: Arc<UploaderInner<Client>>,
-}
-
-#[derive(Debug)]
-struct UploaderInner<Client> {
     client: Client,
     storage_class: Option<String>,
     server_side_encryption: ServerSideEncryption,
@@ -38,6 +42,18 @@ pub enum UploadPutError<S, C> {
     SseCorruptedError(#[from] SseCorruptedError),
 }
 
+#[derive(Debug, Error, Clone)]
+pub enum UploadWriteError<E: std::error::Error> {
+    #[error("put request failed")]
+    PutRequestFailed(#[from] E),
+
+    #[error("out-of-order write is NOT supported by Mountpoint, aborting the upload; expected offset {expected_offset:?} but got {write_offset:?}")]
+    OutOfOrderWrite { write_offset: u64, expected_offset: u64 },
+
+    #[error("object exceeded maximum upload size of {maximum_size} bytes")]
+    ObjectTooBig { maximum_size: usize },
+}
+
 impl<Client: ObjectClient> Uploader<Client> {
     /// Create a new [Uploader] that will make requests to the given client.
     pub fn new(
@@ -46,13 +62,12 @@ impl<Client: ObjectClient> Uploader<Client> {
         server_side_encryption: ServerSideEncryption,
         use_additional_checksums: bool,
     ) -> Self {
-        let inner = UploaderInner {
+        Self {
             client,
             storage_class,
             server_side_encryption,
             use_additional_checksums,
-        };
-        Self { inner: Arc::new(inner) }
+        }
     }
 
     /// Start a new put request to the specified object.
@@ -61,395 +76,125 @@ impl<Client: ObjectClient> Uploader<Client> {
         bucket: &str,
         key: &str,
     ) -> Result<UploadRequest<Client>, UploadPutError<PutObjectError, Client::ClientError>> {
-        UploadRequest::new(Arc::clone(&self.inner), bucket, key).await
+        UploadRequest::new(self, bucket, key).await
     }
 
     #[cfg(test)]
     pub fn corrupt_sse(&mut self, sse_type: Option<String>, sse_kms_key_id: Option<String>) {
-        std::sync::Arc::get_mut(&mut self.inner)
-            .unwrap()
-            .server_side_encryption
-            .corrupt_data(sse_type, sse_kms_key_id)
+        self.server_side_encryption.corrupt_data(sse_type, sse_kms_key_id)
     }
 }
 
-#[derive(Debug, Error, Clone)]
-pub enum UploadWriteError<E: std::error::Error> {
-    #[error("put request failed")]
-    PutRequestFailed(#[from] E),
+/// Maximum number of bytes an `AppendUploadQueue` can take.
+///
+/// We use this limit to prevent a single pipeline from consuming all memory.
+/// The limit may slow down writes eventually, but the overall upload throughput
+/// is already capped by a single PutObject request.
+const MAX_BYTES_IN_QUEUE: usize = 2 * 1024 * 1024 * 1024;
 
-    #[error("out of order write is NOT supported by Mountpoint, aborting the upload; expected offset {expected_offset:?} but got {write_offset:?}")]
+/// An [AppendUploader] creates and manages streaming PutObject requests using the Append API.
+#[derive(Debug)]
+pub struct AppendUploader<Client: ObjectClient> {
+    client: Client,
+    runtime: BoxRuntime,
+    mem_limiter: Arc<MemoryLimiter<Client>>,
+    buffer_size: usize,
+    server_side_encryption: ServerSideEncryption,
+    checksum_algorithm: Option<ChecksumAlgorithm>,
+}
+
+#[derive(Debug, Error)]
+pub enum AppendUploadError<E> {
+    #[error("out-of-order write is NOT supported by Mountpoint, aborting the upload; expected offset {expected_offset:?} but got {write_offset:?}")]
     OutOfOrderWrite { write_offset: u64, expected_offset: u64 },
 
-    #[error("object exceeded maximum upload size of {maximum_size} bytes")]
-    ObjectTooBig { maximum_size: usize },
+    #[error("put request failed")]
+    PutRequestFailed(#[source] ObjectClientError<PutObjectError, E>),
+
+    #[error("upload was already terminated because of previous failures")]
+    UploadAlreadyTerminated,
+
+    #[error("SSE settings corrupted")]
+    SseCorruptedError(#[from] SseCorruptedError),
+
+    #[error("error computing checksums")]
+    ChecksumComputationFailed(#[from] ChecksumHasherError),
+
+    #[error("head object request failed")]
+    HeadObjectFailed(#[from] ObjectClientError<HeadObjectError, E>),
 }
 
-/// Manages the upload of an object to S3.
-///
-/// Wraps a PutObject request and enforces sequential writes.
-pub struct UploadRequest<Client: ObjectClient> {
-    bucket: String,
-    key: String,
-    next_request_offset: u64,
-    hasher: Hasher,
-    request: Client::PutObjectRequest,
-    maximum_upload_size: Option<usize>,
-    sse: ServerSideEncryption,
-}
-
-impl<Client: ObjectClient> UploadRequest<Client> {
-    async fn new(
-        inner: Arc<UploaderInner<Client>>,
-        bucket: &str,
-        key: &str,
-    ) -> Result<UploadRequest<Client>, UploadPutError<PutObjectError, Client::ClientError>> {
-        let mut params = PutObjectParams::new();
-
-        if inner.use_additional_checksums {
-            params = params.trailing_checksums(PutObjectTrailingChecksums::Enabled);
-        } else {
-            params = params.trailing_checksums(PutObjectTrailingChecksums::ReviewOnly);
+impl<Client> AppendUploader<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    pub fn new(
+        client: Client,
+        runtime: impl Spawn + Sync + Send + 'static,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        buffer_size: usize,
+        server_side_encryption: ServerSideEncryption,
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+    ) -> Self {
+        Self {
+            client,
+            runtime: runtime.into(),
+            mem_limiter,
+            buffer_size,
+            server_side_encryption,
+            checksum_algorithm,
         }
-
-        if let Some(storage_class) = &inner.storage_class {
-            params = params.storage_class(storage_class.clone());
-        }
-        // If we have detected corruption of SSE settings, we return an error, which will currently be reported as
-        // `libc::EIO` on `open()`. MP won't be able to open files for write from this point, but this is a relatively
-        // low-risk error as data can not be uploaded with wrong SSE settings yet. Thus there is no strong reason for
-        // MP to crash and it may continue serving read's.
-        let (sse_type, key_id) = inner.server_side_encryption.clone().into_inner()?;
-        params = params.server_side_encryption(sse_type);
-        params = params.ssekms_key_id(key_id);
-
-        let request = inner.client.put_object(bucket, key, &params).await?;
-        let maximum_upload_size = inner
-            .client
-            .write_part_size()
-            .map(|ps| ps.saturating_mul(MAX_S3_MULTIPART_UPLOAD_PARTS));
-
-        Ok(Self {
-            bucket: bucket.to_owned(),
-            key: key.to_owned(),
-            next_request_offset: 0,
-            hasher: Hasher::new(),
-            request,
-            maximum_upload_size,
-            sse: inner.server_side_encryption.clone(),
-        })
     }
 
-    pub fn size(&self) -> u64 {
-        self.next_request_offset
-    }
-
-    pub async fn write(
-        &mut self,
-        offset: i64,
-        data: &[u8],
-    ) -> Result<usize, UploadWriteError<PutRequestError<Client>>> {
-        let next_offset = self.next_request_offset;
-        if offset != next_offset as i64 {
-            return Err(UploadWriteError::OutOfOrderWrite {
-                write_offset: offset as u64,
-                expected_offset: next_offset,
-            });
-        }
-        if let Some(maximum_size) = self.maximum_upload_size {
-            if next_offset + data.len() as u64 > maximum_size as u64 {
-                return Err(UploadWriteError::ObjectTooBig { maximum_size });
-            }
-        }
-
-        self.hasher.update(data);
-        self.request.write(data).await?;
-        self.next_request_offset += data.len() as u64;
-        Ok(data.len())
-    }
-
-    pub async fn complete(self) -> Result<PutObjectResult, PutRequestError<Client>> {
-        let size = self.size();
-        let checksum = self.hasher.finalize();
-        let result = self
-            .request
-            .review_and_complete(move |review| verify_checksums(review, size, checksum))
-            .await?;
-        if let Err(err) = self
-            .sse
-            .verify_response(result.sse_type.as_deref(), result.sse_kms_key_id.as_deref())
-        {
-            error!(key=?self.key, error=?err, "SSE settings were corrupted after the upload completion");
-            // Reaching this point is very unlikely and means that SSE settings were corrupted in transit or on S3 side, this may be a sign of a bug
-            // in CRT code or S3. Thus, we terminate Mountpoint to send the most noticeable signal to customer about the issue. We prefer exiting
-            // instead of returning an error because:
-            // 1. this error would only be reported on `flush` which many applications ignore and
-            // 2. the reported error is severe as the object was already uploaded to S3.
-            std::process::exit(1);
-        }
-        Ok(result)
+    /// Start a new appendable upload to the specified object.
+    pub fn start_upload(
+        &self,
+        bucket: String,
+        key: String,
+        initial_offset: u64,
+        initial_etag: Option<ETag>,
+    ) -> AppendUploadRequest<Client> {
+        let params = AppendUploadQueueParams {
+            bucket,
+            key,
+            initial_offset,
+            initial_etag,
+            server_side_encryption: self.server_side_encryption.clone(),
+            checksum_algorithm: self.checksum_algorithm.clone(),
+            capacity: MAX_BYTES_IN_QUEUE / self.buffer_size,
+        };
+        AppendUploadRequest::new(
+            &self.runtime,
+            self.client.clone(),
+            self.buffer_size,
+            self.mem_limiter.clone(),
+            params,
+        )
     }
 }
 
-impl<Client: ObjectClient> Debug for UploadRequest<Client> {
+struct BoxRuntime(Box<dyn Spawn + Send + Sync>);
+impl BoxRuntime {
+    fn spawn_with_handle<Fut>(&self, future: Fut) -> Result<RemoteHandle<Fut::Output>, SpawnError>
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send,
+    {
+        self.0.spawn_with_handle(future)
+    }
+}
+
+impl Debug for BoxRuntime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UploadRequest")
-            .field("bucket", &self.bucket)
-            .field("key", &self.key)
-            .field("next_request_offset", &self.next_request_offset)
-            .field("hasher", &self.hasher)
-            .finish()
+        f.debug_tuple("BoxRuntime").field(&"dyn").finish()
     }
 }
 
-fn verify_checksums(review: UploadReview, expected_size: u64, expected_checksum: Crc32c) -> bool {
-    let mut uploaded_size = 0u64;
-    let mut uploaded_checksum = Crc32c::new(0);
-    for (i, part) in review.parts.iter().enumerate() {
-        uploaded_size += part.size;
-
-        let Some(checksum) = &part.checksum else {
-            error!(part_number = i + 1, "missing part checksum");
-            return false;
-        };
-        let checksum = match crc32c_from_base64(checksum) {
-            Ok(checksum) => checksum,
-            Err(error) => {
-                error!(part_number = i + 1, ?error, "error decoding part checksum");
-                return false;
-            }
-        };
-
-        uploaded_checksum = combine_checksums(uploaded_checksum, checksum, part.size as usize);
-    }
-
-    if uploaded_size != expected_size {
-        error!(
-            uploaded_size,
-            expected_size, "Total uploaded size differs from expected size"
-        );
-        return false;
-    }
-
-    if uploaded_checksum != expected_checksum {
-        error!(
-            ?uploaded_checksum,
-            ?expected_checksum,
-            "Combined checksum of all uploaded parts differs from expected checksum"
-        );
-        return false;
-    }
-
-    true
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use super::*;
-    use mountpoint_s3_client::{
-        failure_client::{countdown_failure_client, CountdownFailureConfig},
-        mock_client::{MockClient, MockClientConfig, MockClientError},
-    };
-    use test_case::test_case;
-
-    #[tokio::test]
-    async fn complete_test() {
-        let bucket = "bucket";
-        let name = "hello";
-        let key = name;
-
-        let client = Arc::new(MockClient::new(MockClientConfig {
-            bucket: bucket.to_owned(),
-            part_size: 32,
-            ..Default::default()
-        }));
-        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default(), true);
-        let request = uploader.put(bucket, key).await.unwrap();
-
-        assert!(!client.contains_key(key));
-        assert!(client.is_upload_in_progress(key));
-
-        request.complete().await.unwrap();
-
-        assert!(client.contains_key(key));
-        assert!(!client.is_upload_in_progress(key));
-    }
-
-    #[tokio::test]
-    async fn write_order_test() {
-        let bucket = "bucket";
-        let name = "hello";
-        let key = name;
-        let storage_class = "INTELLIGENT_TIERING";
-
-        let client = Arc::new(MockClient::new(MockClientConfig {
-            bucket: bucket.to_owned(),
-            part_size: 32,
-            ..Default::default()
-        }));
-        let uploader = Uploader::new(
-            client.clone(),
-            Some(storage_class.to_owned()),
-            ServerSideEncryption::default(),
-            true,
-        );
-
-        let mut request = uploader.put(bucket, key).await.unwrap();
-
-        let data = b"foo";
-        let mut offset = 0;
-        offset += request.write(offset, data).await.unwrap() as i64;
-
-        request
-            .write(0, data)
-            .await
-            .expect_err("out of order write should fail");
-
-        offset += request
-            .write(offset, data)
-            .await
-            .expect("subsequent in order write should succeed") as i64;
-
-        let size = request.size();
-        assert_eq!(offset, size as i64);
-
-        request.complete().await.unwrap();
-        assert!(client.contains_key(key));
-    }
-
-    #[tokio::test]
-    async fn failure_test() {
-        let bucket = "bucket";
-        let name = "hello";
-        let key = name;
-
-        let client = Arc::new(MockClient::new(MockClientConfig {
-            bucket: bucket.to_owned(),
-            part_size: 32,
-            ..Default::default()
-        }));
-
-        let mut put_failures = HashMap::new();
-        put_failures.insert(1, Ok((1, MockClientError("error".to_owned().into()))));
-        put_failures.insert(2, Ok((2, MockClientError("error".to_owned().into()))));
-
-        let failure_client = Arc::new(countdown_failure_client(
-            client.clone(),
-            CountdownFailureConfig {
-                put_failures,
-                ..Default::default()
-            },
-        ));
-
-        let uploader = Uploader::new(failure_client.clone(), None, ServerSideEncryption::default(), true);
-
-        // First request fails on first write.
-        {
-            let mut request = uploader.put(bucket, key).await.unwrap();
-
-            let data = b"foo";
-            request.write(0, data).await.expect_err("first write should fail");
-        }
-        assert!(!client.is_upload_in_progress(key));
-        assert!(!client.contains_key(key));
-
-        // Second request fails on complete (after one write).
-        {
-            let mut request = uploader.put(bucket, key).await.unwrap();
-
-            let data = b"foo";
-            _ = request.write(0, data).await.unwrap();
-
-            request.complete().await.expect_err("complete should fail");
-        }
-        assert!(!client.is_upload_in_progress(key));
-        assert!(!client.contains_key(key));
-    }
-
-    #[test_case(8000; "divisible by max size")]
-    #[test_case(7000; "not divisible by max size")]
-    #[test_case(320001; "single write too big")]
-    #[tokio::test]
-    async fn maximum_size_test(write_size: usize) {
-        const PART_SIZE: usize = 32;
-
-        let bucket = "bucket";
-        let name = "hello";
-        let key = name;
-
-        let client = Arc::new(MockClient::new(MockClientConfig {
-            bucket: bucket.to_owned(),
-            part_size: PART_SIZE,
-            ..Default::default()
-        }));
-        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default(), true);
-        let mut request = uploader.put(bucket, key).await.unwrap();
-
-        let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;
-        let data = vec![0xaa; write_size];
-        for i in 0..successful_writes {
-            let offset = i * write_size;
-            request.write(offset as i64, &data).await.expect("object should fit");
-        }
-
-        let offset = successful_writes * write_size;
-        request
-            .write(offset as i64, &data)
-            .await
-            .expect_err("object should be too big");
-
-        drop(request);
-
-        assert!(!client.contains_key(key));
-        assert!(!client.is_upload_in_progress(key));
-    }
-
-    #[test_case(Some("aws:kmr"), Some("some_key_alias"))]
-    #[test_case(Some("aws:kms"), Some("some_key_ali`s"))]
-    #[test_case(None, Some("some_key_alias"))]
-    #[test_case(Some("aws:kms"), None)]
-    #[tokio::test]
-    async fn put_with_corrupted_sse_test(sse_type_corrupted: Option<&str>, key_id_corrupted: Option<&str>) {
-        let client = Arc::new(MockClient::new(Default::default()));
-        let mut uploader = Uploader::new(
-            client,
-            None,
-            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key_alias".to_string())),
-            true,
-        );
-        std::sync::Arc::<UploaderInner<Arc<MockClient>>>::get_mut(&mut uploader.inner)
-            .unwrap()
-            .server_side_encryption
-            .corrupt_data(sse_type_corrupted.map(String::from), key_id_corrupted.map(String::from));
-        let err = uploader
-            .put("bucket", "hello")
-            .await
-            .expect_err("sse checksum must be checked");
-        assert!(matches!(
-            err,
-            UploadPutError::SseCorruptedError(SseCorruptedError::ChecksumMismatch(_, _))
-        ));
-    }
-
-    #[tokio::test]
-    async fn put_with_good_sse_test() {
-        let bucket = "bucket";
-        let name = "hello";
-        let key = name;
-
-        let client = Arc::new(MockClient::new(MockClientConfig {
-            bucket: bucket.to_owned(),
-            part_size: 32,
-            ..Default::default()
-        }));
-        let uploader = Uploader::new(
-            client,
-            None,
-            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key".to_string())),
-            true,
-        );
-        uploader.put(bucket, key).await.expect("put with sse should succeed");
+impl<Runtime> From<Runtime> for BoxRuntime
+where
+    Runtime: Spawn + Sync + Send + 'static,
+{
+    fn from(value: Runtime) -> Self {
+        BoxRuntime(Box::new(value))
     }
 }

--- a/mountpoint-s3/src/upload/atomic.rs
+++ b/mountpoint-s3/src/upload/atomic.rs
@@ -1,0 +1,388 @@
+use std::fmt::Debug;
+
+use mountpoint_s3_client::{
+    checksums::{crc32c_from_base64, Crc32c},
+    error::{ObjectClientError, PutObjectError},
+    types::{PutObjectParams, PutObjectResult, PutObjectTrailingChecksums, UploadReview},
+    ObjectClient, PutObjectRequest,
+};
+use mountpoint_s3_crt::checksums::crc32c;
+use tracing::error;
+
+use crate::{checksums::combine_checksums, ServerSideEncryption};
+
+use super::{UploadPutError, UploadWriteError, Uploader};
+
+type PutRequestError<Client> = ObjectClientError<PutObjectError, <Client as ObjectClient>::ClientError>;
+
+const MAX_S3_MULTIPART_UPLOAD_PARTS: usize = 10000;
+
+/// Manages the upload of an object to S3.
+///
+/// Wraps a PutObject request and enforces sequential writes.
+pub struct UploadRequest<Client: ObjectClient> {
+    bucket: String,
+    key: String,
+    next_request_offset: u64,
+    hasher: crc32c::Hasher,
+    request: Client::PutObjectRequest,
+    maximum_upload_size: Option<usize>,
+    sse: ServerSideEncryption,
+}
+
+impl<Client: ObjectClient> UploadRequest<Client> {
+    pub async fn new(
+        uploader: &Uploader<Client>,
+        bucket: &str,
+        key: &str,
+    ) -> Result<Self, UploadPutError<PutObjectError, Client::ClientError>> {
+        let mut params = PutObjectParams::new();
+
+        if uploader.use_additional_checksums {
+            params = params.trailing_checksums(PutObjectTrailingChecksums::Enabled);
+        } else {
+            params = params.trailing_checksums(PutObjectTrailingChecksums::ReviewOnly);
+        }
+
+        if let Some(storage_class) = &uploader.storage_class {
+            params = params.storage_class(storage_class.clone());
+        }
+        // If we have detected corruption of SSE settings, we return an error, which will currently be reported as
+        // `libc::EIO` on `open()`. MP won't be able to open files for write from this point, but this is a relatively
+        // low-risk error as data can not be uploaded with wrong SSE settings yet. Thus there is no strong reason for
+        // MP to crash and it may continue serving read's.
+        let (sse_type, key_id) = uploader.server_side_encryption.clone().into_inner()?;
+        params = params.server_side_encryption(sse_type);
+        params = params.ssekms_key_id(key_id);
+
+        let request = uploader.client.put_object(bucket, key, &params).await?;
+        let maximum_upload_size = uploader
+            .client
+            .write_part_size()
+            .map(|ps| ps.saturating_mul(MAX_S3_MULTIPART_UPLOAD_PARTS));
+
+        Ok(UploadRequest {
+            bucket: bucket.to_owned(),
+            key: key.to_owned(),
+            next_request_offset: 0,
+            hasher: crc32c::Hasher::new(),
+            request,
+            maximum_upload_size,
+            sse: uploader.server_side_encryption.clone(),
+        })
+    }
+
+    pub fn size(&self) -> u64 {
+        self.next_request_offset
+    }
+
+    pub async fn write(
+        &mut self,
+        offset: i64,
+        data: &[u8],
+    ) -> Result<usize, UploadWriteError<PutRequestError<Client>>> {
+        let next_offset = self.next_request_offset;
+        if offset != next_offset as i64 {
+            return Err(UploadWriteError::OutOfOrderWrite {
+                write_offset: offset as u64,
+                expected_offset: next_offset,
+            });
+        }
+        if let Some(maximum_size) = self.maximum_upload_size {
+            if next_offset + data.len() as u64 > maximum_size as u64 {
+                return Err(UploadWriteError::ObjectTooBig { maximum_size });
+            }
+        }
+
+        self.hasher.update(data);
+        self.request.write(data).await?;
+        self.next_request_offset += data.len() as u64;
+        Ok(data.len())
+    }
+
+    pub async fn complete(self) -> Result<PutObjectResult, PutRequestError<Client>> {
+        let size = self.size();
+        let checksum = self.hasher.finalize();
+        let result = self
+            .request
+            .review_and_complete(move |review| verify_checksums(review, size, checksum))
+            .await?;
+        if let Err(err) = self
+            .sse
+            .verify_response(result.sse_type.as_deref(), result.sse_kms_key_id.as_deref())
+        {
+            error!(key=?self.key, error=?err, "SSE settings were corrupted after the upload completion");
+            // Reaching this point is very unlikely and means that SSE settings were corrupted in transit or on S3 side, this may be a sign of a bug
+            // in CRT code or S3. Thus, we terminate Mountpoint to send the most noticeable signal to customer about the issue. We prefer exiting
+            // instead of returning an error because:
+            // 1. this error would only be reported on `flush` which many applications ignore and
+            // 2. the reported error is severe as the object was already uploaded to S3.
+            std::process::exit(1);
+        }
+        Ok(result)
+    }
+}
+
+impl<Client: ObjectClient> Debug for UploadRequest<Client> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UploadRequest")
+            .field("bucket", &self.bucket)
+            .field("key", &self.key)
+            .field("next_request_offset", &self.next_request_offset)
+            .field("hasher", &self.hasher)
+            .finish()
+    }
+}
+
+fn verify_checksums(review: UploadReview, expected_size: u64, expected_checksum: Crc32c) -> bool {
+    let mut uploaded_size = 0u64;
+    let mut uploaded_checksum = Crc32c::new(0);
+    for (i, part) in review.parts.iter().enumerate() {
+        uploaded_size += part.size;
+
+        let Some(checksum) = &part.checksum else {
+            error!(part_number = i + 1, "missing part checksum");
+            return false;
+        };
+        let checksum = match crc32c_from_base64(checksum) {
+            Ok(checksum) => checksum,
+            Err(error) => {
+                error!(part_number = i + 1, ?error, "error decoding part checksum");
+                return false;
+            }
+        };
+
+        uploaded_checksum = combine_checksums(uploaded_checksum, checksum, part.size as usize);
+    }
+
+    if uploaded_size != expected_size {
+        error!(
+            uploaded_size,
+            expected_size, "Total uploaded size differs from expected size"
+        );
+        return false;
+    }
+
+    if uploaded_checksum != expected_checksum {
+        error!(
+            ?uploaded_checksum,
+            ?expected_checksum,
+            "Combined checksum of all uploaded parts differs from expected checksum"
+        );
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::fs::SseCorruptedError;
+    use crate::sync::Arc;
+
+    use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError};
+    use test_case::test_case;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn complete_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default(), true);
+        let request = uploader.put(bucket, key).await.unwrap();
+
+        assert!(!client.contains_key(key));
+        assert!(client.is_upload_in_progress(key));
+
+        request.complete().await.unwrap();
+
+        assert!(client.contains_key(key));
+        assert!(!client.is_upload_in_progress(key));
+    }
+
+    #[tokio::test]
+    async fn write_order_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+        let storage_class = "INTELLIGENT_TIERING";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        let uploader = Uploader::new(
+            client.clone(),
+            Some(storage_class.to_owned()),
+            ServerSideEncryption::default(),
+            true,
+        );
+
+        let mut request = uploader.put(bucket, key).await.unwrap();
+
+        let data = b"foo";
+        let mut offset = 0;
+        offset += request.write(offset, data).await.unwrap() as i64;
+
+        request
+            .write(0, data)
+            .await
+            .expect_err("out of order write should fail");
+
+        offset += request
+            .write(offset, data)
+            .await
+            .expect("subsequent in order write should succeed") as i64;
+
+        let size = request.size();
+        assert_eq!(offset, size as i64);
+
+        request.complete().await.unwrap();
+        assert!(client.contains_key(key));
+    }
+
+    #[tokio::test]
+    async fn failure_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        let mut put_failures = HashMap::new();
+        put_failures.insert(1, Ok((1, MockClientError("error".to_owned().into()))));
+        put_failures.insert(2, Ok((2, MockClientError("error".to_owned().into()))));
+
+        let failure_client = Arc::new(countdown_failure_client(
+            client.clone(),
+            CountdownFailureConfig {
+                put_failures,
+                ..Default::default()
+            },
+        ));
+
+        let uploader = Uploader::new(failure_client.clone(), None, ServerSideEncryption::default(), true);
+
+        // First request fails on first write.
+        {
+            let mut request = uploader.put(bucket, key).await.unwrap();
+
+            let data = b"foo";
+            request.write(0, data).await.expect_err("first write should fail");
+        }
+        assert!(!client.is_upload_in_progress(key));
+        assert!(!client.contains_key(key));
+
+        // Second request fails on complete (after one write).
+        {
+            let mut request = uploader.put(bucket, key).await.unwrap();
+
+            let data = b"foo";
+            _ = request.write(0, data).await.unwrap();
+
+            request.complete().await.expect_err("complete should fail");
+        }
+        assert!(!client.is_upload_in_progress(key));
+        assert!(!client.contains_key(key));
+    }
+
+    #[test_case(8000; "divisible by max size")]
+    #[test_case(7000; "not divisible by max size")]
+    #[test_case(320001; "single write too big")]
+    #[tokio::test]
+    async fn maximum_size_test(write_size: usize) {
+        const PART_SIZE: usize = 32;
+
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: PART_SIZE,
+            ..Default::default()
+        }));
+        let uploader = Uploader::new(client.clone(), None, ServerSideEncryption::default(), true);
+        let mut request = uploader.put(bucket, key).await.unwrap();
+
+        let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;
+        let data = vec![0xaa; write_size];
+        for i in 0..successful_writes {
+            let offset = i * write_size;
+            request.write(offset as i64, &data).await.expect("object should fit");
+        }
+
+        let offset = successful_writes * write_size;
+        request
+            .write(offset as i64, &data)
+            .await
+            .expect_err("object should be too big");
+
+        drop(request);
+
+        assert!(!client.contains_key(key));
+        assert!(!client.is_upload_in_progress(key));
+    }
+
+    #[test_case(Some("aws:kmr"), Some("some_key_alias"))]
+    #[test_case(Some("aws:kms"), Some("some_key_ali`s"))]
+    #[test_case(None, Some("some_key_alias"))]
+    #[test_case(Some("aws:kms"), None)]
+    #[tokio::test]
+    async fn put_with_corrupted_sse_test(sse_type_corrupted: Option<&str>, key_id_corrupted: Option<&str>) {
+        let client = Arc::new(MockClient::new(Default::default()));
+        let mut uploader = Uploader::new(
+            client,
+            None,
+            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key_alias".to_string())),
+            true,
+        );
+        uploader
+            .server_side_encryption
+            .corrupt_data(sse_type_corrupted.map(String::from), key_id_corrupted.map(String::from));
+        let err = uploader
+            .put("bucket", "hello")
+            .await
+            .expect_err("sse checksum must be checked");
+        assert!(matches!(
+            err,
+            UploadPutError::SseCorruptedError(SseCorruptedError::ChecksumMismatch(_, _))
+        ));
+    }
+
+    #[tokio::test]
+    async fn put_with_good_sse_test() {
+        let bucket = "bucket";
+        let name = "hello";
+        let key = name;
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        let uploader = Uploader::new(
+            client,
+            None,
+            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key".to_string())),
+            true,
+        );
+        uploader.put(bucket, key).await.expect("put with sse should succeed");
+    }
+}

--- a/mountpoint-s3/src/upload/hasher.rs
+++ b/mountpoint-s3/src/upload/hasher.rs
@@ -1,0 +1,57 @@
+use mountpoint_s3_client::checksums::{crc32, crc32c, sha1, sha256};
+use mountpoint_s3_client::types::{ChecksumAlgorithm, UploadChecksum};
+use mountpoint_s3_crt::common::allocator::Allocator;
+use thiserror::Error;
+
+#[derive(Debug, Default)]
+pub enum ChecksumHasher {
+    #[default]
+    None,
+    Crc32(crc32::Hasher),
+    Crc32c(crc32c::Hasher),
+    Sha1(sha1::Sha1Hasher),
+    Sha256(sha256::Sha256Hasher),
+}
+
+impl ChecksumHasher {
+    pub fn new(checksum_algorithm: &Option<ChecksumAlgorithm>) -> Result<Self, ChecksumHasherError> {
+        match checksum_algorithm {
+            Some(ChecksumAlgorithm::Crc32) => Ok(Self::Crc32(crc32::Hasher::new())),
+            Some(ChecksumAlgorithm::Crc32c) => Ok(Self::Crc32c(crc32c::Hasher::new())),
+            Some(ChecksumAlgorithm::Sha1) => Ok(Self::Sha1(sha1::Sha1Hasher::new(&Allocator::default())?)),
+            Some(ChecksumAlgorithm::Sha256) => Ok(Self::Sha256(sha256::Sha256Hasher::new(&Allocator::default())?)),
+            Some(other) => Err(ChecksumHasherError::UnsupportedChecksumAlgorithm(other.clone())),
+            None => Ok(Self::None),
+        }
+    }
+
+    pub fn update(&mut self, data: &[u8]) -> Result<(), ChecksumHasherError> {
+        match self {
+            ChecksumHasher::None => {}
+            ChecksumHasher::Crc32(hasher) => hasher.update(data),
+            ChecksumHasher::Crc32c(hasher) => hasher.update(data),
+            ChecksumHasher::Sha1(hasher) => hasher.update(data)?,
+            ChecksumHasher::Sha256(hasher) => hasher.update(data)?,
+        };
+        Ok(())
+    }
+
+    pub fn finalize(self) -> Result<Option<UploadChecksum>, ChecksumHasherError> {
+        match self {
+            ChecksumHasher::None => Ok(None),
+            ChecksumHasher::Crc32(hasher) => Ok(Some(UploadChecksum::Crc32(hasher.finalize()))),
+            ChecksumHasher::Crc32c(hasher) => Ok(Some(UploadChecksum::Crc32c(hasher.finalize()))),
+            ChecksumHasher::Sha1(hasher) => Ok(Some(UploadChecksum::Sha1(hasher.finalize(&Allocator::default())?))),
+            ChecksumHasher::Sha256(hasher) => Ok(Some(UploadChecksum::Sha256(hasher.finalize(&Allocator::default())?))),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ChecksumHasherError {
+    #[error("Checksum algorithm not supported: {0}")]
+    UnsupportedChecksumAlgorithm(ChecksumAlgorithm),
+
+    #[error("Unknown CRT error")]
+    CrtError(#[from] mountpoint_s3_crt::common::error::Error),
+}

--- a/mountpoint-s3/src/upload/incremental.rs
+++ b/mountpoint-s3/src/upload/incremental.rs
@@ -1,0 +1,1194 @@
+//! This module implements an upload pipeline that allows appending to existing objects.
+
+use std::fmt::Debug;
+use std::mem;
+
+use async_channel::{bounded, unbounded, Receiver, Sender};
+use bytes::{Bytes, BytesMut};
+use futures::future::RemoteHandle;
+use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
+use mountpoint_s3_client::types::{
+    ChecksumAlgorithm, ChecksumMode, ETag, HeadObjectParams, PutObjectResult, PutObjectSingleParams, UploadChecksum,
+};
+use mountpoint_s3_client::ObjectClient;
+use tracing::{debug_span, trace, Instrument};
+
+use crate::mem_limiter::{BufferArea, MemoryLimiter};
+use crate::sync::Arc;
+use crate::ServerSideEncryption;
+
+use super::hasher::ChecksumHasher;
+use super::{AppendUploadError, BoxRuntime, ChecksumHasherError};
+
+#[derive(Debug)]
+pub struct AppendUploadRequest<Client: ObjectClient> {
+    /// The current buffer, initialized lazily on write.
+    buffer: Option<UploadBuffer<Client>>,
+    /// The current offset.
+    offset: u64,
+    buffer_size: usize,
+    upload_queue: AppendUploadQueue<Client>,
+}
+
+impl<Client> AppendUploadRequest<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    pub(super) fn new(
+        runtime: &BoxRuntime,
+        client: Client,
+        buffer_size: usize,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        params: AppendUploadQueueParams,
+    ) -> Self {
+        let offset = params.initial_offset;
+        let upload_queue = AppendUploadQueue::new(runtime, client, mem_limiter, params);
+        Self {
+            buffer: None,
+            upload_queue,
+            offset,
+            buffer_size,
+        }
+    }
+
+    /// Write the given slice to the pipeline. This will not trigger the upload right away,
+    /// but will be queued to upload until the buffer is full and all previous buffers have
+    /// been uploaded.
+    /// On success, returns the number of bytes written.
+    pub async fn write(&mut self, offset: u64, data: &[u8]) -> Result<usize, AppendUploadError<Client::ClientError>> {
+        // Bail out if a previous request failed
+        self.upload_queue.verify().await?;
+
+        if offset != self.offset {
+            return Err(AppendUploadError::OutOfOrderWrite {
+                write_offset: offset,
+                expected_offset: self.offset,
+            });
+        }
+
+        let mut slice = data;
+        while !slice.is_empty() {
+            let buffer = match self.buffer.as_mut() {
+                Some(buffer) => buffer,
+                None => {
+                    self.buffer = Some(self.upload_queue.get_buffer(self.buffer_size).await?);
+                    self.buffer.as_mut().unwrap()
+                }
+            };
+
+            let len = slice.len();
+            slice = buffer.write(slice)?;
+            self.offset += (len - slice.len()) as u64;
+
+            // Flush buffer to the queue if it is full
+            if buffer.is_full() {
+                self.upload_queue.push(self.buffer.take().unwrap()).await?;
+            }
+        }
+        Ok((self.offset - offset) as usize)
+    }
+
+    /// Complete the upload and return the last `PutObjectResult` if any PUT requests are submitted.
+    /// The pipeline cannot be used after this.
+    pub async fn complete(mut self) -> Result<Option<PutObjectResult>, AppendUploadError<Client::ClientError>> {
+        if let Some(buffer) = self.buffer.take() {
+            self.upload_queue.push(buffer).await?;
+        } else if self.offset == 0 {
+            // If we are not appending, but uploading a new object or entirely replacing an existing one,
+            // we need to push an empty buffer to ensure a PutObject request is issued.
+            let empty_buffer = self.upload_queue.get_buffer(0).await?;
+            self.upload_queue.push(empty_buffer).await?;
+        }
+        self.upload_queue.join().await
+    }
+
+    pub fn current_offset(&self) -> u64 {
+        self.offset
+    }
+}
+
+#[derive(Debug)]
+enum Output {
+    ChecksumAlgorithm(Option<ChecksumAlgorithm>),
+    Result(PutObjectResult),
+}
+
+#[derive(Debug)]
+struct AppendUploadQueue<Client: ObjectClient> {
+    request_sender: Sender<UploadBuffer<Client>>,
+    output_receiver: Receiver<Result<Output, AppendUploadError<Client::ClientError>>>,
+    mem_limiter: Arc<MemoryLimiter<Client>>,
+    _task_handle: RemoteHandle<()>,
+    /// Algorithm used to compute checksums. Initialized asynchronously in [get_buffer].
+    checksum_algorithm: Option<Option<ChecksumAlgorithm>>,
+    /// Stores the last successful result to return in [join].
+    last_known_result: Option<PutObjectResult>,
+    /// Tracks the requests pushed to the queue but still pending a response.
+    requests_in_queue: usize,
+}
+
+pub struct AppendUploadQueueParams {
+    pub bucket: String,
+    pub key: String,
+    pub initial_offset: u64,
+    pub initial_etag: Option<ETag>,
+    pub server_side_encryption: ServerSideEncryption,
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    pub capacity: usize,
+}
+
+impl<Client> AppendUploadQueue<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    pub fn new(
+        runtime: &BoxRuntime,
+        client: Client,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        params: AppendUploadQueueParams,
+    ) -> Self {
+        let initial_offset = params.initial_offset;
+        let span = debug_span!("append", params.key, initial_offset);
+        let (request_sender, request_receiver) = bounded::<UploadBuffer<Client>>(params.capacity);
+        let (output_sender, output_receiver) = unbounded();
+
+        // Create a task for reading data out of the upload queue and create S3 requests for them.
+        // The task is spawned on the given runtime, which is usually the CRT's event loop.
+        let task_handle = runtime
+            .spawn_with_handle(
+                async move {
+                    async fn send_output<Client: ObjectClient>(
+                        sender: &Sender<Result<Output, AppendUploadError<Client::ClientError>>>,
+                        receiver: &Receiver<UploadBuffer<Client>>,
+                        output: Result<Output, AppendUploadError<Client::ClientError>>,
+                    ) -> bool {
+                        let error = output.is_err();
+                        if error {
+                            // Stop receiving new requests
+                            receiver.close();
+                        }
+                        if sender.send(output).await.is_err() {
+                            trace!("response channel is already closed");
+                            return false;
+                        } else if error {
+                            trace!("closing response channel");
+                            sender.close();
+                            return false;
+                        }
+                        true
+                    }
+
+                    let bucket = params.bucket;
+                    let key = params.key;
+                    let sse = params.server_side_encryption;
+                    let mut etag = params.initial_etag;
+                    let mut offset = params.initial_offset;
+
+                    let first_output = if offset == 0 {
+                        // If we are creating a new object or overwriting (truncate), use the default checksum algorithm.
+                        Ok(Output::ChecksumAlgorithm(params.checksum_algorithm))
+                    } else {
+                        // We are appending to an existing object, find out which checksum algorithm it uses.
+                        match client
+                            .head_object(
+                                &bucket,
+                                &key,
+                                &HeadObjectParams::new().checksum_mode(Some(ChecksumMode::Enabled)),
+                            )
+                            .await
+                        {
+                            Ok(head_object) => {
+                                trace!(?head_object, "received head_object response");
+                                if Some(head_object.etag) != etag {
+                                    // Fail early if the etag has changed.
+                                    Err(AppendUploadError::PutRequestFailed(ObjectClientError::ServiceError(
+                                        PutObjectError::PreconditionFailed,
+                                    )))
+                                } else {
+                                    Ok(Output::ChecksumAlgorithm(
+                                        head_object.checksum.algorithms().first().cloned(),
+                                    ))
+                                }
+                            }
+                            Err(e) => Err(e.into()),
+                        }
+                    };
+                    if !send_output(&output_sender, &request_receiver, first_output).await {
+                        return;
+                    }
+
+                    while let Ok(buffer) = request_receiver.recv().await {
+                        let buffer_len = buffer.len();
+                        let result = append(&client, &bucket, &key, buffer, offset, etag.take(), sse.clone())
+                            .await
+                            .map(|result| {
+                                offset += buffer_len as u64;
+                                etag = Some(result.etag.clone());
+                                Output::Result(result)
+                            })
+                            .inspect_err(|_| trace!("append upload task failed"));
+                        if !send_output(&output_sender, &request_receiver, result).await {
+                            break;
+                        }
+                    }
+                    trace!("append upload task finished");
+                }
+                .instrument(span),
+            )
+            .unwrap();
+        Self {
+            request_sender,
+            output_receiver,
+            last_known_result: None,
+            requests_in_queue: 0,
+            mem_limiter,
+            checksum_algorithm: None,
+            _task_handle: task_handle,
+        }
+    }
+
+    // Push given bytes with its checksum to the upload queue
+    pub async fn push(&mut self, buffer: UploadBuffer<Client>) -> Result<(), AppendUploadError<Client::ClientError>> {
+        if let Err(_send_error) = self.request_sender.send(buffer).await {
+            // The upload queue could be closed if there was a client error from previous requests
+            trace!("upload queue is already closed");
+            while self.consume_next_output().await? {}
+            return Err(AppendUploadError::UploadAlreadyTerminated);
+        }
+        self.requests_in_queue += 1;
+        Ok(())
+    }
+
+    pub async fn verify(&mut self) -> Result<(), AppendUploadError<Client::ClientError>> {
+        if self.request_sender.is_closed() {
+            // The upload queue could be closed if there was a client error from previous requests
+            trace!("upload queue is already closed");
+            while self.consume_next_output().await? {}
+            return Err(AppendUploadError::UploadAlreadyTerminated);
+        }
+        Ok(())
+    }
+
+    // Close the upload queue, wait for all uploads in the queue to complete, and get the last `PutObjectResult`
+    pub async fn join(mut self) -> Result<Option<PutObjectResult>, AppendUploadError<Client::ClientError>> {
+        let terminated = !self.request_sender.close();
+        while self.consume_next_output().await? {}
+        if terminated {
+            return Err(AppendUploadError::UploadAlreadyTerminated);
+        }
+        Ok(self.last_known_result.take())
+    }
+
+    pub async fn get_buffer(
+        &mut self,
+        capacity: usize,
+    ) -> Result<UploadBuffer<Client>, AppendUploadError<Client::ClientError>> {
+        let Some(checksum_algorithm) = self.checksum_algorithm.clone() else {
+            trace!("wait for initial output");
+            match self
+                .output_receiver
+                .recv()
+                .await
+                .unwrap_or(Err(AppendUploadError::UploadAlreadyTerminated))?
+            {
+                Output::ChecksumAlgorithm(algorithm) => {
+                    trace!(?algorithm, "selected checksum algorithm");
+                    self.checksum_algorithm = Some(algorithm.clone());
+                    return Ok(UploadBuffer::new(capacity, &algorithm, self.mem_limiter.clone())?);
+                }
+                _ => unreachable!("the initial output always sets the checksum algorithm"),
+            }
+        };
+
+        while self.requests_in_queue > 0 {
+            match UploadBuffer::try_new(capacity, &checksum_algorithm, self.mem_limiter.clone())? {
+                Some(buffer) => return Ok(buffer),
+                None => {
+                    // wait for requests in the queue to complete before trying to reserve memory again
+                    trace!("wait for the next request to be processed");
+                    if !self.consume_next_output().await? {
+                        return Err(AppendUploadError::UploadAlreadyTerminated);
+                    }
+                }
+            }
+        }
+        // no more requests in the queue, so we force creating a new buffer
+        Ok(UploadBuffer::new(
+            capacity,
+            &checksum_algorithm,
+            self.mem_limiter.clone(),
+        )?)
+    }
+
+    async fn consume_next_output(&mut self) -> Result<bool, AppendUploadError<Client::ClientError>> {
+        let Ok(output) = self.output_receiver.recv().await else {
+            return Ok(false);
+        };
+        if let Output::Result(result) = output? {
+            trace!(?result, "received result");
+            self.requests_in_queue -= 1;
+            self.last_known_result = Some(result);
+        }
+        Ok(true)
+    }
+}
+
+#[derive(Debug)]
+struct UploadBuffer<Client: ObjectClient> {
+    data: BytesMut,
+    // Running checksum for the data.
+    hasher: ChecksumHasher,
+    capacity: usize,
+    mem_limiter: Arc<MemoryLimiter<Client>>,
+}
+
+impl<Client: ObjectClient> UploadBuffer<Client> {
+    /// Force creating a new buffer regardless of available memory
+    fn new(
+        capacity: usize,
+        checksum_algorithm: &Option<ChecksumAlgorithm>,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+    ) -> Result<Self, ChecksumHasherError> {
+        let hasher = ChecksumHasher::new(checksum_algorithm)?;
+        mem_limiter.reserve(BufferArea::Upload, capacity as u64);
+        Ok(Self {
+            data: BytesMut::with_capacity(capacity),
+            hasher,
+            capacity,
+            mem_limiter,
+        })
+    }
+
+    /// Try creating a new buffer, return `None` if unable to reserve memory for a buffer with the given capacity
+    fn try_new(
+        capacity: usize,
+        checksum_algorithm: &Option<ChecksumAlgorithm>,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+    ) -> Result<Option<Self>, ChecksumHasherError> {
+        let hasher = ChecksumHasher::new(checksum_algorithm)?;
+        if mem_limiter.try_reserve(BufferArea::Upload, capacity as u64) {
+            Ok(Some(Self {
+                data: BytesMut::with_capacity(capacity),
+                hasher,
+                capacity,
+                mem_limiter,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Write a slice to the buffer. The slice will be trimmed to fit into the buffer,
+    /// remaining slice is returned back to the caller.
+    fn write<'a>(&mut self, slice: &'a [u8]) -> Result<&'a [u8], ChecksumHasherError> {
+        let available_cap = self.capacity - self.data.len();
+        let (left, right) = slice.split_at(available_cap.min(slice.len()));
+        self.data.extend_from_slice(left);
+        self.hasher.update(left)?;
+        Ok(right)
+    }
+
+    fn is_full(&self) -> bool {
+        self.data.len() == self.capacity
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn freeze(mut self) -> Result<(Bytes, Option<UploadChecksum>), ChecksumHasherError> {
+        let bytes = mem::take(&mut self.data);
+        let checksum = mem::take(&mut self.hasher);
+        Ok((bytes.freeze(), checksum.finalize()?))
+    }
+}
+
+impl<Client: ObjectClient> Drop for UploadBuffer<Client> {
+    fn drop(&mut self) {
+        self.mem_limiter.release(BufferArea::Upload, self.capacity as u64);
+    }
+}
+
+async fn append<Client: ObjectClient>(
+    client: &Client,
+    bucket: &str,
+    key: &str,
+    buffer: UploadBuffer<Client>,
+    offset: u64,
+    etag: Option<ETag>,
+    server_side_encryption: ServerSideEncryption,
+) -> Result<PutObjectResult, AppendUploadError<Client::ClientError>> {
+    let (data, checksum) = buffer.freeze()?;
+    let mut request_params = if offset == 0 {
+        PutObjectSingleParams::new()
+    } else {
+        PutObjectSingleParams::new_for_append(offset).if_match(etag)
+    };
+    let (sse_type, key_id) = server_side_encryption
+        .into_inner()
+        .map_err(AppendUploadError::SseCorruptedError)?;
+    request_params.checksum = checksum;
+    request_params.server_side_encryption = sse_type;
+    request_params.ssekms_key_id = key_id;
+    client
+        .put_object_single(bucket, key, &request_params, data)
+        .await
+        .map_err(AppendUploadError::PutRequestFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::mem_limiter::MINIMUM_MEM_LIMIT;
+
+    use super::super::AppendUploader;
+    use super::*;
+
+    use futures::executor::ThreadPool;
+    use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
+    use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockObject};
+    use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag, GetObjectParams, GetObjectRequest};
+    use test_case::test_case;
+
+    fn new_uploader_for_test<Client>(
+        client: Client,
+        buffer_size: usize,
+        server_side_encryption: Option<ServerSideEncryption>,
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+    ) -> AppendUploader<Client>
+    where
+        Client: ObjectClient + Clone + Send + Sync + 'static,
+    {
+        let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
+        let mem_limiter = MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT);
+        AppendUploader::new(
+            client,
+            runtime,
+            mem_limiter.into(),
+            buffer_size,
+            server_side_encryption.unwrap_or_default(),
+            checksum_algorithm,
+        )
+    }
+
+    #[test_case(None)]
+    #[test_case(Some(MockObject::ramp(0xaa, 2 * 1024 * 1024, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::constant(0xab, 20, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([0xbb; 128])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Crc32])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Sha1])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Sha256])))]
+    #[tokio::test]
+    async fn test_append_align_with_buffer(existing_object: Option<MockObject>) {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        // Create the "before append" object for the test
+        let mut existing_object = existing_object;
+        if let Some(object) = &mut existing_object {
+            client.add_object(key, object.clone());
+            expected_content.extend_from_slice(&object.read(0, object.len()));
+        }
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+        let mut offset = existing_object.as_ref().map_or(0, |object| object.len() as u64);
+        let initial_etag = existing_object.map(|object| object.etag());
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, initial_etag);
+
+        // Write some data
+        let append_data = [0xaa; 128];
+        expected_content.extend_from_slice(&append_data);
+        offset += upload_request
+            .write(offset, &append_data)
+            .await
+            .expect("write should succeed") as u64;
+
+        // The buffer should be updated
+        let buffer = upload_request.buffer.as_ref().unwrap();
+        assert_eq!(buffer_size, buffer.data.capacity());
+        assert_eq!(&append_data, &buffer.data[..]);
+
+        // Write more data to make the buffer full
+        let append_data = [0xab; 128];
+        expected_content.extend_from_slice(&append_data);
+        upload_request
+            .write(offset, &append_data)
+            .await
+            .expect("write should succeed");
+
+        // The upload should be started and the buffer should be none
+        assert!(upload_request.buffer.is_none());
+
+        // Wait for the upload to complete
+        upload_request
+            .complete()
+            .await
+            .expect("upload should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[test_case(None)]
+    #[test_case(Some(MockObject::ramp(0xaa, 2 * 1024 * 1024, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::constant(0xab, 20, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([0xbb; 128])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Crc32])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Sha1])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Sha256])))]
+    #[tokio::test]
+    async fn test_append_not_align_with_buffer(existing_object: Option<MockObject>) {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let mut existing_object = existing_object;
+        if let Some(object) = &mut existing_object {
+            client.add_object(key, object.clone());
+            expected_content.extend_from_slice(&object.read(0, object.len()));
+        }
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+        let mut offset = existing_object.as_ref().map_or(0, |object| object.len() as u64);
+        let initial_etag = existing_object.map(|object| object.etag());
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, initial_etag);
+
+        // Write some data and verify that buffer length should not grow larger than configured capacity
+        let append_data = [0xaa; 384];
+        expected_content.extend_from_slice(&append_data);
+        offset += upload_request
+            .write(offset, &append_data)
+            .await
+            .expect("write should succeed") as u64;
+        let buffer = upload_request.buffer.as_ref().unwrap();
+        assert!(buffer.data.len() < buffer_size);
+
+        // Write more data and verify buffer length
+        let append_data = [0xab; 256];
+        expected_content.extend_from_slice(&append_data);
+        upload_request
+            .write(offset, &append_data)
+            .await
+            .expect("write should succeed");
+        let buffer = upload_request.buffer.as_ref().unwrap();
+        assert!(buffer.data.len() < buffer_size);
+
+        // Wait for the upload to complete
+        upload_request
+            .complete()
+            .await
+            .expect("upload should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[test_case(None, None)]
+    #[test_case(None, Some(ChecksumAlgorithm::Crc32c))]
+    #[test_case(None, Some(ChecksumAlgorithm::Crc32))]
+    #[test_case(None, Some(ChecksumAlgorithm::Sha1))]
+    #[test_case(None, Some(ChecksumAlgorithm::Sha256))]
+    #[test_case(Some(&[]), Some(ChecksumAlgorithm::Crc32c))]
+    #[test_case(Some(&[ChecksumAlgorithm::Crc32c]), None)]
+    #[test_case(Some(&[ChecksumAlgorithm::Crc32]), None)]
+    #[test_case(Some(&[ChecksumAlgorithm::Sha1]), None)]
+    #[test_case(Some(&[ChecksumAlgorithm::Sha256]), None)]
+    #[tokio::test]
+    async fn test_append_respects_checksums(
+        existing_object_checksum_algorithms: Option<&[ChecksumAlgorithm]>,
+        default_checksum_algorithm: Option<ChecksumAlgorithm>,
+    ) {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        let mut expected_checksum_algorithm = default_checksum_algorithm.as_slice();
+        let mut expected_content = Vec::new();
+        let mut offset = 0;
+        let mut initial_etag = None;
+        if let Some(algorithms) = existing_object_checksum_algorithms {
+            let existing_content = [0xbb; 128];
+            let object = MockObject::from(&existing_content).with_computed_checksums(algorithms);
+            expected_content.extend_from_slice(&existing_content);
+            expected_checksum_algorithm = algorithms;
+
+            offset = object.len() as u64;
+            initial_etag = Some(object.etag());
+            // Create the "before append" object for the test
+            client.add_object(key, object);
+        }
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, default_checksum_algorithm.clone());
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, initial_etag);
+
+        // Write some data
+        let append_data = [0xaa; 384];
+        expected_content.extend_from_slice(&append_data);
+        upload_request
+            .write(offset, &append_data)
+            .await
+            .expect("write should succeed");
+
+        // Wait for the upload to complete
+        upload_request
+            .complete()
+            .await
+            .expect("upload should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(
+                bucket,
+                key,
+                &GetObjectParams::default().checksum_mode(Some(ChecksumMode::Enabled)),
+            )
+            .await
+            .expect("get_object failed");
+
+        let checksum = get_request.get_object_checksum().await.expect("failed to get checksum");
+        assert_eq!(checksum.algorithms(), expected_checksum_algorithm);
+
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[test_case(None)]
+    #[test_case(Some(MockObject::ramp(0xaa, 2 * 1024 * 1024, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::constant(0xab, 20, ETag::for_tests()).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[test_case(Some(MockObject::from([0xbb; 128]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c])))]
+    #[tokio::test]
+    async fn test_append_empty(existing_object: Option<MockObject>) {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let mut existing_object = existing_object;
+        if let Some(object) = &mut existing_object {
+            client.add_object(key, object.clone());
+            expected_content.extend_from_slice(&object.read(0, object.len()));
+        }
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+        let initial_offset = existing_object.as_ref().map_or(0, |object| object.len() as u64);
+        let initial_etag = existing_object.map(|object| object.etag());
+        let upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), initial_offset, initial_etag);
+        // Wait for the upload to complete
+        upload_request
+            .complete()
+            .await
+            .expect("upload should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[tokio::test]
+    async fn test_append_failure_at_completion() {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+
+        // Test append with a wrong offset
+        let initial_offset = (existing_object.len() - 1) as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request =
+            uploader.start_upload(bucket.to_owned(), key.to_owned(), initial_offset, Some(initial_etag));
+
+        let append_data = [0xaa; 128];
+        upload_request
+            .write(initial_offset, &append_data)
+            .await
+            .expect("write should succeed");
+        // Verify that the request fails at completion
+        assert!(matches!(
+            upload_request.complete().await,
+            Err(AppendUploadError::PutRequestFailed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_append_partial_failure_at_completion() {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        let mut put_single_failures = HashMap::new();
+        put_single_failures.insert(2, ObjectClientError::ServiceError(PutObjectError::BadChecksum));
+        let failure_client = Arc::new(countdown_failure_client(
+            client.clone(),
+            CountdownFailureConfig {
+                put_single_failures,
+                ..Default::default()
+            },
+        ));
+
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+        expected_content.extend_from_slice(&existing_object.read(0, existing_object.len()));
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(failure_client, buffer_size, None, None);
+        let initial_offset = existing_object.len() as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request =
+            uploader.start_upload(bucket.to_owned(), key.to_owned(), initial_offset, Some(initial_etag));
+
+        // Write data more than the buffer capacity as the first append should succeed
+        let append_data = [0xab; 384];
+        expected_content.extend_from_slice(&append_data[..buffer_size]);
+        upload_request
+            .write(initial_offset, &append_data)
+            .await
+            .expect("write should succeed");
+
+        // Verify that the request fails and the error is surfaced
+        let result = upload_request.complete().await;
+        assert!(matches!(result, Err(AppendUploadError::PutRequestFailed(_))));
+
+        // Verify that object is partially appended from the first request
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[tokio::test]
+    async fn test_append_failure_during_write() {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+
+        // Test append with a wrong offset
+        let mut offset = (existing_object.len() - 1) as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, Some(initial_etag));
+
+        // Keep writing and it should fail eventually
+        let mut write_success_count = 0;
+        let max_retries = 10000;
+        let append_data = [0xab; 256];
+        while write_success_count < max_retries {
+            match upload_request.write(offset, &append_data).await {
+                Ok(len) => {
+                    offset += len as u64;
+                    write_success_count += 1;
+                }
+                Err(e) => {
+                    assert!(matches!(e, AppendUploadError::PutRequestFailed(_)));
+                    break;
+                }
+            }
+        }
+        assert!(
+            write_success_count < max_retries,
+            "retry count should not have been exhausted"
+        );
+
+        // Verify that the pipeline cannot be used after failure
+        assert!(matches!(
+            upload_request.write(offset, b"some data").await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+        assert!(matches!(
+            upload_request.complete().await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_append_partial_failure_during_write() {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        let mut put_single_failures = HashMap::new();
+        put_single_failures.insert(2, ObjectClientError::ServiceError(PutObjectError::BadChecksum));
+        let failure_client = Arc::new(countdown_failure_client(
+            client.clone(),
+            CountdownFailureConfig {
+                put_single_failures,
+                ..Default::default()
+            },
+        ));
+
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+        expected_content.extend_from_slice(&existing_object.read(0, existing_object.len()));
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(failure_client, buffer_size, None, None);
+        let mut offset = existing_object.len() as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, Some(initial_etag));
+
+        // Keep writing and it should fail eventually
+        let mut write_success_count = 0;
+
+        let max_retries = 10000;
+        let append_data = [0xab; 256];
+        // The first request will succeed so we update the expected content
+        expected_content.extend_from_slice(&append_data);
+        while write_success_count < max_retries {
+            match upload_request.write(offset, &append_data).await {
+                Ok(len) => {
+                    offset += len as u64;
+                    write_success_count += 1;
+                }
+                Err(e) => {
+                    assert!(matches!(e, AppendUploadError::PutRequestFailed(_)));
+                    break;
+                }
+            }
+        }
+        assert!(
+            write_success_count < max_retries,
+            "retry count should not have been exhausted"
+        );
+
+        // Verify that the pipeline cannot be used after failure
+        assert!(matches!(
+            upload_request.write(offset, b"some data").await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+        assert!(matches!(
+            upload_request.complete().await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+
+        // Verify that object is partially appended from the first request
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[tokio::test]
+    async fn test_append_failure_on_object_replaced() {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+
+        // Start appending
+        let mut offset = existing_object.len() as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, Some(initial_etag));
+
+        // Replace the existing object
+        let replacing_object = MockObject::from(vec![0xcc; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, replacing_object.clone());
+
+        // Keep writing and it should fail eventually
+        let mut write_success_count = 0;
+        let max_retries = 10000;
+        let append_data = [0xab; 256];
+        while write_success_count < max_retries {
+            match upload_request.write(offset, &append_data).await {
+                Ok(len) => {
+                    offset += len as u64;
+                    write_success_count += 1;
+                }
+                Err(e) => {
+                    assert!(matches!(
+                        e,
+                        AppendUploadError::PutRequestFailed(ObjectClientError::ServiceError(
+                            PutObjectError::PreconditionFailed
+                        ))
+                    ));
+                    break;
+                }
+            }
+        }
+        assert!(
+            write_success_count < max_retries,
+            "retry count should not have been exhausted"
+        );
+
+        // Verify that the pipeline cannot be used after failure
+        assert!(matches!(
+            upload_request.write(offset, b"some data").await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+        assert!(matches!(
+            upload_request.complete().await,
+            Err(AppendUploadError::UploadAlreadyTerminated)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_append_failure_on_out_of_order() {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+
+        let buffer_size = 256;
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), 0, None);
+
+        // Write some data
+        let append_data = [0xaa; 128];
+        upload_request
+            .write(0, &append_data)
+            .await
+            .expect("write should succeed");
+
+        let next_offset = append_data.len() as u64;
+        let wrong_offset = next_offset + 1;
+        let error = upload_request
+            .write(wrong_offset, &append_data)
+            .await
+            .expect_err("out-of-order write should fail");
+
+        assert!(matches!(error, AppendUploadError::OutOfOrderWrite { .. }));
+    }
+
+    #[test_case(Some("aws:kmr"), Some("some_key_alias"))]
+    #[test_case(Some("aws:kms"), Some("some_key_ali`s"))]
+    #[test_case(None, Some("some_key_alias"))]
+    #[test_case(Some("aws:kms"), None)]
+    #[tokio::test]
+    async fn test_append_with_corrupted_sse_test(sse_type_corrupted: Option<&str>, key_id_corrupted: Option<&str>) {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+
+        let buffer_size = 256;
+        let server_side_encryption =
+            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key_alias".to_string()));
+        let mut uploader = new_uploader_for_test(client.clone(), buffer_size, Some(server_side_encryption), None);
+
+        // Corrupt the server side encryption settings
+        uploader
+            .server_side_encryption
+            .corrupt_data(sse_type_corrupted.map(String::from), key_id_corrupted.map(String::from));
+
+        let initial_offset = existing_object.len() as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request =
+            uploader.start_upload(bucket.to_owned(), key.to_owned(), initial_offset, Some(initial_etag));
+
+        let append_data = [0xaa; 128];
+        upload_request
+            .write(initial_offset, &append_data)
+            .await
+            .expect("write should succeed");
+
+        // Verify that the request fails at completion
+        assert!(matches!(
+            upload_request.complete().await,
+            Err(AppendUploadError::SseCorruptedError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_append_with_good_sse_test() {
+        let bucket = "bucket";
+        let key = "hello";
+        let mut expected_content = Vec::new();
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size: 32,
+            ..Default::default()
+        }));
+        // Create the "before append" object for the test
+        let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
+        client.add_object(key, existing_object.clone());
+        expected_content.extend_from_slice(&existing_object.read(0, existing_object.len()));
+
+        let buffer_size = 256;
+        let server_side_encryption =
+            ServerSideEncryption::new(Some("aws:kms".to_string()), Some("some_key_alias".to_string()));
+        let uploader = new_uploader_for_test(client.clone(), buffer_size, Some(server_side_encryption), None);
+
+        let initial_offset = existing_object.len() as u64;
+        let initial_etag = existing_object.etag();
+        let mut upload_request =
+            uploader.start_upload(bucket.to_owned(), key.to_owned(), initial_offset, Some(initial_etag));
+
+        let append_data = [0xaa; 128];
+        expected_content.extend_from_slice(&append_data);
+        upload_request
+            .write(initial_offset, &append_data)
+            .await
+            .expect("write should succeed");
+        upload_request
+            .complete()
+            .await
+            .expect("upload with sse should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+
+    #[test_case(1024, 128, 10)]
+    #[test_case(1024, 4096, 20)]
+    #[tokio::test]
+    async fn test_append_on_low_memory(part_size: usize, write_size: usize, part_count: usize) {
+        let bucket = "bucket";
+        let key = "hello";
+
+        let client = Arc::new(MockClient::new(MockClientConfig {
+            bucket: bucket.to_owned(),
+            part_size,
+            ..Default::default()
+        }));
+
+        // Use a memory limiter with 0 limit
+        let mem_limiter = MemoryLimiter::new(client.clone(), 0);
+        let uploader = AppendUploader::new(
+            client.clone(),
+            ThreadPool::builder().pool_size(1).create().unwrap(),
+            mem_limiter.into(),
+            part_size,
+            Default::default(),
+            None,
+        );
+
+        let mut offset = 0;
+        let mut upload_request = uploader.start_upload(bucket.to_owned(), key.to_owned(), offset, None);
+        let mut expected_content = Vec::new();
+
+        // Write enough data to fill multiple parts
+        while expected_content.len() < part_count * part_size {
+            let append_data = vec![0xaa; write_size];
+            expected_content.extend_from_slice(&append_data);
+            offset += upload_request
+                .write(offset, &append_data)
+                .await
+                .expect("write should succeed") as u64;
+        }
+
+        // Wait for the upload to complete
+        upload_request
+            .complete()
+            .await
+            .expect("upload should complete successfully");
+
+        // Verify content of the object
+        let get_request = client
+            .get_object(bucket, key, &GetObjectParams::default())
+            .await
+            .expect("get_object failed");
+        let actual = get_request.collect().await.expect("failed to collect body");
+        assert_eq!(expected_content, *actual);
+    }
+}

--- a/mountpoint-s3/tests/common/mod.rs
+++ b/mountpoint-s3/tests/common/mod.rs
@@ -59,8 +59,8 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
-    let prefetcher = default_prefetch(runtime, Default::default());
-    S3Filesystem::new(client, prefetcher, bucket, prefix, config)
+    let prefetcher = default_prefetch(runtime.clone(), Default::default());
+    S3Filesystem::new(client, prefetcher, runtime, bucket, prefix, config)
 }
 
 #[track_caller]

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -315,10 +315,11 @@ where
 {
     let mount_point = tempfile::tempdir().unwrap();
     let runtime = client.event_loop_group();
-    let prefetcher = caching_prefetch(cache, runtime, Default::default());
+    let prefetcher = caching_prefetch(cache, runtime.clone(), Default::default());
     let session = create_fuse_session(
         client,
         prefetcher,
+        runtime,
         bucket,
         prefix,
         mount_point.path(),

--- a/mountpoint-s3/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/write_test.rs
@@ -1,4 +1,5 @@
-use std::fs::{metadata, read, read_dir, File};
+use std::fmt::Debug;
+use std::fs::{metadata, read, read_dir, File, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, Write};
 use std::os::unix::prelude::*;
 use std::path::Path;
@@ -6,10 +7,10 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
-use mountpoint_s3_client::types::Checksum;
+use mountpoint_s3_client::types::{Checksum, ChecksumAlgorithm, PutObjectSingleParams, UploadChecksum};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use test_case::test_case;
+use test_case::{test_case, test_matrix};
 
 use mountpoint_s3::fs::CacheConfig;
 use mountpoint_s3::S3FilesystemConfig;
@@ -20,25 +21,105 @@ use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionConfig, Test
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use crate::common::{creds::get_scoped_down_credentials, s3::get_test_kms_key_id};
 
-fn open_for_write(path: impl AsRef<Path>, append: bool, write_only: bool) -> std::io::Result<File> {
-    let mut options = File::options();
-    if !write_only {
-        options.read(true);
-    }
+/// Extend [OptionOptions] to allow configuration using test enums.
+///
+/// This supports us in providing a matrix of test cases and automatically configuring the opened file handle.
+trait OpenOptionsTestExt {
+    fn append_mode(&mut self, append_mode: AppendMode) -> &mut Self;
 
-    if append {
-        options.append(true);
-    } else {
-        options.write(true);
-    }
-    options.create(true).open(path)
+    fn rw_mode(&mut self, rw_mode: ReadWriteMode) -> &mut Self;
 }
 
-fn sequential_write_test(creator_fn: impl TestSessionCreator, prefix: &str, append: bool, write_only: bool) {
+impl OpenOptionsTestExt for OpenOptions {
+    fn append_mode(&mut self, append_mode: AppendMode) -> &mut Self {
+        match append_mode {
+            AppendMode::On => self.append(true),
+            AppendMode::Off => self.write(true),
+        }
+    }
+
+    fn rw_mode(&mut self, rw_mode: ReadWriteMode) -> &mut Self {
+        match rw_mode {
+            ReadWriteMode::WriteOnly => self.write(true).read(false),
+            ReadWriteMode::ReadWrite => self.write(true).read(true),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReadWriteMode {
+    WriteOnly,
+    ReadWrite,
+}
+
+const WRITE_ONLY: ReadWriteMode = ReadWriteMode::WriteOnly;
+const READ_WRITE: ReadWriteMode = ReadWriteMode::ReadWrite;
+
+/// Sets whether to open files with `O_APPEND`.
+#[derive(Clone, Copy)]
+enum AppendMode {
+    On,
+    Off,
+}
+
+const APPEND: AppendMode = AppendMode::On;
+const NO_APPEND: AppendMode = AppendMode::Off;
+
+/// Sets whether to invoke `fsync` after a write.
+#[derive(Clone, Copy)]
+enum FSyncMode {
+    On,
+    Off,
+}
+impl FSyncMode {
+    fn on(&self) -> bool {
+        matches!(self, Self::On)
+    }
+}
+
+const FSYNC: FSyncMode = FSyncMode::On;
+const NO_FSYNC: FSyncMode = FSyncMode::Off;
+
+#[derive(Clone, Copy)]
+enum UploadMode {
+    Atomic,
+    Incremental,
+}
+
+impl UploadMode {
+    fn is_incremental(&self) -> bool {
+        matches!(self, Self::Incremental)
+    }
+}
+
+const ATOMIC_UPLOAD: UploadMode = UploadMode::Atomic;
+const INCREMENTAL_UPLOAD: UploadMode = UploadMode::Incremental;
+
+trait S3FilesystemConfigExt {
+    fn upload_mode(self, upload_mode: UploadMode) -> Self;
+}
+
+impl S3FilesystemConfigExt for S3FilesystemConfig {
+    fn upload_mode(mut self, upload_mode: UploadMode) -> Self {
+        self.incremental_upload = upload_mode.is_incremental();
+        self
+    }
+}
+
+fn sequential_write_test(
+    creator_fn: impl TestSessionCreator,
+    append_mode: AppendMode,
+    rw_mode: ReadWriteMode,
+    upload_mode: UploadMode,
+) {
     const OBJECT_SIZE: usize = 50 * 1024;
     const WRITE_SIZE: usize = 1024;
 
-    let test_session = creator_fn(prefix, Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("sequential_write_test", config);
 
     // Make sure there's an existing directory
     test_session
@@ -49,7 +130,12 @@ fn sequential_write_test(creator_fn: impl TestSessionCreator, prefix: &str, appe
     let subdir = test_session.mount_path().join("dir");
     let path = test_session.mount_path().join("dir/new.txt");
 
-    let mut f = open_for_write(&path, append, write_only).unwrap();
+    let mut f = File::options()
+        .append_mode(append_mode)
+        .rw_mode(rw_mode)
+        .create(true)
+        .open(&path)
+        .unwrap();
 
     // The file is visible with size 0 as soon as we open it for write
     let m = metadata(&path).unwrap();
@@ -93,62 +179,80 @@ fn sequential_write_test(creator_fn: impl TestSessionCreator, prefix: &str, appe
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true, true; "append write only")]
-#[test_case(true, false; "append readwrite")]
-#[test_case(false, true; "no append write only")]
-#[test_case(false, false; "no append readwrite")]
-fn sequential_write_test_s3(append: bool, write_only: bool) {
-    sequential_write_test(fuse::s3_session::new, "sequential_write_test", append, write_only);
+#[test_matrix([APPEND, NO_APPEND], [WRITE_ONLY, READ_WRITE])]
+fn sequential_write_test_s3(append_mode: AppendMode, rw_mode: ReadWriteMode) {
+    sequential_write_test(fuse::s3_session::new, append_mode, rw_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case("", true, true; "no prefix append write only")]
-#[test_case("", true, false; "no prefix append readwrite")]
-#[test_case("", false, true; "no prefix no append write only")]
-#[test_case("", false, false; "no prefix no append readwrite")]
-#[test_case("sequential_write_test", true, true; "prefix append write only")]
-#[test_case("sequential_write_test", true, false; "prefix append readwrite")]
-#[test_case("sequential_write_test", false, true; "prefix no append write only")]
-#[test_case("sequential_write_test", false, false; "prefix no append readwrite")]
-fn sequential_write_test_mock(prefix: &str, append: bool, write_only: bool) {
-    sequential_write_test(fuse::mock_session::new, prefix, append, write_only);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([APPEND, NO_APPEND], [WRITE_ONLY, READ_WRITE])]
+fn sequential_write_test_s3_incremental_upload(append_mode: AppendMode, rw_mode: ReadWriteMode) {
+    sequential_write_test(fuse::s3_session::new, append_mode, rw_mode, INCREMENTAL_UPLOAD);
 }
 
-fn write_errors_test(creator_fn: impl TestSessionCreator, prefix: &str) {
-    let test_session = creator_fn(prefix, Default::default());
+#[test_matrix([APPEND, NO_APPEND], [WRITE_ONLY, READ_WRITE], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn sequential_write_test_mock(append_mode: AppendMode, rw_mode: ReadWriteMode, upload_mode: UploadMode) {
+    sequential_write_test(fuse::mock_session::new, append_mode, rw_mode, upload_mode);
+}
+
+fn write_errors_test(creator_fn: impl TestSessionCreator, upload_mode: UploadMode) {
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("write_errors_test", config);
 
     test_session
         .client()
         .put_object("dir/hello.txt", b"hello world")
         .unwrap();
 
-    let path = test_session.mount_path().join("dir/hello.txt");
+    let existing_file_path = test_session.mount_path().join("dir/hello.txt");
+    let new_file_path = test_session.mount_path().join("dir/new.txt");
 
-    // Existing files should not be writable even in O_APPEND
-    let err = open_for_write(&path, true, true).expect_err("can't append existing file");
+    // Existing files can't be opened with O_SYNC
+    let err = File::options()
+        .write(true)
+        .custom_flags(libc::O_SYNC)
+        .open(&existing_file_path)
+        .expect_err("O_SYNC should fail");
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
-    let err = open_for_write(&path, false, true).expect_err("can't open existing file for write");
-    assert_eq!(err.kind(), ErrorKind::PermissionDenied);
 
     // New files can't be opened with O_SYNC
     let err = File::options()
         .write(true)
-        .create(true)
+        .create_new(true)
         .custom_flags(libc::O_SYNC)
-        .open(&path)
+        .open(&new_file_path)
         .expect_err("O_SYNC should fail");
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
 
-    // Existing files can't be opened with O_APPEND
-    let err = File::options()
-        .write(true)
-        .create(true)
-        .custom_flags(libc::O_APPEND)
-        .open(&path)
-        .expect_err("O_APPEND should fail");
-    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Existing files should not be writable by default
+    if !upload_mode.is_incremental() {
+        let err = File::options()
+            .write(true)
+            .open(&existing_file_path)
+            .expect_err("can't open existing file for write");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+
+        // Existing files can't be opened in append mode
+        let err = File::options()
+            .append(true)
+            .open(&existing_file_path)
+            .expect_err("can't append existing file");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+
+        // Also try explicitly setting O_APPEND
+        let err = File::options()
+            .write(true)
+            .custom_flags(libc::O_APPEND)
+            .open(&existing_file_path)
+            .expect_err("O_APPEND should fail");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    }
 
     // We can't write to a file opened in O_RDONLY
-    let mut file = File::options().read(true).open(&path).unwrap();
+    let mut file = File::options().read(true).open(&existing_file_path).unwrap();
     let err = file
         .write(b"hello world")
         .expect_err("writing to O_RDONLY file should fail");
@@ -158,9 +262,8 @@ fn write_errors_test(creator_fn: impl TestSessionCreator, prefix: &str) {
     let mut file = File::options()
         .read(true)
         .write(true)
-        .create(true)
         .truncate(false)
-        .open(&path)
+        .open(&existing_file_path)
         .unwrap();
     assert!(file.read(&mut [0u8; 1]).is_ok());
     let err = file
@@ -173,7 +276,7 @@ fn write_errors_test(creator_fn: impl TestSessionCreator, prefix: &str) {
         .read(true)
         .write(true)
         .truncate(true)
-        .open(&path)
+        .open(&existing_file_path)
         .expect_err("existing file cannot be opened with O_TRUNC");
     assert_eq!(err.raw_os_error(), Some(libc::EPERM));
 }
@@ -181,13 +284,18 @@ fn write_errors_test(creator_fn: impl TestSessionCreator, prefix: &str) {
 #[cfg(feature = "s3_tests")]
 #[test]
 fn write_errors_test_s3() {
-    write_errors_test(fuse::s3_session::new, "write_errors_test");
+    write_errors_test(fuse::s3_session::new, ATOMIC_UPLOAD);
 }
 
-#[test_case(""; "no prefix append")]
-#[test_case("sequential_write_test"; "prefix")]
-fn write_errors_test_mock(prefix: &str) {
-    write_errors_test(fuse::mock_session::new, prefix);
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn write_errors_test_s3_incremental_update() {
+    write_errors_test(fuse::s3_session::new, INCREMENTAL_UPLOAD);
+}
+
+#[test_matrix([ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn write_errors_test_mock(upload_mode: UploadMode) {
+    write_errors_test(fuse::mock_session::new, upload_mode);
 }
 
 fn sequential_write_streaming_test(creator_fn: impl TestSessionCreator, object_size: usize, write_chunk_size: usize) {
@@ -203,7 +311,7 @@ fn sequential_write_streaming_test(creator_fn: impl TestSessionCreator, object_s
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
 
     // The file is visible with size 0 as soon as we open it for write
     let m = metadata(&path).unwrap();
@@ -261,15 +369,18 @@ fn sequential_write_streaming_test_mock(object_size: usize, write_chunk_size: us
     sequential_write_streaming_test(fuse::mock_session::new, object_size, write_chunk_size);
 }
 
-fn fsync_test(creator_fn: impl TestSessionCreator, write_only: bool) {
+fn fsync_test(creator_fn: impl TestSessionCreator, rw_mode: ReadWriteMode, upload_mode: UploadMode) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
-    let test_session = creator_fn("fsync_test", Default::default());
-
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("fsync_test", config);
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, false, write_only).unwrap();
+    let mut f = File::options().rw_mode(rw_mode).create(true).open(&path).unwrap();
 
     // The file is visible with size 0 as soon as we open it for write
     let m = metadata(&path).unwrap();
@@ -281,16 +392,18 @@ fn fsync_test(creator_fn: impl TestSessionCreator, write_only: bool) {
 
     f.write_all(&body).unwrap();
 
-    assert!(test_session.client().is_upload_in_progress(KEY).unwrap());
+    assert!(upload_mode.is_incremental() || test_session.client().is_upload_in_progress(KEY).unwrap());
 
     f.sync_all().unwrap();
 
-    assert!(!test_session.client().is_upload_in_progress(KEY).unwrap());
+    assert!(upload_mode.is_incremental() || !test_session.client().is_upload_in_progress(KEY).unwrap());
 
     let m = metadata(&path).unwrap();
     assert_eq!(m.len(), body.len() as u64);
 
-    f.write_all(&body).expect_err("write after sync should fail");
+    if !upload_mode.is_incremental() {
+        f.write_all(&body).expect_err("write after sync should fail");
+    }
 
     drop(f);
 
@@ -302,19 +415,23 @@ fn fsync_test(creator_fn: impl TestSessionCreator, write_only: bool) {
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "write only")]
-#[test_case(false; "readwrite")]
-fn fsync_test_s3(write_only: bool) {
-    fsync_test(fuse::s3_session::new, write_only);
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn fsync_test_s3(rw_mode: ReadWriteMode) {
+    fsync_test(fuse::s3_session::new, rw_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case(true; "write only")]
-#[test_case(false; "readwrite")]
-fn fsync_test_mock(write_only: bool) {
-    fsync_test(fuse::mock_session::new, write_only);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn fsync_test_s3_incremental_upload(rw_mode: ReadWriteMode) {
+    fsync_test(fuse::s3_session::new, rw_mode, INCREMENTAL_UPLOAD);
 }
 
-fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
+#[test_matrix([WRITE_ONLY, READ_WRITE], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn fsync_test_mock(rw_mode: ReadWriteMode, upload_mode: UploadMode) {
+    fsync_test(fuse::mock_session::new, rw_mode, upload_mode);
+}
+
+fn fstat_after_writing(creator_fn: impl TestSessionCreator, sync_mode: FSyncMode, upload_mode: UploadMode) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
@@ -325,7 +442,8 @@ fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
             ..Default::default()
         },
         ..Default::default()
-    };
+    }
+    .upload_mode(upload_mode);
     let session_config = TestSessionConfig {
         filesystem_config,
         ..Default::default()
@@ -334,7 +452,7 @@ fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
 
     let stat = f.metadata().expect("fstat should succeed before writing");
     assert_eq!(stat.len(), 0);
@@ -347,7 +465,7 @@ fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
     let stat = f.metadata().expect("fstat should succeed after writing");
     assert_eq!(stat.len(), OBJECT_SIZE as u64);
 
-    if with_fsync {
+    if sync_mode.on() {
         f.sync_all().expect("fsync should succeed since it's the first fsync");
 
         // Wait at least this long in case there's anything bumping the validity that we didn't know of.
@@ -368,16 +486,20 @@ fn fstat_after_writing(creator_fn: impl TestSessionCreator, with_fsync: bool) {
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "with fsync")]
-#[test_case(true; "without fsync")]
-fn fstat_after_writing_s3(with_fsync: bool) {
-    fstat_after_writing(fuse::s3_session::new, with_fsync);
+#[test_matrix([FSYNC, NO_FSYNC])]
+fn fstat_after_writing_s3(sync_mode: FSyncMode) {
+    fstat_after_writing(fuse::s3_session::new, sync_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case(true; "with fsync")]
-#[test_case(true; "without fsync")]
-fn fstat_after_writing_mock(with_fsync: bool) {
-    fstat_after_writing(fuse::mock_session::new, with_fsync);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([FSYNC, NO_FSYNC])]
+fn fstat_after_writing_s3_incremental_upload(sync_mode: FSyncMode) {
+    fstat_after_writing(fuse::s3_session::new, sync_mode, INCREMENTAL_UPLOAD);
+}
+
+#[test_matrix([FSYNC, NO_FSYNC], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn fstat_after_writing_mock(sync_mode: FSyncMode, upload_mode: UploadMode) {
+    fstat_after_writing(fuse::mock_session::new, sync_mode, upload_mode);
 }
 
 fn write_too_big_test(creator_fn: impl TestSessionCreator, write_size: usize) {
@@ -393,7 +515,7 @@ fn write_too_big_test(creator_fn: impl TestSessionCreator, write_size: usize) {
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
 
     let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;
     let data = vec![0xaa; write_size];
@@ -427,15 +549,25 @@ fn write_too_big_test_mock(write_size: usize) {
     write_too_big_test(fuse::mock_session::new, write_size);
 }
 
-fn out_of_order_write_test(creator_fn: impl TestSessionCreator, offset: i64) {
+fn out_of_order_write_test(creator_fn: impl TestSessionCreator, offset: i64, upload_mode: UploadMode) {
     const OBJECT_SIZE: usize = 32;
     const KEY: &str = "new.txt";
 
-    let test_session = creator_fn("out_of_order_write_test", Default::default());
+    let filesystem_config = S3FilesystemConfig::default().upload_mode(upload_mode);
+    let test_config = TestSessionConfig {
+        filesystem_config,
+        ..Default::default()
+    };
+    let test_session = creator_fn("out_of_order_write_test", test_config);
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
 
     // The file is visible with size 0 as soon as we open it for write
     let m = metadata(&path).unwrap();
@@ -467,13 +599,22 @@ fn out_of_order_write_test(creator_fn: impl TestSessionCreator, offset: i64) {
 #[test_case(-1; "earlier offset")]
 #[test_case(1; "later offset")]
 fn out_of_order_write_test_s3(offset: i64) {
-    out_of_order_write_test(fuse::s3_session::new, offset);
+    out_of_order_write_test(fuse::s3_session::new, offset, ATOMIC_UPLOAD);
 }
 
+#[cfg(feature = "s3express_tests")]
 #[test_case(-1; "earlier offset")]
 #[test_case(1; "later offset")]
-fn out_of_order_write_test_mock(offset: i64) {
-    out_of_order_write_test(fuse::mock_session::new, offset);
+fn out_of_order_write_test_s3_incremental_upload(offset: i64) {
+    out_of_order_write_test(fuse::s3_session::new, offset, INCREMENTAL_UPLOAD);
+}
+
+#[test_case(-1, ATOMIC_UPLOAD; "earlier offset")]
+#[test_case(1, ATOMIC_UPLOAD; "later offset")]
+#[test_case(-1, INCREMENTAL_UPLOAD; "earlier offset, incremental upload")]
+#[test_case(1, INCREMENTAL_UPLOAD; "later offset, incremental upload")]
+fn out_of_order_write_test_mock(offset: i64, upload_mode: UploadMode) {
+    out_of_order_write_test(fuse::mock_session::new, offset, upload_mode);
 }
 
 #[cfg(not(feature = "s3express_tests"))]
@@ -534,7 +675,7 @@ fn write_with_invalid_storage_class_test(creator_fn: impl TestSessionCreator, st
 }
 
 fn write_file(path: impl AsRef<Path>) -> std::io::Result<()> {
-    let mut f = open_for_write(&path, false, true)?;
+    let mut f = File::options().append(true).create(true).open(&path)?;
     let data = [0xaa; 16];
     f.write_all(&data)?;
     f.sync_all()?;
@@ -547,16 +688,24 @@ fn write_with_invalid_storage_class_test_s3(storage_class: &str) {
     write_with_invalid_storage_class_test(fuse::s3_session::new, storage_class);
 }
 
-fn flush_test(creator_fn: impl TestSessionCreator, append: bool) {
+fn flush_test(creator_fn: impl TestSessionCreator, append_mode: AppendMode, upload_mode: UploadMode) {
     const OBJECT_SIZE: usize = 50 * 1024;
     const WRITE_SIZE: usize = 1024;
     const KEY: &str = "new.txt";
 
-    let test_session = creator_fn("flush_test", Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("flush_test", config);
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(&path, append, true).unwrap();
+    let mut f = File::options()
+        .append_mode(append_mode)
+        .create(true)
+        .open(&path)
+        .unwrap();
 
     let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
     let mut body = vec![0u8; OBJECT_SIZE];
@@ -566,12 +715,12 @@ fn flush_test(creator_fn: impl TestSessionCreator, append: bool) {
         f.write_all(part).unwrap();
     }
 
-    assert!(test_session.client().is_upload_in_progress(KEY).unwrap());
+    assert!(upload_mode.is_incremental() || test_session.client().is_upload_in_progress(KEY).unwrap());
 
     // Close the file. Will trigger a call to flush.
     drop(f);
 
-    assert!(!test_session.client().is_upload_in_progress(KEY).unwrap());
+    assert!(upload_mode.is_incremental() || !test_session.client().is_upload_in_progress(KEY).unwrap());
 
     // Now it's closed, we can stat or read it
     let m = metadata(&path).unwrap();
@@ -582,22 +731,30 @@ fn flush_test(creator_fn: impl TestSessionCreator, append: bool) {
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "append")]
-#[test_case(false; "no append")]
-fn flush_test_s3(append: bool) {
-    flush_test(fuse::s3_session::new, append);
+#[test_matrix([APPEND, NO_APPEND])]
+fn flush_test_s3(append_mode: AppendMode) {
+    flush_test(fuse::s3_session::new, append_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case(true; "append")]
-#[test_case(false; "no append")]
-fn flush_test_mock(append: bool) {
-    flush_test(fuse::mock_session::new, append);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([APPEND, NO_APPEND])]
+fn flush_test_s3_incremental_upload(append_mode: AppendMode) {
+    flush_test(fuse::s3_session::new, append_mode, INCREMENTAL_UPLOAD);
 }
 
-fn touch_test(creator_fn: impl TestSessionCreator) {
+#[test_matrix([APPEND, NO_APPEND], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn flush_test_mock(append_mode: AppendMode, upload_mode: UploadMode) {
+    flush_test(fuse::mock_session::new, append_mode, upload_mode);
+}
+
+fn touch_test(creator_fn: impl TestSessionCreator, upload_mode: UploadMode) {
     const KEY: &str = "new.txt";
 
-    let test_session = creator_fn("touch_test", Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("touch_test", config);
 
     let path = test_session.mount_path().join(KEY);
 
@@ -629,19 +786,29 @@ fn touch_test(creator_fn: impl TestSessionCreator) {
 #[cfg(feature = "s3_tests")]
 #[test]
 fn touch_test_s3() {
-    touch_test(fuse::s3_session::new);
+    touch_test(fuse::s3_session::new, ATOMIC_UPLOAD);
 }
 
+#[cfg(feature = "s3express_tests")]
 #[test]
-fn touch_test_mock() {
-    touch_test(fuse::mock_session::new);
+fn touch_test_s3_incremental_upload() {
+    touch_test(fuse::s3_session::new, INCREMENTAL_UPLOAD);
 }
 
-fn dd_test(creator_fn: impl TestSessionCreator) {
+#[test_matrix([ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn touch_test_mock(upload_mode: UploadMode) {
+    touch_test(fuse::mock_session::new, upload_mode);
+}
+
+fn dd_test(creator_fn: impl TestSessionCreator, upload_mode: UploadMode) {
     const KEY: &str = "new.txt";
     const SIZE: u64 = 128;
 
-    let test_session = creator_fn("dd_test", Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = creator_fn("dd_test", config);
 
     let path = test_session.mount_path().join(KEY);
 
@@ -664,21 +831,31 @@ fn dd_test(creator_fn: impl TestSessionCreator) {
 #[cfg(feature = "s3_tests")]
 #[test]
 fn dd_test_s3() {
-    dd_test(fuse::s3_session::new);
+    dd_test(fuse::s3_session::new, ATOMIC_UPLOAD);
 }
 
+#[cfg(feature = "s3express_tests")]
 #[test]
-fn dd_test_mock() {
-    dd_test(fuse::mock_session::new);
+fn dd_test_s3_incremental_upload() {
+    dd_test(fuse::s3_session::new, INCREMENTAL_UPLOAD);
 }
 
-#[test]
-fn spawn_test() {
+#[test_matrix([ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn dd_test_mock(upload_mode: UploadMode) {
+    dd_test(fuse::mock_session::new, upload_mode);
+}
+
+#[test_matrix([ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn spawn_test(upload_mode: UploadMode) {
     const KEY: &str = "new.txt";
-    let test_session = fuse::mock_session::new("spawn_test", Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = fuse::mock_session::new("spawn_test", config);
 
     let path = test_session.mount_path().join(KEY);
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
 
     let data = vec![0xaa; 32];
     f.write_all(&data).unwrap();
@@ -694,13 +871,17 @@ fn spawn_test() {
     assert_eq!(m.len(), (data.len() * 2) as u64);
 }
 
-#[test]
-fn multi_thread_test() {
+#[test_matrix([ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn multi_thread_test(upload_mode: UploadMode) {
     const KEY: &str = "new.txt";
-    let test_session = fuse::mock_session::new("spawn_test", Default::default());
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig::default().upload_mode(upload_mode),
+        ..Default::default()
+    };
+    let test_session = fuse::mock_session::new("multi_thread_test", config);
 
     let path = test_session.mount_path().join(KEY);
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
 
     let data = vec![0xaa; 32 * 1024 * 1024];
     f.write_all(&data).unwrap();
@@ -719,11 +900,12 @@ fn multi_thread_test() {
     .unwrap();
 }
 
-fn overwrite_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
+fn overwrite_test(creator_fn: impl TestSessionCreator, prefix: &str, rw_mode: ReadWriteMode, upload_mode: UploadMode) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
-    };
+    }
+    .upload_mode(upload_mode);
     let test_config = TestSessionConfig {
         filesystem_config,
         ..Default::default()
@@ -740,11 +922,7 @@ fn overwrite_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only:
     let path = test_session.mount_path().join("dir/hello.txt");
 
     // Open with O_TRUNC and write something to the file
-    let mut options = File::options();
-    if !write_only {
-        options.read(true);
-    }
-    let mut write_fh = options.write(true).truncate(true).open(&path).unwrap();
+    let mut write_fh = File::options().rw_mode(rw_mode).truncate(true).open(&path).unwrap();
     write_fh.write_all(b"overwrite").expect("write should succeed");
     write_fh.sync_all().unwrap();
     drop(write_fh);
@@ -759,16 +937,20 @@ fn overwrite_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only:
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_test_s3(write_only: bool) {
-    overwrite_test(fuse::s3_session::new, "overwrite_test", write_only);
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_test_s3(rw_mode: ReadWriteMode) {
+    overwrite_test(fuse::s3_session::new, "overwrite_test", rw_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_test_mock(write_only: bool) {
-    overwrite_test(fuse::mock_session::new, "overwrite_test", write_only);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_test_s3_incremental_upload(rw_mode: ReadWriteMode) {
+    overwrite_test(fuse::s3_session::new, "overwrite_test", rw_mode, INCREMENTAL_UPLOAD);
+}
+
+#[test_matrix([WRITE_ONLY, READ_WRITE], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn overwrite_test_mock(rw_mode: ReadWriteMode, upload_mode: UploadMode) {
+    overwrite_test(fuse::mock_session::new, "overwrite_test", rw_mode, upload_mode);
 }
 
 fn overwrite_disallowed_on_concurrent_read_test(creator_fn: impl TestSessionCreator, prefix: &str) {
@@ -829,7 +1011,11 @@ fn overwrite_disallowed_on_concurrent_read_test_mock() {
     );
 }
 
-fn overwrite_fail_on_write_without_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
+fn overwrite_fail_on_write_without_truncate_test(
+    creator_fn: impl TestSessionCreator,
+    prefix: &str,
+    rw_mode: ReadWriteMode,
+) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -851,47 +1037,48 @@ fn overwrite_fail_on_write_without_truncate_test(creator_fn: impl TestSessionCre
 
     // Open should fail without truncate flag
     let mut options = File::options();
-    if !write_only {
-        let mut read_fh = options
-            .read(true)
-            .write(true)
-            .open(path)
-            .expect("using RW should open for read");
-        let err = read_fh
-            .write(b"hello world")
-            .expect_err("writing to a file opened for read should fail");
-        assert_eq!(err.raw_os_error(), Some(libc::EBADF));
-    } else {
-        let err = options
-            .write(true)
-            .open(path)
-            .expect_err("overwriting a file opened without truncate flag should fail");
-        assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+    match rw_mode {
+        ReadWriteMode::WriteOnly => {
+            let err = options
+                .write(true)
+                .open(path)
+                .expect_err("overwriting a file opened without truncate flag should fail");
+            assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+        }
+        ReadWriteMode::ReadWrite => {
+            let mut read_fh = options
+                .read(true)
+                .write(true)
+                .open(path)
+                .expect("using RW should open for read");
+            let err = read_fh
+                .write(b"hello world")
+                .expect_err("writing to a file opened for read should fail");
+            assert_eq!(err.raw_os_error(), Some(libc::EBADF));
+        }
     }
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_fail_on_write_without_truncate_test_s3(write_only: bool) {
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_fail_on_write_without_truncate_test_s3(rw_mode: ReadWriteMode) {
     overwrite_fail_on_write_without_truncate_test(
         fuse::s3_session::new,
         "overwrite_fail_on_write_without_truncate_test",
-        write_only,
+        rw_mode,
     );
 }
 
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_fail_on_write_without_truncate_test_mock(write_only: bool) {
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_fail_on_write_without_truncate_test_mock(rw_mode: ReadWriteMode) {
     overwrite_fail_on_write_without_truncate_test(
         fuse::mock_session::new,
         "overwrite_fail_on_write_without_truncate_test",
-        write_only,
+        rw_mode,
     );
 }
 
-fn overwrite_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, write_only: bool) {
+fn overwrite_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, rw_mode: ReadWriteMode) {
     let filesystem_config = S3FilesystemConfig {
         allow_overwrite: true,
         ..Default::default()
@@ -912,12 +1099,8 @@ fn overwrite_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, wr
     let path = test_session.mount_path().join("dir/hello.txt");
 
     // File should be empty when opened with O_TRUNC even without any write
-    let mut options = File::options();
-    if !write_only {
-        options.read(true);
-    }
-    let write_fh = options
-        .write(true)
+    let write_fh = File::options()
+        .rw_mode(rw_mode)
         .truncate(true)
         .open(&path)
         .expect("open should succeed");
@@ -931,16 +1114,14 @@ fn overwrite_truncate_test(creator_fn: impl TestSessionCreator, prefix: &str, wr
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_truncate_test_s3(write_only: bool) {
-    overwrite_truncate_test(fuse::s3_session::new, "overwrite_truncate_test", write_only);
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_truncate_test_s3(rw_mode: ReadWriteMode) {
+    overwrite_truncate_test(fuse::s3_session::new, "overwrite_truncate_test", rw_mode);
 }
 
-#[test_case(true; "write_only")]
-#[test_case(false; "read_write")]
-fn overwrite_truncate_test_mock(write_only: bool) {
-    overwrite_truncate_test(fuse::mock_session::new, "overwrite_truncate_test", write_only);
+#[test_matrix([WRITE_ONLY, READ_WRITE])]
+fn overwrite_truncate_test_mock(rw_mode: ReadWriteMode) {
+    overwrite_truncate_test(fuse::mock_session::new, "overwrite_truncate_test", rw_mode);
 }
 
 fn overwrite_after_read_test(creator_fn: impl TestSessionCreator, prefix: &str) {
@@ -1103,7 +1284,7 @@ fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_
     let test_session = fuse::s3_session::new("sse_with_policy_test", test_config);
     let file_name = "hello";
     let path = test_session.mount_path().join(file_name);
-    let mut f = open_for_write(&path, false, true).unwrap();
+    let mut f = File::options().write(true).create(true).open(&path).unwrap();
     let data = vec![0xaa; 32];
     let write_result = f.write_all(&data);
 
@@ -1139,7 +1320,11 @@ fn concurrent_open_for_write_test(max_files: usize) {
     let mut open_files = Vec::new();
     for file_name in &file_names {
         let path = test_session.mount_path().join(file_name);
-        let f = open_for_write(&path, false, true).expect("open should succeed");
+        let f = File::options()
+            .append(true)
+            .create(true)
+            .open(&path)
+            .expect("open should succeed");
         open_files.push(f);
     }
 
@@ -1162,15 +1347,29 @@ fn concurrent_open_for_write_test(max_files: usize) {
     }
 }
 
-fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksums: bool) {
+#[derive(Clone, Copy)]
+enum UploadChecksumsMode {
+    Enabled,
+    Disabled,
+}
+
+const CHECKSUMS_ENABLED: UploadChecksumsMode = UploadChecksumsMode::Enabled;
+const CHECKSUMS_DISABLED: UploadChecksumsMode = UploadChecksumsMode::Disabled;
+
+fn write_checksums_test(
+    creator_fn: impl TestSessionCreator,
+    checksums_mode: UploadChecksumsMode,
+    upload_mode: UploadMode,
+) {
     const OBJECT_SIZE: usize = 20 * 1024 * 1024;
     const KEY: &str = "dir/new.txt";
 
     let config = TestSessionConfig {
         filesystem_config: S3FilesystemConfig {
-            use_upload_checksums,
+            use_upload_checksums: matches!(checksums_mode, UploadChecksumsMode::Enabled),
             ..Default::default()
-        },
+        }
+        .upload_mode(upload_mode),
         ..Default::default()
     };
     let test_session = creator_fn("write_checksums_test", config);
@@ -1183,7 +1382,7 @@ fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksum
 
     let path = test_session.mount_path().join(KEY);
 
-    let mut f = open_for_write(path, false, true).unwrap();
+    let mut f = File::options().append(true).create(true).open(&path).unwrap();
     let mut rng = ChaCha20Rng::seed_from_u64(0x12345678 + OBJECT_SIZE as u64);
     let mut body = vec![0u8; OBJECT_SIZE];
     rng.fill(&mut body[..]);
@@ -1200,42 +1399,256 @@ fn write_checksums_test(creator_fn: impl TestSessionCreator, use_upload_checksum
 
     // Now it's fsync'ed and closed, it should be present in S3
     let (object_checksum, part_checksums) = test_session.client().get_object_checksums(KEY).unwrap();
-    if use_upload_checksums {
-        // We should get the correct checksum on the whole object or on the parts.
-        let object_crc32c = object_checksum.is_some_and(|checksum| checksum.checksum_crc32c.is_some());
-        let parts_crc32c = !part_checksums.is_empty()
-            && part_checksums.iter().all(|checksum| {
-                checksum
-                    .as_ref()
-                    .is_some_and(|checksum| checksum.checksum_crc32c.is_some())
-            });
-        assert!(object_crc32c || parts_crc32c, "crc32c is used for trailing checksums");
-    } else {
-        // For S3 Standard, the list of parts is only present if checksums were used, but for S3
-        // Express One Zone the list of parts is always present. The important thing is just that
-        // the *checksums* aren't present, because we disabled those.
-        assert!(
-            object_checksum.is_none_or(|c| c == Checksum::empty()),
-            "checksums should not be present when upload checksums are disabled"
-        );
-        for part_checksum in part_checksums {
+    match checksums_mode {
+        UploadChecksumsMode::Enabled => {
+            // We should get the correct checksum on the whole object or on the parts.
+            let object_crc32c = object_checksum.is_some_and(|checksum| checksum.checksum_crc32c.is_some());
+            let parts_crc32c = !part_checksums.is_empty()
+                && part_checksums.iter().all(|checksum| {
+                    checksum
+                        .as_ref()
+                        .is_some_and(|checksum| checksum.checksum_crc32c.is_some())
+                });
+            assert!(object_crc32c || parts_crc32c, "crc32c is used for trailing checksums");
+        }
+        UploadChecksumsMode::Disabled => {
+            // For S3 Standard, the list of parts is only present if checksums were used, but for S3
+            // Express One Zone the list of parts is always present. The important thing is just that
+            // the *checksums* aren't present, because we disabled those.
             assert!(
-                part_checksum.is_none_or(|c| c == Checksum::empty()),
+                object_checksum.is_none_or(|c| c == Checksum::empty()),
                 "checksums should not be present when upload checksums are disabled"
             );
+            for part_checksum in part_checksums {
+                assert!(
+                    part_checksum.is_none_or(|c| c == Checksum::empty()),
+                    "checksums should not be present when upload checksums are disabled"
+                );
+            }
         }
     }
 }
 
 #[cfg(feature = "s3_tests")]
-#[test_case(true; "enabled")]
-#[test_case(false; "disabled")]
-fn write_checksums_test_s3(use_upload_checksums: bool) {
-    write_checksums_test(fuse::s3_session::new, use_upload_checksums);
+#[test_matrix([CHECKSUMS_ENABLED, CHECKSUMS_DISABLED])]
+fn write_checksums_test_s3(checksums_mode: UploadChecksumsMode) {
+    write_checksums_test(fuse::s3_session::new, checksums_mode, ATOMIC_UPLOAD);
 }
 
-#[test_case(true; "enabled")]
-#[test_case(false; "disabled")]
-fn write_checksums_test_mock(use_upload_checksums: bool) {
-    write_checksums_test(fuse::mock_session::new, use_upload_checksums);
+#[cfg(feature = "s3express_tests")]
+#[test_matrix([CHECKSUMS_ENABLED, CHECKSUMS_DISABLED])]
+fn write_checksums_test_s3_incremental_upload(checksums_mode: UploadChecksumsMode) {
+    write_checksums_test(fuse::s3_session::new, checksums_mode, INCREMENTAL_UPLOAD);
+}
+
+#[test_matrix([CHECKSUMS_ENABLED, CHECKSUMS_DISABLED], [ATOMIC_UPLOAD, INCREMENTAL_UPLOAD])]
+fn write_checksums_test_mock(checksums_mode: UploadChecksumsMode, upload_mode: UploadMode) {
+    write_checksums_test(fuse::mock_session::new, checksums_mode, upload_mode);
+}
+
+#[derive(Debug)]
+struct AppendTestConfig {
+    initial_content: Option<&'static str>,
+    writes: Vec<&'static str>,
+    fsync_after_write: bool,
+}
+
+fn append_test(creator_fn: impl TestSessionCreator, append_config: AppendTestConfig) {
+    const KEY: &str = "append.txt";
+
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn("append_test", config);
+
+    let path = test_session.mount_path().join(KEY);
+
+    let mut expected = Vec::new();
+    if let Some(initial_content) = append_config.initial_content {
+        expected.extend_from_slice(initial_content.as_bytes());
+
+        // Create the file with the initial content
+        test_session.client().put_object(KEY, &expected).unwrap();
+
+        // Check the file already exists and has the expected size
+        let m = metadata(&path).unwrap();
+        assert_eq!(m.len(), expected.len() as u64);
+    }
+
+    let mut f = File::options()
+        .read(false)
+        .append(true)
+        .create(true)
+        .open(&path)
+        .unwrap();
+
+    // The file is visible with the initial size after as we open it for write
+    let m = metadata(&path).unwrap();
+    assert_eq!(m.len(), expected.len() as u64);
+
+    for write_content in append_config.writes {
+        expected.extend_from_slice(write_content.as_bytes());
+
+        f.write_all(write_content.as_bytes()).unwrap();
+
+        if append_config.fsync_after_write {
+            f.sync_all().unwrap();
+
+            let m = metadata(&path).unwrap();
+            assert_eq!(m.len(), expected.len() as u64);
+
+            let new_size = test_session.client().get_object_size(KEY).unwrap();
+            assert_eq!(new_size, expected.len());
+        }
+    }
+
+    drop(f);
+
+    let m = metadata(&path).unwrap();
+    assert_eq!(m.len(), expected.len() as u64);
+
+    let buf = read(&path).unwrap();
+    assert_eq!(&buf[..], &expected[..]);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one.", "two."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one.", "two."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: None, writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: None, writes: vec!["one."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: Some(""), writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some(""), writes: vec!["one."], fsync_after_write: false })]
+fn append_test_s3(config: AppendTestConfig) {
+    append_test(fuse::s3_session::new, config);
+}
+
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one.", "two."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some("initial."), writes: vec!["one.", "two."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: None, writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: None, writes: vec!["one."], fsync_after_write: false })]
+#[test_case(AppendTestConfig { initial_content: Some(""), writes: vec!["one."], fsync_after_write: true })]
+#[test_case(AppendTestConfig { initial_content: Some(""), writes: vec!["one."], fsync_after_write: false })]
+fn append_test_mock(config: AppendTestConfig) {
+    append_test(fuse::mock_session::new, config);
+}
+
+fn append_with_checksums(creator_fn: impl TestSessionCreator, checksum_algorithm: Option<ChecksumAlgorithm>) {
+    const KEY: &str = "append.txt";
+
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn("append_with_checksums", config);
+
+    let path = test_session.mount_path().join(KEY);
+
+    // Create the file with the initial content
+    const INITIAL_CONTENT: &[u8] = b"initial";
+    let checksum = match checksum_algorithm {
+        None => None,
+        Some(ChecksumAlgorithm::Crc32c) => Some(UploadChecksum::Crc32c(
+            mountpoint_s3_client::checksums::crc32c::checksum(INITIAL_CONTENT),
+        )),
+        Some(ChecksumAlgorithm::Crc32) => Some(UploadChecksum::Crc32(
+            mountpoint_s3_client::checksums::crc32::checksum(INITIAL_CONTENT),
+        )),
+        Some(ChecksumAlgorithm::Sha1) => Some(UploadChecksum::Sha1(
+            mountpoint_s3_client::checksums::sha1::checksum(INITIAL_CONTENT).unwrap(),
+        )),
+        Some(ChecksumAlgorithm::Sha256) => Some(UploadChecksum::Sha256(
+            mountpoint_s3_client::checksums::sha256::checksum(INITIAL_CONTENT).unwrap(),
+        )),
+        Some(other) => unimplemented!("checksum algorithm {}", other),
+    };
+    let params = PutObjectSingleParams::new().checksum(checksum);
+    test_session
+        .client()
+        .put_object_single(KEY, INITIAL_CONTENT, params)
+        .unwrap();
+
+    let mut f = File::options().read(false).append(true).open(&path).unwrap();
+
+    const APPEND_CONTENT: &[u8] = b"append";
+    f.write_all(APPEND_CONTENT).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    let expected = [INITIAL_CONTENT, APPEND_CONTENT].concat();
+    let buf = read(&path).unwrap();
+    assert_eq!(&buf[..], &expected[..]);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(None)]
+#[test_case(Some(ChecksumAlgorithm::Crc32c))]
+#[test_case(Some(ChecksumAlgorithm::Crc32))]
+#[test_case(Some(ChecksumAlgorithm::Sha1))]
+#[test_case(Some(ChecksumAlgorithm::Sha256))]
+fn append_with_checksums_s3(checksum_algorithm: Option<ChecksumAlgorithm>) {
+    append_with_checksums(fuse::s3_session::new, checksum_algorithm);
+}
+
+#[test_case(None)]
+#[test_case(Some(ChecksumAlgorithm::Crc32c))]
+#[test_case(Some(ChecksumAlgorithm::Crc32))]
+#[test_case(Some(ChecksumAlgorithm::Sha1))]
+#[test_case(Some(ChecksumAlgorithm::Sha256))]
+fn append_with_checksums_mock(checksum_algorithm: Option<ChecksumAlgorithm>) {
+    append_with_checksums(fuse::mock_session::new, checksum_algorithm);
+}
+
+fn append_fails_on_object_replaced(creator_fn: impl TestSessionCreator) {
+    const KEY: &str = "append.txt";
+
+    let config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn("append_fails_on_object_replaced", config);
+
+    let path = test_session.mount_path().join(KEY);
+
+    // Create the file with the initial content
+    const INITIAL_CONTENT: &[u8] = b"original";
+    test_session.client().put_object(KEY, INITIAL_CONTENT).unwrap();
+
+    let f = File::options().read(false).append(true).open(&path).unwrap();
+
+    // Replace the original file
+    const REPLACED_CONTENT: &[u8] = b"replaced";
+    test_session.client().put_object(KEY, REPLACED_CONTENT).unwrap();
+
+    fn append_to_file(mut f: File) -> std::io::Result<()> {
+        f.write_all(b"append")?;
+        f.sync_all()?;
+        Ok(())
+    }
+
+    append_to_file(f).expect_err("appending to a replaced file should fail");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn append_fails_on_object_replaced_s3() {
+    append_fails_on_object_replaced(fuse::s3_session::new);
+}
+
+#[test]
+fn append_fails_on_object_replaced_mock() {
+    append_fails_on_object_replaced(fuse::mock_session::new);
 }


### PR DESCRIPTION
Introduce a new option for Mountpoint to upload files incrementally and support appending to existing files. The new option can be enabled by setting the `--incremental-upload` flag at mount time and is available when mounting directory buckets in S3 Express One Zone.

Addresses https://github.com/awslabs/mountpoint-s3/issues/1160.

### Does this change impact existing behavior?

No changes under default settings.

### Does this change need a changelog entry?

Yes, added entry to the `mountpoint-s3` changelog, under "New Features".

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
