### PR TITLE
Remove workaround for macOS builds due to pkg-config issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,15 +65,8 @@ jobs:
       with:
         submodules: true
     - name: Install dependencies
-      # Temporarily uninstall pkg-config@0.29.2 in order to work around a homebrew issue with pkg-config
-      # on github runners: https://github.com/actions/runner-images/issues/10984.
-      # Once the runners' image is updated (tracking https://github.com/actions/runner-images/pull/11011),
-      # we could revert to just:
-      #   brew update > /dev/null && brew install pkgconfig
       run: |
-          brew update
-          brew uninstall --ignore-dependencies --force pkg-config@0.29.2
-          brew install pkgconf
+        brew update > /dev/null && brew install pkgconfig
     - name: Install fuse
       run: |
         brew install --cask macfuse


### PR DESCRIPTION
In November, macOS runners had an issue with the `pkg-config` package and we introduced a workaround: https://github.com/awslabs/mountpoint-s3/pull/1158/

We see now that the fix has been released and we should no longer need the workaround: https://github.com/actions/runner-images/issues/10984.

### Does this change impact existing behavior?

No, CI change only.

### Does this change need a changelog entry?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
