### PR TITLE
Package fstab file

### DIFF
--- a/package/mount-s3-suse.spec
+++ b/package/mount-s3-suse.spec
@@ -27,7 +27,9 @@ interface.
 rm -rf %{buildroot}/*
 cp -r %{_builddir}/%{name}-%{version}/* %{buildroot}/
 mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_prefix}/sbin
 ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_bindir}/mount-s3
+ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_prefix}/sbin/mount.mount-s3
 
 %files
 %dir /opt/aws/mountpoint-s3
@@ -38,3 +40,4 @@ ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_bindir}/mount-s3
 /opt/aws/mountpoint-s3/THIRD_PARTY_LICENSES
 /opt/aws/mountpoint-s3/VERSION
 %{_bindir}/mount-s3
+%{_prefix}/sbin/mount.mount-s3

--- a/package/mount-s3.spec
+++ b/package/mount-s3.spec
@@ -27,7 +27,9 @@ interface.
 rm -rf %{buildroot}/*
 cp -r %{_builddir}/%{name}-%{version}/* %{buildroot}/
 mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_prefix}/sbin
 ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_bindir}/mount-s3
+ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_prefix}/sbin/mount.mount-s3
 
 %files
 %dir /opt/aws/mountpoint-s3
@@ -38,3 +40,4 @@ ln -f -s /opt/aws/mountpoint-s3/bin/mount-s3 %{buildroot}/%{_bindir}/mount-s3
 /opt/aws/mountpoint-s3/THIRD_PARTY_LICENSES
 /opt/aws/mountpoint-s3/VERSION
 %{_bindir}/mount-s3
+%{_prefix}/sbin/mount.mount-s3

--- a/package/package.py
+++ b/package/package.py
@@ -290,6 +290,9 @@ def build_deb(metadata: BuildMetadata, package_dir: str) -> str:
     deb_bin_dir = os.path.join(deb_package_dir, "usr/bin")
     os.makedirs(deb_bin_dir)
     os.symlink(f"/{OPT_PATH}/bin/mount-s3", os.path.join(deb_bin_dir, "mount-s3"))
+    deb_sbin_dir = os.path.join(deb_package_dir, "usr/sbin")
+    os.makedirs(deb_sbin_dir)
+    os.symlink(f"/{OPT_PATH}/bin/mount-s3", os.path.join(deb_sbin_dir, "mount.mount-s3"))
 
     # Build the DEB
     deb_path = os.path.join(deb_buildroot, "mount-s3.deb")


### PR DESCRIPTION
Draft PR because I want to remove the fstab feature outside this PR

Adds `mount.mount-s3` symlink to our rpm and deb installers. This file is placed in `/usr/sbin` in the host when installed.

### Does this change impact existing behavior?

Yes, a new `mount.mount-s3` file is added during installation.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
