### PR TITLE
Use manifest in readdir and lookup operations

### DIFF
--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -163,6 +163,7 @@ where
         let superblock_config = SuperblockConfig {
             cache_config: config.cache_config.clone(),
             s3_personality: config.s3_personality,
+            manifest_db_path: config.manifest_db_path.clone(),
         };
         let superblock = Superblock::new(bucket, prefix, superblock_config);
         let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), config.mem_limit));

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use nix::unistd::{getgid, getuid};
 
@@ -38,6 +38,8 @@ pub struct S3FilesystemConfig {
     pub use_upload_checksums: bool,
     /// Memory limit
     pub mem_limit: u64,
+    /// Path to an SQLite DB containing the list of S3 keys available with this mount
+    pub manifest_db_path: Option<PathBuf>,
 }
 
 impl Default for S3FilesystemConfig {
@@ -60,6 +62,7 @@ impl Default for S3FilesystemConfig {
             server_side_encryption: Default::default(),
             use_upload_checksums: true,
             mem_limit: MINIMUM_MEM_LIMIT,
+            manifest_db_path: None,
         }
     }
 }

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -175,6 +175,7 @@ impl ToErrno for InodeError {
             InodeError::CorruptedMetadata(_) => libc::EIO,
             InodeError::SetAttrNotPermittedOnRemoteInode(_) => libc::EPERM,
             InodeError::StaleInode { .. } => libc::ESTALE,
+            InodeError::ManifestError { .. } => libc::EIO,
         }
     }
 }

--- a/mountpoint-s3-fs/src/manifest.rs
+++ b/mountpoint-s3-fs/src/manifest.rs
@@ -1,4 +1,8 @@
+use crate::superblock::InodeError;
+use db::Db;
+use std::{collections::VecDeque, path::Path};
 use thiserror::Error;
+use tracing::{error, trace};
 
 mod builder;
 mod db;
@@ -14,4 +18,141 @@ pub enum ManifestError {
     NoEtagOrSize(String),
     #[error("key is invalid and will be unavailable: {0}")]
     InvalidKey(String),
+    #[error("invalid database row")]
+    InvalidRow,
+    #[error("too many rows returned from db")]
+    TooManyRows,
+}
+
+/// An entry returned by manifest_lookup() and ManifestIter::next()
+#[derive(Debug, Clone)]
+pub enum ManifestEntry {
+    File {
+        full_key: String,
+        etag: String,
+        size: usize,
+    },
+    Directory {
+        full_key: String, // doesn't contain '/'
+    },
+}
+
+impl ManifestEntry {
+    fn from_db_entry(db_entry: DbEntry) -> Result<Self, ManifestError> {
+        if db_entry.full_key.ends_with('/') {
+            Err(ManifestError::InvalidRow)
+        } else if db_entry.etag.is_none() && db_entry.size.is_none() {
+            Ok(ManifestEntry::Directory {
+                full_key: db_entry.full_key,
+            })
+        } else if db_entry.etag.is_some() && db_entry.size.is_some() {
+            Ok(ManifestEntry::File {
+                full_key: db_entry.full_key,
+                etag: db_entry.etag.unwrap(),
+                size: db_entry.size.unwrap(),
+            })
+        } else {
+            Err(ManifestError::InvalidRow)
+        }
+    }
+}
+
+/// Manifest of all available objects in the bucket
+#[derive(Debug)]
+pub struct Manifest {
+    db: Db,
+}
+
+impl Manifest {
+    pub fn new(manifest_db_path: &Path) -> Result<Self, rusqlite::Error> {
+        let db = Db::new(manifest_db_path)?;
+        Ok(Self { db })
+    }
+
+    /// Lookup an entry in the manifest, the result may be a file or a directory
+    pub fn manifest_lookup(
+        &self,
+        parent_full_path: String,
+        name: &str,
+    ) -> Result<Option<ManifestEntry>, ManifestError> {
+        trace!("using manifest to lookup {} in {}", name, parent_full_path);
+        let mut full_path = parent_full_path;
+        full_path.push_str(name);
+
+        // search for an entry
+        let mut db_entries = self.db.select_entries(&full_path)?;
+        let Some(db_entry) = db_entries.pop() else {
+            return Ok(None);
+        };
+        if !db_entries.is_empty() {
+            Err(ManifestError::TooManyRows)
+        } else {
+            ManifestEntry::from_db_entry(db_entry).map(Some)
+        }
+    }
+
+    /// Create an iterator over directory's direct children
+    pub fn iter(&self, bucket: &str, directory_full_path: &str) -> Result<ManifestIter, InodeError> {
+        ManifestIter::new(self.db.clone(), bucket, directory_full_path)
+    }
+}
+
+#[derive(Debug)]
+pub struct ManifestIter {
+    db: Db,
+    /// Prepared entries in order to be returned by the iterator.
+    entries: VecDeque<DbEntry>,
+    /// Key of the directory being listed by this iterator
+    parent_key: String,
+    /// Offset of the next child to search for in the database
+    next_offset: usize,
+    /// Max amount of entries to read from the database at once
+    batch_size: usize,
+    /// Database has no more entries
+    finished: bool,
+}
+
+impl ManifestIter {
+    fn new(db: Db, _bucket: &str, parent_key: &str) -> Result<Self, InodeError> {
+        // remove trailing '/' since we don't store it in the db
+        let parent_key = parent_key.trim_end_matches("/").to_owned();
+        let batch_size = 10000;
+        Ok(Self {
+            db,
+            entries: Default::default(),
+            parent_key,
+            next_offset: 0,
+            batch_size,
+            finished: false,
+        })
+    }
+
+    /// Next child of the directory
+    pub fn next_entry(&mut self) -> Result<Option<ManifestEntry>, ManifestError> {
+        if self.entries.is_empty() && !self.finished {
+            self.search_next_entries()?
+        }
+
+        let Some(db_entry) = self.entries.pop_front() else {
+            return Ok(None);
+        };
+
+        ManifestEntry::from_db_entry(db_entry).map(Some)
+    }
+
+    /// Load next batch of entries from the database, keeping track of the `next_offset`
+    fn search_next_entries(&mut self) -> Result<(), ManifestError> {
+        let db_entries = self
+            .db
+            .select_children(&self.parent_key, self.next_offset, self.batch_size)?;
+
+        if db_entries.len() < self.batch_size {
+            self.finished = true;
+        }
+
+        self.next_offset += db_entries.len();
+        self.entries.extend(db_entries);
+
+        Ok(())
+    }
 }

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -44,6 +44,7 @@
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 
+use crate::manifest::{Manifest, ManifestEntry};
 use mountpoint_s3_client::types::RestoreStatus;
 use mountpoint_s3_client::ObjectClient;
 use time::OffsetDateTime;
@@ -97,7 +98,10 @@ impl ReaddirHandle {
             }
         };
 
-        let iter = if inner.config.s3_personality.is_list_ordered() {
+        let iter = if let Some(manifest) = inner.manifest.as_ref() {
+            trace!("using manifest readdir iter");
+            ReaddirIter::manifest(manifest, &inner.bucket, &full_path)?
+        } else if inner.config.s3_personality.is_list_ordered() {
             ReaddirIter::ordered(&inner.bucket, &full_path, page_size, local_entries.into())
         } else {
             ReaddirIter::unordered(&inner.bucket, &full_path, page_size, local_entries.into())
@@ -316,6 +320,7 @@ impl Ord for ReaddirEntry {
 enum ReaddirIter {
     Ordered(ordered::ReaddirIter),
     Unordered(unordered::ReaddirIter),
+    Manifest(manifest::ReaddirIter),
 }
 
 impl ReaddirIter {
@@ -327,10 +332,18 @@ impl ReaddirIter {
         Self::Unordered(unordered::ReaddirIter::new(bucket, full_path, page_size, local_entries))
     }
 
+    fn manifest(manifest: &Manifest, bucket: &str, full_path: &str) -> Result<Self, InodeError> {
+        Ok(Self::Manifest(manifest::ReaddirIter::new(
+            manifest.iter(bucket, full_path)?,
+            full_path.len(),
+        )))
+    }
+
     async fn next(&mut self, client: &impl ObjectClient) -> Result<Option<ReaddirEntry>, InodeError> {
         match self {
             Self::Ordered(iter) => iter.next(client).await,
             Self::Unordered(iter) => iter.next(client).await,
+            Self::Manifest(iter) => iter.next(),
         }
     }
 }
@@ -602,6 +615,55 @@ mod unordered {
             }
 
             Ok(self.local_iter.pop_front())
+        }
+    }
+}
+
+mod manifest {
+    use time::OffsetDateTime;
+
+    use crate::manifest::ManifestIter;
+
+    use super::*;
+
+    /// Adaptor for [ManifestIter], converts [ManifestEntry] to [ReaddirEntry]
+    #[derive(Debug)]
+    pub struct ReaddirIter {
+        manifest_iter: ManifestIter,
+        full_path_len: usize,
+    }
+
+    impl ReaddirIter {
+        pub(super) fn new(manifest_iter: ManifestIter, full_path_len: usize) -> Self {
+            Self {
+                manifest_iter,
+                full_path_len,
+            }
+        }
+
+        /// Return the next [ReaddirEntry] for the directory stream. If the stream is finished, returns
+        /// `Ok(None)`.
+        pub(super) fn next(&mut self) -> Result<Option<ReaddirEntry>, InodeError> {
+            let readdir_entry = match self.manifest_iter.next_entry()? {
+                Some(ManifestEntry::File { full_key, etag, size }) => {
+                    let name = full_key[self.full_path_len..].to_owned();
+                    Some(ReaddirEntry::RemoteObject {
+                        name,
+                        full_key,
+                        size: size as u64,
+                        last_modified: OffsetDateTime::now_utc(),
+                        storage_class: None,
+                        restore_status: None,
+                        etag,
+                    })
+                }
+                Some(ManifestEntry::Directory { full_key, .. }) => {
+                    let name = full_key[self.full_path_len..].to_owned();
+                    Some(ReaddirEntry::RemotePrefix { name })
+                }
+                None => None,
+            };
+            Ok(readdir_entry)
         }
     }
 }

--- a/mountpoint-s3-fs/tests/common/manifest.rs
+++ b/mountpoint-s3-fs/tests/common/manifest.rs
@@ -79,3 +79,17 @@ pub fn select_all(manifest_db_path: &Path) -> rusqlite::Result<Vec<TestDbEntry>>
     let result: rusqlite::Result<Vec<TestDbEntry>> = stmt.query_map((), TestDbEntry::from_row)?.collect();
     result
 }
+
+pub fn insert_entries(
+    manifest_db_path: &Path,
+    entries: &[(&str, &str, Option<&str>, Option<usize>)],
+) -> rusqlite::Result<()> {
+    let conn = Connection::open(manifest_db_path).expect("must connect to a db");
+    conn.execute_batch("BEGIN TRANSACTION;")?;
+    let mut stmt = conn.prepare("INSERT INTO s3_objects (key, parent_key, etag, size) VALUES (?1, ?2, ?3, ?4)")?;
+    for entry in entries {
+        stmt.execute(*entry)?;
+    }
+    conn.execute_batch("COMMIT;")?;
+    Ok(())
+}

--- a/mountpoint-s3-fs/tests/fuse_tests/manifest_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/manifest_test.rs
@@ -1,0 +1,283 @@
+use crate::common::fuse::{self, read_dir_to_entry_names, TestClient, TestSessionConfig};
+use crate::common::manifest::{create_dummy_manifest, create_manifest, insert_entries};
+#[cfg(feature = "s3_tests")]
+use crate::common::s3::{get_test_bucket_and_prefix, get_test_region, get_test_sdk_client};
+use mountpoint_s3_fs::manifest::DbEntry;
+use mountpoint_s3_fs::S3FilesystemConfig;
+use std::fs::{self, metadata};
+use std::io::ErrorKind;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+#[cfg(feature = "s3_tests")]
+use std::{fs::File, io::Read};
+use test_case::test_case;
+
+#[test_case(&[
+    "dir1/a.txt",
+    "dir1/dir2/b.txt",
+    "dir1/dir2/c.txt",
+    "dir1/dir3/dir4/d.txt",
+    "e.txt",
+], &[], "", &mut ["dir1", "e.txt"]; "root directory")]
+#[test_case(&[
+    "dir1/a.txt",
+    "dir1/dir2/b.txt",
+    "dir1/dir2/c.txt",
+    "dir1/dir3/dir4/d.txt",
+    "e.txt",
+], &[], "dir1", &["a.txt", "dir2", "dir3"]; "child directory")]
+#[test_case(&[
+    "dir1/a.txt",
+    "dir1/dir2/b.txt",
+], &[
+    "dir1/dir2/c.txt",
+    "dir1/dir3/dir4/d.txt",
+    "dir1/e.txt",
+    "f.txt",
+], "dir1", &["a.txt", "dir2"]; "with excluded keys")]
+fn test_readdir_manifest(
+    manifest_keys: &[&str],
+    excluded_keys: &[&str],
+    directory_to_list: &str,
+    expected_children: &[&str],
+) {
+    let (_tmp_dir, db_path) = create_dummy_manifest(manifest_keys, 0).expect("manifest must be created");
+    let test_session = fuse::mock_session::new("", manifest_test_session_config(&db_path));
+    put_dummy_objects(test_session.client(), manifest_keys, excluded_keys);
+
+    let read_dir_iter = fs::read_dir(test_session.mount_path().join(directory_to_list)).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, expected_children, "readdir test failed");
+}
+
+#[test]
+fn test_readdir_manifest_20k_keys() {
+    let manifest_keys = (0..20000).map(|i| format!("dir1/file_{}", i)).collect::<Vec<_>>();
+    let excluded_keys = &["dir1/excluded_file".to_string()];
+    let directory_to_list = "dir1";
+    let mut expected_children = (0..20000).map(|i| format!("file_{}", i)).collect::<Vec<_>>();
+    expected_children.sort(); // children are expected to be in the sorted order
+
+    let (_tmp_dir, db_path) = create_dummy_manifest(&manifest_keys, 0).expect("manifest must be created");
+    let test_session = fuse::mock_session::new("", manifest_test_session_config(&db_path));
+    put_dummy_objects(test_session.client(), &manifest_keys, excluded_keys);
+
+    let read_dir_iter = fs::read_dir(test_session.mount_path().join(directory_to_list)).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, expected_children, "readdir test failed");
+}
+
+#[test_case(Some("dummy_etag"), None; "missing size")]
+#[test_case(None, Some(1); "missing etag")]
+fn test_readdir_manifest_missing_metadata(etag: Option<&str>, size: Option<usize>) {
+    let key = "key";
+    let (_tmp_dir, db_path) = create_dummy_manifest::<&str>(&[], 0).expect("manifest must be created");
+    let test_session = fuse::mock_session::new("", manifest_test_session_config(&db_path));
+    insert_entries(&db_path, &[(key, "", etag, size)]).expect("insert invalid row must succeed");
+
+    let mut read_dir_iter = fs::read_dir(test_session.mount_path()).unwrap();
+    let e = read_dir_iter
+        .next()
+        .expect("iterator not empty")
+        .expect_err("first item is an error");
+    assert_eq!(e.raw_os_error().expect("must be an error"), libc::EIO);
+    assert!(read_dir_iter.next().is_none(), "no more items in the iterator");
+}
+
+#[test]
+fn test_lookup_unicode_keys_manifest() {
+    let file_size = 1024;
+    let keys = &["مرحبًا", "🇦🇺", "🐈/🦀"];
+    let excluded_keys = &["こんにちは"];
+    let (_tmp_dir, db_path) = create_dummy_manifest(keys, file_size).expect("manifest must be created");
+    let test_session = fuse::mock_session::new("", manifest_test_session_config(&db_path));
+    put_dummy_objects(test_session.client(), keys, excluded_keys);
+
+    let m = metadata(test_session.mount_path().join("مرحبًا")).unwrap();
+    assert!(m.file_type().is_file());
+    assert_eq!(m.size(), file_size as u64);
+    let m = metadata(test_session.mount_path().join("🇦🇺")).unwrap();
+    assert!(m.file_type().is_file());
+    let m = metadata(test_session.mount_path().join("🐈")).unwrap();
+    assert!(m.file_type().is_dir());
+    let m = metadata(test_session.mount_path().join("🐈/🦀")).unwrap();
+    assert!(m.file_type().is_file());
+    let e = metadata(test_session.mount_path().join("こんにちは")).expect_err("must not exist");
+    assert_eq!(e.kind(), ErrorKind::NotFound);
+}
+
+#[test_case(Some("dummy_etag"), None; "missing size")]
+#[test_case(None, Some(1); "missing etag")]
+fn test_lookup_manifest_missing_metadata(etag: Option<&str>, size: Option<usize>) {
+    let key = "key";
+    let (_tmp_dir, db_path) = create_dummy_manifest::<&str>(&[], 0).expect("manifest must be created");
+    let test_session = fuse::mock_session::new("", manifest_test_session_config(&db_path));
+    insert_entries(&db_path, &[(key, "", etag, size)]).expect("insert invalid row must succeed");
+
+    let e = metadata(test_session.mount_path().join(key)).expect_err("lookup must fail");
+    assert_eq!(e.raw_os_error().expect("lookup must fail"), libc::EIO);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(false, false; "just read")]
+#[test_case(true, false; "readdir then read")]
+#[test_case(false, true; "stat then read")]
+#[tokio::test]
+async fn test_basic_read_manifest_s3(readdir_before_read: bool, stat_before_read: bool) {
+    let visible_object = ("visible_object_key", vec![b'1'; 1024]);
+    let invisible_object = ("invisible_object_key", vec![b'2'; 1024]);
+
+    // put objects
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_basic_read_manifest_s3");
+    let sdk_client = get_test_sdk_client(&get_test_region()).await;
+    let visible_object_props = put_object(
+        &sdk_client,
+        &bucket,
+        &prefix,
+        visible_object.0,
+        visible_object.1.clone(),
+    )
+    .await;
+    put_object(&sdk_client, &bucket, &prefix, invisible_object.0, invisible_object.1).await;
+
+    // create manifest and do the mount
+    let (_tmp_dir, db_path) = create_manifest(
+        [Ok(DbEntry {
+            full_key: format!("{}{}", prefix, visible_object.0),
+            etag: Some(visible_object_props.0),
+            size: Some(visible_object_props.1),
+        })]
+        .into_iter(),
+        1000,
+    )
+    .expect("manifest must be created");
+    let test_session =
+        fuse::s3_session::new_with_test_client(manifest_test_session_config(&db_path), sdk_client, &bucket, &prefix);
+
+    // if configured so, readdir before read
+    if readdir_before_read {
+        let read_dir_iter = fs::read_dir(test_session.mount_path()).unwrap();
+        let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+        assert_eq!(
+            &dir_entry_names,
+            &["visible_object_key".to_string()],
+            "dir must contain file named visible_object_key"
+        );
+    }
+    // if configured so, stat before read
+    if stat_before_read {
+        let m = metadata(test_session.mount_path().join("visible_object_key")).unwrap();
+        assert!(m.file_type().is_file());
+        assert_eq!(m.size(), visible_object_props.1 as u64);
+    }
+
+    // Read file once
+    let mut fh1 = File::options()
+        .read(true)
+        .open(test_session.mount_path().join(visible_object.0))
+        .unwrap();
+    let mut read_buffer = Default::default();
+    fh1.read_to_end(&mut read_buffer).unwrap();
+    assert_eq!(read_buffer, visible_object.1);
+
+    // We can read from a file more than once at the same time.
+    let mut fh2 = File::options()
+        .read(true)
+        .open(test_session.mount_path().join(visible_object.0))
+        .unwrap();
+    read_buffer.clear();
+    fh2.read_to_end(&mut read_buffer).unwrap();
+    assert_eq!(read_buffer, visible_object.1);
+
+    // File missing in the manifest must not exist
+    let e = File::options()
+        .read(true)
+        .open(test_session.mount_path().join(invisible_object.0))
+        .expect_err("invisible_object_key must not exist");
+    assert_eq!(e.kind(), ErrorKind::NotFound);
+}
+
+#[cfg(feature = "s3_tests")]
+#[test_case(false, true, libc::EIO; "wrong size")]
+#[test_case(true, false, libc::ESTALE; "wrong etag")]
+#[tokio::test]
+async fn test_read_manifest_wrong_metadata(wrong_etag: bool, wrong_size: bool, errno: i32) {
+    let object = ("visible_object_key", vec![b'1'; 1024]);
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_basic_read_manifest_s3");
+    let sdk_client = get_test_sdk_client(&get_test_region()).await;
+    let object_props = put_object(&sdk_client, &bucket, &prefix, object.0, object.1.clone()).await;
+
+    let (_tmp_dir, db_path) = create_manifest(
+        [Ok(DbEntry {
+            full_key: format!("{}{}", prefix, object.0),
+            etag: if wrong_etag {
+                Some("wrong_etag".to_string())
+            } else {
+                Some(object_props.0)
+            },
+            size: if wrong_size { Some(2048) } else { Some(object_props.1) }, // size smaller than actual will result in incomplete response
+        })]
+        .into_iter(),
+        1000,
+    )
+    .expect("manifest must be created");
+    let test_session =
+        fuse::s3_session::new_with_test_client(manifest_test_session_config(&db_path), sdk_client, &bucket, &prefix);
+
+    let mut fh = File::options()
+        .read(true)
+        .open(test_session.mount_path().join(object.0))
+        .unwrap();
+    let mut read_buffer = Default::default();
+    let e = fh.read_to_end(&mut read_buffer).expect_err("read must fail");
+    assert_eq!(e.raw_os_error().expect("read must fail"), errno);
+}
+
+fn manifest_test_session_config(db_path: &Path) -> TestSessionConfig {
+    TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            manifest_db_path: Some(db_path.to_path_buf()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn put_dummy_objects<T: AsRef<str>>(test_client: &dyn TestClient, manifest_keys: &[T], excluded_keys: &[T]) {
+    for name in manifest_keys.iter().chain(excluded_keys.iter()) {
+        let content = vec![b'0'; 1024];
+        test_client.put_object(name.as_ref(), &content).unwrap();
+    }
+}
+
+#[cfg(feature = "s3_tests")]
+async fn put_object(
+    sdk_client: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    key: &str,
+    content: Vec<u8>,
+) -> (String, usize) {
+    use aws_sdk_s3::primitives::ByteStream;
+
+    let full_key = format!("{}{}", prefix, key);
+    sdk_client
+        .put_object()
+        .bucket(bucket)
+        .key(&full_key)
+        .body(ByteStream::from(content))
+        .send()
+        .await
+        .expect("put object must succeed");
+
+    let head_resp = sdk_client
+        .head_object()
+        .bucket(bucket)
+        .key(&full_key)
+        .send()
+        .await
+        .expect("head object must succeed");
+
+    let size = head_resp.content_length().unwrap() as usize;
+    (head_resp.e_tag.unwrap(), size)
+}

--- a/mountpoint-s3-fs/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/mod.rs
@@ -2,6 +2,8 @@
 mod cache_test;
 mod consistency_test;
 mod lookup_test;
+#[cfg(feature = "manifest")]
+mod manifest_test;
 mod mkdir_test;
 mod perm_test;
 mod prefetch_test;


### PR DESCRIPTION
Use metadata stored in an sqlite database instead of s3, when performing lookup and readdir.

### Does this change impact existing behavior?

No, only used in tests.

### Does this change need a changelog entry? Does it require a version change?

No, only used in tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
