### PR TITLE
Update client_benchmark to report Gib/s, disable ANSI in logs

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -71,11 +71,11 @@ fn run_benchmark(
         let elapsed = start.elapsed();
         let received_size = received_size.load(Ordering::SeqCst);
         println!(
-            "{}: received {} bytes in {:.2}s: {:.2}MiB/s",
+            "{}: received {} bytes in {:.2}s: {:.2} Gib/s",
             i,
             received_size,
             elapsed.as_secs_f64(),
-            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024) as f64
+            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024 * 1024 / 8) as f64
         );
     }
 }

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -23,6 +23,7 @@ fn init_tracing_subscriber() {
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .with_writer(std::io::stderr)
+        .with_ansi(false)
         .finish();
 
     subscriber.try_init().expect("unable to install global subscriber");


### PR DESCRIPTION
Report throughput in Gib/s and disable ANSI escape characters in benchmark logs. 

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
