### PR TITLE
Address shadowing divergence in reftest, update semantics doc

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -74,7 +74,7 @@ Mountpoint allows multiple readers to access the same object at the same time.
 However, a new file can only be written to sequentially and by one writer at a time.
 New files that are being written are not available for reading until the writing application closes the file and Mountpoint finishes uploading it to S3.
 If you have multiple Mountpoint mounts for the same bucket, on the same or different hosts, there is no coordination between writes to the same object.
-Your application should not write to the same object from multiple instances at the same time. If you use multiple instances for writing the same key (or another client modifies the Object while the file is open for writing), be aware that Mountpoint currently uses Multipart Uploads (MPU) that are created after the file is opened to upload the data to S3.
+Your application should not write to the same object from multiple instances at the same time.
 
 By default, Mountpoint ensures that new file uploads to a single key are atomic. As soon as an upload completes, other clients are able to see the new key and the entire content of the object. If the `--incremental-upload` flag is set, however, Mountpoint may issue multiple separate uploads during file writes to append data to the object. After each upload, the appended object in your S3 bucket will be visible to other clients.
 
@@ -275,5 +275,3 @@ Mountpoint provides strong read-after-write consistency for new object creation 
 * A process deletes an existing object from your S3 bucket using another client, and then tries to open the object with Mountpoint and read from it. The open operation will fail.
 * A process deletes an existing object from your S3 bucket, using either Mountpoint or another client, and then lists the directory the object was previously in with Mountpoint. The object will not appear in the list.
 * A process deletes an existing object from your S3 bucket using another client, and then queries the object’s metadata with Mountpoint using the `stat`` system call. The returned metadata could reflect the old object for up to 1 second after the DeleteObject request.
-* A process opens a file with Mountpoint, and another Mountpoint client on another instance opens the same file. In this case, the behaviour is determined by the [S3 semantics for concurrent multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#distributedmpupload).
-

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -1290,4 +1290,27 @@ mod mutations {
             0,
         )
     }
+
+    /*
+     Ensure that local files are shadowed by the remote directories.
+    */
+    #[test]
+    fn regression_put_shadowing_new_local_file() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([])),
+            vec![
+                Op::CreateFile(
+                    ValidName("a".into()),
+                    DirectoryIndex(0),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+                Op::PutObject(
+                    DirectoryIndex(0),
+                    Name("a/b".into()),
+                    FileContent(0, FileSize::Small(0)),
+                ),
+            ],
+            0,
+        )
+    }
 }

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -81,7 +81,8 @@ impl MaterializedReference {
     /// Try to add a new node to the tree. Returns whether the node was added.
     ///
     /// If the path already exists it will be overwritten, unless both the existing and new nodes
-    /// are directories. If any intermediate directory is not present, the node won't be added and
+    /// are directories or the new node is a file and were to override a directory.
+    /// If any intermediate directory is not present, the node won't be added and
     /// this function returns false.
     ///
     /// TODO: today our semantics makes local files/directories invisible if any of their ancestors
@@ -109,6 +110,12 @@ impl MaterializedReference {
                     if let Some(Node::Directory { is_local, .. }) = children.get_mut(dir) {
                         *is_local = true;
                         break;
+                    }
+                }
+                // If a directory of this name exists, ignore any local file
+                if let Some(node) = children.get(dir) {
+                    if node.node_type() == NodeType::Directory {
+                        return false;
                     }
                 }
                 let new_node = match typ {


### PR DESCRIPTION
This commit addresses a case where MP model and property tests diverge (https://github.com/awslabs/mountpoint-s3/pull/1066). The issue was caused by the reference not correctly implementing the shadowing order defined in [#4f8cf0b](https://github.com/awslabs/mountpoint-s3/commit/4f8cf0b7054d2ea4dedb11ce28c6847849d2eb53). This commit fixes the reference model, and clarifies the semantics arising from concurrent MPUs.

This is not a breaking change, as it only impacts the reference tests.

This does not need a Changelog entry, as the change does not impact Mountpoint's behaviour.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
