### PR TITLE
Add metrics log output for prefetcher and uploader benchmarks

### DIFF
--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -98,6 +98,7 @@ pub struct CliArgs {
 
 fn main() {
     init_tracing_subscriber();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install();
 
     let args = CliArgs::parse();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -86,6 +86,7 @@ struct UploadBenchmarkArgs {
 
 fn main() {
     init_tracing_subscriber();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install();
 
     let args = UploadBenchmarkArgs::parse();
     println!("starting upload benchmark with {:?}", &args);


### PR DESCRIPTION
Today, the prefetcher and uploader benchmarks configure the tracing library to output logs to `stderr` however no metric sink is installed. This change reuses the metrics module in `mountpoint-s3-fs` to emit metrics in the same way.

If we want to leverage this in `mountpoint-s3-client`'s `client_benchmark`, we'd have to move this to a crate that the client can depend on. I do not think it is worth doing at this time - we plan to review how metrics are emitted later this year.

The motivation for this change now is to support investigation into prefetcher performance.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No, only adds metrics to layer benchmarks.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
