### PR TITLE
Update benchmark chart max datapoints from 20 to 30

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,6 +26,7 @@ env:
   # Optional endpoint url, can be empty
   S3_ENDPOINT_URL: ${{ vars.S3_BENCH_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
+  MAX_VALUES_IN_BENCH_CHART: 30
 
 jobs:
   bench:
@@ -86,7 +87,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: true
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Check resource utilization
       uses: benchmark-action/github-action-benchmark@v1
@@ -102,7 +103,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         skip-fetch-gh-pages: true
         summary-always: true
     - name: Provision static content and push benchmark results
@@ -169,7 +170,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Provision static content and push benchmark results
       # Store the results and deploy GitHub pages if the results are from main branch
@@ -237,7 +238,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Check resource utilization
       uses: benchmark-action/github-action-benchmark@v1
@@ -253,7 +254,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         skip-fetch-gh-pages: true
         summary-always: true
     - name: Provision static content and push benchmark results

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -26,6 +26,7 @@ env:
   # Optional endpoint url, can be empty
   S3_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
+  MAX_VALUES_IN_BENCH_CHART: 30
 
 jobs:
   bench:
@@ -85,7 +86,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: true
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Check resource utilization
       uses: benchmark-action/github-action-benchmark@v1
@@ -101,7 +102,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         skip-fetch-gh-pages: true
         summary-always: true
     - name: Provision static content and push benchmark results
@@ -168,7 +169,7 @@ jobs:
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
         comment-on-alert: false
-        max-items-in-chart: 20
+        max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Provision static content and push benchmark results
       # Store the results and deploy GitHub pages if the results are from main branch


### PR DESCRIPTION
Before this change, benchmark graphs (https://awslabs.github.io/mountpoint-s3/dev/bench/) show up to 20 data points where each data point represents a previous commit. One instance we review this is in a weekly meeting, and we feel that more data points would provide more contextual information of what changed as we could have in excess of 20 commits over a period of one or two weeks.

This change updates the graphs to maintain 30 data points at the expense of clarity.

### Does this change impact existing behavior?

No changes to Mountpoint or its crates. This will allow future benchmark runs to maintain 30 data points in graphs.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
