### PR TITLE
Remove manifest from the released executable

### DIFF
--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -34,7 +34,7 @@ metrics = "0.24.1"
 nix = { version = "0.29.0", default-features = false, features = ["fs", "process", "signal", "user"] }
 rand = "0.8.5"
 regex = "1.11.1"
-rusqlite = { version = "0.34.0", features = ["bundled"] }
+rusqlite = { version = "0.34.0", features = ["bundled"], optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
 sha2 = "0.10.8"
@@ -82,7 +82,7 @@ walkdir = "2.5.0"
 block_size = []
 event_log = []
 mem_limiter = []
-manifest = ["csv"]
+manifest = ["csv", "rusqlite"]
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -160,6 +160,7 @@ where
         let superblock_config = SuperblockConfig {
             cache_config: config.cache_config.clone(),
             s3_personality: config.s3_personality,
+            #[cfg(feature = "manifest")]
             manifest: config.manifest.clone(),
         };
         let superblock = Superblock::new(bucket, prefix, superblock_config);

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use nix::unistd::{getgid, getuid};
 
+#[cfg(feature = "manifest")]
 use crate::manifest::Manifest;
 use crate::mem_limiter::MINIMUM_MEM_LIMIT;
 use crate::prefetch::PrefetcherConfig;
@@ -43,6 +44,7 @@ pub struct S3FilesystemConfig {
     /// Prefetcher configuration
     pub prefetcher_config: PrefetcherConfig,
     /// An SQLite DB containing the list of S3 keys available with this mount
+    #[cfg(feature = "manifest")]
     pub manifest: Option<Manifest>,
 }
 
@@ -67,6 +69,7 @@ impl Default for S3FilesystemConfig {
             use_upload_checksums: true,
             mem_limit: MINIMUM_MEM_LIMIT,
             prefetcher_config: Default::default(),
+            #[cfg(feature = "manifest")]
             manifest: None,
         }
     }

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -175,6 +175,7 @@ impl ToErrno for InodeError {
             InodeError::CorruptedMetadata(_) => libc::EIO,
             InodeError::SetAttrNotPermittedOnRemoteInode(_) => libc::EPERM,
             InodeError::StaleInode { .. } => libc::ESTALE,
+            #[cfg(feature = "manifest")]
             InodeError::ManifestError { .. } => libc::EIO,
         }
     }

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -6,6 +6,7 @@ pub mod data_cache;
 pub mod fs;
 pub mod fuse;
 pub mod logging;
+#[cfg(feature = "manifest")]
 pub mod manifest;
 pub mod mem_limiter;
 pub mod metrics;


### PR DESCRIPTION
Remove the code using `rusqlite` from the released executable. Implementation of the manifest using this crate becomes gated behind the `manifest` feature flag.

### Does this change impact existing behavior?

No, only used in tests.

### Does this change need a changelog entry? Does it require a version change?

No, only used in tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
