### PR TITLE
Add label to errno in error message for clarity

### DIFF
--- a/mountpoint-s3/src/fuse.rs
+++ b/mountpoint-s3/src/fuse.rs
@@ -38,7 +38,7 @@ macro_rules! event {
 macro_rules! fuse_error {
     ($name:literal, $reply:expr, $err:expr) => {{
         let err = $err;
-        event!(err.level, "{} {} failed: {:#}", $name, err.to_errno(), err);
+        event!(err.level, "{} Errno: {} failed: {:#}", $name, err.to_errno(), err);
         ::metrics::counter!("fuse.op_failures", "op" => $name).increment(1);
         $reply.error(err.to_errno());
     }};

--- a/mountpoint-s3/tests/fuse_tests/fork_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/fork_test.rs
@@ -810,7 +810,7 @@ fn read_with_no_permissions_for_a_key_sse() {
         read_result.expect("should be able to read a default-encrypted file after the first read failure");
     }
 
-    let log_line_pattern = format!("^.*WARN.*{encrypted_object}.*read 5 failed: get request failed: get object request failed: Client error: Forbidden: User: .* is not authorized to perform: kms:Decrypt on resource: {key_id} because no session policy allows the kms:Decrypt action.*$");
+    let log_line_pattern = format!("^.*WARN.*{encrypted_object}.*read Errno: 5 failed: get request failed: get object request failed: Client error: Forbidden: User: .* is not authorized to perform: kms:Decrypt on resource: {key_id} because no session policy allows the kms:Decrypt action.*$");
     let expected_log_line = regex::Regex::new(&log_line_pattern).unwrap();
     unmount_and_check_log(child, mount_point.path(), &expected_log_line);
 }


### PR DESCRIPTION
This change improves the clarity of [fuse_error with errono](https://github.com/awslabs/mountpoint-s3/pull/1189).

### Does this change impact existing behavior? No

### Does this change need a changelog entry? No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
