### PR TITLE
Emit malloc metrics

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -584,9 +584,11 @@ impl CliArgs {
 #[cfg(target_os = "linux")]
 fn configure_malloc() {
     unsafe {
+        // Disable dynamic MMAP_THRESHOLD and set it to 4MiB: https://github.com/bminor/glibc/blob/release/2.26/master/malloc/malloc.c#L1739
+
         // NOTE: M_MMAP_MAX is 65536. With 8MiB allocations it allows up to 512GiB of simultaneously allocated memory via mmap, which should fit for most of the cases. For more info:
         // https://github.com/bminor/glibc/blob/release/2.26/master/malloc/malloc.c#L983
-        libc::mallopt(libc::M_MMAP_THRESHOLD, 131072); // disable dynamic MMAP_THRESHOLD: https://github.com/bminor/glibc/blob/release/2.26/master/malloc/malloc.c#L1739
+        libc::mallopt(libc::M_MMAP_THRESHOLD, 4194304);
     }
 }
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -581,12 +581,9 @@ impl CliArgs {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn configure_malloc() {
     unsafe {
-        println!(
-            "glibc version: {:?}",
-            std::ffi::CStr::from_ptr(libc::gnu_get_libc_version())
-        );
         // NOTE: M_MMAP_MAX is 65536. With 8MiB allocations it allows up to 512GiB of simultaneously allocated memory via mmap, which should fit for most of the cases. For more info:
         // https://github.com/bminor/glibc/blob/release/2.26/master/malloc/malloc.c#L983
         libc::mallopt(libc::M_MMAP_THRESHOLD, 131072); // disable dynamic MMAP_THRESHOLD: https://github.com/bminor/glibc/blob/release/2.26/master/malloc/malloc.c#L1739
@@ -599,6 +596,7 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
     Runtime: Spawn + Clone + Send + Sync + 'static,
 {
+    #[cfg(target_os = "linux")]
     configure_malloc();
     let args = CliArgs::parse();
     let successful_mount_msg = format!(

--- a/mountpoint-s3/src/metrics.rs
+++ b/mountpoint-s3/src/metrics.rs
@@ -44,6 +44,7 @@ pub fn install() -> MetricsSinkHandle {
                     Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
                     Err(RecvTimeoutError::Timeout) => {
                         poll_process_metrics(&mut sys);
+                        #[cfg(target_os = "linux")]
                         poll_malloc_metrics();
                         inner.publish()
                     }
@@ -53,6 +54,7 @@ pub fn install() -> MetricsSinkHandle {
             // any new metrics data after the sink shuts down, but we assume a clean shutdown
             // stops generating new metrics before shutting down the sink.
             poll_process_metrics(&mut sys);
+            #[cfg(target_os = "linux")]
             poll_malloc_metrics();
             inner.publish();
         })
@@ -89,6 +91,7 @@ fn poll_process_metrics(sys: &mut System) {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn poll_malloc_metrics() {
     unsafe {
         let mallinfo = libc::mallinfo();


### PR DESCRIPTION
This PR adds malloc metrics, which should help us to reason about memory wasted because of fragmentation. 

Also it tunes malloc to disable dynamic MMAP_THRESHOLD, which may be the reason for fragmentation. In local tests this leads to memory being released straight away to the OS (RSS consumption is lower, strace reports `munmap` being called after each part received from `S3GetObjectResponse`.

### Does this change impact existing behavior?

TBD

### Does this change need a changelog entry?

TBD

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
