### PR TITLE
Simplify get_object by waiting for response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,12 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_cell"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,7 +2422,6 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-trait",
- "async_cell",
  "auto_impl",
  "aws-config",
  "aws-credential-types",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Breaking changes
 
+* `get_object` method now waits for the response headers before returning and may report errors earlier.
+  Moreover, its return type on success has been renamed to `GetObjectResponse` (was `GetObjectRequest`).
+  ([#1171](https://github.com/awslabs/mountpoint-s3/pull/1171))
 * `get_object` method now requires a `GetObjectParams` parameter.
   Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
   ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Unreleased
 
+### Breaking changes
+
+* `get_object` method now requires a `GetObjectParams` parameter.
+  Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
+  ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))
+* `head_object` method now requires a `HeadObjectParams` parameter.
+  The structure itself is not required to specify anything to achieve the existing behavior.
+  ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
+* `HeadObjectResult` no longer contains an `ObjectInfo` struct.
+  Instead, it returns the object attributes as individual fields on the `HeadObjectResult`.
+  The entity tag field has also changed and is now of type `ETag` rather than `String`.
+  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
+* `HeadObjectResult` no longer provides the bucket and key used in the original request.
+  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
+* Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
+  `ChecksumAlgorithm` no longer implements `Copy`.
+  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+
 ### Other changes
 
 * `HeadObjectResult` now includes the server-side encryption settings used when storing the object.
@@ -20,24 +38,6 @@
   ([#1157](https://github.com/awslabs/mountpoint-s3/pull/1157))
 * Amazon S3 introduces support for AWS Dedicated Local Zones.
   ([awslabs/aws-c-s3#465](https://github.com/awslabs/aws-c-s3/pull/465))
-
-### Breaking changes
-
-* `HeadObjectResult` no longer contains an `ObjectInfo` struct.
-  Instead, it returns the object attributes as individual fields on the `HeadObjectResult`.
-  The entity tag field has also changed and is now of type `ETag` rather than `String`.
-  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
-* `HeadObjectResult` no longer provides the bucket and key used in the original request.
-  ([#1058](https://github.com/awslabs/mountpoint-s3/pull/1058))
-* `head_object` method now requires a `HeadObjectParams` parameter.
-  The structure itself is not required to specify anything to achieve the existing behavior.
-  ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))
-* Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
-  `ChecksumAlgorithm` no longer implements `Copy`.
-  ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
-* `get_object` method now requires a `GetObjectParams` parameter.
-  Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
-  ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))
 
 
 ## v0.11.0 (October 17, 2024)

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -11,7 +11,6 @@ description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.10.0" }
 mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.10.0" }
 
-async_cell = "0.2.2"
 async-trait = "0.1.83"
 auto_impl = "1.2.0"
 base64ct = { version = "1.6.0", features = ["std"] }

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -15,7 +15,7 @@ use pin_project::pin_project;
 
 use crate::object_client::{
     Checksum, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, GetBodyPart,
-    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest,
+    GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectResponse,
     HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
     ObjectChecksumError, ObjectClient, ObjectClientError, ObjectClientResult, ObjectMetadata, PutObjectError,
     PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
@@ -75,7 +75,7 @@ where
     State: Send + Sync + 'static,
     GetWrapperState: Send + Sync + 'static,
 {
-    type GetObjectRequest = FailureGetRequest<Client, GetWrapperState>;
+    type GetObjectResponse = FailureGetResponse<Client, GetWrapperState>;
     type PutObjectRequest = FailurePutObjectRequest<Client, GetWrapperState>;
     type ClientError = Client::ClientError;
 
@@ -122,10 +122,10 @@ where
         bucket: &str,
         key: &str,
         params: &GetObjectParams,
-    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectResponse, GetObjectError, Self::ClientError> {
         let wrapper = (self.get_object_cb)(&mut *self.state.lock().unwrap(), bucket, key, params)?;
         let request = self.client.get_object(bucket, key, params).await?;
-        Ok(FailureGetRequest {
+        Ok(FailureGetResponse {
             state: wrapper.state,
             result_fn: wrapper.result_fn,
             request,
@@ -206,16 +206,16 @@ where
 }
 
 #[pin_project]
-pub struct FailureGetRequest<Client: ObjectClient, GetWrapperState> {
+pub struct FailureGetResponse<Client: ObjectClient, GetWrapperState> {
     state: GetWrapperState,
     result_fn: fn(&mut GetWrapperState) -> Result<(), Client::ClientError>,
     #[pin]
-    request: Client::GetObjectRequest,
+    request: Client::GetObjectResponse,
 }
 
 #[cfg_attr(not(docsrs), async_trait)]
-impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectRequest
-    for FailureGetRequest<Client, FailState>
+impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectResponse
+    for FailureGetResponse<Client, FailState>
 {
     type ClientError = Client::ClientError;
 
@@ -238,7 +238,7 @@ impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectReques
     }
 }
 
-impl<Client: ObjectClient, FailState> Stream for FailureGetRequest<Client, FailState> {
+impl<Client: ObjectClient, FailState> Stream for FailureGetResponse<Client, FailState> {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, Client::ClientError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -17,8 +17,8 @@ use crate::object_client::{
     Checksum, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest,
     HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
-    ObjectClient, ObjectClientError, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams,
-    PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
+    ObjectChecksumError, ObjectClient, ObjectClientError, ObjectClientResult, ObjectMetadata, PutObjectError,
+    PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
 };
 
 // Wrapper for injecting failures into a get stream or a put request
@@ -219,12 +219,12 @@ impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectReques
 {
     type ClientError = Client::ClientError;
 
-    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
-        self.request.get_object_metadata().await
+    fn get_object_metadata(&self) -> ObjectMetadata {
+        self.request.get_object_metadata()
     }
 
-    async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError> {
-        self.request.get_object_checksum().await
+    fn get_object_checksum(&self) -> Result<Checksum, ObjectChecksumError> {
+        self.request.get_object_checksum()
     }
 
     fn increment_read_window(self: Pin<&mut Self>, len: usize) {

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -61,7 +61,7 @@ pub mod error_metadata;
 
 pub use object_client::{ObjectClient, PutObjectRequest};
 
-pub use s3_crt_client::{get_object::S3GetObjectRequest, put_object::S3PutObjectRequest, S3CrtClient, S3RequestError};
+pub use s3_crt_client::{get_object::S3GetObjectResponse, put_object::S3PutObjectRequest, S3CrtClient, S3RequestError};
 
 /// Configuration for the S3 client
 pub mod config {
@@ -73,7 +73,7 @@ pub mod config {
 pub mod types {
     pub use super::object_client::{
         Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag,
-        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams, GetObjectRequest,
+        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams, GetObjectResponse,
         HeadObjectParams, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult, ObjectInfo,
         ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
         UploadChecksum, UploadReview, UploadReviewPart,

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -28,7 +28,7 @@ use crate::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use crate::object_client::{
     Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError,
     DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesParts,
-    GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest, HeadObjectError, HeadObjectParams,
+    GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectResponse, HeadObjectError, HeadObjectParams,
     HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectChecksumError, ObjectClient,
     ObjectClientError, ObjectClientResult, ObjectInfo, ObjectMetadata, ObjectPart, PutObjectError, PutObjectParams,
     PutObjectRequest, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
@@ -670,7 +670,7 @@ fn validate_checksum(
 }
 
 #[derive(Debug)]
-pub struct MockGetObjectRequest {
+pub struct MockGetObjectResponse {
     object: MockObject,
     next_offset: u64,
     length: usize,
@@ -679,7 +679,7 @@ pub struct MockGetObjectRequest {
     read_window_end_offset: u64,
 }
 
-impl MockGetObjectRequest {
+impl MockGetObjectResponse {
     /// Helpful test utility to just collect the entire object into memory. Will panic if the object
     /// parts are streamed out of order.
     pub async fn collect(mut self) -> ObjectClientResult<Box<[u8]>, GetObjectError, MockClientError> {
@@ -695,7 +695,7 @@ impl MockGetObjectRequest {
 }
 
 #[cfg_attr(not(docsrs), async_trait)]
-impl GetObjectRequest for MockGetObjectRequest {
+impl GetObjectResponse for MockGetObjectResponse {
     type ClientError = MockClientError;
 
     fn get_object_metadata(&self) -> ObjectMetadata {
@@ -715,7 +715,7 @@ impl GetObjectRequest for MockGetObjectRequest {
     }
 }
 
-impl Stream for MockGetObjectRequest {
+impl Stream for MockGetObjectResponse {
     type Item = ObjectClientResult<GetBodyPart, GetObjectError, MockClientError>;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -761,7 +761,7 @@ fn mock_client_error<T, E>(s: impl Into<Cow<'static, str>>) -> ObjectClientResul
 
 #[cfg_attr(not(docsrs), async_trait)]
 impl ObjectClient for MockClient {
-    type GetObjectRequest = MockGetObjectRequest;
+    type GetObjectResponse = MockGetObjectResponse;
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
@@ -829,7 +829,7 @@ impl ObjectClient for MockClient {
         bucket: &str,
         key: &str,
         params: &GetObjectParams,
-    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectResponse, GetObjectError, Self::ClientError> {
         trace!(bucket, key, ?params.range, ?params.if_match, "GetObject");
         self.inc_op_count(Operation::GetObject);
 
@@ -855,7 +855,7 @@ impl ObjectClient for MockClient {
                 (0, object.len())
             };
 
-            Ok(MockGetObjectRequest {
+            Ok(MockGetObjectResponse {
                 object: object.clone(),
                 next_offset,
                 length,

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -29,10 +29,10 @@ use crate::object_client::{
     Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError,
     DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesError, GetObjectAttributesParts,
     GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest, HeadObjectError, HeadObjectParams,
-    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectClient, ObjectClientError,
-    ObjectClientResult, ObjectInfo, ObjectMetadata, ObjectPart, PutObjectError, PutObjectParams, PutObjectRequest,
-    PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus, UploadChecksum, UploadReview,
-    UploadReviewPart,
+    HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute, ObjectChecksumError, ObjectClient,
+    ObjectClientError, ObjectClientResult, ObjectInfo, ObjectMetadata, ObjectPart, PutObjectError, PutObjectParams,
+    PutObjectRequest, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
+    UploadChecksum, UploadReview, UploadReviewPart,
 };
 
 mod leaky_bucket;
@@ -698,11 +698,11 @@ impl MockGetObjectRequest {
 impl GetObjectRequest for MockGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
-        Ok(self.object.object_metadata.clone())
+    fn get_object_metadata(&self) -> ObjectMetadata {
+        self.object.object_metadata.clone()
     }
 
-    async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError> {
+    fn get_object_checksum(&self) -> Result<Checksum, ObjectChecksumError> {
         Ok(self.object.checksum.clone())
     }
 
@@ -1258,7 +1258,7 @@ mod tests {
         let expected_range = expected_range.start as usize..expected_range.end as usize;
         assert_eq!(&accum[..], &body[expected_range], "body does not match");
 
-        assert_eq!(get_request.get_object_metadata().await, Ok(object_metadata));
+        assert_eq!(get_request.get_object_metadata(), object_metadata);
     }
 
     #[tokio::test]

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -16,8 +16,8 @@ use crate::object_client::{
     Checksum, CopyObjectError, CopyObjectParams, CopyObjectResult, DeleteObjectError, DeleteObjectResult, GetBodyPart,
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectRequest,
     HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
-    ObjectClient, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams, PutObjectResult,
-    PutObjectSingleParams,
+    ObjectChecksumError, ObjectClient, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams,
+    PutObjectResult, PutObjectSingleParams,
 };
 
 /// A [MockClient] that rate limits overall download throughput to simulate a target network
@@ -70,11 +70,11 @@ pub struct ThroughputGetObjectRequest {
 impl GetObjectRequest for ThroughputGetObjectRequest {
     type ClientError = MockClientError;
 
-    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError> {
-        Ok(self.request.object.object_metadata.clone())
+    fn get_object_metadata(&self) -> ObjectMetadata {
+        self.request.object.object_metadata.clone()
     }
 
-    async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError> {
+    fn get_object_checksum(&self) -> Result<Checksum, ObjectChecksumError> {
         Ok(self.request.object.checksum.clone())
     }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -598,12 +598,10 @@ pub trait GetObjectRequest:
     type ClientError: std::error::Error + Send + Sync + 'static;
 
     /// Get the object's user defined metadata.
-    /// If the metadata has already been read, return immediately. Otherwise, resolve the future
-    /// when they're read.
-    async fn get_object_metadata(&self) -> ObjectClientResult<ObjectMetadata, GetObjectError, Self::ClientError>;
+    fn get_object_metadata(&self) -> ObjectMetadata;
 
     /// Get the object's checksum, if uploaded with one
-    async fn get_object_checksum(&self) -> ObjectClientResult<Checksum, GetObjectError, Self::ClientError>;
+    fn get_object_checksum(&self) -> Result<Checksum, ObjectChecksumError>;
 
     /// Increment the flow-control window, so that response data continues downloading.
     ///
@@ -624,6 +622,15 @@ pub trait GetObjectRequest:
     /// Get the upper bound of the current read window. When backpressure is enabled, [GetObjectRequest] can
     /// return data up to this offset *exclusively*.
     fn read_window_end_offset(self: Pin<&Self>) -> u64;
+}
+
+/// Failures to return object checksum
+#[derive(Debug, Error)]
+pub enum ObjectChecksumError {
+    #[error("requested object checksums, but did not specify it in the request")]
+    DidNotRequestChecksums,
+    #[error("object checksum could not be retrieved from headers")]
+    HeadersError(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// A single element of a [`get_object`](ObjectClient::get_object) response stream is a pair of

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -27,7 +27,7 @@ pub use etag::ETag;
 #[cfg_attr(not(docsrs), async_trait)]
 #[auto_impl(Arc)]
 pub trait ObjectClient {
-    type GetObjectRequest: GetObjectRequest<ClientError = Self::ClientError>;
+    type GetObjectResponse: GetObjectResponse<ClientError = Self::ClientError>;
     type PutObjectRequest: PutObjectRequest<ClientError = Self::ClientError>;
     type ClientError: std::error::Error + ProvideErrorMetadata + Send + Sync + 'static;
 
@@ -79,7 +79,7 @@ pub trait ObjectClient {
         bucket: &str,
         key: &str,
         params: &GetObjectParams,
-    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError>;
+    ) -> ObjectClientResult<Self::GetObjectResponse, GetObjectError, Self::ClientError>;
 
     /// List the objects in a bucket under a given prefix
     async fn list_objects(
@@ -592,7 +592,7 @@ impl UploadChecksum {
 /// Each item of the stream is a part of the object body together with the part's offset within the
 /// object.
 #[cfg_attr(not(docsrs), async_trait)]
-pub trait GetObjectRequest:
+pub trait GetObjectResponse:
     Stream<Item = ObjectClientResult<GetBodyPart, GetObjectError, Self::ClientError>> + Send + Sync
 {
     type ClientError: std::error::Error + Send + Sync + 'static;

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -952,6 +952,7 @@ impl<'a> S3Message<'a> {
 #[derive(Debug)]
 #[pin_project(PinnedDrop)]
 struct S3HttpRequest<T, E> {
+    /// Receiver for the result of the `on_finish` callback.
     #[pin]
     receiver: Fuse<oneshot::Receiver<ObjectClientResult<T, E, S3RequestError>>>,
     meta_request: MetaRequest,

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -62,7 +62,7 @@ pub(crate) mod copy_object;
 pub(crate) mod delete_object;
 pub(crate) mod get_object;
 
-pub(crate) use get_object::S3GetObjectRequest;
+pub(crate) use get_object::S3GetObjectResponse;
 pub(crate) mod get_object_attributes;
 
 pub(crate) mod head_object;
@@ -1252,7 +1252,7 @@ fn emit_throughput_metric(bytes: u64, duration: Duration, op: &'static str) {
 
 #[cfg_attr(not(docsrs), async_trait)]
 impl ObjectClient for S3CrtClient {
-    type GetObjectRequest = S3GetObjectRequest;
+    type GetObjectResponse = S3GetObjectResponse;
     type PutObjectRequest = S3PutObjectRequest;
     type ClientError = S3RequestError;
 
@@ -1308,7 +1308,7 @@ impl ObjectClient for S3CrtClient {
         bucket: &str,
         key: &str,
         params: &GetObjectParams,
-    ) -> ObjectClientResult<Self::GetObjectRequest, GetObjectError, Self::ClientError> {
+    ) -> ObjectClientResult<Self::GetObjectResponse, GetObjectError, Self::ClientError> {
         self.get_object(bucket, key, params).await
     }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -10,7 +10,7 @@ use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
-use mountpoint_s3_client::types::GetObjectRequest;
+use mountpoint_s3_client::types::GetObjectResponse;
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_crt::common::allocator::Allocator;
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
@@ -221,7 +221,7 @@ pub async fn check_get_result<E: std::fmt::Debug>(
 /// Check the result of a GET against expected bytes.
 pub async fn check_backpressure_get_result(
     read_window: usize,
-    result: impl GetObjectRequest,
+    result: impl GetObjectResponse,
     range: Option<Range<u64>>,
     expected: &[u8],
 ) {

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -14,7 +14,7 @@ use common::*;
 use futures::pin_mut;
 use futures::stream::StreamExt;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
-use mountpoint_s3_client::types::{Checksum, ChecksumMode, ETag, GetObjectParams, GetObjectRequest};
+use mountpoint_s3_client::types::{Checksum, ChecksumMode, ETag, GetObjectParams, GetObjectResponse};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 
 use test_case::test_case;

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -175,12 +175,9 @@ where
         }
         let buffer = buffer.freeze();
 
-        let object_metadata = result.get_object_metadata().await.map_err(|err| {
-            emit_failure_metric_read("invalid_block_metadata");
-            DataCacheError::IoFailure(err.into())
-        })?;
+        let object_metadata = result.get_object_metadata();
 
-        let checksum = result.get_object_checksum().await.map_err(|err| {
+        let checksum = result.get_object_checksum().map_err(|err| {
             emit_failure_metric_read("invalid_block_checksum");
             DataCacheError::IoFailure(err.into())
         })?;

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -9,7 +9,7 @@ use bytes::BytesMut;
 use futures::{pin_mut, StreamExt};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError, PutObjectError};
 use mountpoint_s3_client::types::{
-    ChecksumMode, GetObjectParams, GetObjectRequest, ObjectClientResult, PutObjectSingleParams, UploadChecksum,
+    ChecksumMode, GetObjectParams, GetObjectResponse, ObjectClientResult, PutObjectSingleParams, UploadChecksum,
 };
 use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_crt::checksums::crc32c::{self, Crc32c};

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -2,7 +2,7 @@ use async_stream::try_stream;
 use bytes::Bytes;
 use futures::task::{Spawn, SpawnExt};
 use futures::{pin_mut, Stream, StreamExt};
-use mountpoint_s3_client::{types::GetObjectParams, types::GetObjectRequest, ObjectClient};
+use mountpoint_s3_client::{types::GetObjectParams, types::GetObjectResponse, ObjectClient};
 use std::marker::{Send, Sync};
 use std::sync::Arc;
 use std::{fmt::Debug, ops::Range};

--- a/mountpoint-s3/src/upload/incremental.rs
+++ b/mountpoint-s3/src/upload/incremental.rs
@@ -486,7 +486,7 @@ mod tests {
     use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
     use mountpoint_s3_client::failure_client::{countdown_failure_client, CountdownFailureConfig};
     use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockObject};
-    use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag, GetObjectParams, GetObjectRequest};
+    use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag, GetObjectParams, GetObjectResponse};
     use test_case::test_case;
 
     fn new_uploader_for_test<Client>(

--- a/mountpoint-s3/src/upload/incremental.rs
+++ b/mountpoint-s3/src/upload/incremental.rs
@@ -723,7 +723,7 @@ mod tests {
             .await
             .expect("get_object failed");
 
-        let checksum = get_request.get_object_checksum().await.expect("failed to get checksum");
+        let checksum = get_request.get_object_checksum().expect("failed to get checksum");
         assert_eq!(checksum.algorithms(), expected_checksum_algorithm);
 
         let actual = get_request.collect().await.expect("failed to collect body");


### PR DESCRIPTION
`S3CrtClient::get_object` was originally implemented so that it would complete immediately and return a `GetObjectRequest` implementation (extending `Stream`) to retrieve body parts. Any error from the S3 request would be returned through the stream.
We recently added additional methods (`get_object_metadata` in #1065 and `get_object_checksum` in #1123) to the response that rely on the headers returned by the (first) `GetObject` request. The new methods required an async signature and a complicated implementation in order to account for failures and they still do not correctly report accurate error information in some cases. 
With this change, we modify `get_object` to await for response headers before returning either an error or a `GetObjectResponse` (note the name change) implementation. The ergonomics of `get_object` are improved:
* `await`ing the initial call can already return some errors (e.g. bucket/key not found),
* `get_object_checksum` and `get_object_metadata` are now sync functions.

### Does this change impact existing behavior?

Yes, `get_object` behavior is different, `get_object_checksum` and `get_object_metadata` signatures have changed, and `GetObjectRequest` was renamed to `GetObjectResponse`.

### Does this change need a changelog entry?

Yes, it requires a breaking change entry for `mountpoint-s3-client`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
