### PR TITLE
Add ability to specify multiple network interfaces to benchmark script

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -54,3 +54,34 @@ This will run the default experiment, including many different configuration com
 Output is written to `multirun/` within directories for the date, time, and experiment number run.
 The output directory includes a few different files from an individual experiment run,
 including the individual benchmark output `benchmark.log`, FIO output, and Mountpoint logs.
+
+## Advanced configuration
+
+### Configuring multiple network interfaces
+
+When investigating performance with multiple network cards,
+we need to tell Mountpoint about what network interfaces are available
+and even configure it with things like a 'target throughput'
+such that it allocates enough resources to maximize its utilisation of the available network bandwidth.
+
+Below shows how to configure two network cards:
+
+```sh
+uv run benchmark.py -- s3_bucket=amzn-s3-demo-bucket \
+    "network.interface_names=['eth0', 'eth1']" network.maximum_throughput_gbps=200
+```
+
+If you want to run experiments varying the interfaces provided to Mountpoint, you can vary it like below:
+
+```sh
+uv run benchmark.py -- s3_bucket=amzn-s3-demo-bucket \
+    "network.interface_names=['eth0'], ['eth0', 'eth1']" network.maximum_throughput_gbps=200
+```
+
+If you want to do specific combinations, you will need to create full dictionaries to vary values over.
+Below is an example of varying both network interfaces alongside the target network throughput.
+
+```sh
+uv run benchmark.py -- s3_bucket=amzn-s3-demo-bucket \
+    "network={interface_names:['eth0'],maximum_throughput_gbps:100},{interface_names:['eth0','eth1'],maximum_throughput_gbps:200}"
+```

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -118,6 +118,11 @@ def _mount_mp(
     if cfg['fuse_threads'] is not None:
         subprocess_args.append(f"--max-threads={cfg['fuse_threads']}")
 
+    for network_interface in cfg['network']['interface_names']:
+        subprocess_args.append(f"--bind={network_interface}")
+    if (max_throughput := cfg['network']['maximum_throughput_gbps']) is not None:
+        subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
+
     log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     try:
         output = subprocess.check_output(subprocess_args, env=subprocess_env)

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -19,6 +19,11 @@ mountpoint_binary: !!null
 mountpoint_debug: false
 mountpoint_debug_crt: false
 
+# No configuration out of the box, use defaults.
+network:
+  interface_names: !!null
+  maximum_throughput_gbps: !!null
+
 # For overriding upload checksums configured for Mountpoint. Passed as `--upload-checksums` argument.
 upload_checksums: !!null
 


### PR DESCRIPTION
To investigate multiple network card performance, we want to run experiments with and without multiple network cards. This change adds the ability to run the benchmark experiment runner and specify both network interfaces and the maximum network throughput parameter.

### Does this change impact existing behavior?

No Mountpoint behavior change, new feature on benchmark script only.

### Does this change need a changelog entry? Does it require a version change?

No, no Mountpoint change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
