### PR TITLE
Add `disk_data_cache.disk_usage_mib` metric

### DIFF
--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -302,6 +302,7 @@ impl DiskDataCache {
     }
 
     fn is_limit_exceeded(&self, size: usize) -> bool {
+        metrics::gauge!("disk_data_cache.disk_usage_mib").set((size / 1024 / 1024) as f64);
         match self.config.limit {
             CacheLimit::Unbounded => false,
             CacheLimit::TotalSize { max_size } => size > max_size,


### PR DESCRIPTION
Add a metric to record the amount of space used by cache as estimated by MP internally. Relevant for https://github.com/awslabs/mountpoint-s3/issues/1389.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
