### PR TITLE
Tidy up build info using unwrap

### DIFF
--- a/mountpoint-s3/src/build_info.rs
+++ b/mountpoint-s3/src/build_info.rs
@@ -24,15 +24,11 @@ const fn is_official_aws_release() -> bool {
 /// Formats the current git commit hash and dirty state as a version suffix.
 /// Returns the empty string if building outside a git repository.
 const fn git_commit_suffix() -> &'static str {
+    // Check first and then unwrap, so we can pull out the hash as a const
     if built::GIT_COMMIT_HASH_SHORT.is_none() {
         return "";
     }
-    // A little hacky so we can pull out the hash as a const
-    const COMMIT_HASH_STR: &str = match built::GIT_COMMIT_HASH_SHORT {
-        Some(hash) => hash,
-        // Evaluated at compile time, but never used
-        None => "unreachable",
-    };
+    const COMMIT_HASH_STR: &str = built::GIT_COMMIT_HASH_SHORT.unwrap();
     const COMMIT_DIRTY_STR: &str = match built::GIT_DIRTY {
         Some(true) => "-dirty",
         _ => "",


### PR DESCRIPTION
With Rust 1.83, we can use `Option::unwrap` in a `const` context and remove the untidy hack we had to resort to in order to get the commit hash.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
