### PR TITLE
Wait for CreateMPU before returning from put_object

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Both `ObjectInfo` and `ChecksumAlgorithm` structs are now marked `non_exhaustive`, to indicate that new fields may be added in the future.
   `ChecksumAlgorithm` no longer implements `Copy`.
   ([#1086](https://github.com/awslabs/mountpoint-s3/pull/1086))
+* `put_object` method now waits for the `CreateMultipartUpload` request to complete before returning and may report errors earlier.
+  ([#1192](https://github.com/awslabs/mountpoint-s3/pull/1192))
 
 ### Other changes
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1054,6 +1054,10 @@ impl S3RequestError {
     fn construction_failure(inner: impl Into<ConstructionError>) -> Self {
         S3RequestError::ConstructionFailure(inner.into())
     }
+
+    fn internal_failure(inner: impl std::error::Error + Send + Sync + 'static) -> Self {
+        S3RequestError::InternalError(Box::new(inner))
+    }
 }
 
 impl ProvideErrorMetadata for S3RequestError {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -120,7 +120,7 @@ impl S3CrtClient {
             result = request => {
                 // If we did not received the headers first, the request must have failed.
                 result?;
-                return Err(ObjectClientError::ClientError(S3RequestError::InternalError(Box::new(ObjectHeadersError::MissingHeaders))));
+                return Err(S3RequestError::internal_failure(ObjectHeadersError::MissingHeaders).into());
             }
         };
 

--- a/mountpoint-s3/examples/upload_benchmark.rs
+++ b/mountpoint-s3/examples/upload_benchmark.rs
@@ -165,7 +165,7 @@ where
 
     let bucket = args.bucket.clone();
     let key = args.key.clone();
-    let mut upload_request = uploader.start_atomic_upload(&bucket, &key).await.unwrap();
+    let mut upload_request = uploader.start_atomic_upload(&bucket, &key).unwrap();
 
     let mut total_bytes_written = 0;
     let target_size = args.object_size;

--- a/mountpoint-s3/src/async_util.rs
+++ b/mountpoint-s3/src/async_util.rs
@@ -1,8 +1,7 @@
-use std::fmt::Debug;
-use std::future::Future;
+use std::{fmt::Debug, future::Future};
 
-use futures::future::{BoxFuture, FutureExt};
-use futures::task::{Spawn, SpawnError};
+use async_channel::{Receiver, Sender};
+use futures::task::{Spawn, SpawnError, SpawnExt};
 
 /// Type-erasure for a [Spawn] implementation.
 pub struct BoxRuntime(Box<dyn Spawn + Send + Sync>);
@@ -23,51 +22,130 @@ impl BoxRuntime {
     pub fn new(runtime: impl Spawn + Sync + Send + 'static) -> Self {
         BoxRuntime(Box::new(runtime))
     }
+
+    /// Spawns a task that polls the given future to completion and return
+    /// a [RemoteResult] with its output.
+    pub fn spawn_with_result<T, E, F>(&self, future: F) -> Result<RemoteResult<T, E>, SpawnError>
+    where
+        T: Send + 'static,
+        E: Send + 'static,
+        F: Future<Output = Result<T, E>> + Send + 'static,
+    {
+        let (sender, receiver) = result_channel();
+        self.spawn(async move {
+            let result = future.await;
+            sender.send(result).await;
+        })?;
+        Ok(receiver)
+    }
 }
 
-/// Holds a value lazily initialized when awaiting a future.
-pub struct Lazy<T, E> {
-    future: Option<BoxFuture<'static, Result<T, E>>>,
+/// Creates an async one shot channel with a [RemoteResult] on the receiving end.
+pub fn result_channel<T, E>() -> (ResultSender<T, E>, RemoteResult<T, E>) {
+    let (sender, receiver) = async_channel::bounded(1);
+    (ResultSender { sender }, RemoteResult { receiver, value: None })
+}
+
+/// Holds the result of a spawned task.
+#[derive(Debug)]
+pub struct RemoteResult<T, E> {
+    receiver: Receiver<Result<T, E>>,
     value: Option<T>,
 }
 
-impl<T, E> Lazy<T, E> {
-    pub fn new(f: impl Future<Output = Result<T, E>> + Send + 'static) -> Self {
-        Self {
-            future: Some(f.boxed()),
-            value: None,
-        }
-    }
+/// Sender side of a [RemoteResult].
+pub struct ResultSender<T, E> {
+    sender: Sender<Result<T, E>>,
+}
 
-    async fn force(&mut self) -> Result<(), E> {
-        if let Some(f) = self.future.take() {
-            self.value = Some(f.await?);
-        }
-        Ok(())
-    }
-
-    pub async fn get_mut(&mut self) -> Result<Option<&mut T>, E> {
-        self.force().await?;
-        Ok(self.value.as_mut())
-    }
-
-    pub async fn into_inner(mut self) -> Result<Option<T>, E> {
-        self.force().await?;
-        Ok(self.value.take())
+impl<T, E> ResultSender<T, E> {
+    pub async fn send(self, value: Result<T, E>) -> bool {
+        self.sender.send(value).await.is_ok()
     }
 }
 
-impl<T, E> Debug for Lazy<T, E>
-where
-    T: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut s = f.debug_struct("Lazy");
-        if let Some(value) = &self.value {
-            s.field("value", value);
-        } else {
-            s.field("future", &"<pending>");
+impl<T, E> RemoteResult<T, E> {
+    async fn receive(&mut self) -> Result<&mut Option<T>, E> {
+        if self.value.is_none() {
+            if let Ok(value) = self.receiver.recv().await {
+                self.value = Some(value?);
+            }
         }
-        s.finish()
+        Ok(&mut self.value)
+    }
+
+    pub async fn get_mut(&mut self) -> Result<Option<&mut T>, E> {
+        Ok(self.receive().await?.as_mut())
+    }
+
+    pub async fn into_inner(mut self) -> Result<Option<T>, E> {
+        Ok(self.receive().await?.take())
+    }
+}
+
+impl<T, E> Drop for RemoteResult<T, E> {
+    fn drop(&mut self) {
+        // Blocks to wait for the result and then drop it.
+        // Ignore the error if the sender has already been dropped.
+        _ = self.receiver.recv_blocking();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use futures::executor::{block_on, ThreadPool};
+    use test_case::test_case;
+
+    use super::{result_channel, BoxRuntime};
+
+    #[test_case(Ok(42))]
+    #[test_case(Err("error"))]
+    fn test_into_inner(result: Result<i32, &'static str>) {
+        let expected = result;
+        let (sender, receiver) = result_channel();
+        block_on(sender.send(result));
+
+        let result = block_on(receiver.into_inner()).transpose().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(Ok(42))]
+    #[test_case(Err("error"))]
+    fn test_get_mut(result: Result<i32, &'static str>) {
+        let expected = result;
+        let (sender, mut receiver) = result_channel();
+        block_on(sender.send(result));
+
+        let result = block_on(receiver.get_mut()).transpose().unwrap();
+        match expected {
+            Ok(expected_value) => assert!(matches!(result, Ok(value) if *value == expected_value)),
+            Err(expected_error) => assert!(matches!(result, Err(error) if *error == *expected_error)),
+        }
+    }
+
+    #[test]
+    fn test_drop() {
+        let runtime = BoxRuntime::new(ThreadPool::new().unwrap());
+
+        struct Dropping(Arc<AtomicBool>);
+
+        impl Drop for Dropping {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let was_dropped = Arc::new(AtomicBool::new(false));
+        let clone = was_dropped.clone();
+
+        let result = runtime
+            .spawn_with_result(async move { Ok::<_, &'static str>(Dropping(clone)) })
+            .unwrap();
+        drop(result);
+
+        assert!(was_dropped.load(Ordering::SeqCst));
     }
 }

--- a/mountpoint-s3/src/fs/handles.rs
+++ b/mountpoint-s3/src/fs/handles.rs
@@ -120,10 +120,11 @@ where
                 written_bytes: 0,
             })
         } else {
-            match fs.uploader.start_atomic_upload(bucket, key).await {
-                Err(e) => return Err(err!(libc::EIO, source:e, "put failed to start")),
-                Ok(request) => FileHandleState::Write(UploadState::MPUInProgress { request, handle }),
-            }
+            let request = fs
+                .uploader
+                .start_atomic_upload(bucket, key)
+                .map_err(|e| err!(libc::EIO, source:e, "put failed to start"))?;
+            FileHandleState::Write(UploadState::MPUInProgress { request, handle })
         };
         metrics::gauge!("fs.current_handles", "type" => "write").increment(1.0);
         Ok(handle)

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -16,6 +16,7 @@ use crate::sync::Arc;
 
 mod atomic;
 pub use atomic::UploadRequest;
+use atomic::UploadRequestParams;
 
 mod hasher;
 pub use hasher::ChecksumHasherError;
@@ -90,12 +91,19 @@ where
     }
 
     /// Start a new atomic upload.
-    pub async fn start_atomic_upload(
+    pub fn start_atomic_upload(
         &self,
         bucket: &str,
         key: &str,
     ) -> Result<UploadRequest<Client>, UploadError<Client::ClientError>> {
-        UploadRequest::new(self, bucket, key).await
+        let params = UploadRequestParams {
+            bucket: bucket.to_owned(),
+            key: key.to_owned(),
+            server_side_encryption: self.server_side_encryption.clone(),
+            default_checksum_algorithm: self.default_checksum_algorithm.clone(),
+            storage_class: self.storage_class.clone(),
+        };
+        UploadRequest::new(&self.runtime, self.client.clone(), params)
     }
 
     /// Start a new incremental upload.

--- a/mountpoint-s3/src/upload/incremental.rs
+++ b/mountpoint-s3/src/upload/incremental.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 use std::mem;
 
 use async_channel::{bounded, unbounded, Receiver, Sender};
-use futures::channel::oneshot;
 use futures::future::RemoteHandle;
 use futures::task::SpawnExt as _;
 use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
@@ -14,7 +13,7 @@ use mountpoint_s3_client::types::{
 use mountpoint_s3_client::ObjectClient;
 use tracing::{debug_span, trace, Instrument};
 
-use crate::async_util::{BoxRuntime, Lazy};
+use crate::async_util::{result_channel, BoxRuntime, RemoteResult};
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::sync::Arc;
 use crate::ServerSideEncryption;
@@ -147,7 +146,7 @@ struct AppendUploadQueue<Client: ObjectClient> {
     mem_limiter: Arc<MemoryLimiter<Client>>,
     _task_handle: RemoteHandle<()>,
     /// Algorithm used to compute checksums. Lazily initialized.
-    checksum_algorithm: Lazy<Option<ChecksumAlgorithm>, UploadError<Client::ClientError>>,
+    checksum_algorithm: RemoteResult<Option<ChecksumAlgorithm>, UploadError<Client::ClientError>>,
     /// Stores the last successful result to return in [join].
     last_known_result: Option<PutObjectResult>,
     /// Tracks the requests pushed to the queue but still pending a response.
@@ -167,7 +166,7 @@ where
         let span = debug_span!("append", key = params.key, initial_offset = params.initial_offset);
         let (request_sender, request_receiver) = bounded(params.capacity);
         let (response_sender, response_receiver) = unbounded();
-        let (checksum_algorithm_sender, checksum_algorithm_receiver) = oneshot::channel();
+        let (checksum_algorithm_sender, checksum_algorithm) = result_channel();
 
         // Create a task for reading data out of the upload queue and create S3 requests for them.
         let task_handle = runtime
@@ -175,7 +174,7 @@ where
                 async move {
                     let checksum_algorithm = get_checksum_algorithm(&client, &params).await;
                     let is_error = checksum_algorithm.is_err();
-                    if checksum_algorithm_sender.send(checksum_algorithm).is_err() || is_error {
+                    if !checksum_algorithm_sender.send(checksum_algorithm).await || is_error {
                         return;
                     }
 
@@ -191,7 +190,7 @@ where
             last_known_result: None,
             requests_in_queue: 0,
             mem_limiter,
-            checksum_algorithm: Lazy::new(async move { checksum_algorithm_receiver.await.unwrap() }),
+            checksum_algorithm,
             _task_handle: task_handle,
         }
     }

--- a/mountpoint-s3/src/upload/incremental.rs
+++ b/mountpoint-s3/src/upload/incremental.rs
@@ -232,7 +232,7 @@ where
         &mut self,
         capacity: usize,
     ) -> Result<UploadBuffer<Client>, UploadError<Client::ClientError>> {
-        let checksum_algorithm = self.checksum_algorithm.get_mut().await?.clone();
+        let checksum_algorithm = self.checksum_algorithm.get_mut().await?.unwrap().clone();
 
         while self.requests_in_queue > 0 {
             match UploadBuffer::try_new(capacity, &checksum_algorithm, self.mem_limiter.clone())? {


### PR DESCRIPTION
`S3CrtClient::put_object` was originally implemented so that it would complete immediately and return a `PutObjectRequest` implementation. Any error from the S3 request would only be returned on calling `write` or `complete` on the `PutObjectRequest`. With this change, we modify `put_object` to await for the initial `CreateMultipartUpload` request to complete and only then either return a `PutObjectRequest` or propagate the error from the request. This is analogous to what done for `get_object` in #1171 and addresses an issue where errors were not propagated correctly (#1007).

At the file handle level, however, we still want the `open` operation to complete quickly, without waiting for `CreateMultipartUpload` to complete. In order to preserve the previous behavior, `upload::atomic` was adapted to spawn a concurrent task in the background when calling `put_object`. 

### Does this change impact existing behavior?

Yes.

### Does this change need a changelog entry?

Yes, for `mountpoint-s3-client`. No user-visible changes in `mountpoint-s3`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
