### PR TITLE
Create a package with custom extension

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -32,8 +32,7 @@ Then install the depdencies:
 
     sudo yum install fuse fuse-devel make cmake3 clang git pkg-config dpkg fakeroot rpmdevtools tar python3
 
-If you don't want to compile a DEB, you can skip `dpkg` and `fakeroot`, and use `--pkg-extensions` flag of the build script to specify which package to build.
-If you don't want to compile an RPM, you can skip `rpmdevtools`, and use `--pkg-extensions` flag of the build script to specify which package to build.
+You can skip `dpkg` and `fakeroot` if you don't want to compile a DEB, and `rpmdevtools` if you don't want to compile an RPM. Use the `--pkg-extensions` flag on the build script to specify which package to build.
 
 You'll also need Rust, and the [cargo-about] tool to generate third-party attribution documents:
 

--- a/package/README.md
+++ b/package/README.md
@@ -32,8 +32,8 @@ Then install the depdencies:
 
     sudo yum install fuse fuse-devel make cmake3 clang git pkg-config dpkg fakeroot rpmdevtools tar python3
 
-If you don't want to compile a DEB, you can skip `dpkg` and `fakeroot`, and pass the `--no-deb` flag to the build script.
-If you don't want to compile an RPM, you can skip `rpmdevtools`, and pass the `--no-rpm` flag to the build script.
+If you don't want to compile a DEB, you can skip `dpkg` and `fakeroot`, and use `--pkg-extensions` flag of the build script to specify which package to build.
+If you don't want to compile an RPM, you can skip `rpmdevtools`, and use `--pkg-extensions` flag of the build script to specify which package to build.
 
 You'll also need Rust, and the [cargo-about] tool to generate third-party attribution documents:
 

--- a/package/package.py
+++ b/package/package.py
@@ -375,7 +375,7 @@ if __name__ == "__main__":
         type=str,
         nargs='+',
         help="list of package extensions to be built",
-        default=["rpm", "suse.rpm", "deb", "tar.gz"]
+        default=["rpm", "suse.rpm", "deb", "tar.gz"],
     )
 
     args = p.parse_args()

--- a/package/package.py
+++ b/package/package.py
@@ -15,7 +15,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional
+from typing import Optional, Tuple
 
 
 def log(msg: str):
@@ -42,9 +42,9 @@ class BuildMetadata:
     def artifact_name(self, extension: str):
         return f"mount-s3-{self.version_string}-{self.arch_name}.{extension}"
 
-    def spec_file_name(self, distr: Optional[str] = None):
-        if distr:
-            return f"mount-s3-{distr}.spec"
+    def spec_file_name(self, ext: str):
+        if "suse" in ext:
+            return f"mount-s3-suse.spec"
         return "mount-s3.spec"
 
 
@@ -57,9 +57,9 @@ def check_dependencies(args: argparse.Namespace):
     log("Checking dependencies")
 
     deps = ["cargo", "cargo-about", "tar", "whereis"]
-    if not args.no_rpm:
+    if any(map(lambda ext: ext.endswith("rpm"), args.pkg_extensions)):
         deps.extend(["rpm", "rpmbuild"])
-    if not args.no_deb:
+    if any(map(lambda ext: ext.endswith("deb"), args.pkg_extensions)):
         deps.extend(["fakeroot", "dpkg-deb"])
 
     for dep in deps:
@@ -205,15 +205,15 @@ def build_package_dir(metadata: BuildMetadata, binary_path: str, attribution_pat
     return package_dir
 
 
-def build_rpm(metadata: BuildMetadata, package_dir: str, distr: Optional[str] = None) -> str:
+def build_rpm(metadata: BuildMetadata, package_dir: str, ext: str) -> str:
     """Build an RPM package from the contents of the package directory. Return the path to the
     final RPM package."""
 
-    rpm_buildroot = os.path.join(metadata.buildroot, "rpm-{}".format(distr or "default"))
+    rpm_buildroot = os.path.join(metadata.buildroot, ext)
     os.mkdir(rpm_buildroot)
 
     rpm_topdir = os.path.join(rpm_buildroot, "rpm-topdir")
-    log("Building RPM in topdir {} for {} Linux distribution".format(rpm_topdir, distr or "default"))
+    log(f"Building RPM in topdir {rpm_topdir} with {ext} extension")
 
     # Assemble the contents of the RPM, rooted at /
     rpm_package_dir = os.path.join(rpm_buildroot, "rpm-package")
@@ -227,7 +227,7 @@ def build_rpm(metadata: BuildMetadata, package_dir: str, distr: Optional[str] = 
     run(["tar", "czvf", source_tar_path, "-C", rpm_package_dir, "opt"])
 
     # Build the RPM
-    spec_file = os.path.join(metadata.cargoroot, f"package/{metadata.spec_file_name(distr)}")
+    spec_file = os.path.join(metadata.cargoroot, f"package/{metadata.spec_file_name(ext)}")
     cmd = [
         "rpmbuild",
         "-bb",
@@ -246,7 +246,7 @@ def build_rpm(metadata: BuildMetadata, package_dir: str, distr: Optional[str] = 
     rpm_path = os.path.join(arch_dir, rpms[0])
     final_rpm_path = os.path.join(
         metadata.output_dir,
-        metadata.artifact_name("{}.rpm".format(distr) if distr else "rpm"),
+        metadata.artifact_name(ext),
     )
     shutil.copy2(rpm_path, final_rpm_path)
 
@@ -338,14 +338,26 @@ def build(args: argparse.Namespace) -> str:
 
     package_dir = build_package_dir(metadata, binary_path, attribution_path)
 
+    def infer_package_type(extension: str) -> Tuple[str, str]:
+        package_types = {
+            "rpm",
+            "deb",
+            "tar.gz",
+        }
+        for pkg_type in package_types:
+            if extension.endswith(pkg_type):
+                return pkg_type
+        raise Exception(f"unable to infer package type from extension {ext}")
+
     artifacts = []
-    if not args.no_rpm:
-        artifacts.append(build_rpm(metadata, package_dir))
-    if not args.no_suse_rpm:
-        artifacts.append(build_rpm(metadata, package_dir, "suse"))
-    if not args.no_deb:
-        artifacts.append(build_deb(metadata, package_dir))
-    artifacts.append(build_package_archive(metadata, package_dir))
+    for ext in args.pkg_extensions:
+        pkg_type = infer_package_type(ext)
+        if pkg_type == "rpm":
+            artifacts.append(build_rpm(metadata, package_dir, ext))
+        elif pkg_type == "deb":
+            artifacts.append(build_deb(metadata, package_dir))
+        elif pkg_type == "tar.gz":
+            artifacts.append(build_package_archive(metadata, package_dir))
 
     for path in artifacts:
         os.chmod(path, 0o755)
@@ -357,10 +369,14 @@ if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("--root-dir", help="override the path to the Cargo workspace")
     p.add_argument("--expected-version", help="expected version number for the Mountpoint binary")
-    p.add_argument("--no-rpm", action="store_true", help="do not build an RPM")
-    p.add_argument("--no-suse-rpm", action="store_true", help="do not build an RPM for SUSE")
-    p.add_argument("--no-deb", action="store_true", help="do not build a DEB")
     p.add_argument("--official", action="store_true", help="build as an official release")
+    p.add_argument(
+        "--pkg-extensions",
+        type=str,
+        nargs='+',
+        help="list of package extensions to be built",
+        default=["rpm", "suse.rpm", "deb", "tar.gz"]
+    )
 
     args = p.parse_args()
 

--- a/package/package.py
+++ b/package/package.py
@@ -15,7 +15,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Tuple
 
 
 def log(msg: str):
@@ -338,26 +337,16 @@ def build(args: argparse.Namespace) -> str:
 
     package_dir = build_package_dir(metadata, binary_path, attribution_path)
 
-    def infer_package_type(extension: str) -> Tuple[str, str]:
-        package_types = {
-            "rpm",
-            "deb",
-            "tar.gz",
-        }
-        for pkg_type in package_types:
-            if extension.endswith(pkg_type):
-                return pkg_type
-        raise Exception(f"unable to infer package type from extension {ext}")
-
     artifacts = []
     for ext in args.pkg_extensions:
-        pkg_type = infer_package_type(ext)
-        if pkg_type == "rpm":
+        if ext.endswith("rpm"):
             artifacts.append(build_rpm(metadata, package_dir, ext))
-        elif pkg_type == "deb":
+        elif ext.endswith("deb"):
             artifacts.append(build_deb(metadata, package_dir))
-        elif pkg_type == "tar.gz":
+        elif ext.endswith("tar.gz"):
             artifacts.append(build_package_archive(metadata, package_dir))
+        else:
+            raise Exception(f"unable to infer package type from extension {ext}")
 
     for path in artifacts:
         os.chmod(path, 0o755)

--- a/package/package.py
+++ b/package/package.py
@@ -15,7 +15,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional, Tuple
+from typing import Tuple
 
 
 def log(msg: str):
@@ -44,7 +44,7 @@ class BuildMetadata:
 
     def spec_file_name(self, ext: str):
         if "suse" in ext:
-            return f"mount-s3-suse.spec"
+            return "mount-s3-suse.spec"
         return "mount-s3.spec"
 
 

--- a/package/validate/validate-rpm-centos8.sh
+++ b/package/validate/validate-rpm-centos8.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+set -e
+
+# Need this because of Centos 8 reached EOL and mirrorlist.centos.org does not exist anymore.
+sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
+yum update -y && yum install -y wget gpg
+cd /tmp
+
+wget https://s3.amazonaws.com/mountpoint-s3-release/$VERSION/$ARCH/mount-s3-$VERSION-$ARCH.$PKG_SUFFIX.rpm
+wget https://s3.amazonaws.com/mountpoint-s3-release/$VERSION/$ARCH/mount-s3-$VERSION-$ARCH.$PKG_SUFFIX.rpm.asc
+
+wget https://s3.amazonaws.com/mountpoint-s3-release/public_keys/KEYS
+gpg --import KEYS
+gpg --verify mount-s3-$VERSION-$ARCH.$PKG_SUFFIX.rpm.asc mount-s3-$VERSION-$ARCH.$PKG_SUFFIX.rpm
+
+yum install -y mount-s3-$VERSION-$ARCH.$PKG_SUFFIX.rpm
+
+. $(dirname "$0")/test-mount-s3.sh

--- a/package/validate/validate.py
+++ b/package/validate/validate.py
@@ -21,6 +21,8 @@ def validate(args: argparse.Namespace) -> str:
         image = "public.ecr.aws/amazonlinux/amazonlinux:2"
     elif package == "rpm-suse":
         image = "registry.suse.com/bci/bci-base:15.6"
+    elif package == "rpm-centos8":
+        image = "public.ecr.aws/docker/library/centos:8"
     else:
         raise Exception(
             f"unsupported OS {args.os} for {args.artifact}. Supported combinations are: deb-ubuntu, rpm-al2, gzip-al2, rpm-suse"
@@ -49,6 +51,7 @@ def validate(args: argparse.Namespace) -> str:
             f"--env=ARCH={args.arch}",
             f"--env=VERSION={args.version}",
             f"--env=BUCKET={args.bucket}",
+            f"--env=PKG_SUFFIX={args.pkg_suffix}",
             image,
             "/bin/bash",
             f"/scripts/{validate_script}",
@@ -61,8 +64,9 @@ if __name__ == "__main__":
     p.add_argument("--version", help="the version number for the Mountpoint release", required=True)
     p.add_argument("--arch", help="the architecture to validate", required=True, choices=["x86_64", "arm64"])
     p.add_argument("--artifact", help="the artifact to validate", required=True, choices=["deb", "rpm", "gzip"])
-    p.add_argument("--os", help="the OS to validate on", required=True, choices=["ubuntu", "al2", "suse"])
+    p.add_argument("--os", help="the OS to validate on", required=True, choices=["ubuntu", "al2", "suse", "centos8"])
     p.add_argument("--bucket", help="the public bucket to mount", required=True)
+    p.add_argument("--pkg-suffix", help="the suffix to add to the package name")
 
     args = p.parse_args()
 


### PR DESCRIPTION
Add a `--pkg-extensions` CLI flag which specifies which packages to build and how to name them. Package type is inferred from top-level component of the provided extension. 

Also add a validation script for such packages.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
