### PR TITLE
Increment crates version numbers for next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.0" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.1" }
 
 async-trait = "0.1.85"
 auto_impl = "1.2.1"

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.12.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.12.1" }
 
 futures = "0.3.31"
 libc = "0.2.169"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 fuser = { path = "../vendor/fuser", version = "0.15.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.13.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.13.1" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"


### PR DESCRIPTION
Increment the version numbers of the client crates after publishing to crates.io.

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
