### PR TITLE
Add negative metadata cache ttl

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -319,6 +319,14 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
 
     #[clap(
         long,
+        help = "Time-to-live (TTL) for cached negative entries in seconds [default: same as metadata TTL]",
+        value_name = "SECONDS|indefinite|minimal",
+        help_heading = CACHING_OPTIONS_HEADER,
+    )]
+    pub negative_cache_ttl: Option<TimeToLive>,
+
+    #[clap(
+        long,
         help = "Maximum size of the cache directory in MiB [default: preserve 5% of available space]",
         value_name = "MiB",
         value_parser = value_parser!(u64),
@@ -934,6 +942,11 @@ where
     }
     tracing::trace!("using metadata TTL setting {metadata_cache_ttl:?}");
     filesystem_config.cache_config = CacheConfig::new(metadata_cache_ttl);
+    if let Some(negative_cache_ttl) = args.negative_cache_ttl {
+        filesystem_config.cache_config = filesystem_config
+            .cache_config
+            .with_negative_cache_ttl(negative_cache_ttl);
+    }
 
     match (args.disk_data_cache_config(), args.express_data_cache_config()) {
         (None, Some((config, bucket_name, cache_bucket_name))) => {

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -323,7 +323,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         value_name = "SECONDS|indefinite|minimal",
         help_heading = CACHING_OPTIONS_HEADER,
     )]
-    pub negative_cache_ttl: Option<TimeToLive>,
+    pub negative_metadata_ttl: Option<TimeToLive>,
 
     #[clap(
         long,
@@ -942,7 +942,7 @@ where
     }
     tracing::trace!("using metadata TTL setting {metadata_cache_ttl:?}");
     filesystem_config.cache_config = CacheConfig::new(metadata_cache_ttl);
-    if let Some(negative_cache_ttl) = args.negative_cache_ttl {
+    if let Some(negative_cache_ttl) = args.negative_metadata_ttl {
         filesystem_config.cache_config = filesystem_config
             .cache_config
             .with_negative_cache_ttl(negative_cache_ttl);

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -945,7 +945,7 @@ where
     if let Some(negative_cache_ttl) = args.negative_metadata_ttl {
         filesystem_config.cache_config = filesystem_config
             .cache_config
-            .with_negative_cache_ttl(negative_cache_ttl);
+            .with_negative_metadata_ttl(negative_cache_ttl);
     }
 
     match (args.disk_data_cache_config(), args.express_data_cache_config()) {

--- a/mountpoint-s3/src/fs/config.rs
+++ b/mountpoint-s3/src/fs/config.rs
@@ -87,6 +87,8 @@ pub struct CacheConfig {
     pub file_ttl: Duration,
     /// How long the kernel will cache metadata for directories
     pub dir_ttl: Duration,
+    /// How long the kernel will cache negative entries
+    pub negative_cache_ttl: Duration,
     /// Maximum number of negative entries to cache.
     pub negative_cache_size: usize,
 }
@@ -116,6 +118,7 @@ impl Default for CacheConfig {
             serve_lookup_from_cache: false,
             file_ttl,
             dir_ttl,
+            negative_cache_ttl: file_ttl,
             negative_cache_size,
         }
     }
@@ -130,13 +133,32 @@ impl CacheConfig {
                 serve_lookup_from_cache: true,
                 file_ttl: TimeToLive::INDEFINITE_DURATION,
                 dir_ttl: TimeToLive::INDEFINITE_DURATION,
+                negative_cache_ttl: TimeToLive::INDEFINITE_DURATION,
                 ..Default::default()
             },
             TimeToLive::Duration(ttl) => Self {
                 serve_lookup_from_cache: true,
                 file_ttl: ttl,
                 dir_ttl: ttl,
+                negative_cache_ttl: ttl,
                 ..Default::default()
+            },
+        }
+    }
+
+    pub fn with_negative_cache_ttl(self, negative_cache_ttl: TimeToLive) -> Self {
+        match negative_cache_ttl {
+            TimeToLive::Minimal => Self {
+                negative_cache_ttl: Self::default().negative_cache_ttl,
+                ..self
+            },
+            TimeToLive::Indefinite => Self {
+                negative_cache_ttl: TimeToLive::INDEFINITE_DURATION,
+                ..self
+            },
+            TimeToLive::Duration(ttl) => Self {
+                negative_cache_ttl: ttl,
+                ..self
             },
         }
     }

--- a/mountpoint-s3/src/fs/config.rs
+++ b/mountpoint-s3/src/fs/config.rs
@@ -146,8 +146,8 @@ impl CacheConfig {
         }
     }
 
-    pub fn with_negative_cache_ttl(self, negative_cache_ttl: TimeToLive) -> Self {
-        match negative_cache_ttl {
+    pub fn with_negative_metadata_ttl(self, negative_metadata_ttl: TimeToLive) -> Self {
+        match negative_metadata_ttl {
             TimeToLive::Minimal => Self {
                 negative_cache_ttl: Self::default().negative_cache_ttl,
                 ..self

--- a/mountpoint-s3/src/fs/config.rs
+++ b/mountpoint-s3/src/fs/config.rs
@@ -87,6 +87,8 @@ pub struct CacheConfig {
     pub file_ttl: Duration,
     /// How long the kernel will cache metadata for directories
     pub dir_ttl: Duration,
+    /// Should the file system cache negative lookups?
+    pub use_negative_cache: bool,
     /// How long the file system will cache negative entries
     pub negative_cache_ttl: Duration,
     /// Maximum number of negative entries to cache.
@@ -118,6 +120,7 @@ impl Default for CacheConfig {
             serve_lookup_from_cache: false,
             file_ttl,
             dir_ttl,
+            use_negative_cache: false,
             negative_cache_ttl: file_ttl,
             negative_cache_size,
         }
@@ -133,6 +136,7 @@ impl CacheConfig {
                 serve_lookup_from_cache: true,
                 file_ttl: TimeToLive::INDEFINITE_DURATION,
                 dir_ttl: TimeToLive::INDEFINITE_DURATION,
+                use_negative_cache: true,
                 negative_cache_ttl: TimeToLive::INDEFINITE_DURATION,
                 ..Default::default()
             },
@@ -140,6 +144,7 @@ impl CacheConfig {
                 serve_lookup_from_cache: true,
                 file_ttl: ttl,
                 dir_ttl: ttl,
+                use_negative_cache: true,
                 negative_cache_ttl: ttl,
                 ..Default::default()
             },
@@ -149,14 +154,17 @@ impl CacheConfig {
     pub fn with_negative_metadata_ttl(self, negative_metadata_ttl: TimeToLive) -> Self {
         match negative_metadata_ttl {
             TimeToLive::Minimal => Self {
+                use_negative_cache: false,
                 negative_cache_ttl: Self::default().negative_cache_ttl,
                 ..self
             },
             TimeToLive::Indefinite => Self {
+                use_negative_cache: true,
                 negative_cache_ttl: TimeToLive::INDEFINITE_DURATION,
                 ..self
             },
             TimeToLive::Duration(ttl) => Self {
+                use_negative_cache: true,
                 negative_cache_ttl: ttl,
                 ..self
             },

--- a/mountpoint-s3/src/fs/config.rs
+++ b/mountpoint-s3/src/fs/config.rs
@@ -87,7 +87,7 @@ pub struct CacheConfig {
     pub file_ttl: Duration,
     /// How long the kernel will cache metadata for directories
     pub dir_ttl: Duration,
-    /// How long the kernel will cache negative entries
+    /// How long the file system will cache negative entries
     pub negative_cache_ttl: Duration,
     /// Maximum number of negative entries to cache.
     pub negative_cache_size: usize,

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -90,7 +90,10 @@ impl Superblock {
         let mut inodes = InodeMap::default();
         inodes.insert(root.ino(), root);
 
-        let negative_cache = NegativeCache::new(config.cache_config.negative_cache_size, config.cache_config.file_ttl);
+        let negative_cache = NegativeCache::new(
+            config.cache_config.negative_cache_size,
+            config.cache_config.negative_cache_ttl,
+        );
 
         let inner = SuperblockInner {
             bucket: bucket.to_owned(),
@@ -1386,6 +1389,7 @@ mod tests {
                     serve_lookup_from_cache: true,
                     dir_ttl: ttl,
                     file_ttl: ttl,
+                    negative_cache_ttl: ttl,
                     ..Default::default()
                 },
                 s3_personality: S3Personality::Standard,

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -792,7 +792,7 @@ impl SuperblockInner {
             return Err(InodeError::NotADirectory(parent.err()));
         }
 
-        if self.config.cache_config.serve_lookup_from_cache {
+        if self.config.cache_config.use_negative_cache {
             match &remote {
                 // Remove negative cache entry.
                 Some(_) => self.negative_cache.remove(parent_ino, name),

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -1167,7 +1167,7 @@ mod tests {
     use test_case::test_case;
     use time::{Duration, OffsetDateTime};
 
-    use crate::fs::{ToErrno, FUSE_ROOT_INODE};
+    use crate::fs::{TimeToLive, ToErrno, FUSE_ROOT_INODE};
 
     use super::*;
 
@@ -1330,12 +1330,7 @@ mod tests {
             bucket,
             &prefix,
             SuperblockConfig {
-                cache_config: CacheConfig {
-                    serve_lookup_from_cache: true,
-                    dir_ttl: ttl,
-                    file_ttl: ttl,
-                    ..Default::default()
-                },
+                cache_config: CacheConfig::new(TimeToLive::Duration(ttl)),
                 s3_personality: S3Personality::Standard,
             },
         );
@@ -1385,13 +1380,7 @@ mod tests {
             bucket,
             &prefix,
             SuperblockConfig {
-                cache_config: CacheConfig {
-                    serve_lookup_from_cache: true,
-                    dir_ttl: ttl,
-                    file_ttl: ttl,
-                    negative_cache_ttl: ttl,
-                    ..Default::default()
-                },
+                cache_config: CacheConfig::new(TimeToLive::Duration(ttl)),
                 s3_personality: S3Personality::Standard,
             },
         );

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -5,7 +5,7 @@ use fuser::FileType;
 use mountpoint_s3::fs::error_metadata::MOUNTPOINT_ERROR_LOOKUP_NONEXISTENT;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use mountpoint_s3::fs::{CacheConfig, OpenFlags, ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3::fs::{CacheConfig, OpenFlags, TimeToLive, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3::prefix::Prefix;
 use mountpoint_s3::s3::S3Personality;
 use mountpoint_s3::S3FilesystemConfig;
@@ -192,13 +192,7 @@ async fn test_read_dir_nested(prefix: &str) {
 #[tokio::test]
 async fn test_lookup_negative_cached() {
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: true,
-            dir_ttl: Duration::from_secs(600),
-            file_ttl: Duration::from_secs(600),
-            negative_cache_ttl: Duration::from_secs(600),
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
         ..Default::default()
     };
     let (client, fs) = make_test_filesystem("test_lookup_negative_cached", &Default::default(), fs_config);
@@ -264,13 +258,7 @@ async fn test_lookup_negative_cached() {
 #[tokio::test]
 async fn test_lookup_then_open_cached() {
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: true,
-            dir_ttl: Duration::from_secs(600),
-            file_ttl: Duration::from_secs(600),
-            negative_cache_ttl: Duration::from_secs(600),
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
         ..Default::default()
     };
     let (client, fs) = make_test_filesystem("test_lookup_then_open_cached", &Default::default(), fs_config);
@@ -299,10 +287,7 @@ async fn test_lookup_then_open_cached() {
 #[tokio::test]
 async fn test_lookup_then_open_no_cache() {
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: false,
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Minimal),
         ..Default::default()
     };
     let (client, fs) = make_test_filesystem("test_lookup_then_open_no_cache", &Default::default(), fs_config);
@@ -331,13 +316,7 @@ async fn test_lookup_then_open_no_cache() {
 #[tokio::test]
 async fn test_readdir_then_open_cached() {
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: true,
-            dir_ttl: Duration::from_secs(600),
-            file_ttl: Duration::from_secs(600),
-            negative_cache_ttl: Duration::from_secs(600),
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
         ..Default::default()
     };
     let (client, fs) = make_test_filesystem("test_readdir_then_open_cached", &Default::default(), fs_config);
@@ -383,13 +362,7 @@ async fn test_readdir_then_open_cached() {
 #[tokio::test]
 async fn test_unlink_cached() {
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: true,
-            dir_ttl: Duration::from_secs(600),
-            file_ttl: Duration::from_secs(600),
-            negative_cache_ttl: Duration::from_secs(600),
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
         allow_delete: true,
         ..Default::default()
     };
@@ -434,13 +407,7 @@ async fn test_unlink_cached() {
 async fn test_mknod_cached() {
     const BUCKET_NAME: &str = "test_mknod_cached";
     let fs_config = S3FilesystemConfig {
-        cache_config: CacheConfig {
-            serve_lookup_from_cache: true,
-            dir_ttl: Duration::from_secs(600),
-            file_ttl: Duration::from_secs(600),
-            negative_cache_ttl: Duration::from_secs(600),
-            ..Default::default()
-        },
+        cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
         ..Default::default()
     };
     let (client, fs) = make_test_filesystem(BUCKET_NAME, &Default::default(), fs_config);

--- a/mountpoint-s3/tests/fs.rs
+++ b/mountpoint-s3/tests/fs.rs
@@ -196,6 +196,7 @@ async fn test_lookup_negative_cached() {
             serve_lookup_from_cache: true,
             dir_ttl: Duration::from_secs(600),
             file_ttl: Duration::from_secs(600),
+            negative_cache_ttl: Duration::from_secs(600),
             ..Default::default()
         },
         ..Default::default()
@@ -267,6 +268,7 @@ async fn test_lookup_then_open_cached() {
             serve_lookup_from_cache: true,
             dir_ttl: Duration::from_secs(600),
             file_ttl: Duration::from_secs(600),
+            negative_cache_ttl: Duration::from_secs(600),
             ..Default::default()
         },
         ..Default::default()
@@ -333,6 +335,7 @@ async fn test_readdir_then_open_cached() {
             serve_lookup_from_cache: true,
             dir_ttl: Duration::from_secs(600),
             file_ttl: Duration::from_secs(600),
+            negative_cache_ttl: Duration::from_secs(600),
             ..Default::default()
         },
         ..Default::default()
@@ -384,6 +387,7 @@ async fn test_unlink_cached() {
             serve_lookup_from_cache: true,
             dir_ttl: Duration::from_secs(600),
             file_ttl: Duration::from_secs(600),
+            negative_cache_ttl: Duration::from_secs(600),
             ..Default::default()
         },
         allow_delete: true,
@@ -434,6 +438,7 @@ async fn test_mknod_cached() {
             serve_lookup_from_cache: true,
             dir_ttl: Duration::from_secs(600),
             file_ttl: Duration::from_secs(600),
+            negative_cache_ttl: Duration::from_secs(600),
             ..Default::default()
         },
         ..Default::default()

--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -5,7 +5,10 @@ use std::{
     time::Duration,
 };
 
-use mountpoint_s3::{fs::CacheConfig, S3FilesystemConfig};
+use mountpoint_s3::{
+    fs::{CacheConfig, TimeToLive},
+    S3FilesystemConfig,
+};
 use test_case::test_case;
 
 use crate::common::fuse::{self, read_dir_to_entry_names, TestSessionConfig, TestSessionCreator};
@@ -195,13 +198,7 @@ fn lookup_with_negative_cache(creator_fn: impl TestSessionCreator) {
     const FILE_NAME: &str = "hello.txt";
     let config = TestSessionConfig {
         filesystem_config: S3FilesystemConfig {
-            cache_config: CacheConfig {
-                serve_lookup_from_cache: true,
-                dir_ttl: Duration::from_secs(600),
-                file_ttl: Duration::from_secs(600),
-                negative_cache_ttl: Duration::from_secs(600),
-                ..Default::default()
-            },
+            cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600))),
             ..Default::default()
         },
         ..Default::default()
@@ -239,13 +236,8 @@ fn lookup_with_negative_cache_ttl(creator_fn: impl TestSessionCreator, ttl: Dura
     const FILE_NAME: &str = "hello.txt";
     let config = TestSessionConfig {
         filesystem_config: S3FilesystemConfig {
-            cache_config: CacheConfig {
-                serve_lookup_from_cache: true,
-                dir_ttl: Duration::from_secs(600),
-                file_ttl: Duration::from_secs(600),
-                negative_cache_ttl: ttl,
-                ..Default::default()
-            },
+            cache_config: CacheConfig::new(TimeToLive::Duration(Duration::from_secs(600)))
+                .with_negative_metadata_ttl(TimeToLive::Duration(ttl)),
             ..Default::default()
         },
         ..Default::default()

--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -199,7 +199,7 @@ fn lookup_with_negative_cache(creator_fn: impl TestSessionCreator) {
                 serve_lookup_from_cache: true,
                 dir_ttl: Duration::from_secs(600),
                 file_ttl: Duration::from_secs(600),
-                negative_ttl: Duration::from_secs(600),
+                negative_cache_ttl: Duration::from_secs(600),
                 ..Default::default()
             },
             ..Default::default()

--- a/mountpoint-s3/tests/fuse_tests/lookup_test.rs
+++ b/mountpoint-s3/tests/fuse_tests/lookup_test.rs
@@ -106,6 +106,7 @@ fn lookup_previously_shadowed_file_test(creator_fn: impl TestSessionCreator) {
             serve_lookup_from_cache: false,
             file_ttl: Duration::ZERO,
             dir_ttl: Duration::ZERO,
+            negative_cache_ttl: Duration::ZERO,
             ..Default::default()
         },
         ..Default::default()
@@ -198,6 +199,7 @@ fn lookup_with_negative_cache(creator_fn: impl TestSessionCreator) {
                 serve_lookup_from_cache: true,
                 dir_ttl: Duration::from_secs(600),
                 file_ttl: Duration::from_secs(600),
+                negative_ttl: Duration::from_secs(600),
                 ..Default::default()
             },
             ..Default::default()

--- a/mountpoint-s3/tests/reftests/harness.rs
+++ b/mountpoint-s3/tests/reftests/harness.rs
@@ -936,6 +936,7 @@ mod mutations {
                 serve_lookup_from_cache: false,
                 dir_ttl: Duration::ZERO,
                 file_ttl: Duration::ZERO,
+                negative_cache_ttl: Duration::ZERO,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
Adds a new CLI argument `--negative-cache-ttl` that lets you set the TTL for negative metadata entries separately from `--metadata-ttl`. My use case is a write once read many bucket. Objects do not get deleted from this bucket, and new objects are added every few minutes. I'd like to be able to set `--metadata-ttl indefinite` and `--negative-cache-ttl 60` to effectively utilize the caching while still being able to pick up new objects. There is an open issue for this here - https://github.com/awslabs/mountpoint-s3/issues/831

### Does this change impact existing behavior?

No, if `--negative-cache-ttl` is omitted the existing behavior is maintained (use `--metadata-ttl` or the default file_ttl).

### Does this change need a changelog entry? Does it require a version change?

Because this is a new feature I believe it would require both.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
