### PR TITLE
Remove prefix from inodes

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other changes
+
+* Reduce memory usage when using the `--prefix` flag. ([#1303](https://github.com/awslabs/mountpoint-s3/pull/1303))
+
 ## v1.15.0 (February 27, 2025)
 
 ### New features

--- a/mountpoint-s3/examples/upload_benchmark.rs
+++ b/mountpoint-s3/examples/upload_benchmark.rs
@@ -162,7 +162,7 @@ where
 
     let bucket = args.bucket.clone();
     let key = args.key.clone();
-    let mut upload_request = uploader.start_atomic_upload(&bucket, &key).unwrap();
+    let mut upload_request = uploader.start_atomic_upload(bucket, key).unwrap();
 
     let mut total_bytes_written = 0;
     let target_size = args.object_size;

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -421,7 +421,7 @@ where
         };
 
         let inode = lookup.inode.clone();
-        let full_key = lookup.inode.full_key().to_owned();
+        let full_key = self.superblock.full_key_for_inode(&inode);
         let handle = FileHandle {
             inode,
             full_key,

--- a/mountpoint-s3/src/fs.rs
+++ b/mountpoint-s3/src/fs.rs
@@ -63,8 +63,6 @@ where
     prefetcher: Prefetcher,
     uploader: Uploader<Client>,
     bucket: String,
-    #[allow(unused)]
-    prefix: Prefix,
     next_handle: AtomicU64,
     dir_handles: AsyncRwLock<HashMap<u64, Arc<DirHandle>>>,
     file_handles: AsyncRwLock<HashMap<u64, Arc<FileHandle<Client, Prefetcher>>>>,
@@ -186,7 +184,6 @@ where
             prefetcher,
             uploader,
             bucket: bucket.to_string(),
-            prefix: prefix.clone(),
             next_handle: AtomicU64::new(1),
             dir_handles: AsyncRwLock::new(HashMap::new()),
             file_handles: AsyncRwLock::new(HashMap::new()),

--- a/mountpoint-s3/src/fs/handles.rs
+++ b/mountpoint-s3/src/fs/handles.rs
@@ -99,7 +99,7 @@ where
         let write_mode = fs.config.write_mode();
         let handle = fs.superblock.write(&fs.client, ino, &write_mode, is_truncate).await?;
         let bucket = &fs.bucket;
-        let key = lookup.inode.full_key();
+        let key = fs.superblock.full_key_for_inode(&lookup.inode);
         let handle = if write_mode.incremental_upload {
             let initial_etag = if is_truncate {
                 None
@@ -107,12 +107,9 @@ where
                 lookup.stat.etag.as_ref().map(|e| e.into())
             };
             let current_offset = if is_truncate { 0 } else { lookup.stat.size as u64 };
-            let request = fs.uploader.start_incremental_upload(
-                bucket.to_owned(),
-                key.to_owned(),
-                current_offset,
-                initial_etag.clone(),
-            );
+            let request =
+                fs.uploader
+                    .start_incremental_upload(bucket.to_owned(), key, current_offset, initial_etag.clone());
             FileHandleState::Write(UploadState::AppendInProgress {
                 request,
                 handle,
@@ -122,7 +119,7 @@ where
         } else {
             let request = fs
                 .uploader
-                .start_atomic_upload(bucket, key)
+                .start_atomic_upload(bucket, &key)
                 .map_err(|e| err!(libc::EIO, source:e, "put failed to start"))?;
             FileHandleState::Write(UploadState::MPUInProgress { request, handle })
         };
@@ -141,7 +138,7 @@ where
             ));
         }
         let handle = fs.superblock.read(&fs.client, lookup.inode.ino()).await?;
-        let full_key = lookup.inode.full_key().to_owned();
+        let full_key = fs.superblock.full_key_for_inode(&lookup.inode);
         let object_size = lookup.stat.size as u64;
         let etag = match &lookup.stat.etag {
             None => return Err(err!(libc::EBADF, "no E-Tag for inode {}", lookup.inode.ino())),

--- a/mountpoint-s3/src/superblock/inode.rs
+++ b/mountpoint-s3/src/superblock/inode.rs
@@ -10,6 +10,7 @@ use mountpoint_s3_client::types::{ETag, RestoreStatus};
 use time::OffsetDateTime;
 use tracing::trace;
 
+use crate::prefix::Prefix;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -34,7 +35,8 @@ struct InodeInner {
     parent: InodeNo,
     name: String,
     // TODO deduplicate keys by string interning or something -- many keys will have common prefixes
-    full_key: String,
+    /// Object key not including the prefix.
+    key: String,
     kind: InodeKind,
     checksum: Crc32c,
 
@@ -68,8 +70,8 @@ impl Inode {
         self.inner.kind
     }
 
-    pub fn full_key(&self) -> &str {
-        &self.inner.full_key
+    pub fn key(&self) -> &str {
+        &self.inner.key
     }
 
     /// Increment lookup count for [Inode] by 1, returning the new value.
@@ -137,17 +139,18 @@ impl Inode {
         ino: InodeNo,
         parent: InodeNo,
         name: String,
-        full_key: String,
+        key: String,
+        prefix: &Prefix,
         kind: InodeKind,
         state: InodeState,
     ) -> Self {
-        let checksum = Self::compute_checksum(ino, &full_key);
+        let checksum = Self::compute_checksum(ino, prefix, &key);
         let sync = RwLock::new(state);
         let inner = InodeInner {
             ino,
             parent,
             name,
-            full_key,
+            key,
             kind,
             checksum,
             sync,
@@ -156,10 +159,11 @@ impl Inode {
     }
 
     /// Create the root inode.
-    pub(super) fn new_root(prefix: String, mount_time: OffsetDateTime) -> Self {
+    pub(super) fn new_root(prefix: &Prefix, mount_time: OffsetDateTime) -> Self {
         Self::new(
             ROOT_INODE_NO,
             ROOT_INODE_NO,
+            String::new(),
             String::new(),
             prefix,
             InodeKind::Directory,
@@ -176,8 +180,8 @@ impl Inode {
     }
 
     /// Verify [Inode] has the expected inode number and the inode content is valid for its checksum.
-    pub fn verify_inode(&self, expected_ino: InodeNo) -> Result<(), InodeError> {
-        let computed = Self::compute_checksum(self.ino(), self.full_key());
+    pub fn verify_inode(&self, expected_ino: InodeNo, prefix: &Prefix) -> Result<(), InodeError> {
+        let computed = Self::compute_checksum(self.ino(), prefix, self.key());
         if computed == self.inner.checksum && self.ino() == expected_ino {
             Ok(())
         } else {
@@ -187,8 +191,13 @@ impl Inode {
 
     /// Verify [Inode] has the expected inode number, expected parent inode number,
     /// and the inode's content is valid for its checksum.
-    pub fn verify_child(&self, expected_parent: InodeNo, expected_name: &str) -> Result<(), InodeError> {
-        let computed = Self::compute_checksum(self.ino(), self.full_key());
+    pub fn verify_child(
+        &self,
+        expected_parent: InodeNo,
+        expected_name: &str,
+        prefix: &Prefix,
+    ) -> Result<(), InodeError> {
+        let computed = Self::compute_checksum(self.ino(), prefix, self.key());
         if computed == self.inner.checksum && self.parent() == expected_parent && self.name() == expected_name {
             Ok(())
         } else {
@@ -196,10 +205,11 @@ impl Inode {
         }
     }
 
-    fn compute_checksum(ino: InodeNo, full_key: &str) -> Crc32c {
+    fn compute_checksum(ino: InodeNo, prefix: &Prefix, key: &str) -> Crc32c {
         let mut hasher = crc32c::Hasher::new();
         hasher.update(ino.to_be_bytes().as_ref());
-        hasher.update(full_key.as_bytes());
+        hasher.update(prefix.as_str().as_bytes());
+        hasher.update(key.as_bytes());
         hasher.finalize()
     }
 
@@ -228,7 +238,7 @@ pub struct InodeErrorInfo(Inode);
 
 impl Display for InodeErrorInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} (full key {:?})", self.0.ino(), self.0.full_key())
+        write!(f, "{} (key {:?})", self.0.ino(), self.0.key())
     }
 }
 
@@ -590,6 +600,7 @@ mod tests {
             ROOT_INODE_NO,
             inode_name.to_owned(),
             inode_name.to_owned(),
+            &superblock.inner.prefix,
             InodeKind::File,
             InodeState {
                 write_status: WriteStatus::Remote,
@@ -721,7 +732,7 @@ mod tests {
                 ino: 42,
                 parent: parent_ino,
                 name: file_name.into(),
-                full_key: file_name.into(),
+                key: file_name.into(),
                 kind: InodeKind::File,
                 checksum: bad_checksum,
                 sync: RwLock::new(InodeState {
@@ -774,6 +785,7 @@ mod tests {
         let inode_name = "made-up-inode";
         let mut hasher = crc32c::Hasher::new();
         hasher.update(ino.to_be_bytes().as_ref());
+        hasher.update(superblock.inner.prefix.as_str().as_bytes());
         hasher.update(inode_name.as_bytes());
         let checksum = hasher.finalize();
         let inode = Inode {
@@ -781,7 +793,7 @@ mod tests {
                 ino,
                 parent: ROOT_INODE_NO,
                 name: inode_name.to_owned(),
-                full_key: inode_name.to_owned(),
+                key: inode_name.to_owned(),
                 kind: InodeKind::File,
                 checksum,
                 sync: RwLock::new(InodeState {

--- a/mountpoint-s3/src/superblock/inode.rs
+++ b/mountpoint-s3/src/superblock/inode.rs
@@ -35,7 +35,7 @@ struct InodeInner {
     parent: InodeNo,
     name: String,
     // TODO deduplicate keys by string interning or something -- many keys will have common prefixes
-    /// Object key not including the prefix.
+    /// Object key not including the prefix (ends in '/' for directories).
     key: String,
     kind: InodeKind,
     checksum: Crc32c,

--- a/mountpoint-s3/src/upload.rs
+++ b/mountpoint-s3/src/upload.rs
@@ -93,12 +93,12 @@ where
     /// Start a new atomic upload.
     pub fn start_atomic_upload(
         &self,
-        bucket: &str,
-        key: &str,
+        bucket: String,
+        key: String,
     ) -> Result<UploadRequest<Client>, UploadError<Client::ClientError>> {
         let params = UploadRequestParams {
-            bucket: bucket.to_owned(),
-            key: key.to_owned(),
+            bucket,
+            key,
             server_side_encryption: self.server_side_encryption.clone(),
             default_checksum_algorithm: self.default_checksum_algorithm.clone(),
             storage_class: self.storage_class.clone(),

--- a/mountpoint-s3/src/upload/atomic.rs
+++ b/mountpoint-s3/src/upload/atomic.rs
@@ -247,7 +247,7 @@ mod tests {
             ..Default::default()
         }));
         let uploader = new_uploader_for_test(client.clone(), None, ServerSideEncryption::default(), true);
-        let mut request = uploader.start_atomic_upload(bucket, key).unwrap();
+        let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
         _ = request.write(0, &[]).await.unwrap();
 
@@ -279,7 +279,7 @@ mod tests {
             true,
         );
 
-        let mut request = uploader.start_atomic_upload(bucket, key).unwrap();
+        let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
         let data = b"foo";
         let mut offset = 0;
@@ -330,7 +330,7 @@ mod tests {
 
         // First request fails on first write.
         {
-            let mut request = uploader.start_atomic_upload(bucket, key).unwrap();
+            let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
             let data = b"foo";
             request.write(0, data).await.expect_err("first write should fail");
@@ -340,7 +340,7 @@ mod tests {
 
         // Second request fails on complete (after one write).
         {
-            let mut request = uploader.start_atomic_upload(bucket, key).unwrap();
+            let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
             let data = b"foo";
             _ = request.write(0, data).await.unwrap();
@@ -368,7 +368,7 @@ mod tests {
             ..Default::default()
         }));
         let uploader = new_uploader_for_test(client.clone(), None, ServerSideEncryption::default(), true);
-        let mut request = uploader.start_atomic_upload(bucket, key).unwrap();
+        let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
         let successful_writes = PART_SIZE * MAX_S3_MULTIPART_UPLOAD_PARTS / write_size;
         let data = vec![0xaa; write_size];
@@ -407,7 +407,7 @@ mod tests {
             .server_side_encryption
             .corrupt_data(sse_type_corrupted.map(String::from), key_id_corrupted.map(String::from));
         let err = uploader
-            .start_atomic_upload("bucket", "hello")
+            .start_atomic_upload("bucket".to_owned(), "hello".to_owned())
             .expect_err("sse checksum must be checked");
         assert!(matches!(
             err,
@@ -433,7 +433,7 @@ mod tests {
             true,
         );
         uploader
-            .start_atomic_upload(bucket, key)
+            .start_atomic_upload(bucket.to_owned(), key.to_owned())
             .expect("put with sse should succeed");
     }
 }


### PR DESCRIPTION
When Mountpoint is configured with the `--prefix` flag, all S3 requests contain the specified prefix as part of the key. Currently, the prefix is duplicated in each `Inode` entry in the `full_key` field. This change remove the unnecessary duplication by only storing the partial `key` and reconstructing the `full_key` by adding the prefix before performing any S3 request.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

`mountpoint-s3` changelog entry. No version change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
