### PR TITLE
Add experimental config to write Mountpoint PID to file

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -1250,15 +1250,12 @@ fn create_client_for_bucket(
 /// PID file configuration is available for attaching debug tooling to Mountpoint, and may be removed in the future.
 fn create_pid_file() -> anyhow::Result<()> {
     const ENV_PID_FILENAME: &str = "UNSTABLE_MOUNTPOINT_PID_FILE";
-    match std::env::var_os(ENV_PID_FILENAME) {
-        Some(val) => {
-            let pid = std::process::id();
-            fs::write(&val, pid.to_string().as_bytes()).context("failed to write PID to file")?;
-            tracing::trace!("PID ({pid} written to file {val:?}");
-            Ok(())
-        }
-        None => Ok(()),
+    if let Some(val) = std::env::var_os(ENV_PID_FILENAME) {
+        let pid = std::process::id();
+        fs::write(&val, pid.to_string()).context("failed to write PID to file")?;
+        tracing::trace!("PID ({pid}) written to file {val:?}");
     }
+    Ok(())
 }
 
 fn parse_perm_bits(perm_bit_str: &str) -> Result<u16, anyhow::Error> {


### PR DESCRIPTION
When investigating performance, we wanted to automate the collection of profiler captures using a tool like `perf`. To do this, we needed the process ID of Mountpoint. By writing out the PID to a file, scripts could automatically record profiles for the lifetime of Mountpoint by providing its PID to `perf`.

This change adds the ability to write Mountpoint's PID to a file under an experimental/unstable environment variable. Since its unclear if we want to expose this properly such as providing a CLI argument, we are taking the unstable environment variable approach to make clear this configuration may change or be removed in future.

### Does this change impact existing behavior?

This change adds a new experimental feature to write Mountpoint's PID to a file.

### Does this change need a changelog entry? Does it require a version change?

Since this is adding an experimental feature, no changelog entry is required. No minor version patch is required, as this is not a stable feature addition.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
