### PR TITLE
Ensure cache blocks are written atomically

### DIFF
--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -42,6 +42,7 @@ sha2 = "0.10.8"
 supports-color = "3.0.2"
 sysinfo = "0.33.1"
 syslog = "7.0.0"
+tempfile = "3.15.0"
 thiserror = "2.0.11"
 time = { version = "0.3.37", features = ["macros", "formatting", "serde-well-known"] }
 tracing = { version = "0.1.41", features = ["log"] }
@@ -74,7 +75,6 @@ rand_chacha = "0.3.1"
 serial_test = "3.2.0"
 sha2 = "0.10.8"
 shuttle = { version = "0.8.0" }
-tempfile = "3.15.0"
 test-case = "3.3.1"
 tokio = { version = "1.44.2", features = ["rt", "macros"] }
 walkdir = "2.5.0"

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -357,10 +357,8 @@ impl DiskDataCache {
     }
 
     fn write_block(&self, path: impl AsRef<Path>, block: DiskBlock) -> DataCacheResult<(NamedTempFile, usize)> {
-        let cache_path_for_key = path
-            .as_ref()
-            .parent()
-            .expect("path should include cache key in directory name");
+        let path = path.as_ref();
+        let cache_path_for_key = path.parent().expect("path should include cache key in directory name");
         fs::DirBuilder::new()
             .mode(0o700)
             .recursive(true)
@@ -372,8 +370,9 @@ impl DiskDataCache {
         trace!(
             key = block.header.s3_key,
             offset = block.header.block_offset,
-            "writing block at {}",
-            path.as_ref().display()
+            block_path = ?path,
+            temp_path = ?temp_file.path(),
+            "writing cache block",
         );
         temp_file.write_all(CACHE_VERSION.as_bytes())?;
         let bytes_written = block.write(&mut temp_file)?;


### PR DESCRIPTION
Address an issue with cache block reads failing while a concurrent write is in progress, observed for example in #1389 (see log entries in [comment](https://github.com/awslabs/mountpoint-s3/issues/1389#issuecomment-2861696762)). This change modifies `put_block` to write to a temporary file first and then rename to the expected cache block file name. 

In addition, this PR also addresses concurrency issues in tracking block usage data for eviction: updates to `UsageInfo` were not previously synchronized correctly with the operations on disk and we could end up recording a new block write when in fact the block had been concurrently deleted. Now we lock `UsageInfo` while performing file system operations.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Bug fix entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
