### PR TITLE
Otlp exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,11 +3006,13 @@ dependencies = [
  "nix",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-proto",
  "opentelemetry_sdk",
  "predicates",
  "procfs",
  "proptest",
  "proptest-derive",
+ "prost 0.12.6",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -3202,7 +3217,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "thiserror 2.0.12",
  "tracing",
@@ -3214,9 +3229,12 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
+ "base64 0.22.1",
+ "hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
+ "serde",
  "tonic",
 ]
 
@@ -3599,12 +3617,35 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4775,10 +4816,15 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
+ "tokio",
  "tokio-stream",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4792,11 +4838,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -843,6 +843,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -1377,7 +1383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1388,7 +1394,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1570,7 +1576,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1681,7 +1687,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1891,7 +1897,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1962,7 +1968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2187,7 +2193,7 @@ dependencies = [
  "async-object-pool",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2477,6 +2483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,7 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2798,6 +2810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,8 +2863,8 @@ dependencies = [
  "predicates",
  "proptest",
  "proptest-derive",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
@@ -2884,8 +2902,8 @@ dependencies = [
  "pin-project",
  "platform-info",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "rusty-fork",
  "serde_json",
@@ -2913,7 +2931,7 @@ dependencies = [
  "libc",
  "log",
  "mountpoint-s3-crt-sys",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "smallstr",
  "static_assertions",
@@ -2973,12 +2991,15 @@ dependencies = [
  "mountpoint-s3-client",
  "mountpoint-s3-fuser",
  "nix",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "predicates",
  "procfs",
  "proptest",
  "proptest-derive",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "rusqlite",
  "serde",
@@ -3144,6 +3165,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,7 +3313,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3482,8 +3577,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -3497,6 +3592,29 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -3530,8 +3648,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3541,7 +3669,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3554,12 +3692,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3568,7 +3715,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3660,6 +3807,43 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
 
 [[package]]
 name = "rfc6979"
@@ -3815,7 +3999,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4024,6 +4208,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,8 +4293,8 @@ dependencies = [
  "generator",
  "hex",
  "owo-colors 3.5.0",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rand_pcg",
  "scoped-tls",
  "smallvec",
@@ -4131,7 +4327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4265,6 +4461,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -4535,6 +4740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,11 +4764,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -4936,7 +5178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4946,7 +5188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4956,7 +5198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4965,7 +5207,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4977,7 +5219,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4989,8 +5231,8 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
- "windows-targets",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5038,12 +5280,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5052,7 +5311,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5062,7 +5330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5071,7 +5348,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5080,7 +5357,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5089,14 +5366,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5106,10 +5399,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5118,10 +5423,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5130,10 +5447,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5142,10 +5471,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winsafe"

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -49,12 +49,17 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 signal-hook = "0.3.17"
 csv = { version = "1.3.1", optional = true }
+opentelemetry = { version = "0.30.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.30.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.30.0", features = ["metrics", "http-proto"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17.0", default-features = false }
 
 [dev-dependencies]
 mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
+opentelemetry-proto = { version = "0.30.0", features = ["metrics", "gen-tonic"] }
+prost = "0.12.0"
 
 assert_cmd = "2.0.16"
 assert_fs = "1.1.2"

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -208,7 +208,8 @@ fn process_manifests(config: &ConfigOptions, database_directory: &Path) -> Resul
 
 fn setup_logging(config: &ConfigOptions) -> Result<(LoggingHandle, MetricsSinkHandle)> {
     let logging = init_logging(config.build_logging_config())?;
-    let metrics = metrics::install();
+    let metrics = metrics::install(None)
+        .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
     Ok((logging, metrics))
 }
 

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -208,8 +208,7 @@ fn process_manifests(config: &ConfigOptions, database_directory: &Path) -> Resul
 
 fn setup_logging(config: &ConfigOptions) -> Result<(LoggingHandle, MetricsSinkHandle)> {
     let logging = init_logging(config.build_logging_config())?;
-    let metrics = metrics::install(None)
-        .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
+    let metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
     Ok((logging, metrics))
 }
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -103,7 +103,7 @@ pub struct CliArgs {
 
 fn main() {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
 
     let args = CliArgs::parse();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -90,7 +90,7 @@ struct UploadBenchmarkArgs {
 
 fn main() {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
 
     let args = UploadBenchmarkArgs::parse();
     println!("starting upload benchmark with {:?}", &args);

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -10,6 +10,7 @@ pub mod logging;
 pub mod manifest;
 pub mod mem_limiter;
 pub mod metrics;
+pub mod metrics_otel;
 pub mod object;
 pub mod prefetch;
 pub mod prefix;

--- a/mountpoint-s3-fs/src/metrics.rs
+++ b/mountpoint-s3-fs/src/metrics.rs
@@ -65,9 +65,8 @@ pub fn install(otlp_config: Option<OtlpConfig>) -> Result<MetricsSinkHandle, Box
     };
 
     let recorder = MetricsRecorder { sink };
-    metrics::set_global_recorder(recorder).map_err(|e| {
-        Box::<dyn std::error::Error>::from(format!("Failed to set global metrics recorder: {}", e))
-    })?;
+    metrics::set_global_recorder(recorder)
+        .map_err(|e| Box::<dyn std::error::Error>::from(format!("Failed to set global metrics recorder: {}", e)))?;
 
     Ok(handle)
 }
@@ -104,9 +103,7 @@ impl MetricsSink {
         let otlp_exporter = if let Some(config) = otlp_config {
             // Basic validation of the endpoint URL
             if !config.endpoint.starts_with("http://") && !config.endpoint.starts_with("https://") {
-                return Err(
-                    "Invalid OTLP endpoint configuration: endpoint must start with http:// or https://".into()
-                );
+                return Err("Invalid OTLP endpoint configuration: endpoint must start with http:// or https://".into());
             }
 
             match OtlpMetricsExporter::new(&config) {

--- a/mountpoint-s3-fs/src/metrics.rs
+++ b/mountpoint-s3-fs/src/metrics.rs
@@ -114,8 +114,7 @@ impl MetricsSink {
                     Some(exporter)
                 }
                 Err(e) => {
-                    let error_msg = format!("Failed to initialise OTLP exporter: {}", e);
-                    tracing::error!("{}", error_msg);
+                    tracing::error!("Failed to initialise OTLP exporter: {}", e);
 
                     // If the user explicitly requested metrics export but it failed,
                     // we should return an error rather than silently continuing without metrics

--- a/mountpoint-s3-fs/src/metrics.rs
+++ b/mountpoint-s3-fs/src/metrics.rs
@@ -3,6 +3,9 @@
 //! This module hooks up the [metrics](https://docs.rs/metrics) facade to a metrics sink that
 //! currently just emits them to a tracing log entry.
 
+use crate::metrics_otel::{OtlpConfig, OtlpMetricsExporter};
+use opentelemetry::KeyValue;
+
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -30,8 +33,8 @@ pub const TARGET_NAME: &str = "mountpoint_s3_fs::metrics";
 /// done with their work; metrics generated after shutting down the sink will be lost.
 ///
 /// Panics if a sink has already been installed.
-pub fn install() -> MetricsSinkHandle {
-    let sink = Arc::new(MetricsSink::new());
+pub fn install(otlp_config: Option<OtlpConfig>) -> Result<MetricsSinkHandle, String> {
+    let sink = Arc::new(MetricsSink::new(otlp_config)?);
     let mut sys = System::new();
 
     let (tx, rx) = channel();
@@ -62,9 +65,9 @@ pub fn install() -> MetricsSinkHandle {
     };
 
     let recorder = MetricsRecorder { sink };
-    metrics::set_global_recorder(recorder).unwrap();
+    metrics::set_global_recorder(recorder).map_err(|e| format!("Failed to set global metrics recorder: {}", e))?;
 
-    handle
+    Ok(handle)
 }
 
 /// Report process level metrics
@@ -90,13 +93,42 @@ fn poll_process_metrics(sys: &mut System) {
 #[derive(Debug)]
 struct MetricsSink {
     metrics: DashMap<Key, Metric>,
+    otlp_exporter: Option<OtlpMetricsExporter>, 
 }
 
 impl MetricsSink {
-    fn new() -> Self {
-        Self {
+    fn new(otlp_config: Option<OtlpConfig>) -> Result<Self, String> {
+        // Initialise the OTLP exporter if a config is provided
+        let otlp_exporter = if let Some(config) = otlp_config {
+            // Basic validation of the endpoint URL
+            if !config.endpoint.starts_with("http://") && !config.endpoint.starts_with("https://") {
+                return Err(format!("Invalid OTLP endpoint configuration: endpoint must start with http:// or https://"));
+            }
+            
+            match OtlpMetricsExporter::new(&config) {
+                Ok(exporter) => {
+                    tracing::info!("OpenTelemetry metrics export enabled to {}", config.endpoint);
+                    Some(exporter)
+                }
+                Err(e) => {
+                    let error_msg = format!("Failed to initialise OTLP exporter: {}", e);
+                    tracing::error!("{}", error_msg);
+                    
+                    // If the user explicitly requested metrics export but it failed,
+                    // we should return an error rather than silently continuing without metrics
+                    return Err(format!("Failed to initialize OTLP metrics exporter: {}. If metrics export is not required, omit the OTLP configuration.", e));
+                }
+            }
+        } else {
+            // No OTLP config provided, running without OpenTelemetry metrics export
+            tracing::debug!("Running without OpenTelemetry metrics export");
+            None
+        };
+
+        Ok(Self {
             metrics: DashMap::with_capacity(64),
-        }
+            otlp_exporter,
+        })
     }
 
     fn counter(&self, key: &Key) -> metrics::Counter {
@@ -115,12 +147,43 @@ impl MetricsSink {
     }
 
     /// Publish all this sink's metrics to `tracing` log messages
+    /// Send metrics to OTLP if enabled
     fn publish(&self) {
         // Collect the output lines so we can sort them to make reading easier
         let mut metrics = vec![];
 
         for mut entry in self.metrics.iter_mut() {
             let (key, metric) = entry.pair_mut();
+
+            // If OTLP export is enabled, also send metrics to OpenTelemetry
+            if let Some(exporter) = &self.otlp_exporter {
+                // Convert labels to OpenTelemetry KeyValue pairs
+                let attributes: Vec<KeyValue> = key
+                    .labels()
+                    .map(|label| KeyValue::new(label.key().to_string(), label.value().to_string()))
+                    .collect();
+
+                // Record the metric based on its type
+                match metric {
+                    Metric::Counter(counter) => {
+                        if let Some((value, _)) = counter.load_and_reset() {
+                            exporter.record_counter(key, value, &attributes);
+                        }
+                    }
+                    Metric::Gauge(gauge) => {
+                        if let Some(value) = gauge.load_if_changed() {
+                            exporter.record_gauge(key, value, &attributes);
+                        }
+                    }
+                    Metric::Histogram(histogram) => {
+                        histogram.run_and_reset(|h| {
+                            let value = h.mean();
+                            exporter.record_histogram(key, value, &attributes);
+                        });
+                    }
+                }
+            }
+
             let Some(metric) = metric.fmt_and_reset() else {
                 continue;
             };
@@ -219,7 +282,7 @@ mod tests {
 
     #[test]
     fn basic_metrics() {
-        let sink = Arc::new(MetricsSink::new());
+        let sink = Arc::new(MetricsSink::new(None).unwrap());
         let recorder = MetricsRecorder { sink: sink.clone() };
         with_local_recorder(&recorder, || {
             // Run twice to check reset works
@@ -309,5 +372,124 @@ mod tests {
                 assert!(inner.load_if_changed().is_none());
             }
         });
+    }
+
+    /// This is a manual test for verifying the integration of the metrics system with OpenTelemetry.
+    /// It provides end-to-end verification of the metrics pipeline without needing to run the full mountpoint application.
+    /// 
+    /// # Requirements
+    /// - An OpenTelemetry collector running at http://localhost:4318/v1/metrics
+    /// 
+    /// # How to run
+    /// ```bash
+    /// # Start the OpenTelemetry collector (e.g., using Docker)
+    /// docker run -p 4317:4317 -p 4318:4318 -v $(pwd)/collector-config.yaml:/etc/otel-collector-config.yaml \
+    ///   otel/opentelemetry-collector:latest --config=/etc/otel-collector-config.yaml
+    /// 
+    /// # Run the test (ignored by default)
+    /// cargo test --package mountpoint-s3-fs --lib -- metrics::tests::otlp_metrics --exact --ignored
+    /// 
+    /// # Verify metrics in collector logs
+    /// ```
+    #[test]
+    #[ignore]
+    fn otlp_metrics() {
+        use tracing::info;
+        use tracing_subscriber::fmt::format::FmtSpan;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        // Initialize tracing for better test output
+        tracing_subscriber::fmt()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(false)
+            .with_thread_ids(true)
+            .with_level(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_test_writer()
+            .set_default();
+
+        info!("Starting OTLP metrics test...");
+
+        // Initialize metrics with an OTLP config pointing to our mock server
+        let config = OtlpConfig::new("http://localhost:4318/v1/metrics").with_interval_secs(1);
+        let sink = Arc::new(MetricsSink::new(Some(config)).unwrap());
+        let recorder = MetricsRecorder { sink: sink.clone() };
+
+        with_local_recorder(&recorder, || {
+            // Test counter with multiple labels
+            let counter = metrics::counter!(
+                "mountpoint_test_counter",
+                "operation" => "write",
+                "status" => "success",
+                "test" => "true"
+            );
+            counter.increment(100);
+            counter.increment(50);
+            info!("Recorded counter with total value 150");
+
+            // Test gauge with updates
+            let gauge = metrics::gauge!(
+                "mountpoint_test_gauge",
+                "component" => "cache",
+                "test" => "true"
+            );
+            gauge.set(1000.0);
+            info!("Set gauge to 1000.0");
+            gauge.set(500.0);
+            info!("Updated gauge to 500.0");
+
+            // Test histogram with multiple records
+            let histogram = metrics::histogram!(
+                "mountpoint_test_histogram",
+                "operation" => "read",
+                "test" => "true"
+            );
+            histogram.record(10.0);
+            histogram.record(20.0);
+            histogram.record(30.0);
+            info!("Recorded histogram values: 10.0, 20.0, 30.0");
+
+            // Publish metrics immediately to verify initial values
+            info!("Publishing initial metrics...");
+            sink.publish();
+
+            // Sleep to allow metrics to be exported
+            std::thread::sleep(std::time::Duration::from_secs(2));
+
+            // Update metrics to verify changes are tracked
+            counter.increment(200);
+            gauge.set(750.0);
+            histogram.record(40.0);
+            info!("Updated all metrics with new values");
+
+            // Publish again to verify updates
+            info!("Publishing updated metrics...");
+            sink.publish();
+
+            // Wait for final export
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            info!("Test complete. Metrics should show in collector logs.");
+        });
+    }
+
+    #[test]
+    fn test_otlp_endpoint_validation() {
+        // Test with an invalid URI - we need to directly test the MetricsSink::new function
+        // since install() will try to set up a global recorder which can only be done once
+        let config = OtlpConfig::new("not-a-valid-uri");
+        let result = MetricsSink::new(Some(config));
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.contains("Invalid OTLP endpoint configuration"), "Error message should indicate invalid configuration: {}", error);
+        
+        // Test with no OTLP config (should succeed)
+        let result = MetricsSink::new(None);
+        assert!(result.is_ok());
+        
+        // Test with a syntactically valid endpoint (should succeed)
+        let config = OtlpConfig::new("http://example.com:4318/v1/metrics");
+        let result = MetricsSink::new(Some(config));
+        assert!(result.is_ok());
     }
 }

--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -1,0 +1,216 @@
+use opentelemetry::global;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use std::time::Duration;
+
+use metrics::Key;
+
+/// Configuration for OpenTelemetry metrics export
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// The endpoint URL to send metrics to
+    pub endpoint: String,
+    /// The export interval in seconds
+    pub interval_secs: u64,
+}
+
+impl OtlpConfig {
+    /// Create a new OtlpConfig with the specified endpoint and default interval
+    pub fn new(endpoint: &str) -> Self {
+        Self {
+            endpoint: endpoint.to_string(),
+            interval_secs: 5, // Default to 5 seconds
+        }
+    }
+
+    /// Set the export interval in seconds
+    pub fn with_interval_secs(mut self, secs: u64) -> Self {
+        self.interval_secs = secs;
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct OtlpMetricsExporter {
+    meter: opentelemetry::metrics::Meter,
+}
+
+impl OtlpMetricsExporter {
+    /// Create a new OtlpMetricsExporter with the specified configuration
+    /// Returns a Result containing the new exporter or an error if initialisation failed
+    pub fn new(config: &OtlpConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        // Initialise OTLP exporter using HTTP binary protocol with the specified endpoint
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(&config.endpoint)
+            .build()?;
+
+        // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
+        let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            // The default interval is 60 seconds so we use a PeriodicReader to allow us to specify a custom interval duration
+            .with_reader(
+                opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+                    .with_interval(Duration::from_secs(config.interval_secs))
+                    .build(),
+            )
+            .build();
+        // Set the configured SdkMeterProvider as the global meter provider making it the default provider that will be used throughout for all OpenTelemetry metrics
+        global::set_meter_provider(meter_provider);
+
+        // Obtain meter instance from global meter provider
+        // The meter will be used to create specific metric instruments (counters, gauges, histograms) and record values to them
+        let meter = global::meter("mountpoint-s3");
+
+        Ok(Self { meter })
+    }
+
+    /// Record a counter metric in OTel format
+    pub fn record_counter(&self, key: &Key, value: u64, attributes: &[KeyValue]) {
+        let counter = self
+            .meter
+            .u64_counter(key.name().to_string())
+            .with_description("Mountpoint counter metric")
+            .build();
+
+        counter.add(value, attributes);
+    }
+
+    /// Record a gauge metric in OTel format
+    pub fn record_gauge(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
+        let gauge = self
+            .meter
+            .f64_gauge(key.name().to_string())
+            .with_description("Mountpoint gauge metric")
+            .build();
+
+        gauge.record(value, attributes);
+    }
+
+    /// Record a histogram metric in OTel format
+    pub fn record_histogram(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
+        let histogram = self
+            .meter
+            .f64_histogram(key.name().to_string())
+            .with_description("Mountpoint histogram metric")
+            .build();
+
+        histogram.record(value, attributes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This is a manual test for verifying OpenTelemetry metrics export functionality.
+    /// It provides end-to-end verification of the metrics pipeline without needing to run the full mountpoint application.
+    /// 
+    /// # Requirements
+    /// - An OpenTelemetry collector running at http://localhost:4318/v1/metrics
+    /// 
+    /// # How to run
+    /// ```bash
+    /// # Start the OpenTelemetry collector (e.g., using Docker)
+    /// docker run -p 4317:4317 -p 4318:4318 -v $(pwd)/collector-config.yaml:/etc/otel-collector-config.yaml \
+    ///   otel/opentelemetry-collector:latest --config=/etc/otel-collector-config.yaml
+    /// 
+    /// # Run the test (ignored by default)
+    /// cargo test --package mountpoint-s3-fs --lib -- metrics_otel::tests::direct_otlp_test --exact --ignored
+    /// 
+    /// # Verify metrics in collector logs
+    #[test]
+    #[ignore]
+    fn direct_otlp_test() {
+        use opentelemetry::global;
+        use opentelemetry_otlp::{Protocol, WithExportConfig};
+        use std::time::Duration;
+        use tracing::info;
+        use tracing_subscriber::fmt::format::FmtSpan;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        // Create and set the subscriber
+        tracing_subscriber::fmt()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(false)
+            .with_thread_ids(true)
+            .with_level(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_test_writer()
+            .set_default();
+
+        info!("Setting up direct OpenTelemetry test...");
+
+        // Create a config with custom settings
+        let config = OtlpConfig::new("http://localhost:4318/v1/metrics").with_interval_secs(1);
+
+        // Initialize the OpenTelemetry SDK directly
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(&config.endpoint)
+            .with_timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to create exporter");
+
+        info!("Created exporter");
+
+        let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(1))
+            .build();
+
+        info!("Created reader");
+
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_reader(reader)
+            .build();
+
+        info!("Created provider");
+
+        global::set_meter_provider(provider.clone());
+
+        info!("Set meter provider");
+
+        let meter = global::meter("mountpoint-s3");
+
+        // Create and record multiple metrics to ensure visibility
+        let counter = meter
+            .u64_counter("test_counter")
+            .with_description("Test counter for direct OTLP export")
+            .with_unit("1")
+            .build();
+
+        info!("Created counter metric");
+
+        // Add multiple data points with different attributes
+        counter.add(
+            100,
+            &[
+                opentelemetry::KeyValue::new("test", "true"),
+                opentelemetry::KeyValue::new("source", "direct_test"),
+                opentelemetry::KeyValue::new("type", "counter"),
+            ],
+        );
+
+        info!("Recorded counter with value 100 to endpoint http://localhost:4318/v1/metrics");
+
+        // Add another data point to ensure we're seeing updates
+        counter.add(
+            150,
+            &[
+                opentelemetry::KeyValue::new("test", "true"),
+                opentelemetry::KeyValue::new("source", "direct_test"),
+                opentelemetry::KeyValue::new("type", "counter"),
+            ],
+        );
+
+        info!("Recorded counter with value 150 to endpoint http://localhost:4318/v1/metrics");
+        info!("Waiting for metrics to be exported...");
+
+        // Wait longer to ensure metrics are exported
+        std::thread::sleep(Duration::from_secs(10));
+
+        info!("Test complete. Check docker logs otel-collector for metrics with prefix 'mountpoint.'");
+    }
+}

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -33,7 +33,8 @@ where
     if args.foreground {
         let _logging = init_logging(args.make_logging_config()).context("failed to initialize logging")?;
 
-        let _metrics = metrics::install();
+        let _metrics = metrics::install(None)
+            .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
         create_pid_file()?;
 
@@ -65,7 +66,8 @@ where
                 let args = parse_cli_args(false);
                 let _logging = init_logging(logging_config).context("failed to initialize logging")?;
 
-                let _metrics = metrics::install();
+                let _metrics = metrics::install(None)
+                    .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
                 create_pid_file()?;
 

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -33,8 +33,7 @@ where
     if args.foreground {
         let _logging = init_logging(args.make_logging_config()).context("failed to initialize logging")?;
 
-        let _metrics = metrics::install(None)
-            .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
+        let _metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
         create_pid_file()?;
 
@@ -66,8 +65,7 @@ where
                 let args = parse_cli_args(false);
                 let _logging = init_logging(logging_config).context("failed to initialize logging")?;
 
-                let _metrics = metrics::install(None)
-                    .map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
+                let _metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
                 create_pid_file()?;
 


### PR DESCRIPTION
This PR adds an implementation of OpenTelemetry Exporting of metrics through the OpenTelemetry protocol (OTLP). Changes are: a new OtlpMetricsExporter struct which handles exporting metrics to an OTLP endpoint, and integration of the OTLP exporter with the existing metrics system. 

Testing:
I tested the implementation with a test otlp_metrics() in metrics.rs and ran a docker container running the OpenTelemetry Collector at the default port

docker run -d --name otel-collector \
  -p 4318:4318 -p 4317:4317 \
  -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml \
  otel/opentelemetry-collector-contrib:latest

Once I ran the test, I verified that the test metrics can be viewed in the collector logs. (viewed using 'docker logs otel-collector'). Here is a screenshot of an example of a test metric collected at the endpoint: 
<img width="391" alt="Screenshot 2025-06-18 at 15 32 16" src="https://github.com/user-attachments/assets/aab7e20a-0472-495b-af1d-23e966495e21" />


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
