### PR TITLE
Fix Clippy warnings on Rust 1.84

### DIFF
--- a/mountpoint-s3-client/src/instance_info.rs
+++ b/mountpoint-s3-client/src/instance_info.rs
@@ -66,7 +66,7 @@ fn retrieve_instance_identity_document() -> Result<IdentityDocument, InstanceInf
 
 fn imds_disabled() -> bool {
     match env::var_os("AWS_EC2_METADATA_DISABLED") {
-        Some(val) => val.to_ascii_lowercase() != "false",
+        Some(val) => !val.eq_ignore_ascii_case("false"),
         None => false,
     }
 }

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -303,7 +303,7 @@ fn get_random_key(key_prefix: &str, key_suffix: &str, min_size_in_bytes: usize) 
     let random_suffix: u64 = rand::thread_rng().gen();
     let last_key_part = format!("{key_suffix}{random_suffix}"); // part of the key after all the "/"
     let full_key = format!("{key_prefix}{last_key_part}");
-    let full_key_size = full_key.as_bytes().len();
+    let full_key_size = full_key.len();
     let padding_size = min_size_in_bytes.saturating_sub(full_key_size);
     let padding = "0".repeat(padding_size);
     format!("{last_key_part}{padding}")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"
 components = ["rust-src"]


### PR DESCRIPTION
Rust 1.84 has just released and with it, new clippy lints have been added.

We're also updating to Rust 1.84 explicitly rather than returning to stable to avoid the issues we had with the most recent release

### Does this change impact existing behavior?

No

### Does this change need a changelog entry?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
