### PR TITLE
Remove fstab feature flag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ env:
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_EXTERNAL }}
   KMS_TEST_KEY_ID: ${{ vars.KMS_TEST_KEY_ID }}
   S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS: ${{ vars.S3_EXPRESS_ONE_ZONE_BUCKET_NAME_SSE_KMS }}
-  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest,fstab
+  RUST_FEATURES: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest
 
 permissions:
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_FEATURES: fuse_tests,fstab
+  RUST_FEATURES: fuse_tests
 
 jobs:
   test:

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -49,7 +49,6 @@ built = { version = "0.7.5", features = ["git2"] }
 # Unreleased feature flags
 block_size = ["mountpoint-s3-fs/block_size"]
 event_log = ["mountpoint-s3-fs/event_log"]
-fstab = []
 mem_limiter = ["mountpoint-s3-fs/mem_limiter"]
 # Features for choosing tests
 s3_tests = ["mountpoint-s3-fs/s3_tests"]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -50,7 +50,7 @@ Arguments:
         ArgGroup::new("cache_group")
             .multiple(true),
     ),
-    after_help = if cfg!(feature = "fstab") {FSTAB_DOCS} else {""},
+    after_help = FSTAB_DOCS,
 )]
 pub struct CliArgs {
     #[clap(

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -13,7 +13,7 @@ pub use run::{create_s3_client, run};
 pub fn parse_cli_args(log_fstab: bool) -> CliArgs {
     let is_fstab = env::args_os().len() == 5 && env::args_os().nth(3).as_deref() == Some("-o".as_ref());
 
-    let cli_args = if is_fstab && cfg!(feature = "fstab") {
+    let cli_args = if is_fstab {
         if log_fstab {
             println!("Using 'fstab' style options as detected use of `-o` argument.");
         }

--- a/mountpoint-s3/tests/cli.rs
+++ b/mountpoint-s3/tests/cli.rs
@@ -291,7 +291,6 @@ fn verify_new_part_size_config_conflict_with_old_one(
     Ok(())
 }
 
-#[cfg(feature = "fstab")]
 #[test]
 fn fstab_rw_conflicts_with_ro() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;
@@ -304,7 +303,6 @@ fn fstab_rw_conflicts_with_ro() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "fstab")]
 #[test]
 fn fstab_cannot_use_foreground() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;
@@ -317,7 +315,6 @@ fn fstab_cannot_use_foreground() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "fstab")]
 #[test]
 fn fstab_cannot_use_read_only() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;
@@ -330,7 +327,6 @@ fn fstab_cannot_use_read_only() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "fstab")]
 #[test]
 fn fstab_cannot_use_multiple_prefixes() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;
@@ -346,7 +342,6 @@ fn fstab_cannot_use_multiple_prefixes() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
-#[cfg(feature = "fstab")]
 #[test]
 fn fstab_no_options() -> Result<(), Box<dyn std::error::Error>> {
     let dir = assert_fs::TempDir::new()?;

--- a/mountpoint-s3/tests/fstab/basic_checks.sh
+++ b/mountpoint-s3/tests/fstab/basic_checks.sh
@@ -5,7 +5,7 @@ set -e
 
 source "$(dirname "$(which "$0")")/spawn_mounts.sh"
 
-build_out=$(cargo build --bin mount-s3 --release --features=fstab --message-format=json-render-diagnostics)
+build_out=$(cargo build --bin mount-s3 --release --message-format=json-render-diagnostics)
 MOUNTPOINT_PATH=$(printf "%s" "$build_out" | jq -js '[.[] | select(.reason == "compiler-artifact") | select(.executable != null)] | last | .executable')
 echo "Mountpoint path: $MOUNTPOINT_PATH"
 


### PR DESCRIPTION
Removes fstab feature flag

### Does this change impact existing behavior?

Yes, enables fstab feature

### Does this change need a changelog entry? Does it require a version change?

Yes - changelog is included in this PR: https://github.com/awslabs/mountpoint-s3/pull/1441

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
