### PR TITLE
Re-enable failure persistance for Proptests

### DIFF
--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -728,6 +728,7 @@ impl Harness {
 /// paths is correct.
 mod read_only {
     use super::*;
+    use std::env;
 
     #[derive(Debug)]
     enum CheckType {
@@ -769,7 +770,10 @@ mod read_only {
 
     proptest! {
         #![proptest_config(ProptestConfig {
-            failure_persistence: None,
+            cases: match env::var("TESTING_PROPTEST_CASES") {
+                    Ok(s) => s.parse::<u32>().unwrap_or(256),
+                    _ => 256
+            },
             .. ProptestConfig::default()
         })]
 
@@ -883,6 +887,7 @@ mod read_only {
 mod mutations {
     use super::*;
     use proptest::collection::vec;
+    use std::env;
 
     fn run_test(initial_tree: TreeNode, ops: Vec<Op>, readdir_limit: usize) {
         const BUCKET_NAME: &str = "test-bucket";
@@ -916,7 +921,10 @@ mod mutations {
 
     proptest! {
         #![proptest_config(ProptestConfig {
-            failure_persistence: None,
+            cases: match env::var("TESTING_PROPTEST_CASES") {
+                    Ok(s) => s.parse::<u32>().unwrap_or(256),
+                    _ => 256
+            },
             .. ProptestConfig::default()
         })]
 

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -728,7 +728,6 @@ impl Harness {
 /// paths is correct.
 mod read_only {
     use super::*;
-    use std::env;
 
     #[derive(Debug)]
     enum CheckType {
@@ -769,14 +768,6 @@ mod read_only {
     }
 
     proptest! {
-        #![proptest_config(ProptestConfig {
-            cases: match env::var("TESTING_PROPTEST_CASES") {
-                    Ok(s) => s.parse::<u32>().unwrap_or(256),
-                    _ => 256
-            },
-            .. ProptestConfig::default()
-        })]
-
         #[test]
         fn reftest_random_tree_full(readdir_limit in 0..10usize, tree in gen_tree(5, 100, 5, 20)) {
             run_test(tree, CheckType::FullTree, readdir_limit);
@@ -887,7 +878,6 @@ mod read_only {
 mod mutations {
     use super::*;
     use proptest::collection::vec;
-    use std::env;
 
     fn run_test(initial_tree: TreeNode, ops: Vec<Op>, readdir_limit: usize) {
         const BUCKET_NAME: &str = "test-bucket";
@@ -920,14 +910,6 @@ mod mutations {
     }
 
     proptest! {
-        #![proptest_config(ProptestConfig {
-            cases: match env::var("TESTING_PROPTEST_CASES") {
-                    Ok(s) => s.parse::<u32>().unwrap_or(256),
-                    _ => 256
-            },
-            .. ProptestConfig::default()
-        })]
-
         #[test]
         fn reftest_random_tree(tree in gen_tree(5, 100, 5, 20), readdir_limit in 0..10usize, ops in vec(any::<Op>(), 1..10)) {
             run_test(tree, ops, readdir_limit);


### PR DESCRIPTION
This PR removes the flag being activated that causes proptests to ignore failure persistance. This will cause a file `harness.proptest-regressions` to be created on a failing proptest, which can be used to easily replicate the failing test outside of the system. 

No breaking changes, only removes the disabling of failure persistance.

No changelog entry, as it only pertains testing.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
