### PR TITLE
Fix benchmark script column names for sweeped params

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -9,13 +9,18 @@ from subprocess import Popen
 import tempfile
 
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 logging.basicConfig(
     level=os.environ.get('LOGLEVEL', 'INFO').upper()
 )
 
 log = logging.getLogger(__name__)
+
+OmegaConf.register_new_resolver(
+    "join",
+    lambda separator, elements: separator.join(elements),
+)
 
 MOUNT_DIRECTORY = "s3"
 MP_LOGS_DIRECTORY = "mp_logs/"

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -12,7 +12,8 @@ write_part_size: 16777216 # to allow for uploads of 100GiB
 
 metadata_ttl: "indefinite"
 
-fio_benchmarks: sequential_read  #, random_read, sequential_write
+fio_benchmarks:
+  - sequential_read
 
 # Path to Mountpoint binary. Recommended to use an absolute path.
 mountpoint_binary: !!null
@@ -28,8 +29,8 @@ iterations: 1
 fuse_threads: !!null
 application_workers: 1
 direct_io: false
-fio_benchmark: "sequential_read"
-iteration: 1
+fio_benchmark: "${fio_benchmarks[0]}"
+iteration: 0
 
 hydra:
   help:
@@ -46,5 +47,5 @@ hydra:
       # Configure if application should use Direct IO, skipping the Linux page cache
       'direct_io': false, true
       # Don't touch the params below, they are based on settings above.
-      'fio_benchmark': "${fio_benchmarks}"
+      'fio_benchmark': "${join:',', ${fio_benchmarks}}"
       'iteration': "range(${iterations})"

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -24,6 +24,13 @@ upload_checksums: !!null
 
 iterations: 1
 
+# Define defaults for these columns, but script will run as MULTIRUN by default
+fuse_threads: !!null
+application_workers: 1
+direct_io: false
+fio_benchmark: "sequential_read"
+iteration: 1
+
 hydra:
   help:
     app_name: "Mountpoint sequential read experiment runner"
@@ -33,11 +40,11 @@ hydra:
   sweeper:
     params:
       # Maximum number of FUSE threads for Mountpoint. Passed as `--max-threads` argument.
-      '+fuse_threads': 16, 32, 64, 128
+      'fuse_threads': 16, 32, 64, 128
       # Number of processes that will be interacting with the file.
-      '+application_workers': 1, 4, 8, 16, 32, 64, 128, 256
+      'application_workers': 1, 4, 8, 16, 32, 64, 128, 256
       # Configure if application should use Direct IO, skipping the Linux page cache
-      '+direct_io': false, true
+      'direct_io': false, true
       # Don't touch the params below, they are based on settings above.
-      '+fio_benchmark': "${fio_benchmarks}"
-      '+iteration': "range(${iterations})"
+      'fio_benchmark': "${fio_benchmarks}"
+      'iteration': "range(${iterations})"


### PR DESCRIPTION
If the column names are not defined in the Hydra script, they will be prefixed by `+`. In order to keep things simple on the analysis side, we'll name the columns with placeholder values which will be replaced when running the script with multiple experiments.

### Does this change impact existing behavior?

It changes output of the benchmark script only.

### Does this change need a changelog entry? Does it require a version change?

No, no changelog entry or version change as no change to Mountpoint itself.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
