### PR TITLE
Add source uri to headers for COPY request

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -28,6 +28,9 @@
 
 ### Other changes
 
+* Copy object operation now support buckets with dots in the name by including extra header with source uri 
+  ([#1228](https://github.com/awslabs/mountpoint-s3/pull/1228)).
+  Support on CRT side was introduced in [awslabs/aws-c-s3/482](https://github.com/awslabs/aws-c-s3/pull/482)
 * `HeadObjectResult` now includes the server-side encryption settings used when storing the object.
   ([#1143](https://github.com/awslabs/mountpoint-s3/pull/1143))
 * Add parameter to request checksum information as part of a `HeadObject` request.

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -28,9 +28,8 @@
 
 ### Other changes
 
-* Copy object operation now support buckets with dots in the name by including extra header with source uri 
-  ([#1228](https://github.com/awslabs/mountpoint-s3/pull/1228)).
-  Support on CRT side was introduced in [awslabs/aws-c-s3/482](https://github.com/awslabs/aws-c-s3/pull/482)
+* Add support for source buckets with dots in the name in `copy_object`.
+  ([#1228](https://github.com/awslabs/mountpoint-s3/pull/1228))
 * `HeadObjectResult` now includes the server-side encryption settings used when storing the object.
   ([#1143](https://github.com/awslabs/mountpoint-s3/pull/1143))
 * Add parameter to request checksum information as part of a `HeadObject` request.

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -2,10 +2,10 @@ use std::ops::Deref;
 use std::os::unix::prelude::OsStrExt;
 
 use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
+use tracing::trace;
 
 use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
 use crate::s3_crt_client::{S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
-use tracing::trace;
 
 impl S3CrtClient {
     /// Create and begin a new CopyObject request.

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -50,16 +50,9 @@ impl S3CrtClient {
             let endpoint = self.inner.endpoint_config.resolve_for_bucket(source_bucket)
                 .map_err(|e| S3RequestError::from(e))?;
             let uri = endpoint.uri()
-                .map_err(|e| S3RequestError::from(e))?;
-            let hostname = uri.host_name().to_str().unwrap();
-            let path_prefix = uri.path().to_os_string().into_string().unwrap();
-            let port = uri.host_port();
-            let hostname_header = if port > 0 {
-                format!("{}:{}", hostname, port)
-            } else {
-                hostname.to_string()
-            };
-            let source_uri = format!("{hostname_header}{path_prefix}/{source_key}");
+                .map_err(|e| S3RequestError::from(e))?
+                .as_os_str();
+            let source_uri = format!("{uri}/{source_key}");
             trace!(source_uri, "resolved source uri");
             options.copy_source_uri(&source_uri);
             self.inner.make_simple_http_request_from_options(options, span, |_| {}, parse_copy_object_error, |_, _| ())?

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -1,9 +1,9 @@
+use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
+use crate::s3_crt_client::{ConstructionError, S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
+use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
 use std::ops::Deref;
 use std::os::unix::prelude::OsStrExt;
 use tracing::trace;
-use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
-use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
-use crate::s3_crt_client::{ConstructionError, S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
 
 impl S3CrtClient {
     /// Create and begin a new CopyObject request.
@@ -40,14 +40,23 @@ impl S3CrtClient {
             );
 
             let mut options = S3CrtClientInner::new_meta_request_options(message, S3Operation::CopyObject);
-            let uri = self.inner.endpoint_config.resolve_for_bucket(source_bucket)
+            let uri = self
+                .inner
+                .endpoint_config
+                .resolve_for_bucket(source_bucket)
                 .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?
                 .uri()
                 .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?;
             let source_uri = format!("{}/{source_key}", uri.as_os_str().to_string_lossy());
             trace!(source_uri, "resolved source uri");
-            options.copy_source_uri(&source_uri);
-            self.inner.make_simple_http_request_from_options(options, span, |_| {}, parse_copy_object_error, |_, _| ())?
+            options.copy_source_uri(source_uri);
+            self.inner.make_simple_http_request_from_options(
+                options,
+                span,
+                |_| {},
+                parse_copy_object_error,
+                |_, _| (),
+            )?
         };
 
         let _body = request.await?;

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -1,8 +1,10 @@
-use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
-use crate::s3_crt_client::{ConstructionError, S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
-use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
 use std::ops::Deref;
 use std::os::unix::prelude::OsStrExt;
+
+use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
+
+use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
+use crate::s3_crt_client::{S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
 use tracing::trace;
 
 impl S3CrtClient {
@@ -44,9 +46,9 @@ impl S3CrtClient {
                 .inner
                 .endpoint_config
                 .resolve_for_bucket(source_bucket)
-                .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?
+                .map_err(S3RequestError::construction_failure)?
                 .uri()
-                .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?;
+                .map_err(S3RequestError::construction_failure)?;
             let source_uri = format!("{}/{source_key}", uri.as_os_str().to_string_lossy());
             trace!(source_uri, "resolved source uri");
             options.copy_source_uri(source_uri);

--- a/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/copy_object.rs
@@ -2,15 +2,8 @@ use std::ops::Deref;
 use std::os::unix::prelude::OsStrExt;
 use tracing::trace;
 use mountpoint_s3_crt::{http::request_response::Header, s3::client::MetaRequestResult};
-use crate::endpoint_config::EndpointError;
 use crate::object_client::{CopyObjectError, CopyObjectParams, CopyObjectResult, ObjectClientResult};
 use crate::s3_crt_client::{ConstructionError, S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError};
-
-impl From<EndpointError> for S3RequestError {
-    fn from(error: EndpointError) -> Self {
-        S3RequestError::ConstructionFailure(ConstructionError::InvalidEndpoint(error))
-    }
-}
 
 impl S3CrtClient {
     /// Create and begin a new CopyObject request.
@@ -47,12 +40,11 @@ impl S3CrtClient {
             );
 
             let mut options = S3CrtClientInner::new_meta_request_options(message, S3Operation::CopyObject);
-            let endpoint = self.inner.endpoint_config.resolve_for_bucket(source_bucket)
-                .map_err(|e| S3RequestError::from(e))?;
-            let uri = endpoint.uri()
-                .map_err(|e| S3RequestError::from(e))?
-                .as_os_str();
-            let source_uri = format!("{uri}/{source_key}");
+            let uri = self.inner.endpoint_config.resolve_for_bucket(source_bucket)
+                .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?
+                .uri()
+                .map_err(|e| S3RequestError::from(ConstructionError::from(e)))?;
+            let source_uri = format!("{}/{source_key}", uri.as_os_str().to_string_lossy());
             trace!(source_uri, "resolved source uri");
             options.copy_source_uri(&source_uri);
             self.inner.make_simple_http_request_from_options(options, span, |_| {}, parse_copy_object_error, |_, _| ())?

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -323,13 +323,13 @@ impl<'a> MetaRequestOptions<'a> {
             endpoint: None,
             signing_config: None,
             checksum_config: None,
+            copy_source_uri: None,
             on_telemetry: None,
             on_headers: None,
             on_body: None,
             on_upload_review: None,
             on_finish: None,
             _pinned: Default::default(),
-            copy_source_uri: None,
         });
 
         // Pin the options in-place. This is because it's about to become self-referential.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -462,6 +462,14 @@ impl<'a> MetaRequestOptions<'a> {
         options.inner.send_using_async_writes = send_using_async_writes;
         self
     }
+
+    /// Set the URI of source bucket/key for COPY request only
+    pub fn copy_source_uri(&mut self, source_uri: &str) -> &mut Self {
+        // SAFETY: we aren't moving out of the struct.
+        let options = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.0)) };
+        options.inner.copy_source_uri = unsafe { source_uri.as_aws_byte_cursor() };
+        self
+    }
 }
 
 impl Default for MetaRequestOptions<'_> {


### PR DESCRIPTION
This changes is to address gap in supporting buckets with dots in the name for COPY requests.
First encountered in s3-torch-connector https://github.com/awslabs/s3-connector-for-pytorch/issues/295 

### Does this change impact existing behavior?

No

### Does this change need a changelog entry?

Yes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
