### PR TITLE
Move part of the logic from the config example to the fs create

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -146,18 +146,10 @@ impl ConfigOptions {
 
     fn determine_throughput(&self) -> Result<f64> {
         match &self.throughput_config {
-            // TODO(chagem): Remove some code duplication, by moving this logic into fs crate.
             ThroughputConfig::Explicit { throughput } => Ok(*throughput),
             ThroughputConfig::IMDSAutoConfigure => {
-                const DEFAULT_THROUGHPUT: f64 = 10.0;
                 let instance_info = InstanceInfo::new();
-                match autoconfigure::network_throughput(&instance_info) {
-                    Ok(throughput) => Ok(throughput),
-                    Err(e) => {
-                        tracing::warn!("Failed to detect network throughput. Using {DEFAULT_THROUGHPUT} gbps: {e:?}");
-                        Ok(DEFAULT_THROUGHPUT)
-                    }
-                }
+                Ok(autoconfigure::network_throughput_with_default(&instance_info, 10.0))
             }
             ThroughputConfig::IMDSLookUp { ec2_instance_type } => {
                 autoconfigure::get_maximum_network_throughput(ec2_instance_type).context("Unrecognized instance ID")

--- a/mountpoint-s3-fs/src/autoconfigure.rs
+++ b/mountpoint-s3-fs/src/autoconfigure.rs
@@ -8,6 +8,16 @@ use crate::s3::config::Region;
 mod instance_throughput;
 use instance_throughput::get_instance_throughput;
 
+pub fn network_throughput_with_default(instance_info: &InstanceInfo, default_throughput: f64) -> f64 {
+    match network_throughput(instance_info) {
+        Ok(throughput) => throughput,
+        Err(e) => {
+            tracing::warn!("Failed to detect network throughput. Using {default_throughput} gbps: {e:?}");
+            default_throughput
+        }
+    }
+}
+
 /// Determine the maximum network throughput for the current instance using IMDS. Returns an error
 /// if the instance type either cannot be retrieved using the IMDS client or does not have a known
 /// network throughput.

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -704,20 +704,8 @@ impl CliArgs {
     }
 
     fn throughput_target_gbps(&self, instance_info: &InstanceInfo) -> f64 {
-        const DEFAULT_TARGET_THROUGHPUT: f64 = 10.0;
-
-        let throughput_target_gbps = self.maximum_throughput_gbps.map(|t| t as f64).unwrap_or_else(|| {
-            match autoconfigure::network_throughput(instance_info) {
-                Ok(throughput) => throughput,
-                Err(e) => {
-                    tracing::warn!(
-                        "failed to detect network throughput. Using {DEFAULT_TARGET_THROUGHPUT} gbps as throughput. \
-                        Use --maximum-throughput-gbps CLI flag to configure a target throughput appropriate for the instance. Detection failed due to: {e:?}",
-                        );
-                    DEFAULT_TARGET_THROUGHPUT
-                }
-            }
-        });
+        const DEFAULT_THROUGHPUT: f64 = 10.0;
+        let throughput_target_gbps = autoconfigure::network_throughput_with_default(instance_info, DEFAULT_THROUGHPUT);
         tracing::info!("target network throughput {throughput_target_gbps} Gbps");
         throughput_target_gbps
     }


### PR DESCRIPTION
This moves part of the throughput configuration into the fs crate.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
