### PR TITLE
Propagate S3 response with `PrefetchReadError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Unreleased
+## Unreleased (v0.15.0)
+
+### Breaking changes
+
+* Variants of the `GetObjectError` and `S3RequestError` enums now contain a `ClientErrorMetadata` field,
+  which stores information from the S3 response. ([#1411](https://github.com/awslabs/mountpoint-s3/pull/1411))
 
 ## v0.14.1 (May 9, 2025)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/src/error_metadata.rs
+++ b/mountpoint-s3-client/src/error_metadata.rs
@@ -1,5 +1,9 @@
+use std::os::unix::ffi::OsStrExt;
+
+use mountpoint_s3_crt::s3::client::MetaRequestResult;
+
 /// Additional data fetched from S3 response, which caused an error
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct ClientErrorMetadata {
     /// http code of the response, e.g. 403
     pub http_code: Option<i32>,
@@ -13,4 +17,40 @@ pub struct ClientErrorMetadata {
 /// which as of today may be s3_crt_client::S3RequestError / mock_client::MockClientError / GetObjectError and etc.
 pub trait ProvideErrorMetadata {
     fn meta(&self) -> ClientErrorMetadata;
+}
+
+impl ClientErrorMetadata {
+    pub fn from_meta_request_result(result: &MetaRequestResult) -> Self {
+        let http_code = if result.response_status >= 100 {
+            Some(result.response_status)
+        } else {
+            None
+        };
+
+        let no_body_result = Self {
+            http_code,
+            ..Default::default()
+        };
+        let Some(body) = result.error_response_body.as_ref() else {
+            return no_body_result;
+        };
+        let Some(root) = xmltree::Element::parse(body.as_bytes()).ok() else {
+            return no_body_result;
+        };
+
+        let error_code = root
+            .get_child("Code")
+            .and_then(|raw| raw.get_text())
+            .map(|field_str| field_str.to_string());
+        let error_message = root
+            .get_child("Message")
+            .and_then(|raw| raw.get_text())
+            .map(|field_str| field_str.to_string());
+
+        Self {
+            http_code,
+            error_code,
+            error_message,
+        }
+    }
 }

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -857,7 +857,9 @@ impl ObjectClient for MockClient {
         self.inc_op_count(Operation::GetObject);
 
         if bucket != self.config.bucket {
-            return Err(ObjectClientError::ServiceError(GetObjectError::NoSuchBucket));
+            return Err(ObjectClientError::ServiceError(GetObjectError::NoSuchBucket(
+                Default::default(),
+            )));
         }
 
         let objects = self.objects.read().unwrap();
@@ -865,7 +867,9 @@ impl ObjectClient for MockClient {
         if let Some(object) = objects.get(key) {
             if let Some(etag_match) = params.if_match.as_ref() {
                 if etag_match != &object.etag {
-                    return Err(ObjectClientError::ServiceError(GetObjectError::PreconditionFailed));
+                    return Err(ObjectClientError::ServiceError(GetObjectError::PreconditionFailed(
+                        Default::default(),
+                    )));
                 }
             }
 
@@ -894,7 +898,9 @@ impl ObjectClient for MockClient {
                 backpressure_handle,
             })
         } else {
-            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey))
+            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(
+                Default::default(),
+            )))
         }
     }
 
@@ -1377,14 +1383,14 @@ mod tests {
 
         assert!(matches!(
             client.get_object("wrong_bucket", "key1", &GetObjectParams::new()).await,
-            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchBucket))
+            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchBucket(_)))
         ));
 
         assert!(matches!(
             client
                 .get_object("test_bucket", "wrong_key", &GetObjectParams::new())
                 .await,
-            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey))
+            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_)))
         ));
 
         assert_client_error!(

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -158,13 +158,42 @@ pub enum ObjectClientError<S, C> {
 
 impl<S, C> ProvideErrorMetadata for ObjectClientError<S, C>
 where
+    S: ProvideErrorMetadata,
     C: ProvideErrorMetadata,
 {
     fn meta(&self) -> ClientErrorMetadata {
         match self {
             Self::ClientError(err) => err.meta(),
-            _ => Default::default(),
+            Self::ServiceError(err) => err.meta(),
         }
+    }
+}
+
+impl ProvideErrorMetadata for GetObjectError {
+    fn meta(&self) -> ClientErrorMetadata {
+        match self {
+            GetObjectError::NoSuchBucket(client_error_metadata) => client_error_metadata.clone(),
+            GetObjectError::NoSuchKey(client_error_metadata) => client_error_metadata.clone(),
+            GetObjectError::PreconditionFailed(client_error_metadata) => client_error_metadata.clone(),
+        }
+    }
+}
+
+impl ProvideErrorMetadata for ListObjectsError {
+    fn meta(&self) -> ClientErrorMetadata {
+        Default::default()
+    }
+}
+
+impl ProvideErrorMetadata for HeadObjectError {
+    fn meta(&self) -> ClientErrorMetadata {
+        Default::default()
+    }
+}
+
+impl ProvideErrorMetadata for DeleteObjectError {
+    fn meta(&self) -> ClientErrorMetadata {
+        Default::default()
     }
 }
 
@@ -176,13 +205,13 @@ pub type ObjectClientResult<T, S, C> = Result<T, ObjectClientError<S, C>>;
 #[non_exhaustive]
 pub enum GetObjectError {
     #[error("The bucket does not exist")]
-    NoSuchBucket,
+    NoSuchBucket(ClientErrorMetadata),
 
     #[error("The key does not exist")]
-    NoSuchKey,
+    NoSuchKey(ClientErrorMetadata),
 
     #[error("At least one of the preconditions specified did not hold")]
-    PreconditionFailed,
+    PreconditionFailed(ClientErrorMetadata),
 }
 
 /// Parameters to a [`get_object`](ObjectClient::get_object) request

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1166,21 +1166,12 @@ impl S3RequestError {
 impl ProvideErrorMetadata for S3RequestError {
     fn meta(&self) -> ClientErrorMetadata {
         match self {
-            Self::ResponseError(request_result) => {
-                let http_code = if request_result.response_status >= 100 {
-                    Some(request_result.response_status)
-                } else {
-                    None
-                };
-                ClientErrorMetadata {
-                    http_code,
-                    ..Default::default()
-                }
-            }
+            Self::ResponseError(request_result) => ClientErrorMetadata::from_meta_request_result(request_result),
             Self::Forbidden(_, metadata) => metadata.clone(),
             Self::Throttled => ClientErrorMetadata {
                 http_code: Some(503),
-                ..Default::default()
+                error_code: Some("SlowDown".to_string()),
+                error_message: Some("Please reduce your request rate.".to_string()),
             },
             _ => Default::default(),
         }

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -358,8 +358,9 @@ async fn test_get_object_wrong_region() {
 
     let key = format!("{prefix}/nonexistent_key");
 
-    let client = S3CrtClient::new(S3ClientConfig::new().endpoint_config(EndpointConfig::new("us-west-1")))
-        .expect("must create a client");
+    let endpoint_config = EndpointConfig::new(&get_secondary_test_region());
+    let client =
+        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("must create a client");
 
     let err = client
         .get_object(&bucket, &key, &GetObjectParams::new())

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -342,14 +342,9 @@ async fn test_get_object_403() {
         err,
         ObjectClientError::ClientError(S3RequestError::Forbidden(_, _))
     ));
-    assert_eq!(
-        err.meta(),
-        ClientErrorMetadata {
-            http_code: Some(403),
-            error_code: Some("AccessDenied".to_string()),
-            error_message: Some("Access Denied".to_string())
-        }
-    );
+    assert_eq!(err.meta().http_code, Some(403));
+    assert_eq!(err.meta().error_code, Some("AccessDenied".to_string()));
+    assert!(err.meta().error_message.is_some());
 }
 
 #[test_case(false; "early")]

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -15,6 +15,7 @@ use futures::pin_mut;
 use futures::stream::StreamExt;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
+use mountpoint_s3_client::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use mountpoint_s3_client::types::{
     Checksum, ChecksumMode, ClientBackpressureHandle, ETag, GetBodyPart, GetObjectParams, GetObjectResponse,
 };
@@ -195,7 +196,7 @@ async fn test_mutated_during_get_object_backpressure() {
     let next = get_request.next().await.expect("result should not be empty");
     assert!(matches!(
         next,
-        Err(ObjectClientError::ServiceError(GetObjectError::PreconditionFailed))
+        Err(ObjectClientError::ServiceError(GetObjectError::PreconditionFailed(_)))
     ));
 }
 
@@ -211,14 +212,24 @@ async fn test_get_object_404_key() {
         .get_object(&bucket, &key, &GetObjectParams::new())
         .await
         .expect_err("get_object should fail");
+
     assert!(matches!(
         err,
-        ObjectClientError::ServiceError(GetObjectError::NoSuchKey)
+        ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_))
     ));
+    assert_eq!(
+        err.meta(),
+        ClientErrorMetadata {
+            http_code: Some(404),
+            error_code: Some("NoSuchKey".to_string()),
+            error_message: Some("The specified key does not exist.".to_string())
+        }
+    );
 
     // TODO: what happens if the object is deleted mid-GET? the CRT does lots of ranged GETs, so they
     // will start failing. need a way to test that.
 }
+
 #[tokio::test]
 async fn test_get_object_404_bucket() {
     let (_bucket, prefix) = get_test_bucket_and_prefix("test_get_object_404_bucket");
@@ -231,10 +242,19 @@ async fn test_get_object_404_bucket() {
         .get_object("amzn-s3-demo-bucket", &key, &GetObjectParams::new())
         .await
         .expect_err("get_object should fail");
+
     assert!(matches!(
         err,
-        ObjectClientError::ServiceError(GetObjectError::NoSuchBucket)
+        ObjectClientError::ServiceError(GetObjectError::NoSuchBucket(_))
     ));
+    assert_eq!(
+        err.meta(),
+        ClientErrorMetadata {
+            http_code: Some(404),
+            error_code: Some("NoSuchBucket".to_string()),
+            error_message: Some("The specified bucket does not exist".to_string())
+        }
+    );
 }
 
 #[tokio::test]
@@ -292,8 +312,44 @@ async fn test_get_object_412_if_match() {
 
     assert!(matches!(
         err,
-        ObjectClientError::ServiceError(GetObjectError::PreconditionFailed)
+        ObjectClientError::ServiceError(GetObjectError::PreconditionFailed(_))
     ));
+    assert_eq!(
+        err.meta(),
+        ClientErrorMetadata {
+            http_code: Some(412),
+            error_code: Some("PreconditionFailed".to_string()),
+            error_message: Some("At least one of the pre-conditions you specified did not hold".to_string())
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_get_object_403() {
+    let (_bucket, prefix) = get_test_bucket_and_prefix("test_get_object_403");
+    let bucket = get_test_bucket_without_permissions();
+
+    let key = format!("{prefix}/nonexistent_key");
+
+    let client: S3CrtClient = get_test_client();
+
+    let err = client
+        .get_object(&bucket, &key, &GetObjectParams::new())
+        .await
+        .expect_err("get_object should fail");
+
+    assert!(matches!(
+        err,
+        ObjectClientError::ClientError(S3RequestError::Forbidden(_, _))
+    ));
+    assert_eq!(
+        err.meta(),
+        ClientErrorMetadata {
+            http_code: Some(403),
+            error_code: Some("AccessDenied".to_string()),
+            error_message: Some("Access Denied".to_string())
+        }
+    );
 }
 
 #[test_case(false; "early")]

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use common::*;
 use futures::pin_mut;
 use futures::stream::StreamExt;
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use mountpoint_s3_client::types::{
@@ -347,8 +347,13 @@ async fn test_get_object_403() {
     assert!(err.meta().error_message.is_some());
 }
 
+// Not sure how to trigger IncorrectRegion with directory buckets: failure occurs on dns resolution (CrtError / AWS_IO_DNS_INVALID_NAME).
+// So only run with S3 Standard.
+#[cfg(not(feature = "s3express_tests"))]
 #[tokio::test]
 async fn test_get_object_wrong_region() {
+    use mountpoint_s3_client::config::EndpointConfig;
+
     let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_wrong_region");
 
     let key = format!("{prefix}/nonexistent_key");

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -30,7 +30,7 @@ async fn test_head_bucket_wrong_region() {
     let result = client.head_bucket(&bucket).await;
 
     match result {
-        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(actual_region))) => {
+        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(actual_region, _))) => {
             assert_eq!(actual_region, expected_region, "wrong region returned")
         }
         _ => panic!("incorrect result {result:?}"),

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -474,7 +474,7 @@ async fn test_put_review(pass_review: bool) {
         let err = get_result.expect_err("getobject should fail for aborted put");
         assert!(matches!(
             err,
-            ObjectClientError::ServiceError(GetObjectError::NoSuchKey)
+            ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_))
         ));
 
         let sdk_client = get_test_sdk_client().await;

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.15.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -186,7 +186,7 @@ where
             .await
         {
             Ok(result) => result,
-            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey)) => {
+            Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_))) => {
                 return Ok(None);
             }
             Err(e) => {
@@ -219,7 +219,7 @@ where
                     // Ensure the flow-control window is large enough.
                     self.ensure_read_window(backpressure_handle.as_mut());
                 }
-                Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey)) => {
+                Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_))) => {
                     return Ok(None);
                 }
                 Err(e) => {

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -126,7 +126,7 @@ impl<E: std::error::Error + Send + Sync + 'static> From<PrefetchReadError<E>> fo
     fn from(err: PrefetchReadError<E>) -> Self {
         match err {
             PrefetchReadError::GetRequestFailed {
-                source: ObjectClientError::ServiceError(GetObjectError::PreconditionFailed),
+                source: ObjectClientError::ServiceError(GetObjectError::PreconditionFailed(_)),
                 metadata,
             } => err!(libc::ESTALE, __source:None, Level::WARN, (*metadata).clone(), "object was mutated remotely",),
             PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -125,13 +125,16 @@ impl<E: std::error::Error + Send + Sync + 'static> From<UploadError<E>> for Erro
 impl<E: std::error::Error + Send + Sync + 'static> From<PrefetchReadError<E>> for Error {
     fn from(err: PrefetchReadError<E>) -> Self {
         match err {
-            PrefetchReadError::GetRequestFailed(ObjectClientError::ServiceError(
-                GetObjectError::PreconditionFailed,
-            )) => err!(libc::ESTALE, "object was mutated remotely"),
+            PrefetchReadError::GetRequestFailed {
+                source: ObjectClientError::ServiceError(GetObjectError::PreconditionFailed),
+                metadata,
+            } => err!(libc::ESTALE, __source:None, Level::WARN, (*metadata).clone(), "object was mutated remotely",),
             PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),
             PrefetchReadError::PartReadFailed(e) => err!(libc::EIO, source:e, "part read failed"),
-            PrefetchReadError::GetRequestFailed(_)
-            | PrefetchReadError::GetRequestTerminatedUnexpectedly
+            PrefetchReadError::GetRequestFailed { source, metadata } => {
+                err!(libc::EIO, source:source, Level::WARN, metadata:(*metadata).clone(), "get request failed")
+            }
+            PrefetchReadError::GetRequestTerminatedUnexpectedly
             | PrefetchReadError::GetRequestReturnedWrongOffset { .. }
             | PrefetchReadError::BackpressurePreconditionFailed
             | PrefetchReadError::ReadWindowIncrement => {

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -129,11 +129,11 @@ impl<E: std::error::Error + Send + Sync + 'static> From<PrefetchReadError<E>> fo
                 source: ObjectClientError::ServiceError(GetObjectError::PreconditionFailed(_)),
                 metadata,
             } => err!(libc::ESTALE, __source:None, Level::WARN, (*metadata).clone(), "object was mutated remotely",),
-            PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),
-            PrefetchReadError::PartReadFailed(e) => err!(libc::EIO, source:e, "part read failed"),
             PrefetchReadError::GetRequestFailed { source, metadata } => {
                 err!(libc::EIO, source:source, Level::WARN, metadata:(*metadata).clone(), "get request failed")
             }
+            PrefetchReadError::Integrity(e) => err!(libc::EIO, source:e, "integrity error"),
+            PrefetchReadError::PartReadFailed(e) => err!(libc::EIO, source:e, "part read failed"),
             PrefetchReadError::GetRequestTerminatedUnexpectedly
             | PrefetchReadError::GetRequestReturnedWrongOffset { .. }
             | PrefetchReadError::BackpressurePreconditionFailed

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -207,7 +207,7 @@ fn validate_client_for_bucket(
     match futures::executor::block_on(list_request) {
         Ok(_) => Ok(client),
         // Don't try to automatically correct the region if it was manually specified incorrectly
-        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(correct_region)))
+        Err(ObjectClientError::ClientError(S3RequestError::IncorrectRegion(correct_region, _)))
             if !region.user_specified =>
         {
             tracing::warn!(

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -8,7 +8,7 @@ use mountpoint_s3_client::config::{
 use mountpoint_s3_client::error_metadata::ClientErrorMetadata;
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_fs::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use mountpoint_s3_fs::fs::{ToErrno, FUSE_ROOT_INODE};
+use mountpoint_s3_fs::fs::{OpenFlags, ToErrno, FUSE_ROOT_INODE};
 
 use mountpoint_s3_fs::S3Filesystem;
 use test_case::test_case;
@@ -125,6 +125,70 @@ async fn test_lookup_unhandled_error_mock() {
                 http_code: Some(409),
                 error_code: None,
                 error_message: None,
+            },
+            error_code: Some(MOUNTPOINT_ERROR_CLIENT.to_string()),
+            s3_bucket_name: Some(bucket.to_string()),
+            s3_object_key: Some(key.to_string())
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_read_unhandled_error_mock() {
+    let bucket = "bucket";
+    let key = "unhandled";
+    let head_object_ok_headers = [
+        ("ETag", "71a5b8dcb22444f1b2b899dedc1e4122"),
+        ("Date", "Thu, 12 Jan 2023 00:04:21 GMT"),
+        ("Last-Modified", "Tue, 10 Jan 2023 23:39:32 GMT"),
+        ("Accept-Ranges", "bytes"),
+        ("Content-Range", "bytes 0-65535/65536"),
+        ("Content-Type", "binary/octet-stream"),
+        ("Content-Length", "1024"),
+    ];
+    let get_object_error_resp = r#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NotARealError</Code><Message>This error is made up.</Message><RequestId>CM0R497NB0WAQ977</RequestId><HostId>w1TqUKGaIuNAIgzqm/L2azuzgEBINxTngWPbV1iH2IvpLsVCCTKHJTh4HsGp4JnggHqVkA+KN1MGqHDw1+WEuA==</HostId></Error>"#;
+
+    let (fs, server) = create_fs_with_mock_s3(bucket);
+
+    // set up a mock for a successful lookup but a failed read
+    server.mock(|when, then| {
+        when.method(Method::GET)
+            .path(format!("/{}/", bucket))
+            .query_param("list-type", "2")
+            .query_param("prefix", format!("{key}/"));
+        then.status(200).body(list_empty_response(bucket, key));
+    });
+    server.mock(|when, then| {
+        when.method(Method::HEAD).path(format!("/{}/{}", bucket, key));
+        set_response_headers(then.status(200), &head_object_ok_headers);
+    });
+    server.mock(|when, then| {
+        when.method(Method::GET).path(format!("/{}/{}", bucket, key));
+        then.status(418).body(get_object_error_resp);
+    });
+
+    // perform a read
+    let entry = fs
+        .lookup(FUSE_ROOT_INODE, key.as_ref())
+        .await
+        .expect("lookup must succeed");
+    let fh = fs
+        .open(entry.attr.ino, OpenFlags::empty(), 0)
+        .await
+        .expect("open must succeed")
+        .fh;
+    let err = fs
+        .read(entry.attr.ino, fh, 0, 4096, 0, None)
+        .await
+        .expect_err("read must fail");
+    let metadata = err.meta();
+    assert_eq!(
+        *metadata,
+        ErrorMetadata {
+            client_error_meta: ClientErrorMetadata {
+                http_code: Some(418),
+                error_code: Some("NotARealError".to_string()),
+                error_message: Some("This error is made up.".to_string()),
             },
             error_code: Some(MOUNTPOINT_ERROR_CLIENT.to_string()),
             s3_bucket_name: Some(bucket.to_string()),

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -86,8 +86,8 @@ async fn test_lookup_throttled_mock(head_object_throttled: bool, list_object_thr
         ErrorMetadata {
             client_error_meta: ClientErrorMetadata {
                 http_code: Some(503),
-                error_code: None,
-                error_message: None,
+                error_code: Some("SlowDown".to_string()),
+                error_message: Some("Please reduce your request rate.".to_string()),
             },
             error_code: Some(MOUNTPOINT_ERROR_CLIENT.to_string()),
             s3_bucket_name: Some(bucket.to_string()),

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.3.0" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.14.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.15.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 clap = { version = "4.5.27", features = ["derive"] }

--- a/mountpoint-s3/tests/fork_test.rs
+++ b/mountpoint-s3/tests/fork_test.rs
@@ -1037,7 +1037,7 @@ fn read_with_no_permissions_for_a_key_sse() {
         read_result.expect("should be able to read a default-encrypted file after the first read failure");
     }
 
-    let log_line_pattern = format!("^.*WARN.*{encrypted_object}.*read failed with errno 5: get request failed: get object request failed: Client error: Forbidden: User: .* is not authorized to perform: kms:Decrypt on resource: {key_id} because no session policy allows the kms:Decrypt action.*$");
+    let log_line_pattern = format!("^.*WARN.*{encrypted_object}.*read failed with errno 5: get request failed: Client error: Forbidden: User: .* is not authorized to perform: kms:Decrypt on resource: {key_id} because no session policy allows the kms:Decrypt action.*$");
     let expected_log_line = regex::Regex::new(&log_line_pattern).unwrap();
     unmount_and_check_log(child, mount_point.path(), &expected_log_line);
 }


### PR DESCRIPTION
For logging purposes we want S3 response (http_code, error_code, error_message) to be retrievable via `fs::Error` when errors occur during `S3FuseFilesystem::read` operation. 

To achieve that we preserve this information during `PrefetchReadError -> fs::Error` conversion in `PrefetchReadError::get_request_failed` method. We also adjust `mountpoint-s3-client` to parse and store S3 response with the following errors:

1. GetObjectError::NoSuchBucket
1. GetObjectError::NoSuchKey
1. GetObjectError::PreconditionFailed
1. S3RequestError::Forbidden
1. S3RequestError::ResponseError
1. S3RequestError::Throttled
1. S3RequestError::IncorrectRegion
1. Other `S3RequestError` variants occur before the response arrives and thus don't provide metadata  

### Does this change impact existing behavior?

In logs, read errors do not contain redundant token:
> ..read failed with errno 5: get request failed: ~get object request failed:~ Client error: ..

### Does this change need a changelog entry? Does it require a version change?

An entry for the `mountpoint-s3-client` changelog and a minor version bump (`0.14.1` -> `0.15.0`) to account for changes to error enum variants? 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
