### PR TITLE
Fstab tests: Ignore empty directory

### DIFF
--- a/mountpoint-s3/tests/fstab/spawn_mounts.sh
+++ b/mountpoint-s3/tests/fstab/spawn_mounts.sh
@@ -10,7 +10,7 @@ function spawn_mounts() {
 
   # systemd-fstab-generator takes 3 arguments, which are paths to put results in
   # It only actually puts anything in the first directory, but it appears standard to call these normal, early, and late.
-  rm -r "$OUTPUT_DIR" || true
+  rm -rf "$OUTPUT_DIR"
   mkdir -p "$OUTPUT_DIR"/{normal,early,late}
 
   # systemd-fstab-generator takes two environment variables as input: 'SYSTEMD_FSTAB' and 'SYSTEMD_PROC_CMDLINE'


### PR DESCRIPTION
Currently, our fstab tests can fail if run in an environment where the output dir does not exist.
This PR changes the `rm -r` call to a `rm -rf` to ignore cases where the directory is empty.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
