### PR TITLE
Fix an issue where GetObject requests may not be cancelled

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Other changes
 
+* Fix an issue where GetObject requests may not be cancelled.
+  ([#1355](https://github.com/awslabs/mountpoint-s3/pull/1355))
+
 ## v0.13.2 (April 1, 2025)
 
 * Fix race condition in GetObject that could result in empty responses.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -622,9 +622,10 @@ unsafe extern "C" fn meta_request_upload_review_callback(
 }
 
 /// An in-progress request to S3.
+///
+/// A dropped [MetaRequest] will still progress. See [MetaRequest::cancel()].
 #[derive(Debug)]
 pub struct MetaRequest {
-    #[allow(unused)]
     inner: NonNull<aws_s3_meta_request>,
 }
 


### PR DESCRIPTION
The change in #1334 introduced an issue where a GetObject request would still run to completion if the future returned by the `get_object` method in `S3CrtClient` was dropped before being ready.

In Mountpoint, this would affect random read workloads where dropped prefetcher requests would not always be cancelled, resulting in reduced throughput and increased memory usage.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Bug fix entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
