### PR TITLE
Update MP client_benchmark to support CRT backpressure

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -189,7 +189,14 @@ fn main() {
             }
             let client = S3CrtClient::new(config).expect("couldn't create client");
 
-            run_benchmark(client, args.iterations, args.downloads, &bucket, &key, args.enable_backpressure);
+            run_benchmark(
+                client,
+                args.iterations,
+                args.downloads,
+                &bucket,
+                &key,
+                args.enable_backpressure,
+            );
         }
         Client::Mock { object_size } => {
             const BUCKET: &str = "bucket";
@@ -204,7 +211,14 @@ fn main() {
 
             client.add_object(KEY, MockObject::ramp(0xaa, object_size as usize, ETag::for_tests()));
 
-            run_benchmark(client, args.iterations, args.downloads, BUCKET, KEY, args.enable_backpressure);
+            run_benchmark(
+                client,
+                args.iterations,
+                args.downloads,
+                BUCKET,
+                KEY,
+                args.enable_backpressure,
+            );
         }
     }
 }

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -162,8 +162,12 @@ struct CliArgs {
     downloads: usize,
     #[arg(long, help = "Enable CRT backpressure mode")]
     enable_backpressure: bool,
-    #[arg(long, help = "Initial window size in bytes", default_value = "0")]
-    initial_window_size: usize,
+    #[arg(
+        long,
+        help = "Initial read window size in bytes, used to dictate how far ahead we request data from S3",
+        default_value = "0"
+    )]
+    initial_window_size: Option<usize>,
 }
 
 fn main() {
@@ -187,7 +191,10 @@ fn main() {
             config = config.part_size(args.part_size);
             if args.enable_backpressure {
                 config = config.read_backpressure(true);
-                config = config.initial_read_window(args.initial_window_size);
+                config = config.initial_read_window(
+                    args.initial_window_size
+                        .expect("read window size is required when backpressure is enabled"),
+                );
             }
             let client = S3CrtClient::new(config).expect("couldn't create client");
 


### PR DESCRIPTION
Update MP client_backmark to support CRT backpressure. Extend the benchmark to optionally enable read-backpressure in CRT, and configure the initial read window size. This test aims to simulate the read-ahead capability of the prefetcher, making it easier to baseline the performance against the prefetcher benchmark.

### Does this change impact existing behavior?

No, changes to the benchmark only.

### Does this change need a changelog entry? Does it require a version change?

No, changes to the benchmark only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
