### PR TITLE
Purge file from the negative cache on create

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Add support for appending to objects originally uploaded with a CRC64-NVME checksum. ([#1235](https://github.com/awslabs/mountpoint-s3/pull/1235))
 
+### Other Changes
+* Fix an issue where file names were not expelled from negative cache.
+
 ## v1.14.0 (January 10, 2025)
 
 ### New features

--- a/mountpoint-s3/src/superblock.rs
+++ b/mountpoint-s3/src/superblock.rs
@@ -367,6 +367,8 @@ impl Superblock {
             let inode = self
                 .inner
                 .create_inode_locked(&parent_inode, &mut parent_state, name, kind, state, true)?;
+            // Expel inode from negative cache, if it is present
+            self.inner.negative_cache.remove(parent_inode.ino(), name);
             LookedUp { inode, stat }
         };
 


### PR DESCRIPTION
This change adds code to remove entries from the negative cache once the new file is created.

Does not need a changelog entry, as it's only a small bugfix.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
