### PR TITLE
Prevent failures in benchmark actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -80,7 +80,7 @@ jobs:
         # This is default value, just make it more explicit
         benchmark-data-dir-path: dev/bench
         alert-threshold: "200%"
-        fail-on-alert: true
+        fail-on-alert: false
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes
@@ -163,7 +163,7 @@ jobs:
         output-file-path: results/output.json
         benchmark-data-dir-path: dev/latency_bench
         alert-threshold: "200%"
-        fail-on-alert: true
+        fail-on-alert: false
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes
@@ -231,7 +231,7 @@ jobs:
         output-file-path: results/output.json
         benchmark-data-dir-path: dev/cache_bench
         alert-threshold: "200%"
-        fail-on-alert: true
+        fail-on-alert: false
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -79,7 +79,7 @@ jobs:
         output-file-path: results/output.json
         benchmark-data-dir-path: dev/s3-express/bench
         alert-threshold: "200%"
-        fail-on-alert: true
+        fail-on-alert: false
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes
@@ -162,7 +162,7 @@ jobs:
         output-file-path: results/output.json
         benchmark-data-dir-path: dev/s3-express/latency_bench
         alert-threshold: "200%"
-        fail-on-alert: true
+        fail-on-alert: false
         # GitHub API token to make a commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes


### PR DESCRIPTION
Benchmarks currently fail when recording a worse than 2x regression. However, failed runs are not included in the workflow summary or in the [performance charts](https://github.com/awslabs/mountpoint-s3/blob/main/doc/BENCHMARKING.md). With this change, a regression will only result in an alert, and not lead to an action failure.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
