### PR TITLE
Add `second_account_tests` feature flag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ env:
   S3_BUCKET_OWNER: ${{ vars.S3_BUCKET_OWNER }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests
 
 permissions:
   id-token: write
@@ -139,9 +139,9 @@ jobs:
       with:
         fuseVersion: ${{ matrix.fuseVersion }}
     - name: Build tests
-      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests,second_account_tests' --no-run
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests' --no-run
     - name: Run tests
-      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests,second_account_tests'
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
     - name: Save dump files
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
       run: ./.github/actions/scripts/save-coredump.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -139,9 +139,9 @@ jobs:
       with:
         fuseVersion: ${{ matrix.fuseVersion }}
     - name: Build tests
-      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests' --no-run
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests,second_account_tests' --no-run
     - name: Run tests
-      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests'
+      run: cargo test --features '${{ env.RUST_FEATURES }},s3express_tests,second_account_tests'
     - name: Save dump files
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
       run: ./.github/actions/scripts/save-coredump.sh

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -90,9 +90,9 @@ fuse_tests = []
 s3_tests = []
 s3express_tests = []
 shuttle = []
+second_account_tests = []
 # Other feature flags
 mock = ["mountpoint-s3-client/mock", "futures/thread-pool"]
-second_account_tests = []
 
 [[bin]]
 name = "mount-s3"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -92,6 +92,7 @@ s3express_tests = []
 shuttle = []
 # Other feature flags
 mock = ["mountpoint-s3-client/mock", "futures/thread-pool"]
+second_account_tests = []
 
 [[bin]]
 name = "mount-s3"


### PR DESCRIPTION
Add and enable the feature flag `second_account_tests` in the selected workflow for [the test](https://github.com/awslabs/mountpoint-s3/pull/1241/files).

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
