### PR TITLE
Prepare crate changelog before releasing up to fs-crate

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.15.0)
+## Unreleased
+
+## v0.15.0 (May 27, 2025)
 
 ### Breaking changes
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,9 @@
-## Unreleased (v0.3.0)
+## Unreleased
 
+## v0.3.0 (May 27, 2025)
+
+* Added ability to configure an error logger which can be used to report errors returned by fuse operations. Use method `MountpointConfig::error_logger` to configure the callback. ([#1416](https://github.com/awslabs/mountpoint-s3/pull/1416))  
+* `PrefetchReadError::GetRequestFailed` error variant has changed. It now contains an additional field `metadata`. ([#1411](https://github.com/awslabs/mountpoint-s3/pull/1411))
 * Improve safety checks when reading disk cache blocks. ([#1427](https://github.com/awslabs/mountpoint-s3/pull/1427))
 
 ## v0.2.0 (May 9, 2025)


### PR DESCRIPTION
Adjusts the Changelogs for the `mountpoint-s3-fs` crate and it's dependencies.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
