### PR TITLE
Add FUSE background and congestion threshold config to benchmark script

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -123,6 +123,12 @@ def _mount_mp(
     if (max_throughput := cfg['network']['maximum_throughput_gbps']) is not None:
         subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
 
+    if cfg ['mountpoint_max_background'] is not None:
+        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(cfg['mountpoint_max_background'])
+
+    if cfg['mountpoint_congestion_threshold'] is not None:
+        subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(cfg["mountpoint_congestion_threshold"])
+
     log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     try:
         output = subprocess.check_output(subprocess_args, env=subprocess_env)

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -21,7 +21,7 @@ mountpoint_debug_crt: false
 
 # No configuration out of the box, use defaults.
 network:
-  interface_names: !!null
+  interface_names: []
   maximum_throughput_gbps: !!null
 
 # For overriding upload checksums configured for Mountpoint. Passed as `--upload-checksums` argument.

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -27,6 +27,11 @@ network:
 # For overriding upload checksums configured for Mountpoint. Passed as `--upload-checksums` argument.
 upload_checksums: !!null
 
+# For overriding fuse max_background and congestion threshold setttings
+# environment variables
+mountpoint_max_background: !!null
+mountpoint_congestion_threshold: !!null
+
 iterations: 1
 
 hydra:


### PR DESCRIPTION
To investigate Mountpoint performance, we want to run experiments with different FUSE max background and congestion threshold settings.

### Does this change impact existing behavior?

No Mountpoint behavior change, an update to benchmark script only.

### Does this change need a changelog entry? Does it require a version change?

No Mountpoint change

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
