### PR TITLE
Store full debug info in `tar.gz` archive

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,10 +17,8 @@ jobs:
       matrix:
         runner:
         - name: x86_64
-          arch: x86_64
           tags: [ubuntu-22.04] # GitHub-hosted
         - name: aarch64
-          arch: arm64
           tags: [self-hosted, linux, arm64]
 
     steps:
@@ -42,7 +40,7 @@ jobs:
       - name: Package an unofficial release
         run: docker run --mount type=bind,source=$(pwd),target=/mountpoint mountpoint-builder
       - name: Check release binary
-        run: mkdir ./pkg-out && tar -xzf ./out/mount-s3*-${{ matrix.runner.arch }}.tar.gz -C ./pkg-out && ./pkg-out/bin/mount-s3 --version
+        run: mkdir ./pkg-out && tar -xzf ./out/mount-s3*.tar.gz -C ./pkg-out && ./pkg-out/bin/mount-s3 --version
       - name: Upload unofficial packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,8 +17,10 @@ jobs:
       matrix:
         runner:
         - name: x86_64
+          arch: x86_64
           tags: [ubuntu-22.04] # GitHub-hosted
         - name: aarch64
+          arch: arm64
           tags: [self-hosted, linux, arm64]
 
     steps:
@@ -40,7 +42,7 @@ jobs:
       - name: Package an unofficial release
         run: docker run --mount type=bind,source=$(pwd),target=/mountpoint mountpoint-builder
       - name: Check release binary
-        run: mkdir ./pkg-out && tar -xzf ./out/mount-s3*.tar.gz -C ./pkg-out && ./pkg-out/bin/mount-s3 --version
+        run: mkdir ./pkg-out && tar -xzf ./out/mount-s3*-${{ matrix.runner.arch }}.tar.gz -C ./pkg-out && ./pkg-out/bin/mount-s3 --version
       - name: Upload unofficial packages
         uses: actions/upload-artifact@v4
         with:

--- a/package/README.md
+++ b/package/README.md
@@ -28,7 +28,7 @@ On Amazon Linux 2, some dependencies come from EPEL, so you'll need to set that 
 
     sudo amazon-linux-extras install epel
 
-Then install the depdencies:
+Then install the dependencies:
 
     sudo yum install fuse fuse-devel make cmake3 clang git pkg-config dpkg fakeroot rpmdevtools tar python3
 

--- a/package/package.py
+++ b/package/package.py
@@ -335,6 +335,7 @@ def build_package_archive(metadata: BuildMetadata, package_dir: str, mountpoint_
 
     return archive_path
 
+
 def ensure_rustup_toolchain_is_installed(args: argparse.Namespace):
     # Starting with v1.28, rustup will not install active toolchain by default,
     # (see https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280)

--- a/package/package.py
+++ b/package/package.py
@@ -48,7 +48,7 @@ class BuildMetadata:
             return "mount-s3-suse.spec"
         return "mount-s3.spec"
 
-@dataclass
+@dataclass(frozen=True)
 class MountpointArtifact:
     binary_path: str
     debug_info_path: str

--- a/package/package.py
+++ b/package/package.py
@@ -19,6 +19,7 @@ import tempfile
 
 OPT_PATH = "opt/aws/mountpoint-s3"
 
+
 def log(msg: str):
     print(f"*** {msg}")
     sys.stdout.flush()
@@ -48,10 +49,12 @@ class BuildMetadata:
             return "mount-s3-suse.spec"
         return "mount-s3.spec"
 
+
 @dataclass(frozen=True)
 class MountpointArtifact:
     binary_path: str
     debug_info_path: str
+
 
 def check_dependencies(args: argparse.Namespace):
     """Check that all the required dependencies are available so we don't fail mid-build."""
@@ -319,7 +322,9 @@ def build_package_archive(metadata: BuildMetadata, package_dir: str) -> str:
     return archive_path
 
 
-def build_debug_package_archive(metadata: BuildMetadata, package_dir: str, mountpoint_artifact: MountpointArtifact) -> str:
+def build_debug_package_archive(
+    metadata: BuildMetadata, package_dir: str, mountpoint_artifact: MountpointArtifact
+) -> str:
     """Build a debug.tar.gz archive from the contents of the package directory including the debug information.
     Return the path to the final debug.tar.gz archive."""
 

--- a/package/package.py
+++ b/package/package.py
@@ -158,11 +158,12 @@ def build_mountpoint(metadata: BuildMetadata, args: argparse.Namespace) -> Mount
     # Strip the debug info
     debug_info_path = f"{binary_path}.debug"
     debug_info_name = os.path.basename(debug_info_path)
+    binary_dir = os.path.dirname(binary_path)
     log(f"Stripping debug info from {binary_path} into {debug_info_path}")
     # Copy only the debug info from "mount-s3" into "mount-s3.debug"
-    run(["objcopy", "--only-keep-debug", binary_path, debug_info_path], cwd=metadata.cargoroot, env=env)
+    run(["objcopy", "--only-keep-debug", binary_path, debug_info_path], cwd=binary_dir, env=env)
     # Now strip the debug info copied into "mount-s3.debug" from "mount-s3", and also add a debug link to "mount-s3.debug"
-    run(["objcopy", "--strip-debug", f"--add-gnu-debuglink={debug_info_name}", binary_path], cwd=metadata.cargoroot, env=env)
+    run(["objcopy", "--strip-debug", f"--add-gnu-debuglink={debug_info_name}", binary_path], cwd=binary_dir, env=env)
     if not os.path.exists(debug_info_path):
         raise Exception(f"debug info wasn't found at path {debug_info_path}")
 


### PR DESCRIPTION
This PR updates packaging script to produce a full debug build, and then strips the debug info as a separate file and packages within the `tar.gz` archive. Other packages (i.e., `.deb` and `.rpm`) won't contain this debug info by default to not increase the package size. The debug info (i.e., `mount-s3.debug`) can be fetched from the `tar.gz` archive, and it can be put next to the `mount-s3` binary (i.e., `/opt/aws/mountpoint-s3/bin/mount-s3.debug`) and then `gdb` and others would automatically pick up the debug info.

Prior to this PR, we were only keeping line information in the released binaries (i.e., `-C debuginfo=line-tables-only`), with this PR, we strip all debug information from the main binary, and it reduces the size of main binary further:
| Artifact                                     | `main` | This PR |
| -------------------------------------------- | ------ | ------- |
| `mount-s3-1.16.2+unofficial-x86_64.deb`      | 12M    | 3.5M    |
| `mount-s3-1.16.2+unofficial-x86_64.rpm`      | 13M    | 3.8M    |
| `mount-s3-1.16.2+unofficial-x86_64.suse.rpm` | 13M    | 3.8M    |
| `mount-s3-1.16.2+unofficial-x86_64.tar.gz`   | 18M    | 35M     |
| `mount-s3`                                   | 70M    | 16M     |
| `mount-s3.debug`                             | -      | 132M    |

## Debugging experience
The idea is that once we need debug info either online (e.g., via debugger) or offline (e.g., via core dump), we can just fetch debug info from the corresponding version's `tar.gz` archive. For example, to connect a release build via `gdb`:
```bash
$ mkdir /tmp/mount-s3-debug
$ sudo tar -C /tmp/mount-s3-debug -xzf ./mount-s3-1.16.2+unofficial-x86_64.tar.gz # unzip tar.gz which contains debug info
$ sudo cp /tmp/mount-s3-debug/bin/mount-s3.debug $(dirname $(realpath $(which mount-s3))) # copy `mount-s3.debug` next to `mount-s3`

$ rust-gdb -p `pgrep -f mount-s3` # now connect via debugger and rust-gdb or gdb would automatically pick up the debug info!
(gdb) bt
#0  0x00007f700dc3ee5d in syscall () from /lib64/libc.so.6
#1  0x000055dc75d3aed6 in std::sys::pal::unix::futex::futex_wait () at library/std/src/sys/pal/unix/futex.rs:72
#2  std::sys::sync::thread_parking::futex::Parker::park () at library/std/src/sys/sync/thread_parking/futex.rs:55
#3  std::thread::Thread::park () at library/std/src/thread/mod.rs:1450
#4  0x000055dc757cf595 in std::sync::mpmc::context::Context::wait_until (deadline=..., self=<optimized out>) at /root/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpmc/context.rs:143
#5  std::sync::mpmc::list::{impl#3}::recv::{closure#1}<mountpoint_s3_fs::fuse::session::Message> (cx=<optimized out>) at /root/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpmc/list.rs:448
...

(gdb) t 41
[Switching to thread 41 (Thread 0x7f700cc74640 (LWP 656438))]
#0  0x00007f700dd3eb0c in read () from /lib64/libc.so.6

(gdb) bt
#0  0x00007f700dd3eb0c in read () from /lib64/libc.so.6
#1  0x000055dc7589744d in fuser::channel::Channel::receive (self=<optimized out>, buffer=&mut [u8](size=16781312) = {...}) at mountpoint-s3-fuser/src/channel.rs:36
...

# We can even print some variables if they're not optimized out!
(gdb) f 3
(gdb) p self.filesystem.fs.config
$5 = mountpoint_s3_fs::fs::config::S3FilesystemConfig {
  cache_config: mountpoint_s3_fs::fs::config::CacheConfig {
    serve_lookup_from_cache: false,
    file_ttl: core::time::Duration {
      secs: 0,
      nanos: core::time::Nanoseconds (
        100000000
      )
    },
    dir_ttl: core::time::Duration {
      secs: 1,
      nanos: core::time::Nanoseconds (
        0
      )
    },
...

```

### Without debug info, compared to `main`
As mentioned previously, we were preserving line numbers and function names up to this PR, and it was allowing us to get  some information even on release builds without any additional debug info:

```
$ rust-gdb -p `pgrep -f mount-s3`
(gdb) bt
#0  0x00007f05c803ee5d in syscall () from /lib64/libc.so.6
#1  0x0000559a65cfc676 in std::sys::pal::unix::futex::futex_wait () at library/std/src/sys/pal/unix/futex.rs:72
#2  std::sys::sync::thread_parking::futex::Parker::park () at library/std/src/sys/sync/thread_parking/futex.rs:55
#3  std::thread::Thread::park () at library/std/src/thread/mod.rs:1450
#4  0x0000559a657909b5 in wait_until () at /root/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpmc/context.rs:143
#5  {closure#1}<mountpoint_s3_fs::fuse::session::Message> () at /root/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpmc/list.rs:448
#6  0x0000559a65790595 in {closure#0}<std::sync::mpmc::list::{impl#3}::recv::{closure_env#1}<mountpoint_s3_fs::fuse::session::Message>, ()> ()
    at /root/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/mpmc/context.rs:49
...
```

With this PR, we won't have that information by default, and the experience would be like:
```
$ rust-gdb -p `pgrep -f mount-s3`
(gdb) bt
#0  0x00007f700dc3ee5d in syscall () from /lib64/libc.so.6
#1  0x000055dc75d3aed6 in std::thread::Thread::park ()
#2  0x000055dc757cf595 in std::sync::mpmc::list::Channel<T>::recv::{{closure}} ()
#3  0x000055dc757cf175 in std::sync::mpmc::list::Channel<T>::recv ()
...
```

### Does this change impact existing behavior?

**TODO: Please confirm there's no breaking change, or call out any that are made.**

### Does this change need a changelog entry? Does it require a version change?

**TODO: Confirm with justification if not required.**

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
