### PR TITLE
Add Python lints to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,3 +308,46 @@ jobs:
         uses: actions/checkout@v4
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v2
+
+
+  benchmark-script-checks:
+    name: Benchmark script checks
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./benchmark/
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "./benchmark/.python-version"
+      - name: Format check
+        # TODO: Remove preservation of quote style
+        run: uvx ruff format --diff . --config "format.quote-style='preserve'"
+      - name: Lint check
+        run: uvx ruff check --output-format=github .
+
+
+  package-script-checks:
+    name: Packaging script checks
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./package/
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Format check
+        run: uvx ruff format --diff .
+      - name: Lint check
+        run: uvx ruff check --output-format=github .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -327,8 +327,7 @@ jobs:
         with:
           python-version-file: "./benchmark/.python-version"
       - name: Format check
-        # TODO: Remove preservation of quote style
-        run: uvx ruff format --diff . --config "format.quote-style='preserve'"
+        run: uvx ruff format --diff .
       - name: Lint check
         run: uvx ruff check --output-format=github .
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -13,7 +13,7 @@ import urllib.request
 import hydra
 from omegaconf import DictConfig
 
-logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
+logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
 
 log = logging.getLogger(__name__)
 
@@ -73,9 +73,7 @@ def _mount_mp(
 
     bucket = cfg['s3_bucket']
 
-    mountpoint_version_output = subprocess.check_output(
-        [*mountpoint_args, "--version"]
-    ).decode("utf-8")
+    mountpoint_version_output = subprocess.check_output([*mountpoint_args, "--version"]).decode("utf-8")
     log.info("Mountpoint version: %s", mountpoint_version_output.strip())
 
     subprocess_args = [
@@ -119,20 +117,12 @@ def _mount_mp(
         subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
 
     if cfg['mountpoint_max_background'] is not None:
-        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(
-            cfg['mountpoint_max_background']
-        )
+        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(cfg['mountpoint_max_background'])
 
     if cfg['mountpoint_congestion_threshold'] is not None:
-        subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(
-            cfg["mountpoint_congestion_threshold"]
-        )
+        subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(cfg["mountpoint_congestion_threshold"])
 
-    log.info(
-        f"Mounting S3 bucket {bucket} with args: %s; env: %s",
-        subprocess_args,
-        subprocess_env,
-    )
+    log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     try:
         output = subprocess.check_output(subprocess_args, env=subprocess_env)
     except subprocess.CalledProcessError as e:
@@ -204,9 +194,7 @@ def _collect_logs() -> None:
         log.debug(f"No Mountpoint log files in directory {logs_directory}")
         return
 
-    assert len(dir_entries) <= 1, (
-        f"Expected no more than one log file in {logs_directory}",
-    )
+    assert len(dir_entries) <= 1, f"Expected no more than one log file in {logs_directory}"
 
     old_log_dir = path.join(logs_directory, dir_entries[0])
     new_log_path = "mountpoint-s3.log"
@@ -236,12 +224,7 @@ def _get_ec2_instance_id() -> Optional[str]:
         token = token_response.read().decode()
 
     metadata_url = "http://169.254.169.254/latest/meta-data/instance-id"
-    metadata_request = urllib.request.Request(
-        metadata_url,
-        headers={
-            "X-aws-ec2-metadata-token": token,
-        },
-    )
+    metadata_request = urllib.request.Request(metadata_url, headers={"X-aws-ec2-metadata-token": token})
     with urllib.request.urlopen(metadata_request) as metadata_response:
         instance_id = metadata_response.read().decode()
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -13,9 +13,7 @@ import urllib.request
 import hydra
 from omegaconf import DictConfig
 
-logging.basicConfig(
-    level=os.environ.get('LOGLEVEL', 'INFO').upper()
-)
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
 
 log = logging.getLogger(__name__)
 
@@ -25,8 +23,8 @@ MP_LOGS_DIRECTORY = "mp_logs/"
 
 @contextmanager
 def _mounted_bucket(
-        cfg: DictConfig,
-        ):
+    cfg: DictConfig,
+):
     """
     Mounts the S3 bucket, providing metadata about the successful mount.
 
@@ -42,7 +40,7 @@ def _mounted_bucket(
             log.debug(f"{mount_dir} unmounted")
             os.rmdir(mount_dir)
         except Exception:
-            log.error(f"Error cleaning up Mountpoint at {mount_dir}:",  exc_info=True)
+            log.error(f"Error cleaning up Mountpoint at {mount_dir}:", exc_info=True)
 
 
 class MountError(Exception):
@@ -50,9 +48,9 @@ class MountError(Exception):
 
 
 def _mount_mp(
-        cfg: DictConfig,
-        mount_dir: str,
-        ) -> dict[str, any] | MountError | subprocess.CalledProcessError:
+    cfg: DictConfig,
+    mount_dir: str,
+) -> dict[str, any] | MountError | subprocess.CalledProcessError:
     """
     Mount an S3 bucket using Mountpoint,
     using the configuration to apply Mountpoint arguments.
@@ -75,12 +73,9 @@ def _mount_mp(
 
     bucket = cfg['s3_bucket']
 
-    mountpoint_version_output = subprocess \
-        .check_output([
-            *mountpoint_args,
-            "--version"
-            ]) \
-        .decode("utf-8")
+    mountpoint_version_output = subprocess.check_output(
+        [*mountpoint_args, "--version"]
+    ).decode("utf-8")
     log.info("Mountpoint version: %s", mountpoint_version_output.strip())
 
     subprocess_args = [
@@ -124,12 +119,20 @@ def _mount_mp(
         subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
 
     if cfg['mountpoint_max_background'] is not None:
-        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(cfg['mountpoint_max_background'])
+        subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(
+            cfg['mountpoint_max_background']
+        )
 
     if cfg['mountpoint_congestion_threshold'] is not None:
-        subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(cfg["mountpoint_congestion_threshold"])
+        subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(
+            cfg["mountpoint_congestion_threshold"]
+        )
 
-    log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
+    log.info(
+        f"Mounting S3 bucket {bucket} with args: %s; env: %s",
+        subprocess_args,
+        subprocess_env,
+    )
     try:
         output = subprocess.check_output(subprocess_args, env=subprocess_env)
     except subprocess.CalledProcessError as e:
@@ -201,7 +204,9 @@ def _collect_logs() -> None:
         log.debug(f"No Mountpoint log files in directory {logs_directory}")
         return
 
-    assert len(dir_entries) <= 1, f"Expected no more than one log file in {logs_directory}"
+    assert len(dir_entries) <= 1, (
+        f"Expected no more than one log file in {logs_directory}",
+    )
 
     old_log_dir = path.join(logs_directory, dir_entries[0])
     new_log_path = "mountpoint-s3.log"
@@ -231,7 +236,12 @@ def _get_ec2_instance_id() -> Optional[str]:
         token = token_response.read().decode()
 
     metadata_url = "http://169.254.169.254/latest/meta-data/instance-id"
-    metadata_request = urllib.request.Request(metadata_url, headers={"X-aws-ec2-metadata-token": token})
+    metadata_request = urllib.request.Request(
+        metadata_url,
+        headers={
+            "X-aws-ec2-metadata-token": token,
+        },
+    )
     with urllib.request.urlopen(metadata_request) as metadata_response:
         instance_id = metadata_response.read().decode()
 

--- a/package/validate/validate.py
+++ b/package/validate/validate.py
@@ -58,29 +58,10 @@ def validate(args: argparse.Namespace) -> str:
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument(
-        "--version",
-        help="the version number for the Mountpoint release",
-        required=True,
-    )
-    p.add_argument(
-        "--arch",
-        help="the architecture to validate",
-        required=True,
-        choices=["x86_64", "arm64"],
-    )
-    p.add_argument(
-        "--artifact",
-        help="the artifact to validate",
-        required=True,
-        choices=["deb", "rpm", "gzip"],
-    )
-    p.add_argument(
-        "--os",
-        help="the OS to validate on",
-        required=True,
-        choices=["ubuntu", "al2", "suse"],
-    )
+    p.add_argument("--version", help="the version number for the Mountpoint release", required=True)
+    p.add_argument("--arch", help="the architecture to validate", required=True, choices=["x86_64", "arm64"])
+    p.add_argument("--artifact", help="the artifact to validate", required=True, choices=["deb", "rpm", "gzip"])
+    p.add_argument("--os", help="the OS to validate on", required=True, choices=["ubuntu", "al2", "suse"])
     p.add_argument("--bucket", help="the public bucket to mount", required=True)
 
     args = p.parse_args()

--- a/package/validate/validate.py
+++ b/package/validate/validate.py
@@ -10,10 +10,11 @@ import argparse
 import os
 import subprocess
 
+
 def validate(args: argparse.Namespace) -> str:
     """Top-level driver."""
 
-    package=f"{args.artifact}-{args.os}"
+    package = f"{args.artifact}-{args.os}"
     if package == "deb-ubuntu":
         image = "public.ecr.aws/ubuntu/ubuntu:20.04"
     elif package == "rpm-al2" or package == "gzip-al2":
@@ -21,7 +22,9 @@ def validate(args: argparse.Namespace) -> str:
     elif package == "rpm-suse":
         image = "registry.suse.com/bci/bci-base:15.6"
     else:
-        raise Exception(f"unsupported OS {args.os} for {args.artifact}. Supported combinations are: deb-ubuntu, rpm-al2, gzip-al2, rpm-suse")
+        raise Exception(
+            f"unsupported OS {args.os} for {args.artifact}. Supported combinations are: deb-ubuntu, rpm-al2, gzip-al2, rpm-suse"
+        )
 
     print("Validating Mountpoint Release Package")
     print(f"\tVersion: {args.version}")
@@ -35,25 +38,49 @@ def validate(args: argparse.Namespace) -> str:
     scripts_dir = os.path.dirname(os.path.realpath(__file__))
 
     subprocess.run(["docker", "pull", image])
-    subprocess.run(["docker",
-                    "run",
-                    "--rm",
-                    "--cap-add=SYS_ADMIN",
-                    "--device=/dev/fuse",
-                    f"-v={scripts_dir}:/scripts",
-                    f"--env=ARCH={args.arch}",
-                    f"--env=VERSION={args.version}",
-                    f"--env=BUCKET={args.bucket}",
-                    image,
-                    "/bin/bash",
-                    f"/scripts/{validate_script}"])
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--cap-add=SYS_ADMIN",
+            "--device=/dev/fuse",
+            f"-v={scripts_dir}:/scripts",
+            f"--env=ARCH={args.arch}",
+            f"--env=VERSION={args.version}",
+            f"--env=BUCKET={args.bucket}",
+            image,
+            "/bin/bash",
+            f"/scripts/{validate_script}",
+        ]
+    )
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument("--version", help="the version number for the Mountpoint release", required=True)
-    p.add_argument("--arch", help="the architecture to validate", required=True, choices=["x86_64", "arm64"])
-    p.add_argument("--artifact", help="the artifact to validate", required=True, choices=["deb", "rpm", "gzip"])
-    p.add_argument("--os", help="the OS to validate on", required=True, choices=["ubuntu", "al2", "suse"])
+    p.add_argument(
+        "--version",
+        help="the version number for the Mountpoint release",
+        required=True,
+    )
+    p.add_argument(
+        "--arch",
+        help="the architecture to validate",
+        required=True,
+        choices=["x86_64", "arm64"],
+    )
+    p.add_argument(
+        "--artifact",
+        help="the artifact to validate",
+        required=True,
+        choices=["deb", "rpm", "gzip"],
+    )
+    p.add_argument(
+        "--os",
+        help="the OS to validate on",
+        required=True,
+        choices=["ubuntu", "al2", "suse"],
+    )
     p.add_argument("--bucket", help="the public bucket to mount", required=True)
 
     args = p.parse_args()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 120
+
+[format]
+# TODO: Remove this relaxation later.
+quote-style = 'preserve'


### PR DESCRIPTION
Before this change, there is no linting or style checks enforced on Python code outside of manual review.

This change introduces both using [Ruff](https://docs.astral.sh/ruff/), a linter/checker written by the same organization owning [uv](https://docs.astral.sh/uv/) which we use as the package manager/runner in `benchmark/` project.

### Does this change impact existing behavior?

No change to Mountpoint. No functional changes to the Python scripts. Two new GitHub CI jobs are introduced to add checks on the Python code.

### Does this change need a changelog entry? Does it require a version change?

No, no impact to Mountpoint itself nor its crates.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
