### PR TITLE
Cherry-pick GetObject cancellation fix (#1355) and prepare for client release 0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v0.13.3 (April 9, 2025)
+
+* Fix an issue where GetObject requests may not be cancelled.
+  ([#1355](https://github.com/awslabs/mountpoint-s3/pull/1355))
+
 ## v0.13.2 (April 1, 2025)
 
 * Fix race condition in GetObject that could result in empty responses.

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -11,7 +11,7 @@ use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
 use mountpoint_s3_crt::http::request_response::{Header, Headers};
 use mountpoint_s3_crt::s3::client::{MetaRequest, MetaRequestResult};
-use pin_project::{pin_project, pinned_drop};
+use pin_project::pin_project;
 use tracing::trace;
 
 use crate::object_client::{
@@ -20,8 +20,8 @@ use crate::object_client::{
 };
 
 use super::{
-    parse_checksum, GetObjectResponse, ObjectChecksumError, ResponseHeadersError, S3CrtClient, S3Operation,
-    S3RequestError,
+    parse_checksum, CancellingMetaRequest, GetObjectResponse, ObjectChecksumError, ResponseHeadersError, S3CrtClient,
+    S3Operation, S3RequestError,
 };
 
 impl S3CrtClient {
@@ -180,9 +180,9 @@ impl ClientBackpressureHandle for S3BackpressureHandle {
 /// Each item of the stream is a part of the object body together with the part's offset within the
 /// object.
 #[derive(Debug)]
-#[pin_project(PinnedDrop)]
+#[pin_project]
 pub struct S3GetObjectResponse {
-    meta_request: MetaRequest,
+    meta_request: CancellingMetaRequest,
     #[pin]
     event_receiver: UnboundedReceiver<S3GetObjectEvent>,
     requested_checksums: bool,
@@ -218,13 +218,6 @@ impl GetObjectResponse for S3GetObjectResponse {
         }
 
         parse_checksum(&self.headers).map_err(|e| ObjectChecksumError::HeadersError(Box::new(e)))
-    }
-}
-
-#[pinned_drop]
-impl PinnedDrop for S3GetObjectResponse {
-    fn drop(self: Pin<&mut Self>) {
-        self.meta_request.cancel();
     }
 }
 


### PR DESCRIPTION
This change include the fix introduced in #1355 and increased the `mountpoint-s3-client` crate version to 0.13.3 in preparation of publishing to [crates.io](https://crates.io).

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Bug fix entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
