### PR TITLE
Explicitly set rust version to 1.83 for release

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## v1.13.1 (January 9, 2025)
+## v1.13.1 (January 10, 2025)
 
 ### New features
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.83"
 components = ["rust-src"]


### PR DESCRIPTION
Explicitly set rust version to 1.83 for release

### Does this change impact existing behavior?

Temporarily forces Rust version to 1.83 for the 1.13.1 release

### Does this change need a changelog entry?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
