### PR TITLE
Update CRT `HeadersError` enum to include header name

### DIFF
--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Checksum hashers no longer implement `std::hash::Hasher`. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
 * Add bindings to remaining checksum types CRC64, SHA1, and SHA256. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
 * Add wrapping type `ByteBuf` for `aws_byte_buf`. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
+* `HeadersError::HeaderNotFound` variant now includes the name of the header.
+  Despite the new field being private, this may impact any code that was pattern matching on this variant.
+  ([#1205](https://github.com/awslabs/mountpoint-s3/pull/1205))
 
 ## v0.10.0 (October 17, 2024)
 

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Checksum hashers no longer implement `std::hash::Hasher`. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
 * Add bindings to remaining checksum types CRC64, SHA1, and SHA256. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
 * Add wrapping type `ByteBuf` for `aws_byte_buf`. ([#1082](https://github.com/awslabs/mountpoint-s3/pull/1082))
-* `HeadersError::HeaderNotFound` variant now includes the name of the header.
-  Despite the new field being private, this may impact any code that was pattern matching on this variant.
+* `HeadersError::HeaderNotFound` and `HeadersError::Invalid` variants now include the name of the header.
+  Despite the new field being private, this may impact any code that was pattern matching on these variants.
   ([#1205](https://github.com/awslabs/mountpoint-s3/pull/1205))
 
 ## v0.10.0 (October 17, 2024)

--- a/mountpoint-s3-crt/src/http/request_response.rs
+++ b/mountpoint-s3-crt/src/http/request_response.rs
@@ -62,7 +62,11 @@ unsafe impl Send for Headers {}
 /// allow threads to simultaneously modify it.
 unsafe impl Sync for Headers {}
 
-/// Errors returned by operations on [Headers]
+/// Errors returned by operations on [Headers].
+///
+/// TODO: Where the variant contains an [OsString] for the header name,
+/// we could explore using a static [OsStr] to avoid unnecessary memory copies
+/// since we know the values at compilation time.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum HeadersError {
     /// The header was not found


### PR DESCRIPTION
We recently saw an error in #1199 where "Header not found" was emitted, but its really unclear what header was missing.

    2024-12-12T18:33:59.379478Z  WARN flush{req=1609 ino=2 fh=1 pid=29257 name="testfile_100M.bin"}: mountpoint_s3::fuse: flush failed: put failed: put request failed: Client error: Internal S3 client error: Header not found

This change updates the `HeadersError::HeaderNotFound` enum variant to contain a copy of the header name, such that error messages can emit it for debugging purposes.

It may make more sense to have all the header names we use statically defined somewhere, such that we could include a static reference to the header and avoid allocating for an error message. However, we don't expect there to be any performance regression introduced by this change. This move to static values could be made later.

### Does this change impact existing behavior?

Header not found and invalid header value errors will now include the header name when printing the error message.

The enum variants change meaning any code using the enum may be impacted.

### Does this change need a changelog entry?

Not for Mountpoint itself. I have added a change log entry to `mountpoint-s3-crt` since it is a breaking API change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
