### PR TITLE
Refactor internal S3 client methods to initiate meta-requests

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client/delete_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/delete_object.rs
@@ -4,7 +4,8 @@ use std::os::unix::prelude::OsStrExt;
 use mountpoint_s3_crt::s3::client::MetaRequestResult;
 
 use crate::object_client::{DeleteObjectError, DeleteObjectResult, ObjectClientResult};
-use crate::s3_crt_client::{S3CrtClient, S3Operation, S3RequestError};
+
+use super::{S3CrtClient, S3Operation, S3RequestError};
 
 impl S3CrtClient {
     /// Create and begin a new DeleteObject request.
@@ -25,11 +26,14 @@ impl S3CrtClient {
                 .set_request_path(format!("/{key}"))
                 .map_err(S3RequestError::construction_failure)?;
 
-            self.inner
-                .make_simple_http_request(message, S3Operation::DeleteObject, span, parse_delete_object_error)?
+            self.inner.meta_request_without_payload(
+                message.into_options(S3Operation::DeleteObject),
+                span,
+                parse_delete_object_error,
+            )?
         };
 
-        let _body = request.await?;
+        request.await?;
 
         Ok(DeleteObjectResult {})
     }

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -16,15 +16,11 @@ use thiserror::Error;
 use tracing::trace;
 
 use crate::object_client::{
-    Checksum, ClientBackpressureHandle, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError,
+    Checksum, ChecksumMode, ClientBackpressureHandle, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError,
     ObjectClientResult, ObjectMetadata,
 };
-use crate::s3_crt_client::{
-    parse_checksum, GetObjectResponse, S3CrtClient, S3CrtClientInner, S3Operation, S3RequestError,
-};
-use crate::types::ChecksumMode;
 
-use super::ObjectChecksumError;
+use super::{parse_checksum, GetObjectResponse, ObjectChecksumError, S3CrtClient, S3Operation, S3RequestError};
 
 impl S3CrtClient {
     /// Create and begin a new GetObject request. The returned [S3GetObjectResponse] is a [Stream] of
@@ -79,12 +75,12 @@ impl S3CrtClient {
                 .set_request_path(key)
                 .map_err(S3RequestError::construction_failure)?;
 
-            let mut options = S3CrtClientInner::new_meta_request_options(message, S3Operation::GetObject);
+            let mut options = message.into_options(S3Operation::GetObject);
             options.part_size(self.inner.read_part_size as u64);
 
             let mut headers_sender = Some(event_sender.clone());
             let part_sender = event_sender.clone();
-            self.inner.make_meta_request_from_options(
+            self.inner.meta_request_with_callbacks(
                 options,
                 span,
                 |_| (),

--- a/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_bucket.rs
@@ -1,6 +1,8 @@
-use crate::object_client::ObjectClientResult;
-use crate::s3_crt_client::{S3CrtClient, S3Operation, S3RequestError};
 use thiserror::Error;
+
+use crate::object_client::ObjectClientResult;
+
+use super::{S3CrtClient, S3Operation, S3RequestError};
 
 /// Errors returned by a [`head_bucket`](S3CrtClient::head_bucket) request.
 #[derive(Error, Debug)]
@@ -12,28 +14,29 @@ pub enum HeadBucketError {
 
 impl S3CrtClient {
     pub async fn head_bucket(&self, bucket: &str) -> ObjectClientResult<(), HeadBucketError, S3RequestError> {
-        let body =
-            {
-                let mut message = self
-                    .inner
-                    .new_request_template("HEAD", bucket)
-                    .map_err(S3RequestError::construction_failure)?;
+        let request = {
+            let mut message = self
+                .inner
+                .new_request_template("HEAD", bucket)
+                .map_err(S3RequestError::construction_failure)?;
 
-                message
-                    .set_request_path("/")
-                    .map_err(S3RequestError::construction_failure)?;
+            message
+                .set_request_path("/")
+                .map_err(S3RequestError::construction_failure)?;
 
-                let span = request_span!(self.inner, "head_bucket");
+            let span = request_span!(self.inner, "head_bucket");
 
-                self.inner
-                    .make_simple_http_request(message, S3Operation::HeadBucket, span, |request_result| {
-                        match request_result.response_status {
-                            404 => Some(HeadBucketError::NoSuchBucket),
-                            _ => None,
-                        }
-                    })?
-            };
+            self.inner.meta_request_without_payload(
+                message.into_options(S3Operation::HeadBucket),
+                span,
+                |request_result| match request_result.response_status {
+                    404 => Some(HeadBucketError::NoSuchBucket),
+                    _ => None,
+                },
+            )?
+        };
 
-        body.await.map(|_body| ())
+        request.await?;
+        Ok(())
     }
 }

--- a/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
@@ -13,7 +13,8 @@ use crate::object_client::{
     ChecksumAlgorithm, ListObjectsError, ListObjectsResult, ObjectClientError, ObjectClientResult, ObjectInfo,
     RestoreStatus,
 };
-use crate::s3_crt_client::{S3CrtClient, S3Operation, S3RequestError};
+
+use super::{S3CrtClient, S3Operation, S3RequestError};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -211,8 +212,11 @@ impl S3CrtClient {
                 prefix
             );
 
-            self.inner
-                .make_simple_http_request(message, S3Operation::ListObjects, span, parse_list_objects_error)?
+            self.inner.meta_request_with_body_payload(
+                message.into_options(S3Operation::ListObjects),
+                span,
+                parse_list_objects_error,
+            )?
         };
 
         let body = body.await?;


### PR DESCRIPTION
Re-organize the group of internal methods in the S3 client used to initiate CRT meta-requests. Follow-up to the changes in #1334.

With this change, `S3CrtClientInner` provides 4 methods:
* `meta_request_with_callbacks`: the lowest-level method, which allows more customization through callbacks. It is the basis for the other methods and it is used directly by `get_object` and `put_object`.
* `meta_request_with_body_payload`: simpler variant that returns the response body. Used by `list_object` and `get_object_attributes`.
* `meta_request_with_headers_payload`: variant returning the headers, but no body. Used by `head_object` and `put_object_single`.
* `meta_request_without_payload`: simplest variant, only returns error.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No. Internal change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
