### PR TITLE
Pin the ring crate version as version 0.17.13 breaks build on cloud

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
+ "ring",
  "serde",
  "serde_json",
  "serial_test",
@@ -3353,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -34,6 +34,7 @@ metrics = "0.24.1"
 nix = { version = "0.29.0", default-features = false, features = ["fs", "process", "signal", "user"] }
 owo-colors = { version = "4.1.0", features = ["supports-colors"] }
 rand = "0.8.5"
+ring = "=0.17.12"
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"


### PR DESCRIPTION
We pin `ring = "=0.17.12"` because the latest version ring = "=0.17.13" breaks the build on Cloud Desktops.
Update was done previously because we'd want to eliminate vulnerabilities.
Pinned version is also fine from RustSec point of view ((link)[https://rustsec.org/advisories/RUSTSEC-2025-0009.html])

### Does this change impact existing behavior?
This change does not impact the current behavior 

### Does this change need a changelog entry? Does it require a version change?
No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
