### PR TITLE
Fix Shadowing in Reference Tests

### DIFF
--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -904,7 +904,7 @@ mod mutations {
         })]
 
         #[test]
-        fn reftest_random_tree(tree in gen_tree(5, 100, 5, 20), readdir_limit in 0..10usize, ops in vec(any::<Op>(), 1..10)) {
+        fn reftest_random_tree(tree in gen_tree(5, 100, 5, 20), readdir_limit in 0..10usize, ops in vec(any::<Op>(), 1..200)) {
             run_test(tree, ops, readdir_limit);
         }
     }
@@ -950,6 +950,52 @@ mod mutations {
             0,
         )
     }
+
+    /*
+      In this test, the opened local file will be shadowed by the walkdir reader.
+      
+     */
+    #[test]
+    fn regression_put_nested_over_open_file() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([])),
+            vec![
+                Op::CreateFile(
+                    ValidName("a".into()),
+                    DirectoryIndex(0),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+                Op::PutObject(
+                    DirectoryIndex(0),
+                    Name("a/b".into()),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+            ],
+            0,
+        )
+    }
+
+    #[test]
+    fn regression_put_nested_over_open_file_inverse() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([])),
+            vec![
+                
+                Op::PutObject(
+                    DirectoryIndex(0),
+                    Name("a/b".into()),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+                Op::CreateFile(
+                    ValidName("a".into()),
+                    DirectoryIndex(0),
+                    FileContent(0, FileSize::Small(0)),
+                )
+            ],
+            0,
+        )
+    }
+
 
     #[test]
     fn regression_out_of_order() {


### PR DESCRIPTION
There was a difference in expected and real behaviour between reference implementation and Mountpoint. 
When creating a local file (i.e. 'a.txt') locally, and then having a remote putobject of "a/b.txt", the reference implementation and the s3-client diverged. 

The test failed, as a file was expected by the reference implementation, however a directory was found. The underlying issue is, that readdir in superblock will skip a.txt (as can be seen from the log message `2024-12-02T14:58:26.933409Z  WARN mountpoint_s3::superblock::readdir::ordered: local file 'a' is omitted because another directory 'a' exist with the same name
`), however the reference implementation overwrote the directory using the local file (while it did not do the same for local directories shadowing directories).

### Does this change impact existing behavior?

Should not affect MP's behaviour, as it only affects the reference implementation.

### Does this change need a changelog entry?

No, as no user-facing change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
