### PR TITLE
Update versions of published crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.1" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.13.0" }
 
 async-trait = "0.1.85"
 auto_impl = "1.2.1"

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.12.1" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.13.0" }
 
 futures = "0.3.31"
 libc = "0.2.169"

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-fs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.0" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.1" }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.13.1" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }


### PR DESCRIPTION
As we released dependencies' crates we bump their current versions.

Tags were created:
* `mountpoint-crt-sys-0.12.1`
* `mountpoint-crt-0.12.1`
* `mountpoint-crt-client-0.13.1`
* `mountpoint-crt-fs-0.1.0`

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

Versions were bumped, change logs do not require updating.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
