### PR TITLE
Update read-path layer benchmarks to consistently report throughput in Gib/s

### DIFF
--- a/mountpoint-s3-crt/examples/download_crt.rs
+++ b/mountpoint-s3-crt/examples/download_crt.rs
@@ -249,12 +249,14 @@ fn main() -> anyhow::Result<()> {
             Ok::<_, anyhow::Error>(bytes_received.load(Ordering::SeqCst))
         })?;
         let elapsed = start.elapsed();
+        let throughput_bytes = num_bytes as f64 / elapsed.as_secs_f64();
+        let throughput_gibibits = throughput_bytes / (1024.0 * 1024.0 * 1024.0 / 8.0);
         println!(
-            "iteration {}: {}b in {}s = {:.2}MiB/s",
+            "{}: received {} bytes in {:.2}s: {:.2} Gib/s",
             i,
             num_bytes,
             elapsed.as_secs_f64(),
-            num_bytes as f64 / elapsed.as_secs_f64() / (1024.0 * 1024.0)
+            throughput_gibibits,
         );
     }
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -174,11 +174,11 @@ fn main() {
 
         let received_size = received_bytes.load(Ordering::SeqCst);
         println!(
-            "{}: received {} bytes in {:.2}s: {:.2}MiB/s",
+            "{}: received {} bytes in {:.2}s: {:.2} Gib/s",
             i,
             received_size,
             elapsed.as_secs_f64(),
-            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024) as f64
+            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024 * 1024 / 8) as f64
         );
     }
 }


### PR DESCRIPTION
This updates the `prefetch_benchmark` and `download_crt` to report throughput consistently with the `client_benchmark`. Note, the upload path is untouched - notably, uploader benchmarks format is quite different from these in reporting and still uses MiB/s.

### Does this change impact existing behavior?

This updates the output of the read-path benchmarks to be consistently formatted. There's no way to switch back to the old format.

### Does this change need a changelog entry? Does it require a version change?

No, benchmark change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
