### PR TITLE
Fix fs_benchmark to correctly configure backpressure

### DIFF
--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -151,6 +151,10 @@ fn mount_file_system(
     throughput_target_gbps: Option<f64>,
 ) -> BackgroundSession {
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
+    let initial_read_window_size = 1024 * 1024 + 128 * 1024;
+    config = config
+        .read_backpressure(true)
+        .initial_read_window(initial_read_window_size);
     if let Some(throughput_target_gbps) = throughput_target_gbps {
         config = config.throughput_target_gbps(throughput_target_gbps);
     }


### PR DESCRIPTION
When running the benchmark script, it fails to run due to client errors where backpressure isn't enabled. This is due to Mountpoint's prefetcher relying on this being enabled, or returning `BackpressurePreconditionFailed`.

This change configures the backpressure on the S3 client used by this benchmark and has been tested on my own Linux machine.

### Does this change impact existing behavior?

Fixes a benchmark script only.

### Does this change need a changelog entry? Does it require a version change?

No, benchmark script change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
