### PR TITLE
Add to cache read failure log 'falling back to S3'

### DIFF
--- a/mountpoint-s3/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3/src/prefetch/caching_stream.rs
@@ -170,7 +170,7 @@ where
                     block_index,
                     ?range,
                     ?error,
-                    "error reading block from cache",
+                    "error reading block from cache, falling back to S3",
                 ),
             }
             // If a block is uncached or reading it fails, fallback to S3 for the rest of the stream.


### PR DESCRIPTION
When a cache read fails, there have been open questions in support cases about if that will have then failed the whole read or asked S3. This is a simple change to address that ambiguity.

### Does this change impact existing behavior?

Simple logging change only.

### Does this change need a changelog entry? Does it require a version change?

No, simple log content change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
