### PR TITLE
Fix Clippy warnings on Rust 1.83

### DIFF
--- a/mountpoint-s3-client/src/endpoint_config.rs
+++ b/mountpoint-s3-client/src/endpoint_config.rs
@@ -215,13 +215,13 @@ impl ResolvedEndpointInfo {
         let auth_scheme_data: serde_json::Value = serde_json::from_slice(endpoint_properties.as_bytes())?;
         let auth_scheme_value = auth_scheme_data["authSchemes"]
             .get(0)
-            .ok_or_else(|| EndpointError::MissingAuthSchemeField("authSchemes"))?;
+            .ok_or(EndpointError::MissingAuthSchemeField("authSchemes"))?;
         let disable_double_encoding = auth_scheme_value["disableDoubleEncoding"]
             .as_bool()
-            .ok_or_else(|| EndpointError::MissingAuthSchemeField("disableDoubleEncoding"))?;
+            .ok_or(EndpointError::MissingAuthSchemeField("disableDoubleEncoding"))?;
         let scheme_name = auth_scheme_value["name"]
             .as_str()
-            .ok_or_else(|| EndpointError::MissingAuthSchemeField("name"))?;
+            .ok_or(EndpointError::MissingAuthSchemeField("name"))?;
         let scheme_name = match scheme_name {
             "sigv4" => SigningAlgorithm::SigV4,
             "sigv4a" => SigningAlgorithm::SigV4A,
@@ -231,12 +231,14 @@ impl ResolvedEndpointInfo {
 
         let signing_name = auth_scheme_value["signingName"]
             .as_str()
-            .ok_or_else(|| EndpointError::MissingAuthSchemeField("signingName"))?;
+            .ok_or(EndpointError::MissingAuthSchemeField("signingName"))?;
         let signing_region = auth_scheme_value
             .get("signingRegion")
             .or_else(|| auth_scheme_value["signingRegionSet"].get(0))
             .and_then(|t| t.as_str())
-            .ok_or_else(|| EndpointError::MissingAuthSchemeField("signingRegion or signingRegionSet"))?;
+            .ok_or(EndpointError::MissingAuthSchemeField(
+                "signingRegion or signingRegionSet",
+            ))?;
 
         Ok(AuthScheme {
             disable_double_encoding,

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -467,7 +467,7 @@ pub struct OperationCounter<'a> {
     operation: Operation,
 }
 
-impl<'a> OperationCounter<'a> {
+impl OperationCounter<'_> {
     /// Return number of requests since the counter was created.
     /// The counter is **not** reset when read.
     pub fn count(&self) -> u64 {
@@ -2153,7 +2153,7 @@ mod tests {
 
         let parts = attrs.object_parts.expect("parts should be returned");
 
-        let expected_parts = (OBJECT_SIZE + PART_SIZE - 1) / PART_SIZE;
+        let expected_parts = OBJECT_SIZE.div_ceil(PART_SIZE);
         assert_eq!(parts.total_parts_count, Some(expected_parts));
 
         if trailing_checksums == PutObjectTrailingChecksums::Enabled {

--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -255,7 +255,7 @@ struct HeadersIterator<'a> {
     offset: usize,
 }
 
-impl<'a> Iterator for HeadersIterator<'a> {
+impl Iterator for HeadersIterator<'_> {
     type Item = (OsString, OsString);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/mountpoint-s3-crt/src/io/stream.rs
+++ b/mountpoint-s3-crt/src/io/stream.rs
@@ -38,7 +38,7 @@ impl<'a> InputStream<'a> {
     }
 }
 
-impl<'a> Drop for InputStream<'a> {
+impl Drop for InputStream<'_> {
     fn drop(&mut self) {
         // SAFETY: self.inner is a valid `aws_input_stream`.
         unsafe {
@@ -100,7 +100,7 @@ impl From<SeekBasis> for aws_stream_seek_basis {
     }
 }
 
-impl<'a> InputStream<'a> {
+impl InputStream<'_> {
     /// Seek to the given offset. Basis is either BEGIN or END, and describes where to seek from.
     pub fn seek(&self, offset: i64, basis: SeekBasis) -> Result<(), Error> {
         // SAFETY: self.inner is a valid input stream.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -260,7 +260,7 @@ struct MetaRequestOptionsInner<'a> {
     _pinned: PhantomPinned,
 }
 
-impl<'a> MetaRequestOptionsInner<'_> {
+impl<'a> MetaRequestOptionsInner<'a> {
     /// Convert from user_data in a callback to a reference to this struct.
     ///
     /// ## Safety
@@ -693,7 +693,7 @@ impl<'r, 's> MetaRequestWrite<'r, 's> {
     }
 }
 
-impl<'r, 's> Future for MetaRequestWrite<'r, 's> {
+impl<'s> Future for MetaRequestWrite<'_, 's> {
     type Output = Result<&'s [u8], Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -293,7 +293,7 @@ where
         FileAttr {
             ino: lookup.inode.ino(),
             size: lookup.stat.size as u64,
-            blocks: (lookup.stat.size as u64 + STAT_BLOCK_SIZE - 1) / STAT_BLOCK_SIZE,
+            blocks: (lookup.stat.size as u64).div_ceil(STAT_BLOCK_SIZE),
             atime: lookup.stat.atime.into(),
             mtime: lookup.stat.mtime.into(),
             ctime: lookup.stat.ctime.into(),

--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -160,7 +160,7 @@ where
             count: &'a mut usize,
         }
 
-        impl<'a> DirectoryReplier for ReplyDirectory<'a> {
+        impl DirectoryReplier for ReplyDirectory<'_> {
             fn add(&mut self, entry: DirectoryEntry) -> bool {
                 let result = self.inner.add(entry.ino, entry.offset, entry.attr.kind, entry.name);
                 if !result {
@@ -199,7 +199,7 @@ where
             count: &'a mut usize,
         }
 
-        impl<'a> DirectoryReplier for ReplyDirectoryPlus<'a> {
+        impl DirectoryReplier for ReplyDirectoryPlus<'_> {
             fn add(&mut self, entry: DirectoryEntry) -> bool {
                 let result = self.inner.add(
                     entry.ino,


### PR DESCRIPTION
Rust 1.83 has been released with new Clippy lints, and it [broke our CI](https://github.com/awslabs/mountpoint-s3/actions/runs/12072806349/job/33667591504?pr=1103) as we use stable toolchain.

This PR fixes Clippy warnings on Rust 1.83. Most fixes are done with `cargo clippy --fix` and manually checked. 

### Does this change impact existing behavior?

None expected, it just changes the code style.

### Does this change need a changelog entry?

No, as there is no behavioral change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
