### PR TITLE
Update S3ClientConfig to support configurable EventLoop thread count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other Changes
+* Add support for overriding the number of threads used by the Event Loop.
+  ([#1240](https://github.com/awslabs/mountpoint-s3/pull/1240/)
+
 ## v0.12.0 (January 20, 2025)
 
 ### Breaking changes

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
-### Other Changes
+### Other changes
 
 * Add support for overriding the number of threads used by the Event Loop.
-  ([#1240](https://github.com/awslabs/mountpoint-s3/pull/1240/)
-* The ECS credentials provider now performs retries in the event of some failures. ([awslabs/aws-c-auth#259][https://github.com/awslabs/aws-c-auth/pull/259/])
+  ([#1240](https://github.com/awslabs/mountpoint-s3/pull/1240/))
+* The ECS credentials provider now performs retries in the event of some failures. ([awslabs/aws-c-auth#259](https://github.com/awslabs/aws-c-auth/pull/259/))
 
 ## v0.12.0 (January 20, 2025)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -103,6 +103,7 @@ pub struct S3ClientConfig {
     initial_read_window: usize,
     network_interface_names: Vec<String>,
     telemetry_callback: Option<Arc<dyn OnTelemetry>>,
+    event_loop_threads: Option<u16>,
 }
 
 impl Default for S3ClientConfig {
@@ -122,6 +123,7 @@ impl Default for S3ClientConfig {
             initial_read_window: DEFAULT_PART_SIZE,
             network_interface_names: vec![],
             telemetry_callback: None,
+            event_loop_threads: None,
         }
     }
 }
@@ -230,6 +232,13 @@ impl S3ClientConfig {
         self.telemetry_callback = Some(telemetry_callback);
         self
     }
+
+    /// Override the number of threads used by the CRTs AwsEventLoop
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn event_loop_threads(mut self, event_loop_threads: u16) -> Self {
+        self.event_loop_threads = Some(event_loop_threads);
+        self
+    }
 }
 
 /// Authentication configuration for the CRT-based S3 client
@@ -304,7 +313,7 @@ impl S3CrtClientInner {
     fn new(config: S3ClientConfig) -> Result<Self, NewClientError> {
         let allocator = Allocator::default();
 
-        let mut event_loop_group = EventLoopGroup::new_default(&allocator, None, || {}).unwrap();
+        let mut event_loop_group = EventLoopGroup::new_default(&allocator, config.event_loop_threads, || {}).unwrap();
 
         let resolver_options = HostResolverDefaultOptions {
             max_entries: 8,

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.15.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.12.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.13.0" }
 mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.0" }
 
 anyhow = { version = "1.0.94", features = ["backtrace"] }


### PR DESCRIPTION
For our use case, we run many mountpoint-s3 clients on a single machine and want to restrict the number of threads each client uses in order to reduce heap fragmentation and CPU contention.

### Does this change impact existing behavior?

No, this only allows for overriding the default value.

### Does this change need a changelog entry? Does it require a version change?

No, there are no breaking changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
