### PR TITLE
Disallow append on non-express buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -892,6 +892,12 @@ where
 
     let (client, runtime, s3_personality) = client_builder(&args, &context_params)?;
 
+    if args.incremental_upload && !matches!(s3_personality, S3Personality::ExpressOneZone) {
+        return Err(anyhow!(
+            "--incremental-upload is only supported for S3 Express One Zone buckets"
+        ));
+    }
+
     let bucket_description = args.bucket_description();
     tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");
 

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -1498,4 +1498,14 @@ mod tests {
     fn test_creating_session_acl_from_mount_options(mount_options: &[MountOption], expected: fuser::SessionACL) {
         assert_eq!(expected, session_acl_from_mount_options(mount_options));
     }
+
+    #[test_case("test-bucket", S3Personality::Standard; "standard")]
+    #[test_case("bucket-base-name--usw2-az1--x-s3", S3Personality::ExpressOneZone; "directory")]
+    #[test_case("arn:aws:s3:region:111122223333:accesspoint/my-access-point", S3Personality::Standard; "access-point")]
+    #[test_case("arn:aws:s3-outposts:us-east-1:555555555555:outpost/outpost-id/accesspoint/accesspoint-name", S3Personality::Outposts; "outpotsts")]
+    fn test_infer_s3_personality(bucket_name: &str, expected_personality: S3Personality) {
+        let endpoint_config = EndpointConfig::new("PLACEHOLDER");
+        let s3_personality = infer_s3_personality(None, bucket_name, endpoint_config);
+        assert_eq!(s3_personality, expected_personality);
+    }
 }

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -151,7 +151,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
 
     #[clap(
         long,
-        help = "Enable incremental uploads and support for appending to existing objects",
+        help = "Enable incremental uploads and support for appending to existing objects. This is only supported on directory buckets in S3 Express One Zone.",
         help_heading = MOUNT_OPTIONS_HEADER,
     )]
     pub incremental_upload: bool,

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -892,14 +892,14 @@ where
 
     let (client, runtime, s3_personality) = client_builder(&args, &context_params)?;
 
-    if args.incremental_upload && !matches!(s3_personality, S3Personality::ExpressOneZone) {
-        return Err(anyhow!(
-            "--incremental-upload is only supported for S3 Express One Zone buckets"
-        ));
-    }
-
     let bucket_description = args.bucket_description();
     tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");
+
+    if args.incremental_upload && !s3_personality.supports_append() {
+        return Err(anyhow!(
+            "--incremental-upload is only supported on directory buckets in S3 Express One Zone"
+        ));
+    }
 
     let mut filesystem_config = S3FilesystemConfig::default();
     if let Some(uid) = args.uid {

--- a/mountpoint-s3-fs/src/s3.rs
+++ b/mountpoint-s3-fs/src/s3.rs
@@ -5,7 +5,7 @@
 ///
 /// This enum intentionally doesn't implement PartialEq/Eq. You shouldn't test it directly. Instead,
 /// use its methods like `is_list_ordered` to check the actual behavior you're looking for.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum S3Personality {
     #[default]
     Standard,

--- a/mountpoint-s3-fs/src/s3.rs
+++ b/mountpoint-s3-fs/src/s3.rs
@@ -29,4 +29,12 @@ impl S3Personality {
             S3Personality::Outposts => false,
         }
     }
+
+    pub fn supports_append(&self) -> bool {
+        match self {
+            S3Personality::Standard => false,
+            S3Personality::ExpressOneZone => true,
+            S3Personality::Outposts => false,
+        }
+    }
 }

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Reduce memory usage when using the `--prefix` flag. ([#1303](https://github.com/awslabs/mountpoint-s3/pull/1303))
 * Add support for endpoint override in credential providers. ([aws-c-auth#263](https://github.com/awslabs/aws-c-auth/pull/263/))
 
+### Breaking changes
+
+* Disallow the usage of `--incremental-upload` command-line argument on non S3 Express buckets ([#1297](https://github.com/awslabs/mountpoint-s3/pull/1297)).
+
 ## v1.15.0 (February 27, 2025)
 
 ### New features

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking changes
 
-* Disallow the usage of `--incremental-upload` command-line argument on non S3 Express buckets ([#1297](https://github.com/awslabs/mountpoint-s3/pull/1297)).
+* Disallow the usage of `--incremental-upload` command-line argument on non S3 Express buckets. ([#1297](https://github.com/awslabs/mountpoint-s3/pull/1297))
 
 ## v1.15.0 (February 27, 2025)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "1.15.1"
+version = "1.16.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Fail early (on mount) with a descriptive error message, when `--incremental-upload` flag is used with standard buckets. We've seen in https://github.com/awslabs/mountpoint-s3/issues/1268 when an error reported on flush can be ignored by certain workloads.
___
Decision is made based on endpoint resolution [infer_s3_personality](https://github.com/awslabs/mountpoint-s3/blob/0c51de8dbd7f57d1a368ddcf522d09c7d89ecd34/mountpoint-s3/src/cli.rs#L1370). This may erroneously assume that the bucket is S3 Standard if either endpoint resolution failed or `auth_scheme` can not be parsed. In case of an error user may bypass it by specifying `--bucket-type=directory` flag. 

As an alternative, we can infer if the bucket is a directory bucket from the name: [docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html). Then we can assume that all directory buckets support `--incremental-upload`.

### Does this change impact existing behavior?

Yes, `mount-s3 s3-standard-bucket <folder> --incremental-upload` will start failing on mount.

### Does this change need a changelog entry? Does it require a version change?

Yes, added.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
