### PR TITLE
Update crate versions and change logs for next crate publish

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -7,6 +7,8 @@
   ([awslabs/aws-c-s3#516](https://github.com/awslabs/aws-c-s3/pull/516))
 * The memory limit for CRT Client can now be configured with the `S3ClientConfig::memory_limit_in_bytes` method.
   ([#1363](https://github.com/awslabs/mountpoint-s3/pull/1363))
+* Fix missing credential caching when using `S3ClientAuthConfig::Profile` credential configuration.
+  ([#1398](https://github.com/awslabs/mountpoint-s3/pull/1398))
 
 ## v0.14.0 (April 9, 2025)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-client"
-# See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
+# See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
 version = "0.14.1"
 edition = "2021"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.2" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.12.3" }
 
 async-trait = "0.1.85"
 auto_impl = "1.2.1"

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-crt-sys"
-# See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
+# See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
 version = "0.13.1"
 edition = "2021"
 license = "Apache-2.0"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3-crt"
-# See `/mountpoint-s3-client/PUBLISHING_CRATES.md` to read how to publish new versions.
+# See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
 version = "0.12.3"
 edition = "2021"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.13.0" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.13.1" }
 
 futures = "0.3.31"
 libc = "0.2.169"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 * Use the Runtime type in the prefetcher. ([#1382](https://github.com/awslabs/mountpoint-s3/pull/1382))
 * Move CliArgs and related functions to the mountpoint-s3 crate. ([#1401](https://github.com/awslabs/mountpoint-s3/pull/1401))
+* Update underlying S3 client version.
 
 ## v0.1.3 (April 9, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mountpoint-s3-fs"
+# See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
 version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -8,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.1" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## Unreleased
 
+### New features
+
+* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
+
 ### Other changes
 
 * Fix compatibility issue with S3-like services by removing `Content-Length: 0` header from GET, HEAD, and DELETE requests.
   ([#1381](https://github.com/awslabs/mountpoint-s3/issues/1381))
   ([awslabs/aws-c-s3#516](https://github.com/awslabs/aws-c-s3/pull/516))
-* Allow changing log level dynamically with `USR2` signal. See [Changing logging verbosity at runtime](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#changing-logging-verbosity-at-runtime) for more details. ([#1367](https://github.com/awslabs/mountpoint-s3/pull/1367))
 * Enable caching of credentials when `--profile` CLI argument is used. ([#1398](https://github.com/awslabs/mountpoint-s3/pull/1398))
 
 ## v1.16.2 (April 9, 2025)

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.2.0" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.1" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 clap = { version = "4.5.27", features = ["derive"] }


### PR DESCRIPTION
This change ensures that all crate versions are up-to-date for publishing new crate releases.
It also ensures the change logs are updated (with some minor reordering), and fixes some comments related to crate versioning.

### Does this change impact existing behavior?

This is version updates and changelog updates only - no.

### Does this change need a changelog entry? Does it require a version change?

This is a changelog update and version change!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
