### PR TITLE
Update readdir and readdirplus metrics to use histogram instead of counter

### DIFF
--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -235,7 +235,7 @@ where
         match block_on(self.fs.readdirplus(parent, fh, offset, replier).in_current_span()) {
             Ok(_) => {
                 reply.ok();
-                metrics::counter!("fuse.readdirplus.entries").increment(count as u64);
+                metrics::histogram!("fuse.readdirplus.entries").record(count as f64);
             }
             Err(e) => fuse_error!("readdirplus", reply, e, self, req),
         }

--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -189,7 +189,7 @@ where
         match block_on(self.fs.readdir(parent, fh, offset, replier).in_current_span()) {
             Ok(_) => {
                 reply.ok();
-                metrics::counter!("fuse.readdir.entries").increment(count as u64);
+                metrics::histogram!("fuse.readdir.entries").record(count as f64);
             }
             Err(e) => fuse_error!("readdir", reply, e, self, req),
         }


### PR DESCRIPTION
Update readdir and readdirplus APIs' `fuse.readdir[plus].entries` metric to use histogram instead of counter, as it would make more sense to record statistics on how many entries were returned in a readdir[plus] request when there was more than one in a given interval, than recording the total readdir[plus] entries per interval.

Addresses https://github.com/awslabs/mountpoint-s3/issues/1236.

### Does this change impact existing behavior?

Yes, the `fuse.readdir[plus].entries` metric type has been changed.

### Does this change need a changelog entry? Does it require a version change?

No, it is only updating a metric. Since metric names and availability are considered unstable, this does not need a changelog entry or version change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
