### PR TITLE
Adding fstab tag to user agent headers

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New features
+
+* Add `mp-fstab` tag to the User-Agent header when Mountpoint is launched via an fstab entry. This enables detection and analysis of fstab-based usage in product analytics. ([#1420](https://github.com/awslabs/mountpoint-s3/pull/1420))
+
 ## v1.17.0 (May 12, 2025)
 
 ### New features

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Unreleased
 
-
 ## v1.17.0 (May 12, 2025)
 
 ### New features

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Unreleased
 
-### New features
-
-* Add `mp-fstab` tag to the User-Agent header when Mountpoint is launched via an fstab entry. This enables detection and analysis of fstab-based usage in product analytics. ([#1420](https://github.com/awslabs/mountpoint-s3/pull/1420))
 
 ## v1.17.0 (May 12, 2025)
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -387,6 +387,9 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         value_name = "NETWORK_INTERFACE",
     )]
     pub bind: Option<Vec<String>>,
+
+    #[clap(skip)]
+    pub is_fstab: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -675,6 +678,9 @@ impl CliArgs {
         let mut user_agent = UserAgent::new_with_instance_info(Some(user_agent_prefix), instance_info);
         if self.read_only {
             user_agent.value("mp-readonly");
+        }
+        if self.is_fstab {
+            user_agent.value("mp-fstab");
         }
         match (&self.cache, self.cache_express_bucket_name()) {
             (None, None) => (),

--- a/mountpoint-s3/src/fstab.rs
+++ b/mountpoint-s3/src/fstab.rs
@@ -25,6 +25,7 @@ impl TryFrom<FsTabCliArgs> for CliArgs {
 
         let mut cli_args = CliArgs::try_parse_from(cli_arg_list)?;
         cli_args.foreground = true;
+        cli_args.is_fstab = true;
         Ok(cli_args)
     }
 }


### PR DESCRIPTION
### What changed and why?

- This PR adds a new mp-fstab tag to the user agent header when Mountpoint is launched via an fstab entry.
- Introduces an is_fstab field to CliArgs, which is set to true when parsing arguments from fstab.
- This allows downstream consumers (like the product team) to detect and analyze fstab-based usage of Mountpoint for Amazon S3, supporting product analytics and future UX improvements.

Example Request Header
<img width="719" alt="image" src="https://github.com/user-attachments/assets/10561b96-b893-496f-bab4-3f00ae568e68" />


### Does this change impact existing behavior?

- No breaking changes.
- The only impact is the addition of the mp-fstab tag in the user agent header for fstab-based mounts.
- All other mounting methods and user agent construction remain unchanged.


### Does this change need a changelog entry? Does it require a version change?
No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
