### PR TITLE
Remove Prefetch trait

### DIFF
--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -8,7 +8,7 @@ use fuser::{BackgroundSession, MountOption, Session};
 use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfig};
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::fuse::S3FuseFilesystem;
-use mountpoint_s3_fs::prefetch::default_prefetch;
+use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig};
 use tempfile::tempdir;
 use tracing_subscriber::fmt::Subscriber;
@@ -159,10 +159,10 @@ fn mount_file_system(
         bucket_name,
         mountpoint.to_str().unwrap()
     );
-    let prefetcher = default_prefetch(runtime.clone(), Default::default());
+    let prefetcher_builder = Prefetcher::default_builder(client.clone());
     let fs = S3Filesystem::new(
         client,
-        prefetcher,
+        prefetcher_builder,
         runtime,
         bucket_name,
         &Default::default(),

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -4,6 +4,7 @@ use nix::unistd::{getgid, getuid};
 
 use crate::manifest::Manifest;
 use crate::mem_limiter::MINIMUM_MEM_LIMIT;
+use crate::prefetch::PrefetcherConfig;
 use crate::s3::S3Personality;
 use crate::superblock::WriteMode;
 
@@ -39,6 +40,8 @@ pub struct S3FilesystemConfig {
     pub use_upload_checksums: bool,
     /// Memory limit
     pub mem_limit: u64,
+    /// Prefetcher configuration
+    pub prefetcher_config: PrefetcherConfig,
     /// An SQLite DB containing the list of S3 keys available with this mount
     pub manifest: Option<Manifest>,
 }
@@ -63,6 +66,7 @@ impl Default for S3FilesystemConfig {
             server_side_encryption: Default::default(),
             use_upload_checksums: true,
             mem_limit: MINIMUM_MEM_LIMIT,
+            prefetcher_config: Default::default(),
             manifest: None,
         }
     }

--- a/mountpoint-s3-fs/src/prefetch/builder.rs
+++ b/mountpoint-s3-fs/src/prefetch/builder.rs
@@ -1,0 +1,104 @@
+use crate::{data_cache::DataCache, sync::Arc};
+
+use mountpoint_s3_client::ObjectClient;
+
+use crate::{mem_limiter::MemoryLimiter, Runtime};
+
+use super::caching_stream::CachingPartStream;
+use super::part_stream::{ClientPartStream, PartStream};
+use super::{Prefetcher, PrefetcherConfig};
+
+/// A builder for [Prefetcher] instances.
+pub struct PrefetcherBuilder<Client> {
+    inner: Box<dyn PrefetcherBuild<Client>>,
+}
+
+impl<Client> PrefetcherBuilder<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    /// Creates an instance of the default [Prefetcher] builder.
+    pub fn default_builder(client: Client) -> Self {
+        Self {
+            inner: Box::new(DefaultPrefetcherBuilder { client }),
+        }
+    }
+
+    /// Creates an instance of a caching [Prefetcher] builder.
+    pub fn caching_builder<Cache>(cache: Cache, client: Client) -> Self
+    where
+        Cache: DataCache + Send + Sync + 'static,
+    {
+        Self {
+            inner: Box::new(CachingPrefetcherBuilder { cache, client }),
+        }
+    }
+
+    /// Build a [Prefetcher] instance.
+    pub fn build(
+        self,
+        runtime: Runtime,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        prefetcher_config: PrefetcherConfig,
+    ) -> Prefetcher<Client> {
+        self.inner.build(runtime, mem_limiter, prefetcher_config)
+    }
+}
+
+/// Internal trait to abstract over default and caching prefetcher implementations.
+///
+/// This is always wrapped in the public [PrefetcherBuilder] struct to hide the
+/// cumbersome boxing due to handling trait objects with:
+/// * a generic [ObjectClient] parameter,
+/// * a build method that consumes `self`.
+trait PrefetcherBuild<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    fn build(
+        self: Box<Self>,
+        runtime: Runtime,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        prefetcher_config: PrefetcherConfig,
+    ) -> Prefetcher<Client>;
+}
+
+struct DefaultPrefetcherBuilder<Client> {
+    client: Client,
+}
+
+impl<Client> PrefetcherBuild<Client> for DefaultPrefetcherBuilder<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    fn build(
+        self: Box<Self>,
+        runtime: Runtime,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        prefetcher_config: PrefetcherConfig,
+    ) -> Prefetcher<Client> {
+        let part_stream = ClientPartStream::new(runtime, self.client, mem_limiter);
+        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
+    }
+}
+
+struct CachingPrefetcherBuilder<Cache, Client> {
+    cache: Cache,
+    client: Client,
+}
+
+impl<Cache, Client> PrefetcherBuild<Client> for CachingPrefetcherBuilder<Cache, Client>
+where
+    Cache: DataCache + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    fn build(
+        self: Box<Self>,
+        runtime: Runtime,
+        mem_limiter: Arc<MemoryLimiter<Client>>,
+        prefetcher_config: PrefetcherConfig,
+    ) -> Prefetcher<Client> {
+        let part_stream = CachingPartStream::new(runtime, self.client, mem_limiter, self.cache);
+        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
+    }
+}

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -12,45 +12,43 @@ use crate::checksums::ChecksummedBytes;
 use crate::data_cache::{BlockIndex, DataCache};
 use crate::mem_limiter::MemoryLimiter;
 use crate::object::ObjectId;
-use crate::prefetch::backpressure_controller::{new_backpressure_controller, BackpressureConfig, BackpressureLimiter};
-use crate::prefetch::part::Part;
-use crate::prefetch::part_queue::{unbounded_part_queue, PartQueueProducer};
-use crate::prefetch::part_stream::{
+
+use super::backpressure_controller::{new_backpressure_controller, BackpressureConfig, BackpressureLimiter};
+use super::part::Part;
+use super::part_queue::{unbounded_part_queue, PartQueueProducer};
+use super::part_stream::{
     read_from_client_stream, ObjectPartStream, RequestRange, RequestReaderOutput, RequestTaskConfig,
 };
-use crate::prefetch::task::RequestTask;
-use crate::prefetch::PrefetchReadError;
+use super::task::RequestTask;
+use super::PrefetchReadError;
 
 /// [ObjectPartStream] implementation which maintains a [DataCache] for the object data
 /// retrieved by an [ObjectClient].
 #[derive(Debug)]
-pub struct CachingPartStream<Cache> {
+pub struct CachingPartStream<Cache, Client: ObjectClient + Clone + Send + Sync + 'static> {
     cache: Arc<Cache>,
     runtime: Runtime,
+    client: Client,
+    mem_limiter: Arc<MemoryLimiter<Client>>,
 }
 
-impl<Cache> CachingPartStream<Cache> {
-    pub fn new(runtime: Runtime, cache: Cache) -> Self {
+impl<Cache, Client: ObjectClient + Clone + Send + Sync + 'static> CachingPartStream<Cache, Client> {
+    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter<Client>>, cache: Cache) -> Self {
         Self {
             cache: Arc::new(cache),
             runtime,
+            client,
+            mem_limiter,
         }
     }
 }
 
-impl<Cache> ObjectPartStream for CachingPartStream<Cache>
+impl<Cache, Client> ObjectPartStream<Client> for CachingPartStream<Cache, Client>
 where
     Cache: DataCache + Send + Sync + 'static,
+    Client: ObjectClient + Clone + Send + Sync + 'static,
 {
-    fn spawn_get_object_request<Client>(
-        &self,
-        client: &Client,
-        config: RequestTaskConfig,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
-    ) -> RequestTask<Client>
-    where
-        Client: ObjectClient + Clone + Send + Sync + 'static,
-    {
+    fn spawn_get_object_request(&self, config: RequestTaskConfig) -> RequestTask<Client> {
         let range = config.range;
 
         let backpressure_config = BackpressureConfig {
@@ -61,13 +59,13 @@ where
             request_range: range.into(),
         };
         let (backpressure_controller, backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, mem_limiter.clone());
-        let (part_queue, part_queue_producer) = unbounded_part_queue(mem_limiter);
+            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
+        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone());
         trace!(?range, "spawning request");
 
         let request_task = {
             let request = CachingRequest::new(
-                client.clone(),
+                self.client.clone(),
                 self.cache.clone(),
                 self.runtime.clone(),
                 backpressure_limiter,
@@ -80,6 +78,10 @@ where
         let task_handle = self.runtime.spawn_with_handle(request_task).unwrap();
 
         RequestTask::from_handle(task_handle, range, part_queue, backpressure_controller)
+    }
+
+    fn client(&self) -> &Client {
+        &self.client
     }
 }
 
@@ -454,7 +456,7 @@ mod tests {
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let stream = CachingPartStream::new(runtime, cache);
+        let stream = CachingPartStream::new(runtime, mock_client.clone(), mem_limiter.clone(), cache);
         let range = RequestRange::new(object_size, offset as u64, preferred_size);
         let expected_start_block = (range.start() as usize).div_euclid(block_size);
         let expected_end_block = (range.end() as usize).div_ceil(block_size);
@@ -472,7 +474,7 @@ mod tests {
                 max_read_window_size,
                 read_window_size_multiplier,
             };
-            let request_task = stream.spawn_get_object_request(&mock_client, config, mem_limiter.clone());
+            let request_task = stream.spawn_get_object_request(config);
             compare_read(&id, &object, request_task);
             get_object_counter.count()
         };
@@ -498,7 +500,7 @@ mod tests {
                 max_read_window_size,
                 read_window_size_multiplier,
             };
-            let request_task = stream.spawn_get_object_request(&mock_client, config, mem_limiter.clone());
+            let request_task = stream.spawn_get_object_request(config);
             compare_read(&id, &object, request_task);
             get_object_counter.count()
         };
@@ -535,7 +537,7 @@ mod tests {
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let stream = CachingPartStream::new(runtime, cache);
+        let stream = CachingPartStream::new(runtime, mock_client, mem_limiter.clone(), cache);
 
         for offset in [0, 512 * KB, 1 * MB, 4 * MB, 9 * MB] {
             for preferred_size in [1 * KB, 512 * KB, 4 * MB, 12 * MB, 16 * MB] {
@@ -549,7 +551,7 @@ mod tests {
                     max_read_window_size,
                     read_window_size_multiplier,
                 };
-                let request_task = stream.spawn_get_object_request(&mock_client, config, mem_limiter.clone());
+                let request_task = stream.spawn_get_object_request(config);
                 compare_read(&id, &object, request_task);
             }
         }

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -4,11 +4,12 @@ use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
-use crate::prefetch::part::Part;
-use crate::prefetch::PrefetchReadError;
 use crate::sync::async_channel::{unbounded, Receiver, RecvError, Sender};
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::Arc;
+
+use super::part::Part;
+use super::PrefetchReadError;
 
 /// A queue of [Part]s where the first part can be partially read from if the reader doesn't want
 /// the entire part in one shot.

--- a/mountpoint-s3-fs/src/prefetch/seek_window.rs
+++ b/mountpoint-s3-fs/src/prefetch/seek_window.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::prefetch::part::Part;
+use super::part::Part;
 
 /// A backwards seek window for a single prefetch stream. Parts can be pushed onto the end of the
 /// window (== closest to the current offset in the stream) and older parts will be dropped to

--- a/mountpoint-s3-fs/src/prefetch/task.rs
+++ b/mountpoint-s3-fs/src/prefetch/task.rs
@@ -1,13 +1,12 @@
 use futures::future::RemoteHandle;
 use mountpoint_s3_client::ObjectClient;
 
-use crate::prefetch::backpressure_controller::BackpressureFeedbackEvent::{DataRead, PartQueueStall};
-use crate::prefetch::part::Part;
-use crate::prefetch::part_queue::PartQueue;
-use crate::prefetch::PrefetchReadError;
-
 use super::backpressure_controller::BackpressureController;
+use super::backpressure_controller::BackpressureFeedbackEvent::{DataRead, PartQueueStall};
+use super::part::Part;
+use super::part_queue::PartQueue;
 use super::part_stream::RequestRange;
+use super::PrefetchReadError;
 
 /// A single GetObject request submitted to the S3 client
 #[derive(Debug)]

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -24,20 +24,18 @@ use mountpoint_s3_client::config::{
 use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
 use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_fs::fs::{DirectoryEntry, DirectoryReplier};
-use mountpoint_s3_fs::prefetch::{default_prefetch, DefaultPrefetcher};
+use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::prefix::Prefix;
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 
-pub type TestS3Filesystem<Client> = S3Filesystem<Client, DefaultPrefetcher>;
-
 pub fn make_test_filesystem(
     bucket: &str,
     prefix: &Prefix,
     config: S3FilesystemConfig,
-) -> (Arc<MockClient>, TestS3Filesystem<Arc<MockClient>>) {
+) -> (Arc<MockClient>, S3Filesystem<Arc<MockClient>>) {
     let client_config = MockClientConfig {
         bucket: bucket.to_string(),
         part_size: 1024 * 1024,
@@ -56,13 +54,13 @@ pub fn make_test_filesystem_with_client<Client>(
     bucket: &str,
     prefix: &Prefix,
     config: S3FilesystemConfig,
-) -> TestS3Filesystem<Client>
+) -> S3Filesystem<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-    let prefetcher = default_prefetch(runtime.clone(), Default::default());
-    S3Filesystem::new(client, prefetcher, runtime, bucket, prefix, config)
+    let prefetcher_builder = Prefetcher::default_builder(client.clone());
+    S3Filesystem::new(client, prefetcher_builder, runtime, bucket, prefix, config)
 }
 
 #[track_caller]

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -20,7 +20,7 @@ use mountpoint_s3_fs::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIEN
 use mountpoint_s3_fs::fs::{CacheConfig, OpenFlags, TimeToLive, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3_fs::prefix::Prefix;
 use mountpoint_s3_fs::s3::S3Personality;
-use mountpoint_s3_fs::S3FilesystemConfig;
+use mountpoint_s3_fs::{S3Filesystem, S3FilesystemConfig};
 use nix::unistd::{getgid, getuid};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -35,7 +35,7 @@ use test_case::test_case;
 mod common;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use common::creds::get_scoped_down_credentials;
-use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply, TestS3Filesystem};
+use common::{assert_attr, make_test_filesystem, make_test_filesystem_with_client, DirectoryReply};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use common::{get_crt_client_auth_config, s3::deny_single_object_access_policy};
 
@@ -1608,7 +1608,7 @@ async fn test_lookup_forbidden() {
     );
 }
 
-async fn new_local_file(fs: &TestS3Filesystem<Arc<MockClient>>, filename: &str) {
+async fn new_local_file(fs: &S3Filesystem<Arc<MockClient>>, filename: &str) {
     let mode = libc::S_IFREG | libc::S_IRWXU; // regular file + 0700 permissions
     let dentry = fs.mknod(FUSE_ROOT_INODE, filename.as_ref(), mode, 0, 0).await.unwrap();
     assert_eq!(dentry.attr.size, 0);
@@ -1623,7 +1623,7 @@ async fn new_local_file(fs: &TestS3Filesystem<Arc<MockClient>>, filename: &str) 
 }
 
 async fn ls(
-    fs: &TestS3Filesystem<Arc<MockClient>>,
+    fs: &S3Filesystem<Arc<MockClient>>,
     dir_handle: u64,
     offset: i64,
     max_entries: usize,

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -6,7 +6,7 @@ use crate::common::s3::{get_test_bucket, get_test_prefix};
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::data_cache::{DataCache, DiskDataCache, DiskDataCacheConfig};
 use mountpoint_s3_fs::object::ObjectId;
-use mountpoint_s3_fs::prefetch::caching_prefetch;
+use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::Runtime;
 
 use fuser::BackgroundSession;
@@ -409,10 +409,10 @@ where
 {
     let mount_point = tempfile::tempdir().unwrap();
     let runtime = Runtime::new(client.event_loop_group());
-    let prefetcher = caching_prefetch(cache, runtime.clone(), Default::default());
+    let prefetcher_builder = Prefetcher::caching_builder(cache, client.clone());
     let (session, _mount) = create_fuse_session(
         client,
-        prefetcher,
+        prefetcher_builder,
         runtime,
         bucket,
         prefix,

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use common::{make_test_filesystem_with_client, TestS3Filesystem};
+use common::make_test_filesystem_with_client;
 use httpmock::{Method, MockServer, Then};
 use mountpoint_s3_client::config::{
     AddressingStyle, Allocator, EndpointConfig, S3ClientAuthConfig, S3ClientConfig, Uri,
@@ -10,6 +10,7 @@ use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
 use mountpoint_s3_fs::fs::FUSE_ROOT_INODE;
 
+use mountpoint_s3_fs::S3Filesystem;
 use test_case::test_case;
 
 mod common;
@@ -124,7 +125,7 @@ async fn test_lookup_unhandled_error_mock() {
     );
 }
 
-fn create_fs_with_mock_s3(bucket: &str) -> (TestS3Filesystem<S3CrtClient>, MockServer) {
+fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, MockServer) {
     let server = MockServer::start();
     let endpoint = format!("http://{}", server.address());
     let endpoint = Uri::new_from_str(&Allocator::default(), endpoint).expect("must be a valid uri");

--- a/mountpoint-s3-fs/tests/reftests/harness.rs
+++ b/mountpoint-s3-fs/tests/reftests/harness.rs
@@ -1,7 +1,7 @@
 //! Provides the test harness along with operations that can be performed against
 //! the [Harness::reference] model and the system under test [Harness::fs].
 //!
-//! Note that the system under test is Mountpoint's file system type wrapped by [TestS3Filesystem],
+//! Note that the system under test is Mountpoint's file system type [S3Filesystem],
 //! and does not include FUSE integration.
 //!
 //! - TODO: How can we test the new incremental upload mode?
@@ -19,12 +19,12 @@ use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_fs::fs::{CacheConfig, InodeNo, OpenFlags, ToErrno, FUSE_ROOT_INODE};
 use mountpoint_s3_fs::prefix::Prefix;
-use mountpoint_s3_fs::S3FilesystemConfig;
+use mountpoint_s3_fs::{S3Filesystem, S3FilesystemConfig};
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use tracing::{debug, debug_span, trace};
 
-use crate::common::{make_test_filesystem, DirectoryReply, TestS3Filesystem};
+use crate::common::{make_test_filesystem, DirectoryReply};
 use crate::reftests::generators::{flatten_tree, gen_tree, FileContent, FileSize, Name, TreeNode, ValidName};
 use crate::reftests::reference::{File, Node, Reference};
 
@@ -190,7 +190,7 @@ pub struct Harness {
     /// Reference model for the system under test (SUT) to be compared against.
     reference: Reference,
     /// The system under test (SUT) that we compare against the [Self::reference].
-    fs: TestS3Filesystem<Arc<MockClient>>,
+    fs: S3Filesystem<Arc<MockClient>>,
     /// An S3 client, used for performing operations against the 'remote' S3.
     client: Arc<MockClient>,
     bucket: String,
@@ -200,7 +200,7 @@ pub struct Harness {
 impl Harness {
     /// Create a new test harness
     pub fn new(
-        fs: TestS3Filesystem<Arc<MockClient>>,
+        fs: S3Filesystem<Arc<MockClient>>,
         client: Arc<MockClient>,
         reference: Reference,
         bucket: &str,


### PR DESCRIPTION
Simplify the type signature of `S3Filesystem` and related types by removing the `Prefetch` trait and replacing it with a single `Prefetcher` implementation, which has an `ObjectClient` generic parameter. 

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
