### PR TITLE
Add network config to all component benchmarks

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -89,6 +89,12 @@ enum Client {
         key: String,
         #[arg(long, help = "AWS region", default_value = "us-east-1")]
         region: String,
+        #[clap(
+            long,
+            help = "One or more network interfaces to use when accessing S3. Requires Linux 5.7+ or running as root.",
+            value_name = "NETWORK_INTERFACE"
+        )]
+        bind: Option<Vec<String>>,
     },
     #[command(about = "Download a key from a mock S3 server")]
     Mock {
@@ -122,9 +128,17 @@ fn main() {
     let args = CliArgs::parse();
 
     match args.client {
-        Client::Real { bucket, key, region } => {
+        Client::Real {
+            bucket,
+            key,
+            region,
+            bind,
+        } => {
             let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&region));
             config = config.throughput_target_gbps(args.throughput_target_gbps);
+            if let Some(interfaces) = &bind {
+                config = config.network_interface_names(interfaces.clone());
+            }
             config = config.part_size(args.part_size);
             let client = S3CrtClient::new(config).expect("couldn't create client");
 

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -101,7 +101,12 @@ enum Client {
 struct CliArgs {
     #[command(subcommand)]
     client: Client,
-    #[arg(long, help = "Desired throughput in Gbps", default_value = "10.0")]
+    #[arg(
+        long,
+        help = "Desired throughput in Gbps",
+        default_value_t = 10.0,
+        visible_alias = "maximum-throughput-gbps"
+    )]
     throughput_target_gbps: f64,
     #[arg(long, help = "Part size for multi-part GET", default_value = "8388608")]
     part_size: usize,

--- a/mountpoint-s3-client/examples/download.rs
+++ b/mountpoint-s3-client/examples/download.rs
@@ -44,6 +44,15 @@ pub struct CliArgs {
     )]
     pub range: Option<Range<u64>>,
 
+    #[arg(
+        long,
+        help = "Configure S3 client's desired throughput in Gbps",
+        default_value_t = 10.0,
+        visible_alias = "maximum-throughput-gbps",
+        value_name = "GBPS"
+    )]
+    throughput_target_gbps: f64,
+
     #[clap(
         long,
         help = "One or more network interfaces to use when accessing S3. Requires Linux 5.7+ or running as root.",
@@ -90,6 +99,7 @@ fn main() {
     let mut config = S3ClientConfig::new();
 
     config = config.endpoint_config(EndpointConfig::new(region));
+    config = config.throughput_target_gbps(args.throughput_target_gbps);
     if let Some(interfaces) = &args.bind {
         config = config.network_interface_names(interfaces.clone());
     }

--- a/mountpoint-s3-client/examples/download.rs
+++ b/mountpoint-s3-client/examples/download.rs
@@ -43,22 +43,6 @@ pub struct CliArgs {
         value_parser = parse_range,
     )]
     pub range: Option<Range<u64>>,
-
-    #[arg(
-        long,
-        help = "Configure S3 client's desired throughput in Gbps",
-        default_value_t = 10.0,
-        visible_alias = "maximum-throughput-gbps",
-        value_name = "GBPS"
-    )]
-    throughput_target_gbps: f64,
-
-    #[clap(
-        long,
-        help = "One or more network interfaces to use when accessing S3. Requires Linux 5.7+ or running as root.",
-        value_name = "NETWORK_INTERFACE"
-    )]
-    pub bind: Option<Vec<String>>,
 }
 
 /// Empty error type, since we don't care too much for an example.
@@ -96,15 +80,8 @@ fn main() {
     let region = &args.region;
     let range = args.range;
 
-    let mut config = S3ClientConfig::new();
-
-    config = config.endpoint_config(EndpointConfig::new(region));
-    config = config.throughput_target_gbps(args.throughput_target_gbps);
-    if let Some(interfaces) = &args.bind {
-        config = config.network_interface_names(interfaces.clone());
-    }
-
-    let client = S3CrtClient::new(config).expect("couldn't create client");
+    let client = S3CrtClient::new(S3ClientConfig::new().endpoint_config(EndpointConfig::new(region)))
+        .expect("couldn't create client");
 
     let last_offset = Arc::new(Mutex::new(None));
     let last_offset_clone = Arc::clone(&last_offset);

--- a/mountpoint-s3-crt/examples/download_crt.rs
+++ b/mountpoint-s3-crt/examples/download_crt.rs
@@ -203,11 +203,11 @@ struct CliArgs {
     region: String,
     #[arg(
         long,
-        help = "max throughput (gigabits/second)",
+        help = "Target throughput (gigabits/second)",
         value_name = "GBPS",
-        default_value = "10.0"
+        visible_alias = "maximum-throughput-gbps"
     )]
-    maximum_throughput_gbps: f64,
+    throughput_target_gbps: f64,
     #[arg(long, help = "part size (bytes)", default_value = "8388608")]
     part_size: usize,
     #[clap(
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
 
     let config = CrtClientConfig {
         region: args.region,
-        throughput_target_gbps: args.maximum_throughput_gbps,
+        throughput_target_gbps: args.throughput_target_gbps,
         part_size: args.part_size,
         network_interface_names: args.bind,
     };

--- a/mountpoint-s3-crt/examples/download_crt.rs
+++ b/mountpoint-s3-crt/examples/download_crt.rs
@@ -79,6 +79,7 @@ struct CrtClientConfig {
     region: String,
     throughput_target_gbps: f64,
     part_size: usize,
+    network_interface_names: Option<Vec<String>>,
 }
 
 impl CrtClient {
@@ -123,6 +124,9 @@ impl CrtClient {
             .retry_strategy(retry_strategy);
         client_config.throughput_target_gbps(config.throughput_target_gbps);
         client_config.part_size(config.part_size);
+        if let Some(ref network_interface_names) = config.network_interface_names {
+            client_config.network_interface_names(network_interface_names.clone());
+        }
 
         let client = Client::new(&allocator, client_config)?;
 
@@ -206,6 +210,12 @@ struct CliArgs {
     maximum_throughput_gbps: f64,
     #[arg(long, help = "part size (bytes)", default_value = "8388608")]
     part_size: usize,
+    #[clap(
+        long,
+        help = "One or more network interfaces to use when accessing S3. Requires Linux 5.7+ or running as root.",
+        value_name = "NETWORK_INTERFACE"
+    )]
+    bind: Option<Vec<String>>,
     #[arg(long, help = "number of times to download", default_value = "1")]
     iterations: usize,
 }
@@ -220,6 +230,7 @@ fn main() -> anyhow::Result<()> {
         region: args.region,
         throughput_target_gbps: args.maximum_throughput_gbps,
         part_size: args.part_size,
+        network_interface_names: args.bind,
     };
     let client = CrtClient::new(config)?;
 

--- a/mountpoint-s3/examples/fs_benchmark.rs
+++ b/mountpoint-s3/examples/fs_benchmark.rs
@@ -49,7 +49,7 @@ pub struct CliArgs {
 
     #[clap(
         long,
-        help = "Target throughput in gibibits per second",
+        help = "Target throughput in gigabits per second",
         value_name = "N",
         value_parser = value_parser!(u64).range(1..),
         alias = "throughput-target-gbps",

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -55,7 +55,7 @@ pub struct CliArgs {
         value_parser = value_parser!(u64).range(1..),
         alias = "throughput-target-gbps",
     )]
-    pub maximum_throughput_gbps: Option<f64>,
+    pub maximum_throughput_gbps: Option<u64>,
 
     #[clap(
         long,
@@ -110,7 +110,7 @@ fn main() {
         .read_backpressure(true)
         .initial_read_window(initial_read_window_size);
     if let Some(throughput_target_gbps) = args.maximum_throughput_gbps {
-        config = config.throughput_target_gbps(throughput_target_gbps);
+        config = config.throughput_target_gbps(throughput_target_gbps as f64);
     }
     if let Some(part_size) = args.part_size {
         config = config.part_size(part_size as usize);

--- a/mountpoint-s3/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3/examples/prefetch_benchmark.rs
@@ -87,6 +87,13 @@ pub struct CliArgs {
 
     #[arg(long, help = "Number of concurrent downloads", default_value_t = 1, value_name = "N")]
     downloads: usize,
+
+    #[clap(
+        long,
+        help = "One or more network interfaces to use when accessing S3. Requires Linux 5.7+ or running as root.",
+        value_name = "NETWORK_INTERFACE"
+    )]
+    pub bind: Option<Vec<String>>,
 }
 
 fn main() {
@@ -107,6 +114,9 @@ fn main() {
     }
     if let Some(part_size) = args.part_size {
         config = config.part_size(part_size as usize);
+    }
+    if let Some(interfaces) = &args.bind {
+        config = config.network_interface_names(interfaces.clone());
     }
     let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
 


### PR DESCRIPTION
This change introduces both the CRT's target network throughput configuration and the network interface configuration to each of the benchmarks for layers/components in Mountpoint's read path.

These are added primarily to support performance investigations, so we can identify where there are gaps in performance and narrow them to improve throughput of Mountpoint overall.

The target throughput default of 10.0 Gbps is removed on the lowest level of the benchmark, given we don't know what the default is for the CRT itself. It is left in place on all other layers as we default the value to 10.0 Gbps inside Mountpoint's S3 client.

### Does this change impact existing behavior?

No, adds new arguments to benchmark scripts only. Even in those scripts, we alias any command line arguments that change.

### Does this change need a changelog entry? Does it require a version change?

No, this is benchmarking changes only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
