### PR TITLE
Upgrade cargo-deny action, remove deprecated deny configurations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
       # Once the runners' image is updated (tracking https://github.com/actions/runner-images/pull/11011),
       # we could revert to just:
       #   brew update > /dev/null && brew install pkgconfig
-      run: |           
+      run: |
           brew update
           brew uninstall --ignore-dependencies --force pkg-config@0.29.2
           brew install pkgconf
@@ -280,11 +280,5 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          # setup-rust-toolchain sets "-D warnings" by default, and Rust treats any warning as compile error.
-          # We need to this currently because `vendor/fuser` contains some warnings and it breaks the build.
-          rustflags: ""
       - name: Run cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,4 @@ license-files = [
 ]
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "warn"
-notice = "deny"


### PR DESCRIPTION
The `cargo-deny` action we depend on release v2 in August, and with it made breaking changes. Dependabot was unable to merge due to these breaking changes: https://github.com/awslabs/mountpoint-s3/pull/969/

This change removes the deprecated configurations. `cargo-deny` now marks all of those we configured as denied rather than allowing the violations to be downgraded to warnings or allowed. This impacts us only for 'unmaintained' crates which is fine, if needed we can always create an exception entry.

### Does this change impact existing behavior?

This is a CI change only. We upgrade, removing unused and deprecated fields. Unmaintained crates will now fail CI.

### Does this change need a changelog entry?

No, there is no customer-facing change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
