### PR TITLE
Return `GetRequestTerminatedUnexpectedly` error if first `GetObject` request terminates early

### DIFF
--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -1222,7 +1222,7 @@ mod tests {
                 PrefetchReadError::GetRequestTerminatedUnexpectedly,
             ));
 
-            // Second read will return first part, ben then terminate early before returning the remaining parts
+            // Second read will return first part, but then terminate early before returning the remaining parts
             let bytes = request.read(0, PART_SIZE).await.unwrap();
             let expected = ramp_bytes(0xaa, PART_SIZE);
             assert_eq!(bytes.into_bytes().unwrap()[..], expected[..]);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -1171,6 +1171,78 @@ mod tests {
         });
     }
 
+    #[test_case(default_stream())]
+    #[test_case(caching_stream(8192))]
+    fn test_short_read_failure<Stream: ObjectPartStream + Send + Sync + 'static>(part_stream: Stream) {
+        const PART_SIZE: usize = 8192;
+        const OBJECT_SIZE: usize = 2 * PART_SIZE;
+
+        let config = MockClientConfig {
+            bucket: "test-bucket".to_string(),
+            part_size: PART_SIZE,
+            enable_backpressure: true,
+            initial_read_window_size: PART_SIZE,
+            ..Default::default()
+        };
+        let client = MockClient::new(config);
+        let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
+        let etag = object.etag();
+        client.add_object("hello", object);
+
+        let mut get_failures = HashMap::new();
+        // On first request, terminate the stream without producing any data
+        get_failures.insert(1, GetObjectFailureMode::StreamShortCircuit(1));
+        // On third request (second request of second prefetcher),
+        // terminate the stream early without producing all the requested data
+        get_failures.insert(3, GetObjectFailureMode::StreamShortCircuit(1));
+
+        let client = Arc::new(countdown_failure_client(
+            client,
+            CountdownFailureConfig {
+                get_failures,
+                ..Default::default()
+            },
+        ));
+        let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT));
+        let prefetcher = Prefetcher::new(part_stream, Default::default());
+
+        block_on(async {
+            let object_id = ObjectId::new("hello".to_owned(), etag.clone());
+            let mut request = prefetcher.prefetch(
+                client,
+                mem_limiter,
+                "test-bucket".to_owned(),
+                object_id,
+                OBJECT_SIZE as u64,
+            );
+
+            // First read will terminate early
+            assert!(matches!(
+                request.read(0, 10).await.expect_err("read should fail"),
+                PrefetchReadError::GetRequestTerminatedUnexpectedly,
+            ));
+
+            // Second read will return first part, ben then terminate early before returning the remaining parts
+            let bytes = request.read(0, PART_SIZE).await.unwrap();
+            let expected = ramp_bytes(0xaa, PART_SIZE);
+            assert_eq!(bytes.into_bytes().unwrap()[..], expected[..]);
+            _ = request
+                .read(PART_SIZE as u64, PART_SIZE)
+                .await
+                .expect_err("read should fail");
+
+            // There are no more failures injected, since the prefetcher will reset on failure, now we should be able to read the whole data.
+            let bytes = request.read(0, OBJECT_SIZE).await.unwrap();
+            let expected = ramp_bytes(0xaa, OBJECT_SIZE);
+            assert_eq!(bytes.into_bytes().unwrap()[..], expected[..]);
+
+            // Shouldn't fail if the short read is due to object size not due to the stream terminating early
+            let bytes = request.read(PART_SIZE as u64, OBJECT_SIZE).await.unwrap();
+            let expected = ramp_bytes(0xaa + PART_SIZE, PART_SIZE);
+            assert_eq!(bytes.into_bytes().unwrap()[..], expected[..]);
+        });
+    }
+
     #[test_case(0, 25; "no first read")]
     #[test_case(60, 25; "read beyond first part")]
     #[test_case(20, 25; "read in first part")]

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -302,7 +302,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
         let first_req_range = range.trim_end(first_read_window_end_offset);
-        let mut first_req_bytes_read = 0;
+        let mut current_offset = first_req_range.start();
         if !first_req_range.is_empty() {
             let first_request_stream = read_from_request(
                 backpressure_limiter,
@@ -314,7 +314,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
             pin_mut!(first_request_stream);
             while let Some(next) = first_request_stream.next().await {
                 let next = next?;
-                first_req_bytes_read += next.data.len();
+                current_offset = next.offset + next.data.len() as u64;
                 yield(next);
             }
         }
@@ -323,17 +323,17 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
         // but only if there is something left to be fetched.
         let range = range.trim_start(first_read_window_end_offset);
         if !range.is_empty() {
-            if !first_req_range.is_empty() && first_req_range.len() > first_req_bytes_read {
+            if current_offset < range.start() {
                 // We got less data than we requested. We assume the consumer will consume
-                // all the data up to `first_read_window_end_offset` and will increase the
-                // read window, thus the next line `wait_for_read_window_increment(range.start()).await?`.
-                // However, if we get less data then we expected, the consumer wouldn't consume
+                // all the data up to `range.start()` and will increase the read window,
+                // thus, the next line, `wait_for_read_window_increment(range.start())` will eventually be satisfied.
+                // However, if we get less data than we expected, the consumer wouldn't consume
                 // enough data and wouldn't increase the read window, and the next await would block forever
                 // as there is no one to increase the read window.
                 //
                 // This is an runtime error instead of an `assert!` because the prefetcher resets the
                 // prefetch to the offset again in case of an error, and that would cause a new `read_from_client_stream`
-                // to be created and which in turn would succeed in next try if this was a transient error.
+                // to be created which in turn would succeed in the next try if this was a transient issue.
                 Err(PrefetchReadError::GetRequestTerminatedUnexpectedly)?;
             }
 

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -334,6 +334,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 // This is an runtime error instead of an `assert!` because the prefetcher resets the
                 // prefetch to the offset again in case of an error, and that would cause a new `read_from_client_stream`
                 // to be created which in turn would succeed in the next try if this was a transient issue.
+                error!(key=object_id.key(), current_range=?range, current_offset, "Previous GetObject request terminated unexpectedly");
                 Err(PrefetchReadError::GetRequestTerminatedUnexpectedly)?;
             }
 

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -302,6 +302,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
         let first_req_range = range.trim_end(first_read_window_end_offset);
+        let mut first_req_bytes_read = 0;
         if !first_req_range.is_empty() {
             let first_request_stream = read_from_request(
                 backpressure_limiter,
@@ -312,7 +313,9 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
             );
             pin_mut!(first_request_stream);
             while let Some(next) = first_request_stream.next().await {
-                yield(next?);
+                let next = next?;
+                first_req_bytes_read += next.data.len();
+                yield(next);
             }
         }
 
@@ -320,6 +323,20 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
         // but only if there is something left to be fetched.
         let range = range.trim_start(first_read_window_end_offset);
         if !range.is_empty() {
+            if !first_req_range.is_empty() && first_req_range.len() > first_req_bytes_read {
+                // We got less data than we requested. We assume the consumer will consume
+                // all the data up to `first_read_window_end_offset` and will increase the
+                // read window, thus the next line `wait_for_read_window_increment(range.start()).await?`.
+                // However, if we get less data then we expected, the consumer wouldn't consume
+                // enough data and wouldn't increase the read window, and the next await would block forever
+                // as there is no one to increase the read window.
+                //
+                // This is an runtime error instead of an `assert!` because the prefetcher resets the
+                // prefetch to the offset again in case of an error, and that would cause a new `read_from_client_stream`
+                // to be created and which in turn would succeed in next try if this was a transient error.
+                Err(PrefetchReadError::GetRequestTerminatedUnexpectedly)?;
+            }
+
             // To optimize random reads we don't start the second request until half of the first one was read as the second
             // request may not be needed. After increment threshold is reached `backpressure_limiter` will receive a diff to
             // add to the window. This diff will be the initial read window size of the second request and we use it as


### PR DESCRIPTION
To read data from S3, we use `read_from_client_stream` method. This method creates two `GetObject` requests, with different ranges (if there are enough data to read):
1. Starting position to `initial_read_window_size` (by default 1.125 MiB)
2. Starting position + `initial_read_window_size` to end position (by default end of the object)

To limit memory usage, `read_from_client_stream` applies a back pressure between these two requests. It doesn't send the second request until the half of the first request has been consumed (signalled via `BackpressureController::send_feedback`). It understands this by using `BackpressureLimiter::wait_for_read_window_increment(<second request starting pos>).await`. Therefore, the `read_from_client_stream` assumes that, the consumer will consume first request and then will increase the read window. This could fail if a faulty `ObjectClient` returns a `GetObject` stream that terminates early before producing the whole requested range.

This PR fails at runtime if a faulty client returns less data than we expect. Previously, the `read_from_client_stream` would hang at `wait_for_read_window_increment` call forever.


### Does this change impact existing behavior?

No breaking change, Mountpoint will return an `read_from_client_stream` error instead of hanging forever if this issue happens.

### Does this change need a changelog entry? Does it require a version change?

Probably doesn't require a changelog entry. This PR also makes some breaking changes on `FailureClient` in `mountpoint-s3-client` crate, but the `FailureClient` seems like doc hidden and not sure if it requires a changelog entry as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
