### PR TITLE
Add expected bucket owner test for shared XZ cache

### DIFF
--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -50,6 +50,17 @@ pub fn get_test_region() -> String {
     std::env::var("S3_REGION").expect("Set S3_REGION to run integration tests")
 }
 
+/// Account ID owning buckets specified in `S3_BUCKET_NAME` and `S3_EXPRESS_ONE_ZONE_BUCKET_NAME`
+pub fn get_bucket_owner() -> String {
+    std::env::var("S3_BUCKET_OWNER").expect("Set S3_BUCKET_OWNER to run integration tests")
+}
+
+/// A name of an S3 Express bucket which is owned by a different account (different to `S3_BUCKET_OWNER`)
+pub fn get_external_express_bucket() -> String {
+    std::env::var("S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL")
+        .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL to run integration tests")
+}
+
 /// Optional config for testing against a custom endpoint url
 pub fn get_test_endpoint_url() -> Option<String> {
     if cfg!(feature = "s3express_tests") {

--- a/mountpoint-s3/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/cache_test.rs
@@ -16,10 +16,10 @@ use std::time::Duration;
 use tempfile::TempDir;
 use test_case::test_case;
 
+#[cfg(all(feature = "s3express_tests", feature = "second_account_tests"))]
+use crate::common::s3::{get_bucket_owner, get_external_express_bucket, get_test_endpoint_config};
 #[cfg(feature = "s3express_tests")]
-use crate::common::s3::{
-    get_bucket_owner, get_express_bucket, get_external_express_bucket, get_standard_bucket, get_test_endpoint_config,
-};
+use crate::common::s3::{get_express_bucket, get_standard_bucket};
 #[cfg(feature = "s3express_tests")]
 use mountpoint_s3::data_cache::{build_prefix, get_s3_key, BlockIndex, ExpressDataCache};
 #[cfg(feature = "s3express_tests")]
@@ -294,7 +294,7 @@ where
 #[test_case(get_express_bucket(), true, true; "bucket owned by the expected account")]
 #[test_case(get_external_express_bucket(), true, false; "bucket owned by another account")]
 #[test_case(get_external_express_bucket(), false, false; "bucket owned by another account, not checked")]
-#[cfg(feature = "s3express_tests")]
+#[cfg(all(feature = "s3express_tests", feature = "second_account_tests"))]
 fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool, owner_matches: bool) {
     use futures::executor::block_on;
     use mountpoint_s3_client::config::S3ClientConfig;
@@ -324,7 +324,7 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
             _ => panic!("expected S3RequestError::Forbidden, got: {:?}", cache_valid),
         }
     } else {
-        cache_valid.unwrap(); // Ok(()) is expected
+        cache_valid.expect("should succeed if not enforcing bucket owner");
     }
 
     let cache = CacheTestWrapper::new(cache);


### PR DESCRIPTION
Add the expected bucket owner test. The test attempts to use a bucket in another AWS account as a cache and verifies that:

- write to the cache is not done if the expected bucket owner check is enabled
- write to the cache is done if the check is disabled
- write to the cache is done if the cache bucket belongs to the expected account

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
