### PR TITLE
Store the name of a mounted bucket in block's metadata

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Other changes
 
 * Fix an issue where an interrupt during `readdir` syscall leads to an error. ([#965](https://github.com/awslabs/mountpoint-s3/pull/965))
-* Fix an issue with the missing verification of source bucket of a cache block ([#1208](https://github.com/awslabs/mountpoint-s3/pull/1208))
+* Fix an issue where the source bucket of a shared cache block was not correctly validated ([#1208](https://github.com/awslabs/mountpoint-s3/pull/1208))
 
 ## v1.13.0 (December 2, 2024)
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Other changes
 
 * Fix an issue where an interrupt during `readdir` syscall leads to an error. ([#965](https://github.com/awslabs/mountpoint-s3/pull/965))
+* Fix an issue with the missing verification of source bucket of a cache block ([#1208](https://github.com/awslabs/mountpoint-s3/pull/1208))
 
 ## v1.13.0 (December 2, 2024)
 

--- a/mountpoint-s3/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/express_data_cache.rs
@@ -83,7 +83,7 @@ where
         // calculates the prefix.
         let data = format!(
             "source_bucket={}\nblock_size={}",
-            self.bucket_name, self.config.block_size
+            self.source_bucket_name, self.config.block_size
         );
 
         // put_object is sufficient for validating cache, as S3 Directory buckets only support


### PR DESCRIPTION
The field `x-amz-meta-source-bucket-name` of the cache block was intended to store the name of the mounted bucket (source bucket). Currently it stores the name of the cache bucket.

### Does this change impact existing behavior?

Yes, we update the version of the block schema. All blocks written with previous versions of Mountpoint won't be accessible (attempts will be cache misses).

### Does this change need a changelog entry?

Yes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
