### PR TITLE
Disable ANSI colors where not supported for fs and client examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ dependencies = [
  "rusty-fork",
  "serde_json",
  "static_assertions",
+ "supports-color 3.0.2",
  "tempfile",
  "test-case",
  "thiserror 2.0.12",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -53,6 +53,7 @@ tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 # default, so we take a dev-dependency on ourself with that feature enabled.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 mountpoint-s3-client = { path = ".", features = ["mock"] }
+supports-color = "3.0.2"
 
 [build-dependencies]
 built = { version = "0.7.5", features = ["git2"] }

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -22,8 +22,8 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
-        .with_ansi(false)
         .finish();
 
     subscriber.try_init().expect("unable to install global subscriber");

--- a/mountpoint-s3-client/examples/download.rs
+++ b/mountpoint-s3-client/examples/download.rs
@@ -19,6 +19,7 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
         .finish();
 

--- a/mountpoint-s3-client/examples/list.rs
+++ b/mountpoint-s3-client/examples/list.rs
@@ -13,6 +13,7 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
         .finish();
 

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -23,6 +23,7 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
         .finish();
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -22,6 +22,7 @@ fn init_tracing_subscriber() {
 
     let subscriber = Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
         .finish();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -20,6 +20,7 @@ fn init_tracing_subscriber() {
     let env_filter = EnvFilter::from_default_env();
     let subscriber = Subscriber::builder()
         .with_env_filter(env_filter)
+        .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
         .with_writer(std::io::stderr)
         .finish();
 


### PR DESCRIPTION
Simple change - currently, redirecting the logs to a file will keep ANSI colors. With this change, the scripts will automatically turn off ANSI colors when the standard error output is redirected.

This change is not urgent as users can turn off ANSI colors using `NO_COLOR=1`.

### Does this change impact existing behavior?

For relevant examples/benchmarks only, ANSI color will be disabled when not supported (i.e. not console output).

### Does this change need a changelog entry? Does it require a version change?

No, benchmarking/example change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
