### PR TITLE
Improve tracing and assertion messages for reftests

### DIFF
--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -734,6 +734,7 @@ where
                 None => return Ok(reply.finish(offset, &dir_handle).await),
                 Some(next) => next,
             };
+            trace!(next_inode = ?next.inode, "new inode yielded by readdir handle");
 
             let attr = self.make_attr(&next);
             let entry = DirectoryEntry {

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -937,6 +937,7 @@ impl SuperblockInner {
                 }
 
                 trace!(
+                    ino=?existing_inode.ino(),
                     same_kind,
                     same_etag,
                     existing_is_remote,

--- a/mountpoint-s3/tests/reftests/reference.rs
+++ b/mountpoint-s3/tests/reftests/reference.rs
@@ -3,7 +3,6 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
-use tracing::trace;
 
 #[derive(Debug)]
 pub enum File {
@@ -92,7 +91,11 @@ impl MaterializedReference {
     /// implemented the opposite case; it's kept here in case we change back.
     fn add_local_node(&mut self, path: impl AsRef<Path>, typ: NodeType) -> bool {
         let mut components = path.as_ref().components().peekable();
-        assert_eq!(components.next(), Some(Component::RootDir));
+        assert_eq!(
+            components.next(),
+            Some(Component::RootDir),
+            "first component should always be the root dir",
+        );
 
         let mut parent_node = &mut self.root;
         while let Some(dir) = components.next() {
@@ -158,7 +161,7 @@ impl Reference {
     }
 
     fn rematerialize(&self) -> MaterializedReference {
-        trace!(
+        tracing::debug!(
             remote_keys=?self.remote_keys, local_files=?self.local_files, local_directories=?self.local_directories,
             "rematerialize",
         );


### PR DESCRIPTION
This change adds some additional tracing to reftests and makes some adjustments to assertion messages to make it clearer why we assert what we assert and would return a better message when things go wrong.

There are no significant changes, this is primarily readability and debugging improvements.

### Does this change impact existing behavior?

No change to behavior of Mountpoint or its libraries.

### Does this change need a changelog entry?

No, no behavior change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
