### PR TITLE
chore: rename FUSER fork as mountpoint-s3-fuser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "fuser"
-description = "Filesystem in Userspace (FUSE) for Rust"
+name = "mountpoint-s3-fuser"
+description = "A fork of fuser - Filesystem in Userspace (FUSE) for Rust - only for use in Mountpoint for Amazon S3"
 license = "MIT"
-repository = "https://github.com/cberner/fuser"
-documentation = "https://docs.rs/fuser"
-homepage = "https://github.com/cberner/fuser"
-version = "0.15.1"
+homepage = "https://github.com/awslabs/mountpoint-s3/tree/fuser/fork"
+version = "0.1.0"
 edition = "2021"
 readme = "README.md"
-authors = ["Christopher Berner <christopherberner@gmail.com>"]
 keywords = ["fuse", "filesystem", "system", "bindings"]
 categories = ["external-ffi-bindings", "api-bindings", "filesystem", "os::unix-apis"]
 build = "build.rs"
+
+[lib]
+name = "fuser"
 
 [dependencies]
 libc = "0.2.51"


### PR DESCRIPTION
**This is a "read only PR", not to be merged!**
Rename fork of FUSER library to `mountpoint-s3-fuser` for publishing.


### Next steps:
* We will cherry-pick this commit into the `fuser/fork` branch and push it into remote
* Update [publishing runbook](https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3-client/PUBLISHING_CRATES.md#publishing) by adding info about new crate
* Create a PR with re-vendored FUSER
* Publish `mountpoint-s3-fuser@0.1.0`.

### Does this change impact existing behavior?

No, this is an aux change

### Does this change need a changelog entry? Does it require a version change?

We set the version of the `mountpoint-s3-fuser` as `0.1.0` since this is now considered a new crate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
