### PR TITLE
Turn off comment on benchmark alert

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,7 +86,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # Make sure to add this chart to the step provisioning static content and pushing the changes
         auto-push: false
-        comment-on-alert: true
+        comment-on-alert: false
         max-items-in-chart: ${{ env.MAX_VALUES_IN_BENCH_CHART }}
         summary-always: true
     - name: Check resource utilization


### PR DESCRIPTION
Disable the last comment on alert for benchmarks. We don't rely on this mechanism anymore, and it is currently broken for pull requests: https://github.com/awslabs/mountpoint-s3/actions/runs/14933031147/job/41953835707#step:9:138.

Instead, you should review the benchmark summary on the job.

### Does this change impact existing behavior?

For benchmarks on GitHub Actions, the last remaining case (throughput benchmarks S3 standard) will no longer make commit comments.

### Does this change need a changelog entry? Does it require a version change?

No, repo change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
