### PR TITLE
Add feature flags for manifest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ env:
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest_tests
 
 permissions:
   id-token: write

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ env:
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest_tests
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest
 
 permissions:
   id-token: write

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -77,11 +77,10 @@ tokio = { version = "1.44.2", features = ["rt", "macros"] }
 walkdir = "2.5.0"
 
 [features]
-# Unreleased feature flags
+# Unreleased and/or experimental features: not enabled in the release binary and may be dropped in future
 block_size = []
 event_log = []
 mem_limiter = []
-# Experimental features: not enabled in the release binary and may be dropped in future
 manifest = []
 # Features for choosing tests
 fips_tests = []
@@ -90,4 +89,3 @@ s3_tests = []
 s3express_tests = []
 shuttle = []
 second_account_tests = []
-manifest_tests = []

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -81,6 +81,8 @@ walkdir = "2.5.0"
 block_size = []
 event_log = []
 mem_limiter = []
+# Experimental features: not enabled in the release binary and may be dropped in future
+manifest = []
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []
@@ -88,3 +90,4 @@ s3_tests = []
 s3express_tests = []
 shuttle = []
 second_account_tests = []
+manifest_tests = []


### PR DESCRIPTION
We'd like to have implementation of the manifest hidden behind the feature flag. We enable tests in workflows now, so they will be triggered in the subsequent PRs. 

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
