### PR TITLE
Move ctrl-c handler out of FuseSession

### DIFF
--- a/mountpoint-s3-fs/src/config.rs
+++ b/mountpoint-s3-fs/src/config.rs
@@ -62,7 +62,9 @@ impl MountpointConfig {
         );
 
         let fuse_fs = S3FuseFilesystem::new(fs, self.error_logger);
-        FuseSession::new(fuse_fs, self.fuse_session_config)
+        let session = FuseSession::new(fuse_fs, self.fuse_session_config)?;
+        ctrlc::set_handler(session.shutdown_fn()).context("failed to set interrupt handler")?;
+        Ok(session)
     }
 }
 


### PR DESCRIPTION
Minor change to decouple `FuseSession` from the ctrl-c signal handler. `FuseSession` will now expose a function to signal shutdown, which can be used by the caller when installing the signal handler.

Prerequisite to start using `FuseSession` in tests, where we do not want to install multiple signal handlers when testing multiple instances of `FuseSession`.

### Does this change impact existing behavior?

No, it's only an internal refactor.

### Does this change need a changelog entry? Does it require a version change?

`fs` crate only

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
