### PR TITLE
Fix example for using fstab in user data

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -363,7 +363,11 @@ Example user data script (tested on AL2023). This will only work for x86 systems
 # Install Mountpoint
 MP_RPM=$(mktemp --suffix=.rpm)
 curl https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.rpm > $MP_RPM
-yum install -y $MP_RPM
+
+while true; do
+yum install -y $MP_RPM && break
+done
+
 rm $MP_RPM
 
 # Setup the fstab file and create the mount


### PR DESCRIPTION
The previous example for using fstab with user data failed to install Mountpoint occasionally on AL2023 hosts, and appears to be impacted by this bug: https://github.com/amazonlinux/amazon-linux-2023/issues/397 & https://repost.aws/questions/QU_tj7NQl6ReKoG53zzEqYOw/amazon-linux-2023-issue-with-installing-packages-with-cloud-init.

Updating the example user data script to retry installing Mountpoint if it fails.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
