### PR TITLE
Add mock-mount-s3 to benchmark/ scripts

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -76,9 +76,11 @@ def _mount_mp(
         ]
 
         if stub_mode == "s3_client":
+            # `mock-mount-s3` requires bucket to be prefixed with `sthree-` to verify we're not actually reaching S3
             logging.debug("using mock-mount-s3 due to `stub_mode`, bucket will be prefixed with \"sthree-\"")
-            mountpoint_args.append("--bin=mock-mount-s3")
             bucket = f"sthree-{cfg['s3_bucket']}"
+
+            mountpoint_args.append("--bin=mock-mount-s3")
 
         # End Cargo command, begin passing arguments to Mountpoint
         mountpoint_args.append("--")

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -63,6 +63,8 @@ def _mount_mp(
 
     Returns Mountpoint version string.
     """
+    bucket = cfg['s3_bucket']
+    stub_mode = str(cfg["stub_mode"]).lower()
 
     if cfg['mountpoint_binary'] is None:
         mountpoint_args = [
@@ -70,14 +72,20 @@ def _mount_mp(
             "run",
             "--quiet",
             "--release",
-            "--",
+            "--features=mock",
         ]
+
+        if stub_mode == "s3_client":
+            logging.debug("using mock-mount-s3 due to `stub_mode`, bucket will be prefixed with \"sthree-\"")
+            mountpoint_args.append("--bin=mock-mount-s3")
+            bucket = f"sthree-{cfg['s3_bucket']}"
+
+        # End Cargo command, begin passing arguments to Mountpoint
+        mountpoint_args.append("--")
     else:
         mountpoint_args = [cfg['mountpoint_binary']]
 
     os.makedirs(MP_LOGS_DIRECTORY, exist_ok=True)
-
-    bucket = cfg['s3_bucket']
 
     mountpoint_version_output = subprocess.check_output([*mountpoint_args, "--version"]).decode("utf-8")
     log.info("Mountpoint version: %s", mountpoint_version_output.strip())
@@ -118,6 +126,10 @@ def _mount_mp(
     for network_interface in cfg['network']['interface_names']:
         subprocess_args.append(f"--bind={network_interface}")
     if (max_throughput := cfg['network']['maximum_throughput_gbps']) is not None:
+        if stub_mode == "s3_client":
+            raise ValueError(
+                "should not use `stub_mode=s3_client` with `maximum_throughput_gbps`, throughput will be limited"
+            )
         subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
 
     if cfg['mountpoint_max_background'] is not None:
@@ -126,7 +138,6 @@ def _mount_mp(
     if cfg['mountpoint_congestion_threshold'] is not None:
         subprocess_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(cfg["mountpoint_congestion_threshold"])
 
-    stub_mode = str(cfg["stub_mode"]).lower()
     if stub_mode != "off" and cfg["mountpoint_binary"] is not None:
         raise ValueError("Cannot use `stub_mode` with `mountpoint_binary`, `stub_mode` requires recompilation")
     match stub_mode:
@@ -134,6 +145,9 @@ def _mount_mp(
             pass
         case "fs_handler":
             subprocess_env["MOUNTPOINT_BUILD_STUB_FS_HANDLER"] = "1"
+        case "s3_client":
+            # Already handled when building cargo command
+            pass
         case _:
             raise ValueError(f"Unknown stub_mode: {stub_mode}")
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -37,7 +37,7 @@ mountpoint_congestion_threshold: !!null
 with_bwm: false
 
 # Works automatically ONLY where this script manages compilation. It has no effect if `mountpoint_binary` is set.
-stub_mode: "off" # fs_handler
+stub_mode: "off" # fs_handler, s3_client
 
 iterations: 1
 

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -43,15 +43,12 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
 
     tracing::warn!("using mock client");
 
+    // TODO: Actually update the mock client to support different part sizes
     let part_size = {
-        // TODO: Actually update the mock client to support different part sizes
-        let values = [Some(args.part_size), args.read_part_size, args.write_part_size];
-        values
-            .iter()
-            .copied()
-            .flatten()
-            .max()
-            .expect("always at least one value given part_size is not optional")
+        if args.read_part_size.is_some() || args.write_part_size.is_some() {
+            tracing::warn!("mock client does not support separate part sizes for reading and writing, ignoring");
+        }
+        args.part_size
     };
 
     let config = MockClientConfig {

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -43,9 +43,20 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
 
     tracing::warn!("using mock client");
 
+    let part_size = {
+        // TODO: Actually update the mock client to support different part sizes
+        let values = [Some(args.part_size), args.read_part_size, args.write_part_size];
+        values
+            .iter()
+            .copied()
+            .flatten()
+            .max()
+            .expect("always at least one value given part_size is not optional")
+    };
+
     let config = MockClientConfig {
         bucket: bucket_name,
-        part_size: args.part_size as usize,
+        part_size: part_size as usize,
         unordered_list_seed: None,
         enable_backpressure: true,
         initial_read_window_size: 1024 * 1024 + 128 * 1024, // matching real MP

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -93,6 +93,13 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
         };
         client.add_object(&key, MockObject::ramp(0x11, size as usize, ETag::for_tests()));
     }
+    // Some objects that are useful for benchmarking
+    for job_num in 0..1024 {
+        let size_gib = 100;
+        let size_bytes = size_gib * 1024u64.pow(3);
+        let key = format!("j{job_num}_{size_gib}GiB.bin");
+        client.add_object(&key, MockObject::constant(1u8, size_bytes as usize, ETag::for_tests()));
+    }
     client.add_object("hello.txt", MockObject::from_bytes(b"hello world", ETag::for_tests()));
     client.add_object("empty", MockObject::from_bytes(b"", ETag::for_tests()));
     client.add_object(


### PR DESCRIPTION
This change allows us to run our benchmark scripts in `benchmark/` using the `mock-mount-s3` binary, which presents a Mountpoint file system backed by an in-memory mock S3 client.

This change itself incorporates quite a few changes (which may have been better suited as separate commits). There are some changes to accommodate configuration of part sizes in `mock-mount-s3`, removal of throughput limits (which is useful for benchmarking!), and finally adding the configuration options to the benchmarking scripts.

This change does include some hardcoded objects being added to `mock-mount-s3` which can accomodate the benchmarking scripts. This means that if the object keys change, the files will be created by FIO and "uploaded" / populated in memory, which probably isn't what you want.

### Does this change impact existing behavior?

No, there are no changes to main Mountpoint code.

### Does this change need a changelog entry? Does it require a version change?

No, no behavior changes new or existing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
