### PR TITLE
Allow changing log level dynamically with `USR2` signal 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.16.2"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "shuttle",
+ "signal-hook",
  "supports-color 3.0.2",
  "sysinfo",
  "syslog",
@@ -4009,6 +4010,16 @@ dependencies = [
  "scoped-tls",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -42,6 +42,17 @@ To enable more verbose logging for the AWS Common Runtime that Mountpoint uses t
 
 For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LOG` environment variable, which overrides the verbosity options above. The `MOUNTPOINT_LOG` environment variable uses the [`tracing-subscriber` directive syntax](https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html), and can be used to control log verbosity on a per-subject basis. For example, setting `MOUNTPOINT_LOG` to `trace` enables all trace-level logs, while `trace,awscrt=warn` enables trace-level logs for all log subjects except `awscrt`, which has only warning-level logging enabled.
 
+#### Changing logging verbosity on runtime
+
+Mountpoint allows changing logging verbosity dynamically on runtime using `USR2` Unix signal, e.g., `kill -USR2 <mount-s3-pid>`.
+
+Mountpoint toggles between the following verbosity levels each time it receives a `USR2` signal:
+  1. Default logging verbosity
+  2. Debug logging for all except CRT (i.e., `debug,awscrt=off`)
+  3. Debug logging for all (i.e., `debug,awscrt=debug`)
+  4. Trace logging for all except CRT (i.e., `trace,awscrt=off`)
+  5. Trace logging for all (i.e., `trace,awscrt=trace`)
+
 ## Metrics
 
 Mountpoint optionally collects metrics measuring various values across different components.

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -44,10 +44,10 @@ For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LO
 
 #### Changing logging verbosity on runtime
 
-_This is an unstable interface and might be subject to change in the future._
-
 > [!WARNING]
-> Default action of `SIGUSR2` POSIX signal is to terminate the process.
+> This is an unstable interface and might be subject to change in the future.
+>
+> The default action of `SIGUSR2` POSIX signal is to terminate the process.
 > Ensure Mountpoint version supports `SIGUSR2` signal before sending it, as otherwise it might terminate the process. Mountpoint v1.17.0 onward supports `SIGUSR2` signal as long as `--no-log` options is not passed.
 
 Mountpoint allows changing logging verbosity dynamically on runtime using `SIGUSR2` POSIX signal, e.g., `kill -USR2 <mount-s3-pid>`.
@@ -58,6 +58,8 @@ Mountpoint toggles between the following verbosity levels each time it receives 
   3. Debug logging for all (i.e., `debug,awscrt=debug`)
   4. Trace logging for all except CRT (i.e., `trace,awscrt=off`)
   5. Trace logging for all (i.e., `trace,awscrt=trace`)
+
+Note that increasing logging verbosity might affect runtime performance and cause more more log entries to be generated. Caution must be taken before using this feature in a production workload.
 
 ## Metrics
 

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -42,7 +42,7 @@ To enable more verbose logging for the AWS Common Runtime that Mountpoint uses t
 
 For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LOG` environment variable, which overrides the verbosity options above. The `MOUNTPOINT_LOG` environment variable uses the [`tracing-subscriber` directive syntax](https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html), and can be used to control log verbosity on a per-subject basis. For example, setting `MOUNTPOINT_LOG` to `trace` enables all trace-level logs, while `trace,awscrt=warn` enables trace-level logs for all log subjects except `awscrt`, which has only warning-level logging enabled.
 
-#### Changing logging verbosity on runtime
+#### Changing logging verbosity at runtime
 
 > [!WARNING]
 > This is an unstable interface and might be subject to change in the future.

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -44,10 +44,16 @@ For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LO
 
 #### Changing logging verbosity on runtime
 
-Mountpoint allows changing logging verbosity dynamically on runtime using `USR2` Unix signal, e.g., `kill -USR2 <mount-s3-pid>`.
+_This is an unstable interface and might be subject to change in the future._
 
-Mountpoint toggles between the following verbosity levels each time it receives a `USR2` signal:
-  1. Default logging verbosity
+> [!WARNING]
+> Default action of `SIGUSR2` POSIX signal is to terminate the process.
+> Ensure Mountpoint version supports `SIGUSR2` signal before sending it, as otherwise it might terminate the process. Mountpoint v1.17.0 onward supports `SIGUSR2` signal as long as `--no-log` options is not passed.
+
+Mountpoint allows changing logging verbosity dynamically on runtime using `SIGUSR2` POSIX signal, e.g., `kill -USR2 <mount-s3-pid>`.
+
+Mountpoint toggles between the following verbosity levels each time it receives a `SIGUSR2` signal:
+  1. Default logging verbosity (i.e., the one configured using `--debug`, `--debug-crt`, or `MOUNTPOINT_LOG` environment variable)
   2. Debug logging for all except CRT (i.e., `debug,awscrt=off`)
   3. Debug logging for all (i.e., `debug,awscrt=debug`)
   4. Trace logging for all except CRT (i.e., `trace,awscrt=off`)

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -50,7 +50,7 @@ For finer-grained control over log verbosity, Mountpoint uses the `MOUNTPOINT_LO
 > The default action of `SIGUSR2` POSIX signal is to terminate the process.
 > Ensure Mountpoint version supports `SIGUSR2` signal before sending it, as otherwise it might terminate the process. Mountpoint v1.17.0 onward supports `SIGUSR2` signal as long as `--no-log` options is not passed.
 
-Mountpoint allows changing logging verbosity dynamically on runtime using `SIGUSR2` POSIX signal, e.g., `kill -USR2 <mount-s3-pid>`.
+Mountpoint allows changing logging verbosity dynamically at runtime using `SIGUSR2` POSIX signal, e.g., `kill -USR2 <mount-s3-pid>`.
 
 Mountpoint toggles between the following verbosity levels each time it receives a `SIGUSR2` signal:
   1. Default logging verbosity (i.e., the one configured using `--debug`, `--debug-crt`, or `MOUNTPOINT_LOG` environment variable)

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Updated `network_performance.sh` to set maximum throughput correctly for newer instances (i.e. `trn2.48xlarge`, `i7ie.6xlarge`).
   ([#1369](https://github.com/awslabs/mountpoint-s3/pull/1369))
-* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity on runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-on-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 
 ## v0.1.3 (April 9, 2025)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Updated `network_performance.sh` to set maximum throughput correctly for newer instances (i.e. `trn2.48xlarge`, `i7ie.6xlarge`).
   ([#1369](https://github.com/awslabs/mountpoint-s3/pull/1369))
-* Allow changing log level dynamically with `USR2` signal. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity on runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-on-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 
 ## v0.1.3 (April 9, 2025)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated `network_performance.sh` to set maximum throughput correctly for newer instances (i.e. `trn2.48xlarge`, `i7ie.6xlarge`).
   ([#1369](https://github.com/awslabs/mountpoint-s3/pull/1369))
+* Allow changing log level dynamically with `USR2` signal. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 
 ## v0.1.3 (April 9, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-fs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -46,6 +46,7 @@ time = { version = "0.3.37", features = ["macros", "formatting"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+signal-hook = "0.3.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17.0", default-features = false }

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -617,7 +617,7 @@ where
     );
 
     if args.foreground {
-        init_logging(args.make_logging_config()).context("failed to initialize logging")?;
+        let _logging = init_logging(args.make_logging_config()).context("failed to initialize logging")?;
 
         let _metrics = metrics::install();
 
@@ -649,7 +649,7 @@ where
         match pid.expect("Failed to fork mount process") {
             ForkResult::Child => {
                 let args = CliArgs::parse();
-                init_logging(logging_config).context("failed to initialize logging")?;
+                let _logging = init_logging(logging_config).context("failed to initialize logging")?;
 
                 let _metrics = metrics::install();
 
@@ -693,7 +693,7 @@ where
                 }
             }
             ForkResult::Parent { child } => {
-                init_logging(logging_config).context("failed to initialize logging")?;
+                let _logging = init_logging(logging_config).context("failed to initialize logging")?;
 
                 // close unused file descriptor, we only read from this end.
                 drop(write_fd);

--- a/mountpoint-s3-fs/src/logging.rs
+++ b/mountpoint-s3-fs/src/logging.rs
@@ -19,8 +19,9 @@ use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-use crate::metrics::metrics_tracing_span_layer;
 use mountpoint_s3_client::config::{RustLogAdapter, AWSCRT_LOG_TARGET};
+
+use crate::metrics::metrics_tracing_span_layer;
 
 #[cfg(test)]
 mod testing;

--- a/mountpoint-s3-fs/src/logging.rs
+++ b/mountpoint-s3-fs/src/logging.rs
@@ -18,6 +18,11 @@ use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+#[cfg(test)]
+mod testing;
+
+mod envfilter;
+
 mod syslog;
 use self::syslog::SyslogLayer;
 

--- a/mountpoint-s3-fs/src/logging.rs
+++ b/mountpoint-s3-fs/src/logging.rs
@@ -209,9 +209,13 @@ fn toggle_filter_on_signals<S: 'static>(
 
     let thread_handle = thread::spawn(move || {
         for _ in &mut signals.forever() {
-            warn!("Changing log verbosity");
-            if let Err(err) = toggle_handle.next() {
-                warn!("Failed to change log verbosity: {err}");
+            match toggle_handle.next() {
+                Ok(desc) => {
+                    warn!("Changed log verbosity to {desc}");
+                }
+                Err(err) => {
+                    warn!("Failed to change log verbosity: {err}");
+                }
             }
         }
     });

--- a/mountpoint-s3-fs/src/logging.rs
+++ b/mountpoint-s3-fs/src/logging.rs
@@ -164,10 +164,15 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<LoggingHandl
     };
 
     let (filter, filter_handle) = toggleable(vec![
+        // Default logging verbosity (i.e., the one configured using `--debug`, `--debug-crt`, or `MOUNTPOINT_LOG` environment variable)
         make_default_filter(config.default_filter),
+        // Debug logging for all except CRT (i.e., `debug,awscrt=off`)
         make_filter(LevelFilter::DEBUG, LevelFilter::OFF),
+        // Debug logging for all (i.e., `debug,awscrt=debug`)
         make_filter(LevelFilter::DEBUG, LevelFilter::DEBUG),
+        // Trace logging for all except CRT (i.e., `trace,awscrt=off`)
         make_filter(LevelFilter::TRACE, LevelFilter::OFF),
+        // Trace logging for all (i.e., `trace,awscrt=trace`)
         make_filter(LevelFilter::TRACE, LevelFilter::TRACE),
     ]);
 

--- a/mountpoint-s3-fs/src/logging.rs
+++ b/mountpoint-s3-fs/src/logging.rs
@@ -6,22 +6,27 @@ use std::panic::{self, PanicHookInfo};
 use std::path::{Path, PathBuf};
 use std::thread;
 
-use crate::metrics::metrics_tracing_span_layer;
 use anyhow::Context;
-use mountpoint_s3_client::config::RustLogAdapter;
 use rand::Rng;
+use signal_hook::consts::SIGUSR2;
+use signal_hook::iterator::{Handle as SignalsHandle, Signals};
 use time::format_description::FormatItem;
 use time::macros;
 use time::OffsetDateTime;
 use tracing::Span;
+use tracing_log::log::warn;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::metrics::metrics_tracing_span_layer;
+use mountpoint_s3_client::config::{RustLogAdapter, AWSCRT_LOG_TARGET};
 
 #[cfg(test)]
 mod testing;
 
 mod envfilter;
+use envfilter::{toggleable, ToggleableHandle};
 
 mod syslog;
 use self::syslog::SyslogLayer;
@@ -40,16 +45,28 @@ pub struct LoggingConfig {
     pub default_filter: String,
 }
 
+#[derive(Default)]
+/// A handle for logging that cleans up all allocated resources on drop.
+pub struct LoggingHandle {
+    _toggle_signal_handle: Option<ToggleSignalHandle>,
+}
+
 /// Set up all our logging infrastructure.
 ///
 /// This method:
 /// - initializes the `tracing` subscriber for capturing log output
 /// - sets up the logging adapters for the CRT and for metrics
 /// - installs a panic hook to capture panics and log them with `tracing`
-pub fn init_logging(config: LoggingConfig) -> anyhow::Result<()> {
-    init_tracing_subscriber(config)?;
+/// - sets up a signal listener and toggles the logging verbosity each time it receives a `USR2` signal
+pub fn init_logging(config: LoggingConfig) -> anyhow::Result<LoggingHandle> {
+    let handle = init_tracing_subscriber(config)?;
     install_panic_hook();
-    Ok(())
+    Ok(handle)
+}
+
+/// Record the object name in the current [Span].
+pub fn record_name(name: &str) {
+    Span::current().record("name", name);
 }
 
 /// For a given log directory, prepare a file name for this Mountpoint.
@@ -105,14 +122,11 @@ fn install_panic_hook() {
     }))
 }
 
-fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
-    // Create the logging config from the MOUNTPOINT_LOG environment variable or the default config
-    // if that variable is unset.
-    let env_filter =
-        EnvFilter::try_from_env("MOUNTPOINT_LOG").unwrap_or_else(|_| EnvFilter::new(&config.default_filter));
+fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<LoggingHandle> {
     // Don't create the files or subscribers if we'll never emit any logs
-    if env_filter.max_level_hint() == Some(LevelFilter::OFF) {
-        return Ok(());
+    let default_filter = make_default_filter(config.default_filter.clone())();
+    if default_filter.max_level_hint() == Some(LevelFilter::OFF) {
+        return Ok(LoggingHandle::default());
     }
 
     RustLogAdapter::try_init().context("failed to initialize CRT logger")?;
@@ -148,17 +162,82 @@ fn init_tracing_subscriber(config: LoggingConfig) -> anyhow::Result<()> {
         None
     };
 
+    let (filter, filter_handle) = toggleable(vec![
+        make_default_filter(config.default_filter),
+        make_filter(LevelFilter::DEBUG, LevelFilter::OFF),
+        make_filter(LevelFilter::DEBUG, LevelFilter::DEBUG),
+        make_filter(LevelFilter::TRACE, LevelFilter::OFF),
+        make_filter(LevelFilter::TRACE, LevelFilter::TRACE),
+    ]);
+
+    let toggle_signal_handle = toggle_filter_on_signals(vec![SIGUSR2], filter_handle)?;
+
     tracing_subscriber::registry()
-        .with(env_filter)
+        .with(filter)
         .with(syslog_layer)
         .with(file_layer)
         .with(console_layer)
         .with(metrics_tracing_span_layer())
         .init();
 
-    Ok(())
+    Ok(LoggingHandle {
+        _toggle_signal_handle: Some(toggle_signal_handle),
+    })
 }
 
-pub fn record_name(name: &str) {
-    Span::current().record("name", name);
+/// Create a default logging filter from the `MOUNTPOINT_LOG` environment variable or the default config
+/// if that variable is unset.
+fn make_default_filter(default_directives: String) -> Box<dyn FnMut() -> EnvFilter + Send> {
+    Box::new(move || {
+        EnvFilter::try_from_env("MOUNTPOINT_LOG").unwrap_or_else(|_| EnvFilter::new(default_directives.clone()))
+    })
+}
+
+/// Create a logging filter using provided global and CRT [level](LevelFilter)s.
+fn make_filter(level: LevelFilter, crt_level: LevelFilter) -> Box<dyn FnMut() -> EnvFilter + Send> {
+    Box::new(move || EnvFilter::new(format!("{level},{AWSCRT_LOG_TARGET}={crt_level}")))
+}
+
+/// Creates a new thread to listen specified Unix signals, and toggles the log filter each time it receives a signal.
+/// Returns a [handle](ToggleSignalHandle), and cleans up signal listener and the created thread once the handle is dropped.
+fn toggle_filter_on_signals<S: 'static>(
+    signals: Vec<Signal>,
+    mut toggle_handle: ToggleableHandle<S>,
+) -> anyhow::Result<ToggleSignalHandle> {
+    let mut signals = Signals::new(signals)?;
+    let signals_handle = signals.handle();
+
+    let thread_handle = thread::spawn(move || {
+        for _ in &mut signals.forever() {
+            warn!("Changing log verbosity");
+            if let Err(err) = toggle_handle.next() {
+                warn!("Failed to change log verbosity: {err}");
+            }
+        }
+    });
+
+    Ok(ToggleSignalHandle {
+        signals_handle,
+        thread_handle: Some(thread_handle),
+    })
+}
+
+/// An Unix signal.
+type Signal = libc::c_int;
+
+/// A handle returned by [toggle_filter_on_signals] which cleans up all allocated resources on [drop](ToggleSignalHandle::drop).
+struct ToggleSignalHandle {
+    signals_handle: SignalsHandle,
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for ToggleSignalHandle {
+    fn drop(&mut self) {
+        if !self.signals_handle.is_closed() {
+            self.signals_handle.close();
+        }
+        if let Some(handle) = self.thread_handle.take() {
+            _ = handle.join();
+        }
+    }
 }

--- a/mountpoint-s3-fs/src/logging/envfilter.rs
+++ b/mountpoint-s3-fs/src/logging/envfilter.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use tracing_subscriber::reload::{Handle as ReloadHandle, Layer};
+use tracing_subscriber::EnvFilter;
+
+/// A List of filters to toggle between.
+type ToggleableFilters = Vec<Box<dyn FnMut() -> EnvFilter + Send + 'static>>;
+
+/// A toggleable [EnvFilter] layer.
+type ToggleableLayer<S> = Layer<EnvFilter, S>;
+
+/// ToggleableHandle allows toggling between [filters](ToggleableFilters) using the [ToggleableHandle::next] method.
+pub struct ToggleableHandle<S> {
+    index: usize,
+    filters: ToggleableFilters,
+    handle: ReloadHandle<EnvFilter, S>,
+}
+
+impl<S> ToggleableHandle<S> {
+    /// Switches to next [EnvFilter].
+    pub fn next(&mut self) -> Result<()> {
+        self.index = (self.index + 1) % self.filters.len();
+        let next_filter = self.filters[self.index]();
+        self.handle.modify(|filter| *filter = next_filter)?;
+        Ok(())
+    }
+}
+
+/// Returns a new [tracing_subscriber::Layer] and a [handle](ToggleableHandle) to toggle between given [filters](ToggleableFilters).
+pub fn toggleable<S>(mut filters: ToggleableFilters) -> (ToggleableLayer<S>, ToggleableHandle<S>) {
+    assert!(filters.len() > 1, "there must be at least 2 filters to toggle between");
+
+    let first = filters[0]();
+    let (filter, handle) = Layer::new(first);
+
+    (
+        filter,
+        ToggleableHandle {
+            index: 0,
+            filters,
+            handle,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+    use crate::logging::testing::LockedWriter;
+
+    #[test]
+    fn it_works() {
+        let buf = LockedWriter::default();
+
+        let filters = vec![make_filter("error"), make_filter("debug"), make_filter("info")];
+        let (filter, mut handle) = toggleable(filters);
+
+        let writer = buf.clone();
+        let subscriber = tracing_subscriber::registry().with(filter).with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .without_time()
+                .compact()
+                .with_writer(move || writer.clone()),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(target: "test", "error log 1");
+            tracing::debug!(target: "test", "debug log 1");
+
+            handle.next().unwrap(); // Will toggle to `DEBUG` level
+            tracing::trace!(target: "test", "trace log 1");
+            tracing::debug!(target: "test", "debug log 2");
+
+            handle.next().unwrap(); // Will toggle to `INFO` level
+            tracing::debug!(target: "test", "debug log 3");
+            tracing::info!(target: "test", "info log 1");
+
+            handle.next().unwrap(); // Will reset back to `ERROR` level
+            tracing::info!(target: "test", "info log 2");
+            tracing::error!(target: "test", "error log 2");
+        });
+
+        assert_eq!(
+            buf.into_string(),
+            "\
+ERROR test: error log 1
+DEBUG test: debug log 2
+ INFO test: info log 1
+ERROR test: error log 2
+"
+        );
+    }
+
+    fn make_filter(level: &str) -> Box<dyn FnMut() -> EnvFilter + Send + 'static> {
+        let level = level.to_string();
+        Box::new(move || EnvFilter::new(level.clone()))
+    }
+}

--- a/mountpoint-s3-fs/src/logging/envfilter.rs
+++ b/mountpoint-s3-fs/src/logging/envfilter.rs
@@ -16,12 +16,13 @@ pub struct ToggleableHandle<S> {
 }
 
 impl<S> ToggleableHandle<S> {
-    /// Switches to next [EnvFilter].
-    pub fn next(&mut self) -> Result<()> {
+    /// Switches to the next [EnvFilter] and returns a description of the next [EnvFilter].
+    pub fn next(&mut self) -> Result<String> {
         self.index = (self.index + 1) % self.filters.len();
         let next_filter = self.filters[self.index]();
+        let next_filter_desc = format!("{next_filter}");
         self.handle.modify(|filter| *filter = next_filter)?;
-        Ok(())
+        Ok(next_filter_desc)
     }
 }
 
@@ -69,15 +70,15 @@ mod tests {
             tracing::error!(target: "test", "error log 1");
             tracing::debug!(target: "test", "debug log 1");
 
-            handle.next().unwrap(); // Will toggle to `DEBUG` level
+            assert_eq!(handle.next().unwrap(), "debug"); // Will toggle to `DEBUG` level
             tracing::trace!(target: "test", "trace log 1");
             tracing::debug!(target: "test", "debug log 2");
 
-            handle.next().unwrap(); // Will toggle to `INFO` level
+            assert_eq!(handle.next().unwrap(), "info"); // Will toggle to `INFO` level
             tracing::debug!(target: "test", "debug log 3");
             tracing::info!(target: "test", "info log 1");
 
-            handle.next().unwrap(); // Will reset back to `ERROR` level
+            assert_eq!(handle.next().unwrap(), "error"); // Will reset back to `ERROR` level
             tracing::info!(target: "test", "info log 2");
             tracing::error!(target: "test", "error log 2");
         });

--- a/mountpoint-s3-fs/src/logging/testing.rs
+++ b/mountpoint-s3-fs/src/logging/testing.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Default)]
+pub struct LockedWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl LockedWriter {
+    pub fn into_string(self) -> String {
+        let buf = Arc::try_unwrap(self.inner).unwrap().into_inner().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+}
+
+impl std::io::Write for LockedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Allow changing log level dynamically with `USR2` signal. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity on runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-on-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 
 ## v1.16.2 (April 9, 2025)
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity on runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-on-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 
 ## v1.16.2 (April 9, 2025)
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Allow changing log level dynamically with `USR2` signal. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+
 ## v1.16.2 (April 9, 2025)
 
 * Address an issue introduced in v1.16.0 that could affect throughput and memory usage in

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mountpoint-s3"
-version = "1.16.2"
+version = "1.17.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.3" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.4" }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }


### PR DESCRIPTION
This PR makes Mountpoint capable of changing log verbosity dynamically with `USR2` Unix signal. The users can send a `USR2` signal to Mountpoint process, e.g., `kill -USR2 <mount-s3-pid>`, to toggle between the following log verbosity levels:
  1. Default logging verbosity
  2. Debug logging for all except CRT (i.e., `debug,awscrt=off`)
  3. Debug logging for all (i.e., `debug,awscrt=debug`)
  4. Trace logging for all except CRT (i.e., `trace,awscrt=off`)
  5. Trace logging for all (i.e., `trace,awscrt=trace`)

### Does this change impact existing behavior?

No breaking change, a new runtime behavior with `USR2` Unix signal.

### Does this change need a changelog entry? Does it require a version change?

Yes, will update.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
