### PR TITLE
Add an Express bucket with KMS default SSE to the CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,7 @@ env:
   S3_BUCKET_OWNER: ${{ vars.S3_BUCKET_OWNER }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
+  S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS }}
   RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests
 
 permissions:


### PR DESCRIPTION
Addition of this bucket to the CI will enable us to test [the case](https://github.com/vladem/mountpoint-s3/commit/0bab01c5037c80f0c245ebd881276ad8652818c4#diff-280514ac541c555aa616d3bfa819ad7cc7a23c372e9c37d9fc6c62477e63503dR145), when KMS encryption is enforced on a cache xz bucket.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
