### PR TITLE
Add failing reference test (MountPoint loses local state)

### DIFF
--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -1308,6 +1308,7 @@ mod mutations {
         )
     }
 
+
     /*
      Ensure that local files are shadowed by the remote directories.
     */
@@ -1330,4 +1331,65 @@ mod mutations {
             0,
         )
     }
+
+
+    #[test]
+    fn regression_local_lost_when_removing_remote_entries() {
+        run_test(TreeNode::Directory(BTreeMap::from([])), vec![
+            Op::CreateDirectory(
+                DirectoryIndex(
+                    0,
+                ),
+                ValidName(
+                    "a".into(),
+                ),
+            ),
+            Op::CreateDirectory(
+                DirectoryIndex(
+                    0,
+                ),
+                ValidName(
+                    "-".into(),
+                ),
+            ),
+            Op::WriteFile(
+                ValidName(
+                    "a".into(),
+                ),
+                DirectoryIndex(
+                    1,
+                ),
+                FileContent(
+                    0,
+                    FileSize::Small(0),
+                ),
+            ),
+            Op::CreateFile(
+                ValidName(
+                    "aa".into(),
+                ),
+                DirectoryIndex(
+                    1,
+                ),
+                FileContent(
+                    0,
+                    FileSize::Small(0),
+                ),
+            ),
+            Op::DeleteObject(
+                KeyIndex(
+                    0,
+                ),
+            ),
+            Op::CreateDirectory(
+                DirectoryIndex(
+                    0,
+                ),
+                ValidName(
+                    "a".into(),
+                ),
+            ),
+        ], 0)
+    }
+
 }


### PR DESCRIPTION
Adds a proptest that exposes (most likely) a bug in Mountpoint regarding the local content (a file that is created, but not open yet) of a directory being forgotten, if all of the remote content is deleted.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
