### PR TITLE
Reduce memory usage for strings in inode metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Reduce memory usage for strings in inode metadata.
+  ([#1346](https://github.com/awslabs/mountpoint-s3/pull/1346))
+
 ## v0.1.1 (April 1, 2025)
 
 * Address an issue in GetObject requests that could result in read operations to fail.

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-fs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -703,8 +703,8 @@ impl SuperblockInner {
             select_biased! {
                 result = file_lookup => {
                     match result {
-                        Ok(HeadObjectResult { size, last_modified, restore_status ,etag, storage_class, .. }) => {
-                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag.as_str().to_string()), storage_class, restore_status, self.config.cache_config.file_ttl);
+                        Ok(HeadObjectResult { size, last_modified, restore_status, etag, storage_class, .. }) => {
+                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag.into_inner().into_boxed_str()), storage_class.as_deref(), restore_status, self.config.cache_config.file_ttl);
                             file_state = Some(stat);
                         }
                         // If the object is not found, might be a directory, so keep going

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -999,7 +999,7 @@ impl SuperblockInner {
                 writing_children,
                 ..
             } => {
-                let existing_inode = children.insert(name.to_string(), inode.clone());
+                let existing_inode = children.insert(name.as_ref().into(), inode.clone());
                 if is_new_file {
                     writing_children.insert(next_ino);
                 }

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -278,7 +278,7 @@ pub(super) enum InodeKindData {
         ///
         /// The existence of a child or lack thereof does not imply the object does not exist,
         /// nor that it currently exists in S3 in that state.
-        children: HashMap<String, Inode>,
+        children: HashMap<Box<str>, Inode>,
 
         /// A set of inode numbers that have been opened for write but not completed yet.
         /// This should be a subset of the [children](Self::Directory::children) field.

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -177,8 +177,8 @@ impl ReaddirHandle {
                 let stat = InodeStat::for_file(
                     object_info.size as usize,
                     object_info.last_modified,
-                    Some(object_info.etag.clone()),
-                    object_info.storage_class.clone(),
+                    Some(object_info.etag.as_str().into()),
+                    object_info.storage_class.as_deref(),
                     object_info.restore_status,
                     self.inner.config.cache_config.file_ttl,
                 );

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Unreleased
 
+* Reduce memory usage for strings in inode metadata. ([#1346](https://github.com/awslabs/mountpoint-s3/pull/1346))
+
 ## v1.16.0 (April 1, 2025)
 
 ### New features
+
 * Mountpoint for Amazon S3 adds support for S3 Access Points for directory buckets in AWS Dedicated Local Zones. ([aws-c-s3#502](https://github.com/awslabs/aws-c-s3/pull/502/))
 
 ### Other changes

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mountpoint-s3"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.1" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.2" }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.13.2" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }


### PR DESCRIPTION
Reduce memory usage for strings included in inode metadata, like object keys, etags, and inode names. Using a `Box<str>` instead of a `String` ensures that no slack capacity is wasted and saves the `usize` field to keep track of the buffer capacity.

### Does this change impact existing behavior?

No functional changes.

### Does this change need a changelog entry? Does it require a version change?

Yes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
