### PR TITLE
Improve get_object interface for backpressure

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -9,7 +9,7 @@
   Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
   ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))
 * `increment_read_window` and `read_window_end_offset` methods have been removed from `GetObjectResponse`.
-  `ClientBackpressureHandle` can be used to interact with flow-control window instead, it can be retrieved from `take_backpressure_handle` method.
+  `ClientBackpressureHandle` can be used to interact with flow-control window instead, it can be retrieved from `backpressure_handle` method.
   ([#1200](https://github.com/awslabs/mountpoint-s3/pull/1200))
 * `head_object` method now requires a `HeadObjectParams` parameter.
   The structure itself is not required to specify anything to achieve the existing behavior.

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -8,6 +8,9 @@
 * `get_object` method now requires a `GetObjectParams` parameter.
   Two of the existing parameters, `range` and `if_match` have been moved to `GetObjectParams`.
   ([#1121](https://github.com/awslabs/mountpoint-s3/pull/1121))
+* `increment_read_window` and `read_window_end_offset` methods have been removed from `GetObjectResponse`.
+  `ClientBackpressureHandle` can be used to interact with flow-control window instead, it can be retrieved from `take_backpressure_handle` method.
+  ([#1200](https://github.com/awslabs/mountpoint-s3/pull/1200))
 * `head_object` method now requires a `HeadObjectParams` parameter.
   The structure itself is not required to specify anything to achieve the existing behavior.
   ([#1083](https://github.com/awslabs/mountpoint-s3/pull/1083))

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -77,7 +77,6 @@ where
 {
     type GetObjectResponse = FailureGetResponse<Client, GetWrapperState>;
     type PutObjectRequest = FailurePutObjectRequest<Client, GetWrapperState>;
-    type BackpressureHandle = Client::BackpressureHandle;
     type ClientError = Client::ClientError;
 
     fn read_part_size(&self) -> Option<usize> {
@@ -218,11 +217,11 @@ pub struct FailureGetResponse<Client: ObjectClient, GetWrapperState> {
 impl<Client: ObjectClient + Send + Sync, FailState: Send + Sync> GetObjectResponse
     for FailureGetResponse<Client, FailState>
 {
-    type BackpressureHandle = Client::BackpressureHandle;
+    type BackpressureHandle = <<Client as ObjectClient>::GetObjectResponse as GetObjectResponse>::BackpressureHandle;
     type ClientError = Client::ClientError;
 
-    fn take_backpressure_handle(&mut self) -> Option<Self::BackpressureHandle> {
-        self.request.take_backpressure_handle()
+    fn backpressure_handle(&mut self) -> Option<&mut Self::BackpressureHandle> {
+        self.request.backpressure_handle()
     }
 
     fn get_object_metadata(&self) -> ObjectMetadata {

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -72,11 +72,11 @@ pub mod config {
 /// Types used by all object clients
 pub mod types {
     pub use super::object_client::{
-        Checksum, ChecksumAlgorithm, ChecksumMode, CopyObjectParams, CopyObjectResult, DeleteObjectResult, ETag,
-        GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams, GetObjectResponse,
-        HeadObjectParams, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult, ObjectInfo,
-        ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums, RestoreStatus,
-        UploadChecksum, UploadReview, UploadReviewPart,
+        Checksum, ChecksumAlgorithm, ChecksumMode, ClientBackpressureHandle, CopyObjectParams, CopyObjectResult,
+        DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams,
+        GetObjectResponse, HeadObjectParams, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult,
+        ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums,
+        RestoreStatus, UploadChecksum, UploadReview, UploadReviewPart,
     };
 }
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -73,8 +73,8 @@ impl GetObjectResponse for ThroughputGetObjectResponse {
     type BackpressureHandle = MockBackpressureHandle;
     type ClientError = MockClientError;
 
-    fn take_backpressure_handle(&mut self) -> Option<Self::BackpressureHandle> {
-        self.request.take_backpressure_handle()
+    fn backpressure_handle(&mut self) -> Option<&mut Self::BackpressureHandle> {
+        self.request.backpressure_handle()
     }
 
     fn get_object_metadata(&self) -> ObjectMetadata {
@@ -106,7 +106,6 @@ impl Stream for ThroughputGetObjectResponse {
 impl ObjectClient for ThroughputMockClient {
     type GetObjectResponse = ThroughputGetObjectResponse;
     type PutObjectRequest = MockPutObjectRequest;
-    type BackpressureHandle = MockBackpressureHandle;
     type ClientError = MockClientError;
 
     fn read_part_size(&self) -> Option<usize> {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -13,7 +13,6 @@ use std::time::{Duration, Instant};
 
 use futures::future::{Fuse, FusedFuture};
 use futures::FutureExt;
-use get_object::S3BackpressureHandle;
 use mountpoint_s3_crt::auth::credentials::{
     CredentialsProvider, CredentialsProviderChainDefaultOptions, CredentialsProviderProfileOptions,
 };
@@ -1256,7 +1255,6 @@ fn emit_throughput_metric(bytes: u64, duration: Duration, op: &'static str) {
 impl ObjectClient for S3CrtClient {
     type GetObjectResponse = S3GetObjectResponse;
     type PutObjectRequest = S3PutObjectRequest;
-    type BackpressureHandle = S3BackpressureHandle;
     type ClientError = S3RequestError;
 
     fn read_part_size(&self) -> Option<usize> {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use futures::future::{Fuse, FusedFuture};
 use futures::FutureExt;
+use get_object::S3BackpressureHandle;
 use mountpoint_s3_crt::auth::credentials::{
     CredentialsProvider, CredentialsProviderChainDefaultOptions, CredentialsProviderProfileOptions,
 };
@@ -1255,6 +1256,7 @@ fn emit_throughput_metric(bytes: u64, duration: Duration, op: &'static str) {
 impl ObjectClient for S3CrtClient {
     type GetObjectResponse = S3GetObjectResponse;
     type PutObjectRequest = S3PutObjectRequest;
+    type BackpressureHandle = S3BackpressureHandle;
     type ClientError = S3RequestError;
 
     fn read_part_size(&self) -> Option<usize> {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -2,6 +2,8 @@ use std::future::Future;
 use std::ops::Deref;
 use std::os::unix::prelude::OsStrExt;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
@@ -9,12 +11,13 @@ use futures::channel::mpsc::UnboundedReceiver;
 use futures::future::FusedFuture;
 use futures::{select_biased, Stream};
 use mountpoint_s3_crt::http::request_response::{Header, Headers};
-use mountpoint_s3_crt::s3::client::MetaRequestResult;
+use mountpoint_s3_crt::s3::client::{MetaRequest, MetaRequestResult};
 use pin_project::pin_project;
 use thiserror::Error;
 
 use crate::object_client::{
-    Checksum, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError, ObjectClientResult, ObjectMetadata,
+    Checksum, ClientBackpressureHandle, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError,
+    ObjectClientResult, ObjectMetadata,
 };
 use crate::s3_crt_client::{
     parse_checksum, GetObjectResponse, S3CrtClient, S3CrtClientInner, S3HttpRequest, S3Operation, S3RequestError,
@@ -35,6 +38,7 @@ impl S3CrtClient {
         let requested_checksums = params.checksum_mode.as_ref() == Some(&ChecksumMode::Enabled);
         let next_offset = params.range.as_ref().map(|r| r.start).unwrap_or(0);
         let read_window_end_offset = next_offset + self.inner.initial_read_window_size as u64;
+        let read_window_end_offset = Arc::new(AtomicU64::new(read_window_end_offset));
 
         let (part_sender, part_receiver) = futures::channel::mpsc::unbounded();
         let (headers_sender, mut headers_receiver) = futures::channel::oneshot::channel();
@@ -127,11 +131,20 @@ impl S3CrtClient {
         // Guaranteed when select_biased! executes the headers branch.
         assert!(!request.is_terminated());
 
+        let backpressure_handle = if self.inner.enable_backpressure {
+            Some(S3BackpressureHandle {
+                read_window_end_offset: read_window_end_offset.clone(),
+                meta_request: request.meta_request.clone(),
+            })
+        } else {
+            None
+        };
         Ok(S3GetObjectResponse {
             request,
             part_receiver,
             requested_checksums,
             enable_backpressure: self.inner.enable_backpressure,
+            backpressure_handle,
             headers,
             next_offset,
             read_window_end_offset,
@@ -144,6 +157,23 @@ impl S3CrtClient {
 enum ObjectHeadersError {
     #[error("response headers are missing")]
     MissingHeaders,
+}
+
+#[derive(Clone, Debug)]
+pub struct S3BackpressureHandle {
+    read_window_end_offset: Arc<AtomicU64>,
+    meta_request: MetaRequest,
+}
+
+impl ClientBackpressureHandle for S3BackpressureHandle {
+    fn increment_read_window(&mut self, len: usize) {
+        self.read_window_end_offset.fetch_add(len as u64, Ordering::SeqCst);
+        self.meta_request.increment_read_window(len as u64);
+    }
+
+    fn read_window_end_offset(&self) -> u64 {
+        self.read_window_end_offset.load(Ordering::SeqCst)
+    }
 }
 
 /// A streaming response to a GetObject request.
@@ -160,17 +190,23 @@ pub struct S3GetObjectResponse {
     part_receiver: UnboundedReceiver<GetBodyPart>,
     requested_checksums: bool,
     enable_backpressure: bool,
+    backpressure_handle: Option<S3BackpressureHandle>,
     headers: Headers,
     /// Next offset of the data to be polled from [poll_next]
     next_offset: u64,
     /// Upper bound of the current read window. When backpressure is enabled, [S3GetObjectRequest]
     /// can return data up to this offset *exclusively*.
-    read_window_end_offset: u64,
+    read_window_end_offset: Arc<AtomicU64>,
 }
 
 #[cfg_attr(not(docsrs), async_trait)]
 impl GetObjectResponse for S3GetObjectResponse {
+    type BackpressureHandle = S3BackpressureHandle;
     type ClientError = S3RequestError;
+
+    fn take_backpressure_handle(&mut self) -> Option<Self::BackpressureHandle> {
+        self.backpressure_handle.take()
+    }
 
     fn get_object_metadata(&self) -> ObjectMetadata {
         self.headers
@@ -189,15 +225,6 @@ impl GetObjectResponse for S3GetObjectResponse {
         }
 
         parse_checksum(&self.headers).map_err(|e| ObjectChecksumError::HeadersError(Box::new(e)))
-    }
-
-    fn increment_read_window(mut self: Pin<&mut Self>, len: usize) {
-        self.read_window_end_offset += len as u64;
-        self.request.meta_request.increment_read_window(len as u64);
-    }
-
-    fn read_window_end_offset(self: Pin<&Self>) -> u64 {
-        self.read_window_end_offset
     }
 }
 
@@ -224,7 +251,8 @@ impl Stream for S3GetObjectResponse {
                 // the next chunk we want to return error instead of keeping the request blocked.
                 // This prevents a risk of deadlock from using the [S3CrtClient], users must implement
                 // their own logic to block the request if they really want to block a [GetObjectRequest].
-                if *this.enable_backpressure && this.read_window_end_offset <= this.next_offset {
+                let read_window_end_offset = this.read_window_end_offset.load(Ordering::SeqCst);
+                if *this.enable_backpressure && read_window_end_offset <= *this.next_offset {
                     return Poll::Ready(Some(Err(ObjectClientError::ClientError(
                         S3RequestError::EmptyReadWindow,
                     ))));

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -228,7 +228,8 @@ pub async fn check_backpressure_get_result(
     let mut accum = vec![];
     let mut next_offset = range.map(|r| r.start).unwrap_or(0);
     let mut backpressure_handle = response
-        .take_backpressure_handle()
+        .backpressure_handle()
+        .cloned()
         .expect("should be able to get a backpressure handle");
     pin_mut!(response);
     while let Some(r) = response.next().await {

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -165,7 +165,6 @@ async fn test_mutated_during_get_object_backpressure() {
         .get_object(&bucket, &key, &GetObjectParams::new().range(Some(range.clone())))
         .await
         .expect("should not fail");
-    let mut backpressure_handle = get_request.take_backpressure_handle().unwrap();
 
     // Verify that we can receive the first part successfully
     let first_part = get_request.next().await.expect("result should not be empty");
@@ -186,7 +185,10 @@ async fn test_mutated_during_get_object_backpressure() {
         .await
         .unwrap();
 
-    backpressure_handle.increment_read_window(part_size);
+    get_request
+        .backpressure_handle()
+        .unwrap()
+        .increment_read_window(part_size);
 
     // Verify that the next part is error
     let next = get_request.next().await.expect("result should not be empty");

--- a/mountpoint-s3/src/prefetch/part_stream.rs
+++ b/mountpoint-s3/src/prefetch/part_stream.rs
@@ -2,7 +2,10 @@ use async_stream::try_stream;
 use bytes::Bytes;
 use futures::task::{Spawn, SpawnExt};
 use futures::{pin_mut, Stream, StreamExt};
-use mountpoint_s3_client::{types::GetObjectParams, types::GetObjectResponse, ObjectClient};
+use mountpoint_s3_client::{
+    types::{ClientBackpressureHandle, GetObjectParams, GetObjectResponse},
+    ObjectClient,
+};
 use std::marker::{Send, Sync};
 use std::sync::Arc;
 use std::{fmt::Debug, ops::Range};
@@ -359,18 +362,16 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     request_range: Range<u64>,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
-        let request = client
+        let mut request = client
             .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(PrefetchReadError::GetRequestFailed)?;
 
-        pin_mut!(request);
-        let read_window_size_diff = backpressure_limiter
-            .read_window_end_offset()
-            .saturating_sub(request.as_ref().read_window_end_offset()) as usize;
-        request.as_mut().increment_read_window(read_window_size_diff);
+        let mut backpressure_handle = request.take_backpressure_handle();
+        ensure_read_window(&mut backpressure_handle, backpressure_limiter.read_window_end_offset());
 
+        pin_mut!(request);
         while let Some(next) = request.next().await {
             let (offset, body) = next
                 .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject body part failed"))
@@ -394,12 +395,19 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
                 metrics::histogram!("s3.client.read_window_excess_bytes").record(excess_bytes as f64);
             }
             // Blocks if read window increment if it's not enough to read the next offset
-            if let Some(next_read_window_offset) = backpressure_limiter.wait_for_read_window_increment(next_offset).await? {
-                let diff = next_read_window_offset.saturating_sub(request.as_ref().read_window_end_offset()) as usize;
-                request.as_mut().increment_read_window(diff);
+            if let Some(next_read_window_end_offset) = backpressure_limiter.wait_for_read_window_increment(next_offset).await? {
+                ensure_read_window(&mut backpressure_handle, next_read_window_end_offset);
             }
         }
         trace!("request finished");
+    }
+}
+
+fn ensure_read_window(backpressure_handle: &mut Option<impl ClientBackpressureHandle>, desired_end_offset: u64) {
+    if let Some(backpressure_handle) = backpressure_handle {
+        let read_window_size_diff =
+            desired_end_offset.saturating_sub(backpressure_handle.read_window_end_offset()) as usize;
+        backpressure_handle.increment_read_window(read_window_size_diff);
     }
 }
 


### PR DESCRIPTION
Currently, we support flow-control window for GetObject requests by allowing applications to call `GetObjectResponse::increment_read_window` but it is tricky to use because we need to hold onto the stream itself in order to control the feedback loop while also consuming the data.

This change introduces a new trait `ClientBackpressureHandle` for controlling the read window so that the stream and the flow-control paths are decoupled.

Applications can now call `GetObjectResponse::take_backpressure_handle` to get a backpressure handle from the response and use this handle to extend the read window.

### Does this change impact existing behavior?

Yes, there is a breaking change for `mountpoint-s3-client`.

### Does this change need a changelog entry?

Yes, for `mountpoint-s3-client`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
