### PR TITLE
Fstab cliargs roundtrip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,6 +2825,7 @@ dependencies = [
  "owo-colors 4.2.0",
  "predicates",
  "proptest",
+ "proptest-derive",
  "rand",
  "rand_chacha",
  "regex",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -33,6 +33,7 @@ aws-sdk-s3 = "1.71.0"
 futures = { version = "0.3.31", features = ["thread-pool"] }
 predicates = "3.1.3"
 proptest = "1.6.0"
+proptest-derive = "0.5.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/mountpoint-s3/proptest-regressions/fstab.txt
+++ b/mountpoint-s3/proptest-regressions/fstab.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 0f845f1bdd8577c9701386f5f670cb06bfa06cbebad721a40530a4593f47cbc6 # shrinks to original = CliArgs { bucket_name: "bucket-aaa", mount_point: "/mnt/test-a", prefix: None, region: None, endpoint_url: None, force_path_style: false, transfer_acceleration: false, dual_stack: false, requester_pays: false, bucket_type: None, no_sign_request: false, profile: None, read_only: false, storage_class: None, allow_delete: false, allow_overwrite: false, incremental_upload: false, auto_unmount: false, allow_root: false, allow_other: false, maximum_throughput_gbps: None, max_threads: 16, part_size: 8388608, read_part_size: None, write_part_size: None, uid: Some(0), gid: None, dir_mode: None, file_mode: None, foreground: false, expected_bucket_owner: None, log_directory: None, log_metrics: false, debug: false, debug_crt: false, no_log: false, cache: None, metadata_ttl: None, negative_metadata_ttl: None, max_cache_size: None, cache_xz: None, user_agent_prefix: None, sse: None, sse_kms_key_id: None, upload_checksums: None, bind: None }

--- a/mountpoint-s3/src/fstab.rs
+++ b/mountpoint-s3/src/fstab.rs
@@ -150,6 +150,8 @@ mod tests {
     use super::*;
     use proptest::{prop_assert_eq, proptest};
     use test_case::test_case;
+    use proptest::prelude::*;
+
 
     #[test_case("no commas", Some(["no commas"].to_vec()))]
     #[test_case("simple,case", Some(["simple", "case"].to_vec()))]
@@ -249,6 +251,118 @@ mod tests {
 
                 prop_assert_eq!(string, reconstructed, "\n split string was {:?}", split);
             }
+        }
+    }
+
+    fn valid_cli_args_strategy() -> impl Strategy<Value = CliArgs> {
+        (
+            "bucket-[a-z]{3,10}",         
+            "/mnt/test-[a-z]{1,5}",       
+            1..=u32::MAX,            // the uid must be > zero
+            any::<bool>(),                // read_only
+            any::<bool>(),                // allow_delete
+            any::<bool>(),                // for the debug 
+        )
+        .prop_filter("Disallow invalid combos", |(_, _, _, ro, _, _)| {
+            // Disallow read_only=true  since fstab mode does not support read-only . So, these need to be excluded from test generation 
+            *ro != true
+        })
+        .prop_map(|(bucket_name, mount_point, uid, read_only, allow_delete, debug)| {
+            CliArgs {
+                bucket_name,
+                mount_point: mount_point.into(),
+                prefix: None,
+                region: None,
+                endpoint_url: None,
+                force_path_style: false,
+                transfer_acceleration: false,
+                dual_stack: false,
+                requester_pays: false,
+                bucket_type: None,
+                no_sign_request: false,
+                profile: None,
+                read_only,
+                storage_class: None,
+                allow_delete,
+                allow_overwrite: false,
+                incremental_upload: false,
+                auto_unmount: false,
+                allow_root: false,
+                allow_other: false,
+                maximum_throughput_gbps: None,
+                max_threads: 16,
+                part_size: 8388608,
+                read_part_size: None,
+                write_part_size: None,
+                uid: Some(uid),
+                gid: None,
+                dir_mode: None,
+                file_mode: None,
+                foreground: false,
+                expected_bucket_owner: None,
+                log_directory: None,
+                log_metrics: false,
+                debug,
+                debug_crt: false,
+                no_log: false,
+                cache: None,
+                metadata_ttl: None,
+                negative_metadata_ttl: None,
+                max_cache_size: None,
+                cache_xz: None,
+                user_agent_prefix: None,
+                sse: None,
+                sse_kms_key_id: None,
+                upload_checksums: None,
+                bind: None,
+            }
+        })
+    }
+
+
+    fn serialize_to_fstab_args(cli_args: &CliArgs) -> Vec<String> {
+        let mut args = vec![
+            "mount-s3".to_string(),
+            cli_args.bucket_name.clone(),
+            cli_args.mount_point.to_string_lossy().into_owned(),
+        ];
+    
+        let mut options = Vec::new();
+        if let Some(uid) = cli_args.uid {
+            options.push(format!("uid={}", uid));
+        }
+        if cli_args.read_only {
+            options.push("ro".to_string());
+        }
+        if cli_args.allow_delete {
+            options.push("allow-delete".to_string());
+        }
+        if cli_args.debug {
+            options.push("debug".to_string());
+        }
+    
+        if !options.is_empty() {
+            args.push("-o".to_string());
+            args.push(options.join(","));
+        }
+    
+        args
+    }
+
+    // This addresses the PR suggestion to test roundtrip from CliArgs -> FsTabCliArgs -> CliArgs
+    proptest! {
+        #[test]
+        fn cli_args_roundtrip_from_fstab_args(original in valid_cli_args_strategy()) {
+            let args = serialize_to_fstab_args(&original);
+            let fstab = FsTabCliArgs::try_parse_from(&args).unwrap();
+            let roundtripped: CliArgs = fstab.try_into().unwrap();
+
+            prop_assert_eq!(roundtripped.bucket_name, original.bucket_name);
+            prop_assert_eq!(roundtripped.mount_point, original.mount_point);
+            prop_assert_eq!(roundtripped.uid, original.uid);
+            prop_assert_eq!(roundtripped.read_only, original.read_only);
+            prop_assert_eq!(roundtripped.allow_delete, original.allow_delete);
+            prop_assert_eq!(roundtripped.debug, original.debug);
         }
     }
 }

--- a/mountpoint-s3/src/fstab.rs
+++ b/mountpoint-s3/src/fstab.rs
@@ -148,7 +148,6 @@ fn split_commas(string: &str) -> anyhow::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
     use proptest::{prop_assert_eq, proptest};
     use proptest_derive::Arbitrary;
     use test_case::test_case;
@@ -265,7 +264,6 @@ mod tests {
         allow_delete: bool,
         allow_other: bool,
         debug: bool,
-        #[proptest(value = "false")]
         read_only: bool,
     }
 
@@ -300,16 +298,19 @@ mod tests {
         if cli_args.debug {
             options.push("debug".to_string());
         }
+        if cli_args.read_only {
+            options.push("ro".to_string());
+        }
 
         args.push("-o".to_string());
         args.push(options.join(","));
         args
     }
 
-    // This addresses the PR suggestion to test roundtrip from CliArgs -> FsTabCliArgs -> CliArgs
+    // Test roundtrip conversion between CLI argument formats
     proptest! {
         #[test]
-        fn cli_args_roundtrip_from_fstab_args(original in any::<FstabCompatibleCliArgs>()) {
+        fn cli_args_roundtrip_from_fstab_args(original: FstabCompatibleCliArgs) {
             let args = serialize_to_fstab_args(&original);
             let fstab = FsTabCliArgs::try_parse_from(&args).unwrap();
             let roundtripped: CliArgs = fstab.try_into().unwrap();


### PR DESCRIPTION
### Fstab cliargs roundtrip tests



This PR adds a property-based test that ensures roundtrip conversion between CliArgs and FsTabCliArgs behaves as expected. Specifically, we:

Implemented a custom FstabCompatibleCliArgs strategy for generating valid CliArgs inputs.

Serialise these into fstab-style CLI arguments.

Parse them back into CliArgs through the FsTabCliArgs path.

Assert equality with the original input.

This responds to a prior review comment requesting a test for round-trip parsing of CLI arguments.



### Does this change impact existing behavior?

No, this change does not impact runtime behavior. It only adds non-breaking test code under #[cfg(test)].

### Does this change need a changelog entry? Does it require a version change?

No changelog entry is required. This is an internal test-only enhancement and does not affect functionality or the public interface.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
