### PR TITLE
Make CRT memory limit configurable in Mountpoint's S3 client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Other changes
+* The memory limit for CRT Client can now be configured with the `S3ClientConfig::memory_limit_in_bytes` method.
+  ([#1363](https://github.com/awslabs/mountpoint-s3/pull/1363))
+
 ## v0.14.0 (April 9, 2025)
 
 ### Breaking changes

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -115,6 +115,13 @@ struct CliArgs {
         visible_alias = "maximum-throughput-gbps"
     )]
     throughput_target_gbps: f64,
+    #[arg(
+        long,
+        help = "CRT Memory limit in GB",
+        default_value = "0",
+        visible_alias = "memory-limit-gb"
+    )]
+    crt_memory_limit_gb: u64,
     #[arg(long, help = "Part size for multi-part GET", default_value = "8388608")]
     part_size: usize,
     #[arg(long, help = "Number of benchmark iterations", default_value = "1")]
@@ -137,6 +144,7 @@ fn main() {
         } => {
             let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(&region));
             config = config.throughput_target_gbps(args.throughput_target_gbps);
+            config = config.memory_limit_in_bytes(args.crt_memory_limit_gb * 1024 * 1024 * 1024);
             if let Some(interfaces) = &bind {
                 config = config.network_interface_names(interfaces.clone());
             }

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -92,6 +92,7 @@ macro_rules! event {
 pub struct S3ClientConfig {
     auth_config: S3ClientAuthConfig,
     throughput_target_gbps: f64,
+    memory_limit_in_bytes: u64,
     read_part_size: usize,
     write_part_size: usize,
     endpoint_config: EndpointConfig,
@@ -112,6 +113,7 @@ impl Default for S3ClientConfig {
         Self {
             auth_config: Default::default(),
             throughput_target_gbps: 10.0,
+            memory_limit_in_bytes: 0,
             read_part_size: DEFAULT_PART_SIZE,
             write_part_size: DEFAULT_PART_SIZE,
             endpoint_config: EndpointConfig::new("us-east-1"),
@@ -166,6 +168,13 @@ impl S3ClientConfig {
     #[must_use = "S3ClientConfig follows a builder pattern"]
     pub fn throughput_target_gbps(mut self, throughput_target_gbps: f64) -> Self {
         self.throughput_target_gbps = throughput_target_gbps;
+        self
+    }
+
+    /// Set the memory limit in bytes for the S3 client
+    #[must_use = "S3ClientConfig follows a builder pattern"]
+    pub fn memory_limit_in_bytes(mut self, memory_limit_in_bytes: u64) -> Self {
+        self.memory_limit_in_bytes = memory_limit_in_bytes;
         self
     }
 
@@ -404,6 +413,7 @@ impl S3CrtClientInner {
             .retry_strategy(retry_strategy);
 
         client_config.throughput_target_gbps(config.throughput_target_gbps);
+        client_config.memory_limit_in_bytes(config.memory_limit_in_bytes);
 
         // max_part_size is 5GB or less depending on the platform (4GB on 32-bit)
         let max_part_size = cmp::min(5_u64 * 1024 * 1024 * 1024, usize::MAX as u64) as usize;

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -200,6 +200,14 @@ impl ClientConfig {
         self
     }
 
+    /// Memory limit in bytes the client can use.
+    ///
+    /// When not set, the client will determine this value based on throughput_target_gbps.
+    pub fn memory_limit_in_bytes(&mut self, memory_limit_in_bytes: u64) -> &mut Self {
+        self.inner.memory_limit_in_bytes = memory_limit_in_bytes;
+        self
+    }
+
     /// When set, this will cap the number of active connections. Otherwise, the client will
     /// determine this value based on throughput_target_gbps. (Recommended)
     pub fn max_active_connections_override(&mut self, max_active_connections_override: u32) -> &mut Self {


### PR DESCRIPTION
This is useful for benchmarking Mountpoint client with different memory limits.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

Yes, for the client. Updated minor version of `mountpoint-s3-client`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
