### PR TITLE
Set "ring" version to "0.17.12"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",


### PR DESCRIPTION
We set `ring = "=0.17.12"` because the latest version ring = "=0.17.13" has the [issue](https://github.com/briansmith/ring/issues/2463) with old GNU builds.

`ring` is a test dependency of Mountpoint. Update was done previously in this [PR](https://github.com/awslabs/mountpoint-s3/pull/1306/files) to address vulnerability warnings.
Pinned version is also fine from RustSec point of view ([link](https://rustsec.org/advisories/RUSTSEC-2025-0009.html))

### Does this change impact existing behavior?
This change does not impact the current behavior 

### Does this change need a changelog entry? Does it require a version change?
No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
