### PR TITLE
Use the Runtime type in the prefetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,8 +1,9 @@
-## Unreleased
+## Unreleased (v0.2.0)
 
 * Updated `network_performance.sh` to set maximum throughput correctly for newer instances (i.e. `trn2.48xlarge`, `i7ie.6xlarge`).
   ([#1369](https://github.com/awslabs/mountpoint-s3/pull/1369))
 * Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+* Use the Runtime type in the prefetcher. ([#1382](https://github.com/awslabs/mountpoint-s3/pull/1382))
 
 ## v0.1.3 (April 9, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-fs"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -9,7 +9,7 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::fuse::S3FuseFilesystem;
 use mountpoint_s3_fs::prefetch::default_prefetch;
-use mountpoint_s3_fs::{S3Filesystem, S3FilesystemConfig};
+use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig};
 use tempfile::tempdir;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -147,7 +147,7 @@ fn mount_file_system(
         config = config.throughput_target_gbps(throughput_target_gbps);
     }
     let client = S3CrtClient::new(config).expect("Failed to create S3 client");
-    let runtime = client.event_loop_group();
+    let runtime = Runtime::new(client.event_loop_group());
 
     let mut options = vec![MountOption::RO, MountOption::FSName("mountpoint-s3".to_string())];
     options.push(MountOption::AutoUnmount);

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -11,6 +11,7 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{default_prefetch, Prefetch, PrefetchResult};
+use mountpoint_s3_fs::Runtime;
 use sysinfo::{RefreshKind, System};
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -135,7 +136,7 @@ fn main() {
     let etag = head_object_result.etag;
 
     for i in 0..args.iterations {
-        let runtime = client.event_loop_group();
+        let runtime = Runtime::new(client.event_loop_group());
         let manager = default_prefetch(runtime, Default::default());
         let received_bytes = Arc::new(AtomicU64::new(0));
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -7,7 +7,7 @@ use mountpoint_s3_client::types::ChecksumAlgorithm;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
 use mountpoint_s3_fs::upload::Uploader;
-use mountpoint_s3_fs::ServerSideEncryption;
+use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use sysinfo::{RefreshKind, System};
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -100,7 +100,7 @@ fn main() {
         .throughput_target_gbps(args.throughput_target_gbps as f64)
         .write_part_size(args.write_part_size);
     let client = Arc::new(S3CrtClient::new(config).expect("couldn't create client"));
-    let runtime = client.event_loop_group();
+    let runtime = Runtime::new(client.event_loop_group());
 
     for i in 0..args.iterations {
         let max_memory_target = if let Some(target) = args.max_memory_target {

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -16,6 +16,7 @@ mod superblock;
 mod sync;
 pub mod upload;
 
+pub use async_util::Runtime;
 pub use fs::{S3Filesystem, S3FilesystemConfig, ServerSideEncryption};
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use futures::task::Spawn;
-
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError, PutObjectError};
 use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag};
 use mountpoint_s3_client::ObjectClient;
@@ -9,7 +7,7 @@ use mountpoint_s3_client::ObjectClient;
 use thiserror::Error;
 use tracing::error;
 
-use crate::async_util::BoxRuntime;
+use crate::async_util::Runtime;
 use crate::fs::{ServerSideEncryption, SseCorruptedError};
 use crate::mem_limiter::MemoryLimiter;
 use crate::sync::Arc;
@@ -29,7 +27,7 @@ pub use incremental::AppendUploadRequest;
 #[derive(Debug)]
 pub struct Uploader<Client: ObjectClient> {
     client: Client,
-    runtime: BoxRuntime,
+    runtime: Runtime,
     mem_limiter: Arc<MemoryLimiter<Client>>,
     storage_class: Option<String>,
     server_side_encryption: ServerSideEncryption,
@@ -72,7 +70,7 @@ where
     /// Create a new [Uploader] that will make requests to the given client.
     pub fn new(
         client: Client,
-        runtime: impl Spawn + Sync + Send + 'static,
+        runtime: Runtime,
         mem_limiter: Arc<MemoryLimiter<Client>>,
         storage_class: Option<String>,
         server_side_encryption: ServerSideEncryption,
@@ -81,7 +79,7 @@ where
     ) -> Self {
         Self {
             client,
-            runtime: BoxRuntime::new(runtime),
+            runtime,
             mem_limiter,
             storage_class,
             server_side_encryption,

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -8,7 +8,7 @@ use mountpoint_s3_client::types::{
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
 use tracing::error;
 
-use crate::async_util::{BoxRuntime, RemoteResult};
+use crate::async_util::{RemoteResult, Runtime};
 use crate::checksums::combine_checksums;
 use crate::ServerSideEncryption;
 
@@ -43,7 +43,7 @@ where
     Client: ObjectClient + Send + 'static,
 {
     pub fn new(
-        runtime: &BoxRuntime,
+        runtime: &Runtime,
         client: Client,
         params: UploadRequestParams,
     ) -> Result<Self, UploadError<Client::ClientError>> {
@@ -222,7 +222,7 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let buffer_size = client.write_part_size().unwrap();
-        let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
+        let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let mem_limiter = MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(
             client,

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -23,12 +23,12 @@ use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_fs::fs::{DirectoryEntry, DirectoryReplier};
 use mountpoint_s3_fs::prefetch::{default_prefetch, DefaultPrefetcher};
 use mountpoint_s3_fs::prefix::Prefix;
-use mountpoint_s3_fs::{S3Filesystem, S3FilesystemConfig};
+use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 
-pub type TestS3Filesystem<Client> = S3Filesystem<Client, DefaultPrefetcher<ThreadPool>>;
+pub type TestS3Filesystem<Client> = S3Filesystem<Client, DefaultPrefetcher>;
 
 pub fn make_test_filesystem(
     bucket: &str,
@@ -57,7 +57,7 @@ pub fn make_test_filesystem_with_client<Client>(
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
-    let runtime = ThreadPool::builder().pool_size(1).create().unwrap();
+    let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
     let prefetcher = default_prefetch(runtime.clone(), Default::default());
     S3Filesystem::new(client, prefetcher, runtime, bucket, prefix, config)
 }

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -7,6 +7,7 @@ use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::data_cache::{DataCache, DiskDataCache, DiskDataCacheConfig};
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::caching_prefetch;
+use mountpoint_s3_fs::Runtime;
 
 use fuser::BackgroundSession;
 use rand::{Rng, RngCore, SeedableRng};
@@ -407,7 +408,7 @@ where
     Cache: DataCache + Send + Sync + 'static,
 {
     let mount_point = tempfile::tempdir().unwrap();
-    let runtime = client.event_loop_group();
+    let runtime = Runtime::new(client.event_loop_group());
     let prefetcher = caching_prefetch(cache, runtime.clone(), Default::default());
     let (session, _mount) = create_fuse_session(
         client,

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.1.4" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.2.0" }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }


### PR DESCRIPTION
Modify the prefetcher to use the `Runtime` type (previously `BoxRuntime`) instead of a generic parameter implementing `Spawn`.

This change simplifies the type signatures for many types used by the Prefetcher, including `ObjectPartStream` and `DataCache` implementations, in a similar way as already done for the Uploader.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Yes, for `mountpoint-s3-fs`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
