### PR TITLE
Add compile-time flag to stub FS read handler for performance testing

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -128,6 +128,17 @@ def _mount_mp(
     if cfg['mountpoint_congestion_threshold'] is not None:
         subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(cfg["mountpoint_congestion_threshold"])
 
+    stub_mode = str(cfg["stub_mode"]).lower()
+    if stub_mode != "off" and cfg["mountpoint_binary"] is not None:
+        raise ValueError("Cannot use `stub_mode` with `mountpoint_binary`, `stub_mode` requires recompilation")
+    match stub_mode:
+        case "off":
+            pass
+        case "fs_handler":
+            subprocess_env["MOUNTPOINT_BUILD_STUB_FS_HANDLER"] = "1"
+        case _:
+            raise ValueError(f"Unknown stub_mode: {stub_mode}")
+
     log.info(f"Mounting S3 bucket {bucket} with args: %s; env: %s", subprocess_args, subprocess_env)
     try:
         output = subprocess.check_output(subprocess_args, env=subprocess_env)

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -36,6 +36,9 @@ mountpoint_congestion_threshold: !!null
 # For monitoring network bandwidth
 with_bwm: false
 
+# Works automatically ONLY where this script manages compilation. It has no effect if `mountpoint_binary` is set.
+stub_mode: "off" # fs_handler
+
 iterations: 1
 
 # Define defaults for these columns, but script will run as MULTIRUN by default

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -452,6 +452,13 @@ where
             size
         );
 
+        if option_env!("MOUNTPOINT_BUILD_STUB_FS_HANDLER").is_some() {
+            // This compile-time configuration allows us to return simply zeroes to FUSE,
+            // allowing us to remove Mountpoint's logic from the loop and compare performance
+            // with and without the rest of Mountpoint's logic (such as file handle interaction, prefetcher, etc.).
+            return Ok(vec![0u8; size as usize].into());
+        }
+
         let handle = {
             let file_handles = self.file_handles.read().await;
             match file_handles.get(&fh) {


### PR DESCRIPTION
This change adds an environment variable that allows Mountpoint to return zeroed bytes when reading instead of going to S3. This is useful for determining the maximum throughput possible between the client application and Mountpoint's filesystem handlers, omitting major components like file handles, prefetcher, and network calls to S3.

### Does this change impact existing behavior?

No existing behavior change.

### Does this change need a changelog entry? Does it require a version change?

No, benchmarking change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
