### PR TITLE
Add ETag to complete upload debug log

### DIFF
--- a/mountpoint-s3/src/fs/handles.rs
+++ b/mountpoint-s3/src/fs/handles.rs
@@ -353,7 +353,7 @@ where
         let size = upload.size();
         let (put_result, etag) = match upload.complete().await {
             Ok(result) => {
-                debug!(key, size, "put succeeded");
+                debug!(etag = ?result.etag.as_str(), key, size, "put succeeded");
                 (Ok(()), Some(result.etag))
             }
             Err(e) => (Err(err!(libc::EIO, source:e, "put failed")), None),


### PR DESCRIPTION
Small change to add etag to debug logs when an MPU completes.

We already have size and object key, so this is the only missing information.

### Does this change impact existing behavior?

Adds etag to debug logs only.

### Does this change need a changelog entry? Does it require a version change?

No, minor logging change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
