### PR TITLE
Fix Proptest inflight_write invalidation after PutObject to same element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,6 +2538,7 @@ dependencies = [
  "humansize",
  "libc",
  "linked-hash-map",
+ "log",
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -47,6 +47,7 @@ time = { version = "0.3.37", features = ["macros", "formatting"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+log = "0.4.22"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17.0", default-features = false }


### PR DESCRIPTION
Adds a failing proptest, and a potential fix for it. The root cause seems to have been that if after a file has been opened, and then modified by i.e., a remote PutObject, the old ino is stale, but will be opened in the inflight-write regardless. 

This code change fixes this issue by removing such a inflight write. For reviewers: 
* Maybe this code should go into inflight_writes (i.e. add a ``invalidate`` method to invalidate based on a PathBuf)?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
