### PR TITLE
[DRAFT] Add prefetcher logic to inc. read window after part consumed

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -120,6 +120,10 @@ def _mount_mp(
     if (max_throughput := cfg['network']['maximum_throughput_gbps']) is not None:
         subprocess_args.append(f"--maximum-throughput-gbps={max_throughput}")
 
+    if cfg['mountpoint_prefetcher_heuristic'] is not None:
+        # use with `+mountpoint_prefetcher_heuristic="HALF_CONSUMED, LINEAR_READSIZE"`
+        subprocess_env["UNSTABLE_MOUNTPOINT_BACKPRESSURE_INC_HEURISTIC"] = str(cfg['mountpoint_prefetcher_heuristic'])
+
     if cfg['mountpoint_max_background'] is not None:
         subprocess_env["UNSTABLE_MOUNTPOINT_MAX_BACKGROUND"] = str(cfg['mountpoint_max_background'])
 

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -576,6 +576,7 @@ impl S3CrtClientInner {
                 };
                 debug!(%request_type, ?crt_error, http_status, ?range, ?duration, ?ttfb, %request_id, "{}", message);
                 trace!(detailed_metrics=?metrics, "S3 request completed");
+                tracing::info!(target: "benchmarking_instrumentation", detailed_metrics=?metrics, "S3 request on_telemetry");
 
                 let op = span_telemetry.metadata().map(|m| m.name()).unwrap_or("unknown");
                 if let Some(ttfb) = ttfb {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -100,6 +100,12 @@ impl S3CrtClient {
                     }
                 },
                 move |offset, data| {
+                    tracing::info!(
+                        target: "benchmarking_instrumentation",
+                        offset,
+                        length = data.len(),
+                        "S3 request on_body",
+                    );
                     _ = part_sender.unbounded_send(S3GetObjectEvent::BodyPart(GetBodyPart {
                         offset,
                         data: Bytes::copy_from_slice(data),
@@ -166,6 +172,7 @@ pub struct S3BackpressureHandle {
 impl ClientBackpressureHandle for S3BackpressureHandle {
     fn increment_read_window(&mut self, len: usize) {
         self.read_window_end_offset.fetch_add(len as u64, Ordering::SeqCst);
+        tracing::info!(target: "benchmarking_instrumentation", len, "on_meta_inc_window");
         self.meta_request.increment_read_window(len as u64);
     }
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -160,10 +160,24 @@ fn main() {
                 scope.spawn(|| {
                     futures::executor::block_on(async move {
                         let mut offset = 0;
+                        // Initial event so we can plot a start time
+                        tracing::info!(
+                            target: "benchmarking_instrumentation",
+                            offset,
+                            length = 0,
+                            "consuming data",
+                        );
                         while offset < size {
                             let bytes = request.read(offset, args.read_size).await.unwrap();
-                            offset += bytes.len() as u64;
-                            received_bytes.fetch_add(bytes.len() as u64, Ordering::SeqCst);
+                            let length = bytes.len() as u64;
+                            offset += length;
+                            tracing::info!(
+                                target: "benchmarking_instrumentation",
+                                offset,
+                                length,
+                                "consuming data",
+                            );
+                            received_bytes.fetch_add(length, Ordering::SeqCst);
                         }
                     })
                 });

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -1,3 +1,4 @@
+use std::env::VarError;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -48,6 +49,35 @@ pub struct BackpressureController<Client: ObjectClient> {
     /// data up to this offset *exclusively*.
     request_end_offset: u64,
     mem_limiter: Arc<MemoryLimiter<Client>>,
+    increment_heuristic: BackpressureIncrementHeuristic,
+}
+
+#[derive(Debug, Default)]
+enum BackpressureIncrementHeuristic {
+    /// The [BackpressureController] will wait until at least half of its current read window has been consumed
+    /// before sending a read increment via its corresponding [BackpressureLimiter].
+    AfterHalfConsumed,
+    /// Backpressure is incremented directly by the values provided in [BackpressureController::send_feedback],
+    /// which is typically the way the value was read by the consumer.
+    #[default]
+    Linear,
+}
+
+impl BackpressureIncrementHeuristic {
+    /// Determines the heuristic used by [BackpressureController] to manage a read ahead window.
+    ///
+    /// Panics when finding an unexpected value for the environment variable.
+    fn from_env() -> Self {
+        match std::env::var("UNSTABLE_MOUNTPOINT_BACKPRESSURE_INC_HEURISTIC")
+            .as_ref()
+            .map(|string| string.as_str())
+        {
+            Err(VarError::NotPresent) => BackpressureIncrementHeuristic::default(),
+            Ok("LINEAR_READSIZE") => BackpressureIncrementHeuristic::Linear,
+            Ok("HALF_CONSUMED") => BackpressureIncrementHeuristic::AfterHalfConsumed,
+            Ok(_) | Err(_) => panic!("unexpected value for UNSTABLE_MOUNTPOINT_BACKPRESSURE_INC_HEURISTIC, oh no!"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -85,6 +115,9 @@ pub fn new_backpressure_controller<Client: ObjectClient>(
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
 
+    let increment_heuristic = BackpressureIncrementHeuristic::from_env();
+    tracing::debug!("using backpressure heuristic {increment_heuristic:?}");
+
     let controller = BackpressureController {
         read_window_updater,
         preferred_read_window_size: config.initial_read_window_size,
@@ -95,6 +128,7 @@ pub fn new_backpressure_controller<Client: ObjectClient>(
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
         mem_limiter,
+        increment_heuristic,
     };
 
     let limiter = BackpressureLimiter {
@@ -121,38 +155,56 @@ impl<Client: ObjectClient> BackpressureController<Client> {
                 self.mem_limiter.release(BufferArea::Prefetch, length as u64);
                 let remaining_window = self.read_window_end_offset.saturating_sub(self.next_read_offset) as usize;
 
-                // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
-                // When memory is low the `preferred_read_window_size` will be scaled down so we have to keep trying
-                // until we have enough read window.
-                while remaining_window < (self.preferred_read_window_size / 2)
-                    && self.read_window_end_offset < self.request_end_offset
-                {
-                    let new_read_window_end_offset = self
-                        .next_read_offset
-                        .saturating_add(self.preferred_read_window_size as u64)
-                        .min(self.request_end_offset);
-                    // We can skip if the new `read_window_end_offset` is less than or equal to the current one, this
-                    // could happen after the read window is scaled down.
-                    if new_read_window_end_offset <= self.read_window_end_offset {
-                        break;
+                match &self.increment_heuristic {
+                    BackpressureIncrementHeuristic::Linear => {
+                        let new_read_window_end_offset = self
+                            .next_read_offset
+                            .saturating_add(self.preferred_read_window_size as u64)
+                            .min(self.request_end_offset);
+                        let to_increase =
+                            new_read_window_end_offset.saturating_sub(self.read_window_end_offset) as usize;
+                        if to_increase > 0 {
+                            // TODO: This currently just forces the reservation, we should implement scale down.
+                            self.mem_limiter.reserve(BufferArea::Prefetch, to_increase as u64);
+                            self.increment_read_window(to_increase).await;
+                        }
                     }
-                    let to_increase = new_read_window_end_offset.saturating_sub(self.read_window_end_offset) as usize;
+                    BackpressureIncrementHeuristic::AfterHalfConsumed => {
+                        // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
+                        // When memory is low the `preferred_read_window_size` will be scaled down so we have to keep trying
+                        // until we have enough read window.
+                        while remaining_window < (self.preferred_read_window_size / 2)
+                            && self.read_window_end_offset < self.request_end_offset
+                        {
+                            let new_read_window_end_offset = self
+                                .next_read_offset
+                                .saturating_add(self.preferred_read_window_size as u64)
+                                .min(self.request_end_offset);
+                            // We can skip if the new `read_window_end_offset` is less than or equal to the current one, this
+                            // could happen after the read window is scaled down.
+                            if new_read_window_end_offset <= self.read_window_end_offset {
+                                break;
+                            }
+                            let to_increase =
+                                new_read_window_end_offset.saturating_sub(self.read_window_end_offset) as usize;
 
-                    // Force incrementing read window regardless of available memory when we are already at minimum
-                    // read window size.
-                    if self.preferred_read_window_size <= self.min_read_window_size {
-                        self.mem_limiter.reserve(BufferArea::Prefetch, to_increase as u64);
-                        self.increment_read_window(to_increase).await;
-                        break;
-                    }
+                            // Force incrementing read window regardless of available memory when we are already at minimum
+                            // read window size.
+                            if self.preferred_read_window_size <= self.min_read_window_size {
+                                self.mem_limiter.reserve(BufferArea::Prefetch, to_increase as u64);
+                                self.increment_read_window(to_increase).await;
+                                break;
+                            }
 
-                    // Try to reserve the memory for the length we want to increase before sending the request,
-                    // scale down the read window if it fails.
-                    if self.mem_limiter.try_reserve(BufferArea::Prefetch, to_increase as u64) {
-                        self.increment_read_window(to_increase).await;
-                        break;
-                    } else {
-                        self.scale_down();
+                            // Try to reserve the memory for the length we want to increase before sending the request,
+                            // scale down the read window if it fails.
+                            if self.mem_limiter.try_reserve(BufferArea::Prefetch, to_increase as u64) {
+                                self.increment_read_window(to_increase).await;
+                                break;
+                            } else {
+                                self.scale_down();
+                            }
+                        }
                     }
                 }
             }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -219,6 +219,12 @@ impl<Client: ObjectClient> BackpressureController<Client> {
                 new_size = formatter(new_read_window_size),
                 "scaled down read window"
             );
+            tracing::info!(
+                target: "benchmarking_instrumentation",
+                old_read_window_size = ?self.preferred_read_window_size,
+                new_read_window_size,
+                "read_window_scale",
+            );
             self.preferred_read_window_size = new_read_window_size;
             metrics::histogram!("prefetch.window_after_decrease_mib")
                 .record((self.preferred_read_window_size / 1024 / 1024) as f64);

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -260,9 +260,9 @@ impl BackpressureLimiter {
         // Reaching here means there is not enough read window, so we block until it is large enough
         while self.read_window_end_offset <= offset && self.read_window_end_offset < self.request_end_offset {
             trace!(
-                offset,
-                read_window_offset = self.read_window_end_offset,
-                "blocking for read window increment"
+                desired_offset = offset,
+                current_offset = self.read_window_end_offset,
+                "blocking for read window increment",
             );
             match self.read_window_increment_queue.recv_drain().await {
                 Ok(len) => self.read_window_end_offset += len as u64,


### PR DESCRIPTION
This is a temporary PR to put the code in a sharable location, and also run the regression benchmarks.

**TODO: What changed and why?**

### Does this change impact existing behavior?

**TODO: Please confirm there's no breaking change, or call out any that are made.**

### Does this change need a changelog entry? Does it require a version change?

**TODO: Confirm with justification if not required.**

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
