### PR TITLE
Make fio io engine configurable in benchmark.

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -180,9 +180,7 @@ def _run_fio(cfg: DictConfig, mount_dir: str) -> None:
         "SIZE_GIB": "100",
         "DIRECT": "1" if cfg['direct_io'] else "0",
         "UNIQUE_DIR": datetime.now(tz=timezone.utc).isoformat(),
-        # TODO: Confirm assumption that `libaio` should make direct IO go faster.
-        # TODO: Review if we should use sync or psync. We use `sync` in other benchmarks.
-        "IO_ENGINE": "libaio" if cfg['direct_io'] else "psync",
+        "IO_ENGINE": cfg['fio_io_engine'],
     }
     log.info("Running FIO with args: %s; env: %s", subprocess_args, subprocess_env)
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -46,6 +46,7 @@ fuse_threads: !!null
 application_workers: 1
 direct_io: false
 fio_benchmark: "${fio_benchmarks[0]}"
+fio_io_engine: "psync"
 iteration: 0
 
 hydra:


### PR DESCRIPTION
Currently we pick a different io engine based on direct io configuration. However, the io engine configuration  should be independent.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
