### PR TITLE
chore(clippy): remove exclusions for fixed false-positive rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,7 @@ fmt-check:
 	done; \
 	exit $$fail
 
-DISABLED_LINTS =
-DISABLED_LINTS += -A clippy::items-after-test-module  # https://github.com/rust-lang/rust-clippy/issues/11153
-DISABLED_LINTS += -A clippy::arc-with-non-send-sync  # https://github.com/proptest-rs/proptest/issues/364
-
 .PHONY: clippy
 clippy:
 	@packages=`echo "$(CRATES)" | sed -E 's/(^| )/ -p /g'`; \
-	cargo clippy $$packages --no-deps --all-targets --all-features -- -D warnings -D clippy::all $(DISABLED_LINTS)
+	cargo clippy $$packages --no-deps --all-targets --all-features -- -D warnings -D clippy::all


### PR DESCRIPTION
### Overview

We removed exclusions for false positive Clippy rules as they were fixed and this workaround is no longer needed.

### Does this change impact existing behavior?

No, this is a small boilerplate change.

### Does this change need a changelog entry? Does it require a version change?

Change log and version changes are not needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
