### PR TITLE
Remove fstab feature flag

### DIFF
--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -49,7 +49,6 @@ built = { version = "0.7.5", features = ["git2"] }
 # Unreleased feature flags
 block_size = ["mountpoint-s3-fs/block_size"]
 event_log = ["mountpoint-s3-fs/event_log"]
-fstab = []
 mem_limiter = ["mountpoint-s3-fs/mem_limiter"]
 # Features for choosing tests
 s3_tests = ["mountpoint-s3-fs/s3_tests"]


### PR DESCRIPTION
Removes fstab file from cargo.toml - previous commit removed from CI as well as code usages. This is just cleaning up.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
