### PR TITLE
Extract ClientConfig from CliArgs

### DIFF
--- a/mountpoint-s3-fs/src/autoconfigure.rs
+++ b/mountpoint-s3-fs/src/autoconfigure.rs
@@ -33,17 +33,17 @@ pub fn get_maximum_network_throughput(ec2_instance_type: &str) -> anyhow::Result
 ///  * `AWS_REGION` environment variable (user-provided),
 ///  * EC2 instance region (using the IMDS client),
 ///  * default region (us-east-1).
-pub fn get_region(instance_info: &InstanceInfo, args_region: Option<String>) -> Region {
+pub fn get_region(instance_info: &InstanceInfo, region_override: Option<String>) -> Region {
     const DEFAULT_REGION: &str = "us-east-1";
 
     // Use --region (user-provided).
-    if let Some(region) = args_region {
+    if let Some(region) = region_override {
         return Region::new_user_specified(region);
     }
 
     // Use AWS_REGION (user-provided).
     if let Some(region) = env_region() {
-        tracing::debug!("using AWS_REGION: {region}");
+        tracing::debug!("using AWS_REGION: {region} (environment variable)");
         return Region::new_user_specified(region);
     }
 

--- a/mountpoint-s3-fs/src/cli.rs
+++ b/mountpoint-s3-fs/src/cli.rs
@@ -595,7 +595,7 @@ impl CliArgs {
         FuseSessionConfig::new(mount_point, fuse_options, self.max_threads as usize)
     }
 
-    fn user_agent(&self, instance_info: &InstanceInfo, version: String) -> UserAgent {
+    fn user_agent(&self, instance_info: &InstanceInfo, version: &str) -> UserAgent {
         let user_agent_prefix = if let Some(custom_prefix) = &self.user_agent_prefix {
             format!("{} mountpoint-s3/{}", custom_prefix, version)
         } else {
@@ -666,7 +666,7 @@ impl CliArgs {
         }
     }
 
-    fn client_config(&self, version: String) -> ClientConfig {
+    fn client_config(&self, version: &str) -> ClientConfig {
         let instance_info = InstanceInfo::new();
         let user_agent = self.user_agent(&instance_info, version);
         let throughput_target_gbps = self.throughput_target_gbps(&instance_info);
@@ -851,7 +851,7 @@ pub fn create_s3_client(
     // We keep this logic here until we decouple config layer from FS implementation
     // Once we do that, we can move this logic into a hosting app as it will know the full context
     // and remove the contextParams struct
-    let version = context_params.full_version.to_owned();
+    let version = &context_params.full_version;
     let client_config = args.client_config(version);
 
     let channel = args.channel();

--- a/mountpoint-s3-fs/src/s3.rs
+++ b/mountpoint-s3-fs/src/s3.rs
@@ -1,6 +1,10 @@
 //! Personalities of different S3 implementations. We use this to auto-configure some sensible
 //! defaults that differ between implementations.
 
+use mountpoint_s3_client::config::{EndpointConfig, SigningAlgorithm};
+
+pub mod config;
+
 /// The type of S3 we're talking to.
 ///
 /// This enum intentionally doesn't implement PartialEq/Eq. You shouldn't test it directly. Instead,
@@ -14,6 +18,22 @@ pub enum S3Personality {
 }
 
 impl S3Personality {
+    pub fn infer_from_bucket(bucket: &str, endpoint_config: &EndpointConfig) -> Self {
+        let Ok(resolved) = endpoint_config.resolve_for_bucket(bucket) else {
+            return S3Personality::Standard;
+        };
+        let Ok(auth_scheme) = resolved.auth_scheme() else {
+            return S3Personality::Standard;
+        };
+        if auth_scheme.scheme_name() == SigningAlgorithm::SigV4Express {
+            S3Personality::ExpressOneZone
+        } else if auth_scheme.signing_name() == "s3-outposts" {
+            S3Personality::Outposts
+        } else {
+            S3Personality::Standard
+        }
+    }
+
     pub fn is_list_ordered(&self) -> bool {
         match self {
             S3Personality::Standard => true,

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -1,0 +1,229 @@
+use std::fmt::Display;
+use std::num::NonZeroUsize;
+
+use anyhow::Context as _;
+use mountpoint_s3_client::config::{
+    AddressingStyle, Allocator, EndpointConfig, S3ClientAuthConfig, S3ClientConfig, Uri,
+};
+use mountpoint_s3_client::error::ObjectClientError;
+use mountpoint_s3_client::user_agent::UserAgent;
+use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
+
+use crate::prefix::Prefix;
+
+#[derive(Debug)]
+pub struct ClientConfig {
+    /// AWS region
+    pub region: Region,
+
+    /// S3 endpoint URL
+    pub endpoint_url: Option<String>,
+
+    /// The addressing style for endpoint resolution
+    pub addressing_style: AddressingStyle,
+
+    /// Use dual-stack endpoints when accessing S3
+    pub dual_stack: bool,
+
+    /// Use S3 Transfer Acceleration when accessing S3. This must be enabled on the bucket
+    pub transfer_acceleration: bool,
+
+    /// Authentication configuration
+    pub auth_config: S3ClientAuthConfig,
+
+    /// Set the 'x-amz-request-payer' to 'requester' on S3 requests
+    pub requester_pays: bool,
+
+    /// Account ID of the expected bucket owner
+    pub expected_bucket_owner: Option<String>,
+
+    /// Target throughput in Gbps
+    pub throughput_target_gbps: f64,
+
+    /// One or more network interfaces to use when accessing S3
+    pub bind: Option<Vec<String>>,
+
+    /// Part size for multi-part GET and PUT
+    pub part_config: PartConfig,
+
+    /// Value for the user-agent header
+    pub user_agent: UserAgent,
+}
+
+#[derive(Debug, Clone)]
+pub struct Channel {
+    /// Name of bucket
+    pub bucket_name: String,
+
+    /// Prefix inside the bucket
+    pub prefix: Prefix,
+}
+
+impl Channel {
+    pub fn new(bucket_name: String, prefix: Prefix) -> Self {
+        Self { bucket_name, prefix }
+    }
+}
+
+#[derive(Debug)]
+pub struct PartConfig {
+    /// Part size for GET in bytes
+    read_size_bytes: usize,
+
+    /// Part size for multi-part PUT in bytes
+    write_size_bytes: usize,
+}
+
+impl PartConfig {
+    pub(crate) fn with_read_write_sizes(read_size_bytes: usize, write_size_bytes: usize) -> Self {
+        Self {
+            read_size_bytes,
+            write_size_bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Region {
+    /// Region name
+    name: String,
+    /// Whether the region was provided by the user
+    user_specified: bool,
+}
+
+impl Region {
+    pub fn new_user_specified(region: String) -> Self {
+        Self {
+            name: region,
+            user_specified: true,
+        }
+    }
+
+    pub fn new_inferred(region: String) -> Self {
+        Self {
+            name: region,
+            user_specified: false,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Display for Region {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name)
+    }
+}
+
+// This is a weird looking number! We really want our first request size to be 1MiB,
+// which is a common IO size. But Linux's readahead will try to read an extra 128k on on
+// top of a 1MiB read, which we'd have to wait for a second request to service. Because
+// FUSE doesn't know the difference between regular reads and readahead reads, it will
+// send us a READ request for that 128k, so we'll have to block waiting for it even if
+// the application doesn't want it. This is all in the noise for sequential IO, but
+// waiting for the readahead hurts random IO. So we add 128k to the first request size
+// to avoid the latency hit of the second request.
+//
+// Note the CRT does not respect this value right now, they always return chunks of part size
+// but this is the first window size we prefer.
+const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 + 128 * 1024;
+
+impl ClientConfig {
+    /// Create an [S3CrtClient]
+    pub fn create_client(self, validate_on_channel: Option<&Channel>) -> anyhow::Result<S3CrtClient> {
+        let mut client_config = S3ClientConfig::new()
+            .auth_config(self.auth_config)
+            .throughput_target_gbps(self.throughput_target_gbps)
+            .read_part_size(self.part_config.read_size_bytes)
+            .write_part_size(self.part_config.write_size_bytes)
+            .read_backpressure(true)
+            .initial_read_window(INITIAL_READ_WINDOW_SIZE)
+            .user_agent(self.user_agent);
+        if let Some(interfaces) = self.bind {
+            client_config = client_config.network_interface_names(interfaces);
+        }
+        if self.requester_pays {
+            client_config = client_config.request_payer("requester");
+        }
+        if let Some(owner) = &self.expected_bucket_owner {
+            client_config = client_config.bucket_owner(owner);
+        }
+        // Transient errors are really bad for file systems (applications don't usually expect them), so
+        // let's be more stubborn than the SDK default. With the CRT defaults of 500ms backoff, full
+        // jitter, and 20s max backoff time, 10 attempts will take an average of 55 seconds.
+        client_config = client_config.max_attempts(NonZeroUsize::new(10).unwrap());
+
+        let mut endpoint_config = EndpointConfig::new("PLACEHOLDER")
+            .addressing_style(self.addressing_style)
+            .use_accelerate(self.transfer_acceleration)
+            .use_dual_stack(self.dual_stack)
+            .region(self.region.as_str());
+
+        if let Some(uri) = self.endpoint_url {
+            if !self.region.user_specified {
+                tracing::warn!(
+                    "endpoint specified but region unspecified. using {} as the signing region.",
+                    self.region
+                );
+            }
+
+            let endpoint_uri = Uri::new_from_str(&Allocator::default(), uri).context("Failed to parse endpoint URL")?;
+            endpoint_config = endpoint_config.endpoint(endpoint_uri);
+        }
+
+        let client = S3CrtClient::new(client_config.clone().endpoint_config(endpoint_config.clone()))?;
+
+        if let Some(channel) = validate_on_channel {
+            validate_client_for_bucket(client, channel, self.region, endpoint_config, client_config)
+        } else {
+            Ok(client)
+        }
+    }
+}
+
+/// Validate a client by sending a ListObjectsV2 request to the given bucket/prefix. If the region was not
+/// explicitly provided by the user, attempt to infer it by first sending a ListObjectsV2 to the default region.
+///
+/// This also has the nice side effect of triggering the CRT's DNS resolver to start pooling
+/// responses, which means we don't have to wait for the first file read to start the rampup period.
+fn validate_client_for_bucket(
+    client: S3CrtClient,
+    channel: &Channel,
+    region: Region,
+    endpoint_config: EndpointConfig,
+    client_config: S3ClientConfig,
+) -> anyhow::Result<S3CrtClient> {
+    let list_request = client.list_objects(&channel.bucket_name, None, "", 0, channel.prefix.as_str());
+    match futures::executor::block_on(list_request) {
+        Ok(_) => Ok(client),
+        // Don't try to automatically correct the region if it was manually specified incorrectly
+        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(correct_region)))
+            if !region.user_specified =>
+        {
+            tracing::warn!(
+                "bucket {} is in region {}, not {}. redirecting...",
+                channel.bucket_name,
+                correct_region,
+                region
+            );
+            let new_client = S3CrtClient::new(client_config.endpoint_config(endpoint_config.region(&correct_region)))?;
+            let list_request = new_client.list_objects(&channel.bucket_name, None, "", 0, channel.prefix.as_str());
+            futures::executor::block_on(list_request)
+                .map(|_| new_client)
+                .with_context(|| {
+                    format!(
+                        "initial ListObjectsV2 failed for bucket {} in region {}",
+                        channel.bucket_name, correct_region
+                    )
+                })
+        }
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "initial ListObjectsV2 failed for bucket {} in region {}",
+                channel.bucket_name, region
+            )
+        }),
+    }
+}

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -155,11 +155,10 @@ impl ClientConfig {
         // jitter, and 20s max backoff time, 10 attempts will take an average of 55 seconds.
         client_config = client_config.max_attempts(NonZeroUsize::new(10).unwrap());
 
-        let mut endpoint_config = EndpointConfig::new("PLACEHOLDER")
+        let mut endpoint_config = EndpointConfig::new(self.region.as_str())
             .addressing_style(self.addressing_style)
             .use_accelerate(self.transfer_acceleration)
-            .use_dual_stack(self.dual_stack)
-            .region(self.region.as_str());
+            .use_dual_stack(self.dual_stack);
 
         if let Some(uri) = self.endpoint_url {
             if !self.region.user_specified {


### PR DESCRIPTION
The new `ClientConfig` type captures all the configuration settings used to initialize the S3 client. A `ClientConfig` instance can be built from the relevant arguments in `CliArgs`, integrated with the settings detected from `InstanceInfo`.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
