### PR TITLE
Add support for passing S3 URIs as part of the bucket name field

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -127,7 +127,13 @@ Mountpoint for Amazon S3 also supports [access points](#access-points) and [obje
 
 You can use Mountpoint to access only a prefix of your S3 bucket rather than the entire bucket. This allows you to isolate multiple users, applications, or workloads from each other within a single bucket. Use the `--prefix` command-line argument to specify a prefix of your S3 bucket, which must end with the `/` character. With this argument, only objects in your bucket that begin with the given prefix will be visible with Mountpoint.
 
-When constructing the directory structure for your mount, Mountpoint removes the prefix you specify with `--prefix` from object keys. For example, if your bucket has a key `2023/Files/data.json`, and you specify the `--prefix 2023/` command-line argument, the mounted directory will contain a single sub-directory `Files` with a file `data.json` inside it. If you specify the `--prefix 2023/Files/` command-line argument, the mounted directory will contain only a file `data.json` at its root.
+Alternatively, you can mount using an S3 URI including a prefix. Note that using an S3 URI prevents usage of ARNs to identify the bucket name.
+
+```
+mount-s3 s3://amzn-s3-demo-bucket/my/prefix/here/ /path/to/mount
+```
+
+When constructing the directory structure for your mount, Mountpoint removes any prefix you specify from object keys. For example, if your bucket has a key `2023/Files/data.json`, and you specify the `--prefix 2023/` command-line argument, the mounted directory will contain a single sub-directory `Files` with a file `data.json` inside it. If you specify the `--prefix 2023/Files/` command-line argument, the mounted directory will contain only a file `data.json` at its root.
 
 ### Region detection
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Improve safety checks when reading disk cache blocks. ([#1427](https://github.com/awslabs/mountpoint-s3/pull/1427))
 * `S3Path::new` now takes a `BucketName` instead of a `String`. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
-* Adds `parse_s3_uri_or_bucket_name`, which parses a `String` into an `BucketNameOrS3Uri`, which can then be converted into either a `BucketName` or an `S3Uri` to be used with `S3Path`. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
+* Adds `BucketNameOrS3Uri`, built using `try_from(String)` and can then be converted into either a `BucketName` or an `S3Uri` to be used with `S3Path`. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
 
 ## v0.2.0 (May 9, 2025)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased (v0.3.0)
 
 * Improve safety checks when reading disk cache blocks. ([#1427](https://github.com/awslabs/mountpoint-s3/pull/1427))
-* `S3Path` now accepts s3:// formatted bucket names. If given a `bucket_name` with a prefix, the `prefix` parameter must be empty. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
-* `S3Path::new` now returns `Result<S3Path, S3PathError>` ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
+* `S3Path::new` now takes a `BucketName` instead of a `String`. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
+* Adds `parse_s3_uri_or_bucket_name`, which parses a `String` into an `BucketNameOrS3Uri`, which can then be converted into either a `BucketName` or an `S3Uri` to be used with `S3Path`. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
 
 ## v0.2.0 (May 9, 2025)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased (v0.3.0)
 
 * Improve safety checks when reading disk cache blocks. ([#1427](https://github.com/awslabs/mountpoint-s3/pull/1427))
+* `S3Path` now accepts s3:// formatted bucket names. If given a `bucket_name` with a prefix, the `prefix` parameter must be empty. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
+* `S3Path::new` now returns `Result<S3Path, S3PathError>` ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
 
 ## v0.2.0 (May 9, 2025)
 

--- a/mountpoint-s3-fs/src/prefix.rs
+++ b/mountpoint-s3-fs/src/prefix.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum PrefixError {
     #[error("prefix must end in '/'")]
     MissingFinalDelimiter,
@@ -24,6 +24,10 @@ impl Prefix {
                 path: prefix.to_owned(),
             })
         }
+    }
+
+    pub fn empty() -> Self {
+        Self::new("").unwrap()
     }
 
     pub fn as_str(&self) -> &str {

--- a/mountpoint-s3-fs/src/prefix.rs
+++ b/mountpoint-s3-fs/src/prefix.rs
@@ -27,7 +27,7 @@ impl Prefix {
     }
 
     pub fn empty() -> Self {
-        Self::new("").unwrap()
+        Self { path: "".to_owned() }
     }
 
     pub fn as_str(&self) -> &str {

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -118,9 +118,9 @@ fn validate_s3_uri(s3_uri: String) -> Result<S3Uri, S3PathError> {
     let bucket_prefix = s3_uri.strip_prefix("s3://").ok_or(S3PathError::ExpectedS3URI)?;
     let (bucket, prefix) = {
         if let Some((bucket, prefix_str)) = bucket_prefix.split_once("/") {
-            (bucket, Prefix::new(prefix_str)?)
+            (bucket, prefix_str)
         } else {
-            (bucket_prefix, Prefix::empty())
+            (bucket_prefix, "")
         }
     };
     validate_bucket_length(bucket)?;
@@ -129,7 +129,7 @@ fn validate_s3_uri(s3_uri: String) -> Result<S3Uri, S3PathError> {
     }
     Ok(S3Uri {
         bucket_name: BucketName(bucket.to_string()),
-        prefix,
+        prefix: Prefix::new(prefix)?,
     })
 }
 

--- a/mountpoint-s3-fs/tests/reftests/harness.rs
+++ b/mountpoint-s3-fs/tests/reftests/harness.rs
@@ -797,7 +797,7 @@ mod read_only {
     fn run_test(tree: TreeNode, check: CheckType, readdir_limit: usize) {
         const BUCKET_NAME: &str = "test-bucket";
 
-        let test_prefix = Prefix::new("").expect("valid prefix");
+        let test_prefix = Prefix::empty();
         let config = S3FilesystemConfig {
             readdir_size: 5,
             ..Default::default()
@@ -941,7 +941,7 @@ mod mutations {
     fn run_test(initial_tree: TreeNode, ops: Vec<Op>, readdir_limit: usize) {
         const BUCKET_NAME: &str = "test-bucket";
 
-        let test_prefix = Prefix::new("").expect("valid prefix");
+        let test_prefix = Prefix::empty();
         let config = S3FilesystemConfig {
             readdir_size: 5,
             allow_delete: true,

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Unreleased
+## Unreleased (v1.18.0)
+
+### New features
+
+* Allow passing in s3:// URIs as the first argument to Mountpoint. The `--prefix` option is not allowed if a prefix is passed in as part of the S3 URI. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
+* Allow passing in s3:// URIs to the `--cache-xz` parameter. Use of prefixes is still unsupported. ([#1434](https://github.com/awslabs/mountpoint-s3/pull/1434))
 
 ## v1.17.0 (May 12, 2025)
 

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -30,8 +30,8 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClient>, Runtime, S3Personality)> {
-    let bucket_name = match &args.bucket_name {
-        BucketNameOrS3Uri::BucketName(bucket_name) => bucket_name,
+    let bucket_name: String = match &args.bucket_name {
+        BucketNameOrS3Uri::BucketName(bucket_name) => bucket_name.clone().into(),
         BucketNameOrS3Uri::S3Uri(_) => panic!("mock-mount-s3 bucket names do not support S3 URIs"),
     };
 
@@ -39,7 +39,7 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
     // this one. Buckets starting with "sthree-" are always invalid against real S3:
     // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     anyhow::ensure!(
-        bucket_name.starts_with("sthree-"),
+        &bucket_name.starts_with("sthree-"),
         "mock-mount-s3 bucket names must start with `sthree-`"
     );
 
@@ -53,7 +53,7 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
     tracing::info!("mock client target network throughput {max_throughput_gbps} Gbps");
 
     let config = MockClientConfig {
-        bucket: bucket_name.clone(),
+        bucket: bucket_name,
         part_size: args.part_size as usize,
         unordered_list_seed: None,
         enable_backpressure: true,

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -13,7 +13,7 @@ use mountpoint_s3_fs::fuse::config::{FuseOptions, FuseSessionConfig, MountPoint}
 use mountpoint_s3_fs::logging::{prepare_log_file_name, LoggingConfig};
 use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
 use mountpoint_s3_fs::prefix::Prefix;
-use mountpoint_s3_fs::s3::config::{parse_s3_uri_or_bucket_name, BucketNameOrS3Uri, ClientConfig, PartConfig, S3Path};
+use mountpoint_s3_fs::s3::config::{BucketNameOrS3Uri, ClientConfig, PartConfig, S3Path};
 use mountpoint_s3_fs::s3::S3Personality;
 use mountpoint_s3_fs::{autoconfigure, metrics, S3FilesystemConfig};
 use sysinfo::{RefreshKind, System};
@@ -55,7 +55,7 @@ Arguments:
 pub struct CliArgs {
     #[clap(
         help = "Name of bucket, or an S3 URI, to mount",
-        value_parser = parse_s3_uri_or_bucket_name,
+        value_parser = |arg: &str| BucketNameOrS3Uri::try_from(arg.to_string()),
     )]
     pub bucket_name: BucketNameOrS3Uri,
 
@@ -345,7 +345,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         help_heading = CACHING_OPTIONS_HEADER,
         value_name = "BUCKET",
         group = "cache_group",
-        value_parser = parse_s3_uri_or_bucket_name,
+        value_parser = |arg: &str| BucketNameOrS3Uri::try_from(arg.to_string()),
     )]
     pub cache_xz: Option<BucketNameOrS3Uri>,
 

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -207,7 +207,7 @@ where
 
 /// Create a real S3 client
 pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, Runtime, S3Personality)> {
-    let client_config = args.client_config(build_info::FULL_VERSION)?;
+    let client_config = args.client_config(build_info::FULL_VERSION);
 
     let s3_path = args.s3_path()?;
     let client = client_config

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -26,7 +26,7 @@ where
 {
     let successful_mount_msg = format!(
         "{} is mounted at {}",
-        args.bucket_description(),
+        args.bucket_description()?,
         args.mount_point.display()
     );
 
@@ -181,12 +181,12 @@ where
 
     let (client, runtime, s3_personality) = client_builder(&args)?;
 
-    let bucket_description = args.bucket_description();
+    let bucket_description = args.bucket_description()?;
     tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");
 
-    let s3_path = args.s3_path();
+    let s3_path = args.s3_path()?;
     let filesystem_config = args.filesystem_config(sse.clone(), s3_personality);
-    let mut data_cache_config = args.data_cache_config(sse);
+    let mut data_cache_config = args.data_cache_config(sse)?;
 
     let managed_cache_dir = setup_disk_cache_directory(&mut data_cache_config)?;
 
@@ -207,9 +207,9 @@ where
 
 /// Create a real S3 client
 pub fn create_s3_client(args: &CliArgs) -> anyhow::Result<(S3CrtClient, Runtime, S3Personality)> {
-    let client_config = args.client_config(build_info::FULL_VERSION);
+    let client_config = args.client_config(build_info::FULL_VERSION)?;
 
-    let s3_path = args.s3_path();
+    let s3_path = args.s3_path()?;
     let client = client_config
         .create_client(Some(&s3_path))
         .context("Failed to create S3 client")?;

--- a/mountpoint-s3/tests/fstab/basic_checks.sh
+++ b/mountpoint-s3/tests/fstab/basic_checks.sh
@@ -11,7 +11,7 @@ echo "Mountpoint path: $MOUNTPOINT_PATH"
 
 FSTAB_CONTENT="
 ${MOUNTPOINT_PATH}#${S3_BUCKET_NAME} /mnt/mountpoint_ro fuse allow-other,_netdev,nosuid,nodev,prefix=${S3_BUCKET_TEST_PREFIX},ro 0 0
-${MOUNTPOINT_PATH}#${S3_BUCKET_NAME} /mnt/mountpoint_rw fuse allow-other,_netdev,nosuid,nodev,prefix=${S3_BUCKET_TEST_PREFIX},rw 0 0
+${MOUNTPOINT_PATH}#s3://${S3_BUCKET_NAME}/${S3_BUCKET_TEST_PREFIX} /mnt/mountpoint_rw fuse allow-other,_netdev,nosuid,nodev,rw 0 0
 "
 
 spawn_mounts "$FSTAB_CONTENT"


### PR DESCRIPTION
Allows invoking Mountpoint with an S3 URI in the 'bucket name' parameter


- When using an S3 URI, a prefix can also be supplied. When it is, the `--prefix` option cannot be given.
- Allows using an S3 URI with the `--cache-xz` parameter, but without a prefix.
- Documentation entry for the feature was introduced

### Does this change impact existing behavior?

Yes, the 'bucket name' and 'cache-xz' parameters now can take S3 URIs.
There are no breaking changes.

### Does this change need a changelog entry? Does it require a version change?

Changelog entry was made. Needs minor version bump.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
