### PR TITLE
Add failing reference test (double local dir)

### DIFF
--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -1330,4 +1330,46 @@ mod mutations {
             0,
         )
     }
+
+    /*
+     * In this test, a directory is duplicated.
+     */
+    #[test]
+    fn regression_duplicate_localdir() {
+        run_test(
+            TreeNode::Directory(BTreeMap::from([("-".into(), TreeNode::Directory(BTreeMap::from([("aaa".into(), TreeNode::File(FileContent(0, FileSize::Small(0)))), ]))), ])),
+            vec![
+                Op::CreateDirectory(
+                    DirectoryIndex(
+                        1,
+                    ),
+                    ValidName(
+                        "aa".into(),
+                    ),
+                ),
+                Op::DeleteObject(
+                    KeyIndex(
+                        0,
+                    ),
+                ),
+                Op::CreateDirectory(
+                    DirectoryIndex(
+                        0,
+                    ),
+                    ValidName(
+                        "-".into(),
+                    ),
+                ),
+                Op::CreateDirectory(
+                    DirectoryIndex(
+                        1,
+                    ),
+                    ValidName(
+                        "aa".into(),
+                    ),
+                ),
+            ],
+            0
+        );
+    }
 }


### PR DESCRIPTION
Adds a failing proptest. While this bug presents itself as a reference failure (i.e. the reference panics, as a local directory is created twice), this is the same bug as #1220. Here, deleting the file ``aaa.txt`` causes the file-system side to forget the local directories, which  then leads to the duplicate creation being allowed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
