### PR TITLE
Introduce file rename support for directory buckets in S3 Express One Zone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2818,6 +2818,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "syscalls",
  "sysinfo",
  "tempfile",
  "test-case",
@@ -2827,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2866,6 +2867,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "xmltree",
 ]
 
@@ -2905,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2956,6 +2958,7 @@ dependencies = [
  "shuttle",
  "signal-hook",
  "supports-color 3.0.2",
+ "syscalls",
  "sysinfo",
  "syslog",
  "tempfile",
@@ -4057,6 +4060,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.102",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,6 +4323,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.102",
+]
+
+[[package]]
+name = "syscalls"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d0e35dc7d73976a53c7e6d7d177ef804a0c0ee774ec77bcc520c2216fd7cbe"
+dependencies = [
+ "serde",
+ "serde_repr",
 ]
 
 [[package]]
@@ -4740,6 +4764,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -241,11 +241,16 @@ Mountpoint automatically configures reasonable defaults for file system settings
 
 By default, Mountpoint allows creating new files but does not allow deleting or overwriting existing objects.
 
-If you want to allow file deletion, use the `--allow-delete` flag at mount time. Delete operations immediately delete the object from S3, even if the file is being read from.
+If you want to allow file deletion, use the `--allow-delete` flag at mount time.
+Delete operations are immediately actioned against the object in S3, even if the file is being read from.
+
+File rename is supported for objects stored in the S3 Express One Zone storage class.
+Renames that would replace the destination file are only enabled when the `--allow-overwrite` flag is set.
+Rename operations are immediately actioned against the objects in S3, even where the source or any destination file is being read from.
 
 If you want to allow overwriting existing files, use the `--allow-overwrite` flag at mount time. The file must be opened with the `O_TRUNC` flag which will truncate the existing file. All writes must start from the beginning of the file and must be made sequentially.
 
-You can also allow appending to existing files in directory buckets in S3 Express One Zone, by setting the `--incremental-upload` flag at mount time. In this mode, writes to existing files opened without the `O_TRUNC` flag are allowed, provided they start at the end of the file and are made sequentially. For more details, see [Reading and writing files](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#reading-and-writing-files).
+You can also allow appending to existing files for objects stored in the S3 Express One Zone storage class, by setting the `--incremental-upload` flag at mount time. In this mode, writes to existing files opened without the `O_TRUNC` flag are allowed, provided they start at the end of the file and are made sequentially. For more details, see [Reading and writing files](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#reading-and-writing-files).
 
 If you want to forbid all mutating actions on your S3 bucket via Mountpoint, use the `--read-only` command-line flag.
 
@@ -303,7 +308,7 @@ You can use the following example to edit the fstab file to configure automatic 
 s3://amzn-s3-demo-bucket/example-prefix/ /mnt/mountpoint mount-s3 _netdev,nosuid,nodev,nofail,rw 0 0
 ```
 
-Where: 
+Where:
 
 * `_netdev` specifies that the filesystem requires networking to mount.
 * `nosuid` specifies that the filesystem cannot contain set userid files.

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -5,7 +5,7 @@ Mountpoint for Amazon S3 allows your applications to access objects stored in Am
 ## Behavior tenets
 
 While the rest of this document gives details on specific file system behaviors, we can summarize the Mountpoint approach in three high-level tenets:
-1. Mountpoint does not support file behaviors that cannot be implemented efficiently against S3's object APIs. It does not emulate operations like `rename` that would require many API calls to S3 to perform.
+1. Mountpoint does not support file behaviors that cannot be implemented efficiently against S3's object APIs. It does not emulate operations like `rename` on S3 general purpose buckets, which would require many API calls to S3 to perform.
 2. Mountpoint presents a common view of S3 object data through both file and object APIs. It does not emulate POSIX file features that have no close analog in S3's object APIs, such as mutable ownership and permissions.
 3. When these tenets conflict with POSIX requirements, Mountpoint fails early and explicitly. We would rather cause applications to fail with IO errors than silently accept operations that Mountpoint will never successfully persist, such as extended attributes.
 
@@ -15,13 +15,23 @@ Mountpoint supports opening and reading existing objects from your S3 bucket. It
 
 Mountpoint supports creating new objects in your S3 bucket by allowing writes to new files. If the `--allow-overwrite` flag is set at startup time, Mountpoint also supports replacing existing objects by allowing writes to existing files, but only when the `O_TRUNC` flag is used at open time to truncate the existing file. In both cases, writes must always start from the beginning of the file and must be made sequentially. Mountpoint uploads new files to S3 asynchronously, and optimizes for high write throughput using multiple concurrent upload requests. If your application needs to guarantee that a new file has been uploaded to S3, it should call `fsync` on the file before closing it. You cannot continue writing to the file after calling `fsync`. The new (or overwritten) object will be visible to other S3 clients only after closing it (or on `fsync`).
 
-For directory buckets in S3 Express One Zone, Mountpoint also supports appending to existing files. If the `--incremental-upload` flag is set at startup time, Mountpoint allows opening existing files without specifying the `O_TRUNC` flag. All writes must still be sequential and start from the end of the file. In this mode, Mountpoint will always upload data to S3 in sequential increments and offer the same throughput of a single PUT API call on S3. Moreover, partial writes will be visible to other S3 clients before the file is closed. Applications can call `fsync` to guarantee that the data written so far is uploaded to S3 and are then allowed to continue writing to the file.
-
 By default, Mountpoint does not allow deleting existing objects with commands like `rm`. To enable deletion, pass the `--allow-delete` flag to Mountpoint at startup time. Delete operations immediately delete the object from S3, even if the file is being read from. We recommend that you enable [Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) to help protect against unintentionally deleting objects. You cannot delete a file while it is being written.
 
-You cannot rename an existing file using Mountpoint.
+For objects stored in S3 Express One Zone, Mountpoint supports appending to files. If the `--incremental-upload` flag is set at startup time, Mountpoint allows opening existing files without specifying the `O_TRUNC` flag. All writes must still be sequential and start from the end of the file. In this mode, Mountpoint will always upload data to S3 in sequential increments and offer the same throughput of a single PUT API call on S3. Moreover, partial writes will be visible to other S3 clients before the file is closed. Applications can call `fsync` to guarantee that the data written so far is uploaded to S3 and are then allowed to continue writing to the file.
+
+Mountpoint supports file rename for objects stored in the S3 Express One Zone storage class.
+Attempting to rename files where unsupported by S3 will result in the operation being rejected.
+Mountpoint distinguishes between rename operations that move to an empty destination (non-replacing) and those that replace an existing object at the destination (replacing).
+While non-replacing renames do not require further flags to be set, replacing rename require passing the `--allow-overwrite` flag to Mountpoint at startup time.
+Rename operations immediately rename the object in S3.
+Existing readers (to source or destination) may eventually fail to read more data from the object after it has been renamed.
+You cannot rename a file while it or the destination of a rename is being written by the same Mountpoint instance.
+
+Append and rename are not supported for directory buckets that reside in Local Zones. You can only append data to or rename existing objects in directory buckets that reside in Availability Zones.
+You should not pass the `--incremental-upload` flag to Mountpoint in this case, as writes to files will fail. Attempting to rename files in this case will lead to the operation being rejected.
 
 Objects in the S3 Glacier Flexible Retrieval and S3 Glacier Deep Archive storage classes, and the Archive Access and Deep Archive Access tiers of S3 Intelligent-Tiering, are only accessible with Mountpoint if they have been restored. To access these objects with Mountpoint, [restore](https://docs.aws.amazon.com/AmazonS3/latest/userguide/restoring-objects.html) them first.
+
 
 ## Directories
 
@@ -148,13 +158,13 @@ S3 places fewer restrictions on [valid object keys](https://docs.aws.amazon.com/
 
   * `blue`
   * `blue/image.jpg`
-  
-  then mounting your bucket would give a file system with a `blue` directory, containing the file `image.jpg`. 
+
+  then mounting your bucket would give a file system with a `blue` directory, containing the file `image.jpg`.
 The `blue` object will not be accessible. Deleting the key `blue/image.jpg` will remove the `blue` directory, and cause the `blue` file to become visible.
 
-Additionally, remote directories will always shadow local directories or files. 
+Additionally, remote directories will always shadow local directories or files.
 Thus Mountpoint shadows directory entries in the following order, where the first takes precedence: remote directories, any local state, remote files.
-For example, if you create a directory i.e. `blue/` and a conflicting object with key `blue` appears in the bucket, the local directory will still be accessible.  
+For example, if you create a directory i.e. `blue/` and a conflicting object with key `blue` appears in the bucket, the local directory will still be accessible.
 
 We test Mountpoint against these restrictions using a [reference model](https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/tests/reftests/reference.rs) that programmatically encodes the expected mapping between S3 objects and file system structure.
 
@@ -223,7 +233,7 @@ Basic read-only directory operations (`opendir`, `readdir`, `closedir`, `rewindd
 
 Sorting order of `readdir` results:
 * For general purpose buckets, `readdir` returns results in lexicographical order.
-* For directory buckets (S3 Express One Zone), `readdir` does not return results in lexicographical order.
+* For directory buckets, `readdir` does not return results in lexicographical order.
 
 Creating directories (`mkdir`) is supported, with the following behavior:
 
@@ -231,7 +241,7 @@ Creating directories (`mkdir`) is supported, with the following behavior:
 * Note that this is different from e.g. the S3 Console, which creates "directory markers" (i.e. zero-byte objects with `<directory-name>/` key) in the bucket.
 * If a file is created under the new (or a nested) directory and committed to S3, Mountpoint will revert to using the default mapping of S3 object keys. This implies that the directory will be visible as long as there are keys which contain it as a prefix.
 
-Renaming files and directories (`rename`, `renameat`) is not currently supported.
+Rename (`rename`, `renameat`, `renameat2`) semantics are described in the [File and directory rename](#file-and-directory-rename) section.
 
 File deletion (`unlink`) semantics are described in the [Deletes](#deletes) section above.
 
@@ -246,6 +256,32 @@ Empty directory removal (`rmdir`) is supported, with the following semantics:
 * On success, the directory will be deleted immediately. Subsequent reads or writes to the directory (e.g. creating a file or subdirectory) will fail.
 
 Synchronization operations (`fsync`) on directories are not supported.
+
+### File and directory rename
+
+File and directory renames refer to the `rename` family of system calls, where a file is moved from one part of the file system tree to another.
+
+On Amazon S3 directory buckets in S3 Express One Zone, renaming individual files within the same bucket is supported with the following semantics:
+
+* Non-replacing file rename will work without any further Mountpoint configuration.
+* If a file already exists at the new destination path (replacing rename), the rename will fail, unless the `--allow-overwrite` flag was set
+  at mount time and the system call does not specify the `RENAME_NOREPLACE` flag.
+* For files currently open for writing or not yet committed to S3, the client does not permit `rename` or `renameat2` operations.
+  Similarly, if the destination file of a rename operation is open for writing, the rename will be rejected.
+* For files not open for writing, the client _immediately_ renames the corresponding S3 object,
+  and moves the file in the local file system representation.
+* Mountpoint does not support `rename` or `renameat2` where `RENAME_EXCHANGE` is specified, as exchanging two objects is not supported by Amazon S3.
+* Mountpoint does not support `rename` or `renameat2` where `RENAME_WHITEOUT` is specified, as Mountpoint is not an overlay/union file system.
+* If there are still open read file handles to the file being renamed or the destination file, future reads to them will fail.
+* Because the object is immediately renamed in S3, future reads with file handles from other hosts will also fail.
+* Concurrent rename to a destination and uploads to the same key may result in the renamed object being overwritten.
+  We do not recommend concurrent mutations to the same key.
+* Note, that renaming the last file in a directory has a similar effect to that directory as removing the last file. Thus, moving the last file out of a directory
+  may lead to that directory being inaccessible, as there will no longer be an object in S3 under that directory.
+
+Renaming individual files is not supported by Amazon S3 general purpose buckets, nor objects not in the S3 Express One Zone storage class.
+
+Directory rename is not supported on any Amazon S3 bucket type.
 
 ### File and directory metadata and permissions
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased (v0.16.0)
 
-* Add support for RenameObject API. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
+* Add support for RenameObject API. ([#1468](https://github.com/awslabs/mountpoint-s3/pull/1468))
 
 ## v0.15.0 (May 27, 2025)
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v0.16.0)
+
+* Add support for RenameObject API. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
 
 ## v0.15.0 (May 27, 2025)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
@@ -26,6 +26,7 @@ static_assertions = "1.1.0"
 thiserror = "2.0.11"
 time = { version = "0.3.37", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.41", default-features = false, features = ["std", "log"] }
+uuid = { version = "1.16.0", features = ["v4"]}
 xmltree = "0.11.0"
 
 # Dependencies for the mock client only

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -18,7 +18,8 @@ use crate::object_client::{
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectResponse,
     HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
     ObjectChecksumError, ObjectClient, ObjectClientError, ObjectClientResult, ObjectMetadata, PutObjectError,
-    PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams, UploadReview,
+    PutObjectParams, PutObjectRequest, PutObjectResult, PutObjectSingleParams, RenameObjectError, RenameObjectParams,
+    RenameObjectResult, UploadReview,
 };
 
 // Wrapper for injecting failures into a get stream or a put request
@@ -199,6 +200,17 @@ where
         self.client
             .get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
             .await
+    }
+
+    async fn rename_object(
+        &self,
+        bucket: &str,
+        src_key: &str,
+        dst_key: &str,
+        params: &RenameObjectParams,
+    ) -> ObjectClientResult<RenameObjectResult, RenameObjectError, Self::ClientError> {
+        // TODO failure hook for rename_object
+        self.client.rename_object(bucket, src_key, dst_key, params).await
     }
 }
 

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -88,7 +88,8 @@ pub mod types {
         DeleteObjectResult, ETag, GetBodyPart, GetObjectAttributesParts, GetObjectAttributesResult, GetObjectParams,
         GetObjectResponse, HeadObjectParams, HeadObjectResult, ListObjectsResult, ObjectAttribute, ObjectClientResult,
         ObjectInfo, ObjectPart, PutObjectParams, PutObjectResult, PutObjectSingleParams, PutObjectTrailingChecksums,
-        RestoreStatus, UploadChecksum, UploadReview, UploadReviewPart,
+        RenameObjectParams, RenameObjectResult, RenamePreconditionTypes, RestoreStatus, UploadChecksum, UploadReview,
+        UploadReviewPart,
     };
 }
 
@@ -100,7 +101,7 @@ pub mod types {
 pub mod error {
     pub use super::object_client::{
         CopyObjectError, DeleteObjectError, GetObjectAttributesError, GetObjectError, HeadObjectError,
-        ListObjectsError, ObjectClientError, PutObjectError,
+        ListObjectsError, ObjectClientError, PutObjectError, RenameObjectError,
     };
     #[doc(hidden)]
     pub use super::s3_crt_client::CrtError;

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -17,7 +17,7 @@ use crate::object_client::{
     GetObjectAttributesError, GetObjectAttributesResult, GetObjectError, GetObjectParams, GetObjectResponse,
     HeadObjectError, HeadObjectParams, HeadObjectResult, ListObjectsError, ListObjectsResult, ObjectAttribute,
     ObjectChecksumError, ObjectClient, ObjectClientResult, ObjectMetadata, PutObjectError, PutObjectParams,
-    PutObjectResult, PutObjectSingleParams,
+    PutObjectResult, PutObjectSingleParams, RenameObjectError, RenameObjectParams, RenameObjectResult,
 };
 
 use super::MockBackpressureHandle;
@@ -223,6 +223,16 @@ impl ObjectClient for ThroughputMockClient {
         self.inner
             .get_object_attributes(bucket, key, max_parts, part_number_marker, object_attributes)
             .await
+    }
+
+    async fn rename_object(
+        &self,
+        bucket: &str,
+        src_key: &str,
+        dst_key: &str,
+        params: &RenameObjectParams,
+    ) -> ObjectClientResult<RenameObjectResult, RenameObjectError, Self::ClientError> {
+        self.inner.rename_object(bucket, src_key, dst_key, params).await
     }
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -128,6 +128,15 @@ pub trait ObjectClient {
         part_number_marker: Option<usize>,
         object_attributes: &[ObjectAttribute],
     ) -> ObjectClientResult<GetObjectAttributesResult, GetObjectAttributesError, Self::ClientError>;
+
+    /// Rename an object from some source key to a destination key within the same bucket.
+    async fn rename_object(
+        &self,
+        bucket: &str,
+        src_key: &str,
+        dest_key: &str,
+        params: &RenameObjectParams,
+    ) -> ObjectClientResult<RenameObjectResult, RenameObjectError, Self::ClientError>;
 }
 
 /// The top-level error type returned by calls to an [`ObjectClient`].
@@ -192,6 +201,12 @@ impl ProvideErrorMetadata for HeadObjectError {
 }
 
 impl ProvideErrorMetadata for DeleteObjectError {
+    fn meta(&self) -> ClientErrorMetadata {
+        Default::default()
+    }
+}
+
+impl ProvideErrorMetadata for RenameObjectError {
     fn meta(&self) -> ClientErrorMetadata {
         Default::default()
     }
@@ -425,6 +440,94 @@ pub enum GetObjectAttributesError {
 
     #[error("The key does not exist")]
     NoSuchKey,
+}
+
+/// Parameters to a [`rename_object`](ObjectClient::rename_object) request
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct RenameObjectParams {
+    /// Can be set to * to disable overwrite
+    pub if_none_match: Option<String>,
+    /// Optional ETag that the destination must match
+    pub if_match: Option<ETag>,
+    /// Optional ETag that the source must match
+    pub if_source_match: Option<ETag>,
+    /// Idempotency token
+    pub client_token: Option<String>,
+    /// Can be used for custom headers
+    pub custom_headers: Vec<(String, String)>,
+}
+
+impl RenameObjectParams {
+    /// Create a default [RenameObjectParams].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set if-none-match header
+    pub fn if_none_match(mut self, value: Option<String>) -> Self {
+        self.if_none_match = value;
+        self
+    }
+
+    /// Set if-match header
+    pub fn if_match(mut self, value: Option<ETag>) -> Self {
+        self.if_match = value;
+        self
+    }
+
+    /// Set if-source-match header
+    pub fn if_source_match(mut self, value: Option<ETag>) -> Self {
+        self.if_source_match = value;
+        self
+    }
+
+    /// Set idempotency token
+    pub fn client_token(mut self, value: Option<String>) -> Self {
+        self.client_token = value;
+        self
+    }
+
+    /// Set custom headers
+    pub fn custom_headers(mut self, value: Vec<(String, String)>) -> Self {
+        self.custom_headers = value;
+        self
+    }
+}
+
+/// Result of a [`rename_object`](ObjectClient::rename_object) request
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct RenameObjectResult {}
+
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RenamePreconditionTypes {
+    IfMatch,
+    IfNoneMatch,
+    Other,
+}
+
+/// Errors returned by a [`rename_object`](ObjectClient::rename_object) request
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RenameObjectError {
+    #[error("The bucket does not exist")]
+    NoSuchBucket,
+    #[error("The destination key provided is too long")]
+    KeyTooLong,
+    #[error("The key was not found")]
+    KeyNotFound,
+    #[error("A Precondition")]
+    PreConditionFailed(RenamePreconditionTypes),
+    #[error("The service does not implement rename")]
+    NotImplementedError,
+    #[error("The service returned an Internal Error")]
+    InternalError,
+    #[error("You do not have access to this resource")]
+    AccessDenied,
+    #[error("Bad Request")]
+    BadRequest,
 }
 
 pub type ObjectMetadata = HashMap<String, String>;

--- a/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object_attributes.rs
@@ -10,7 +10,7 @@ use crate::object_client::{
     ObjectClientResult, ObjectPart,
 };
 
-use super::{S3CrtClient, S3Operation, S3RequestError};
+use super::{QueryFragment, S3CrtClient, S3Operation, S3RequestError};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -118,7 +118,7 @@ impl S3CrtClient {
 
             let path = format!("/{key}");
             message
-                .set_request_path_and_query(path, query)
+                .set_request_path_and_query(path, QueryFragment::Query(&query))
                 .map_err(S3RequestError::construction_failure)?;
 
             if let Some(max_parts) = max_parts {

--- a/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/list_objects.rs
@@ -14,7 +14,7 @@ use crate::object_client::{
     RestoreStatus,
 };
 
-use super::{S3CrtClient, S3Operation, S3RequestError};
+use super::{QueryFragment, S3CrtClient, S3Operation, S3RequestError};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -199,7 +199,7 @@ impl S3CrtClient {
             }
 
             message
-                .set_request_path_and_query("/", query)
+                .set_request_path_and_query("/", QueryFragment::Query(&query))
                 .map_err(S3RequestError::construction_failure)?;
 
             let span = request_span!(

--- a/mountpoint-s3-client/src/s3_crt_client/rename_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/rename_object.rs
@@ -1,0 +1,124 @@
+use std::ops::Deref;
+use std::os::unix::prelude::OsStrExt;
+
+use mountpoint_s3_crt::http::request_response::Header;
+use mountpoint_s3_crt::s3::client::MetaRequestResult;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::object_client::{
+    ObjectClientResult, RenameObjectError, RenameObjectParams, RenameObjectResult, RenamePreconditionTypes,
+};
+
+use super::{QueryFragment, S3CrtClient, S3Operation, S3RequestError};
+
+impl S3CrtClient {
+    pub(super) async fn rename_object(
+        &self,
+        bucket: &str,
+        src_key: &str,
+        dst_key: &str,
+        params: &RenameObjectParams,
+    ) -> ObjectClientResult<RenameObjectResult, RenameObjectError, S3RequestError> {
+        const RENAME_QUERY_PARAM: &str = "renameObject";
+        const RENAME_SOURCE_HEADER: &str = "x-amz-rename-source";
+        const RENAME_SOURCE_IF_MATCH_HEADER: &str = "x-amz-rename-source-if-match";
+
+        let span = request_span!(self.inner, "rename_object_request", bucket);
+
+        let body = {
+            let mut message = self
+                .inner
+                .new_request_template("PUT", bucket)
+                .map_err(S3RequestError::construction_failure)?;
+
+            let key = format!("/{dst_key}");
+            message
+                .set_request_path_and_query(&key, QueryFragment::Action(RENAME_QUERY_PARAM))
+                .map_err(S3RequestError::construction_failure)?;
+            message
+                .set_header(&Header::new(RENAME_SOURCE_HEADER, src_key))
+                .expect("failed to set rename source key header");
+
+            if let Some(src_etag) = &params.if_source_match {
+                message
+                    .set_header(&Header::new(RENAME_SOURCE_IF_MATCH_HEADER, src_etag.as_str()))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
+
+            if let Some(etag) = &params.if_match {
+                message
+                    .set_header(&Header::new("If-Match", etag.as_str()))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
+
+            if let Some(guard) = &params.if_none_match {
+                if guard != "*" {
+                    debug!("Unexpected if-none-match guard");
+                }
+                message
+                    .set_header(&Header::new("If-None-Match", guard))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
+
+            if let Some(token) = &params.client_token {
+                message
+                    .set_header(&Header::new("x-amz-client-token", token))
+                    .map_err(S3RequestError::construction_failure)?;
+            } else {
+                // Generate a client token for this request automatically
+                let token = Uuid::new_v4();
+                message
+                    .set_header(&Header::new("x-amz-client-token", token.to_string()))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
+
+            for (name, value) in &params.custom_headers {
+                message
+                    .inner
+                    .add_header(&Header::new(name, value))
+                    .map_err(S3RequestError::construction_failure)?;
+            }
+
+            let options = message.into_options(S3Operation::PutObjectSingle);
+            self.inner
+                .meta_request_without_payload(options, span, parse_rename_object_error)?
+        };
+
+        body.await?;
+        Ok(RenameObjectResult {})
+    }
+}
+
+fn parse_rename_object_error(result: &MetaRequestResult) -> Option<RenameObjectError> {
+    match result.response_status {
+        400 => {
+            let body = result.error_response_body.as_ref()?;
+            let root = xmltree::Element::parse(body.as_bytes()).ok()?;
+            let error_code = root.get_child("Code")?;
+            let error_str = error_code.get_text()?;
+
+            match error_str.deref() {
+                "KeyTooLong" => Some(RenameObjectError::KeyTooLong),
+                _ => Some(RenameObjectError::BadRequest),
+            }
+        }
+        404 => Some(RenameObjectError::KeyNotFound),
+        412 => {
+            let body = result.error_response_body.as_ref()?;
+            let root = xmltree::Element::parse(body.as_bytes()).ok()?;
+            let condition = root.get_child("Condition")?;
+            let failed_condition = condition.get_text()?;
+
+            match failed_condition.deref() {
+                "If-Match" => Some(RenameObjectError::PreConditionFailed(RenamePreconditionTypes::IfMatch)),
+                "If-None-Match" => Some(RenameObjectError::PreConditionFailed(
+                    RenamePreconditionTypes::IfNoneMatch,
+                )),
+                _ => Some(RenameObjectError::PreConditionFailed(RenamePreconditionTypes::Other)),
+            }
+        }
+        501 => Some(RenameObjectError::NotImplementedError),
+        _ => None,
+    }
+}

--- a/mountpoint-s3-client/tests/rename_object.rs
+++ b/mountpoint-s3-client/tests/rename_object.rs
@@ -1,0 +1,337 @@
+#![cfg(feature = "s3express_tests")]
+
+use mountpoint_s3_client::config::S3ClientConfig;
+use mountpoint_s3_client::error::{ObjectClientError, RenameObjectError};
+use mountpoint_s3_client::types::ETag;
+use mountpoint_s3_client::types::{
+    HeadObjectParams, PutObjectParams, PutObjectSingleParams, RenameObjectParams, RenamePreconditionTypes,
+    UploadChecksum,
+};
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient};
+use mountpoint_s3_crt::checksums::crc64nvme;
+use tracing::debug;
+use uuid::Uuid;
+
+pub mod common;
+use common::{get_test_bucket_and_prefix, get_test_endpoint_config};
+
+// Test that rename with source matching works as expected
+#[tokio::test]
+async fn simple_rename() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    // Get the ETag from HeadObject
+    let headobjectparams = HeadObjectParams::new();
+    let head_result = client
+        .head_object(&bucket, &source_key, &headobjectparams)
+        .await
+        .expect("head object request should succeed");
+    let etag = head_result.etag;
+    // Perform a rename
+    let rename_params = RenameObjectParams::new().if_source_match(Some(etag));
+    let _ = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await
+        .expect("rename should succeed");
+}
+
+#[tokio::test]
+async fn put_append_rename_append_test() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    // Append to it
+    let object_size = b"data".len();
+    let contents = vec![0u8; 32];
+    let params = PutObjectSingleParams::new_for_append(object_size as u64)
+        .checksum(Some(UploadChecksum::Crc64nvme(crc64nvme::checksum(&contents))));
+    let put_object_result = client
+        .put_object_single(&bucket, &source_key, &params, &contents)
+        .await
+        .expect("put_object_single should succeed");
+
+    // Get the ETag from HeadObject
+    let headobjectparams = HeadObjectParams::new();
+    let head_result = client
+        .head_object(&bucket, &source_key, &headobjectparams)
+        .await
+        .expect("head object request should succeed");
+    let etag = ETag::from(
+        head_result
+            .etag
+            .as_str()
+            .strip_suffix("\"")
+            .unwrap()
+            .strip_prefix("\"")
+            .unwrap(),
+    );
+    // Perform a rename
+    debug!(?etag, "have got Etag from Head Object Request");
+    debug!(?put_object_result.etag, "have got Etag from Put Object Request");
+
+    let rename_params = RenameObjectParams::new().if_source_match(Some(put_object_result.etag));
+    let _ = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await
+        .expect("rename should succeed");
+}
+
+// Perform a test where overwritten file has different ETag
+// Test that rename with source matching works as expected
+#[tokio::test]
+async fn rename_destination_does_not_match() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("rename_destination_does_not_match");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &dest_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"other").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+    // Get the ETag from HeadObject
+    let headobjectparams = HeadObjectParams::new();
+    let head_result = client
+        .head_object(&bucket, &source_key, &headobjectparams)
+        .await
+        .expect("head object request should succeed");
+    let etag = head_result.etag;
+    // Perform a rename
+    let rename_params = RenameObjectParams::new()
+        .if_source_match(Some(etag.clone()))
+        .if_match(Some(etag));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_err(), "Result should be an error variant");
+    assert!(matches!(
+        result.err().unwrap(),
+        ObjectClientError::ServiceError(RenameObjectError::PreConditionFailed(RenamePreconditionTypes::IfMatch))
+    ));
+}
+
+#[tokio::test]
+async fn rename_overwrite_error() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("rename_overwrite_error");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &dest_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"other").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    let rename_params = RenameObjectParams::new().if_none_match(Some("*".into()));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_err(), "Result should be an error variant");
+    assert!(matches!(
+        result.err().unwrap(),
+        ObjectClientError::ServiceError(RenameObjectError::PreConditionFailed(
+            RenamePreconditionTypes::IfNoneMatch
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn rename_double_error() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("rename_double_error");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &dest_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"other").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+    let headobjectparams = HeadObjectParams::new();
+    let head_result = client
+        .head_object(&bucket, &source_key, &headobjectparams)
+        .await
+        .expect("head object request should succeed");
+    let etag = head_result.etag;
+
+    let rename_params = RenameObjectParams::new()
+        .if_none_match(Some("*".into()))
+        .if_match(Some(etag));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_err(), "Result should be an error variant");
+    assert!(matches!(
+        result.err().unwrap(),
+        ObjectClientError::ServiceError(RenameObjectError::PreConditionFailed(RenamePreconditionTypes::IfMatch))
+    ));
+}
+
+// Try a rename where the source does not match
+// Perform a test where overwritten file has different ETag
+// Test that rename with source matching works as expected
+#[tokio::test]
+async fn rename_source_does_not_match() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("rename_source_does_not_match");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &dest_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"other").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+    // Get the ETag from HeadObject
+    let headobjectparams = HeadObjectParams::new();
+    let head_result = client
+        .head_object(&bucket, &dest_key, &headobjectparams)
+        .await
+        .expect("head object request should succeed");
+    let etag = head_result.etag;
+    // Perform a rename
+    let rename_params = RenameObjectParams::new().if_source_match(Some(etag.clone()));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_err(), "Result should be an error variant");
+    assert!(matches!(
+        result.err().unwrap(),
+        ObjectClientError::ServiceError(RenameObjectError::PreConditionFailed(RenamePreconditionTypes::IfMatch))
+    ));
+}
+
+#[tokio::test]
+async fn rename_idempotency_test() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("rename_idempotency_test");
+    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let source_key = format!("{prefix}a.txt");
+    let dest_key = format!("{prefix}b.txt");
+
+    let params = PutObjectParams::new();
+    let mut request = client
+        .put_object(&bucket, &source_key, &params)
+        .await
+        .expect("put should succeed");
+    request.write(b"data").await.expect("write should succeed");
+    request
+        .complete()
+        .await
+        .expect("the upload should complete successfully");
+    // This needs to be a fresh token on each run.
+    let rename_params = RenameObjectParams::new().client_token(Some(Uuid::new_v4().to_string()));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_ok(), "First rename should work");
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params)
+        .await;
+    assert!(result.is_ok(), "Second rename should be replayed");
+    // Attempt a third rename with a w.h.p. different token
+    let rename_params_new = RenameObjectParams::new().client_token(Some(Uuid::new_v4().to_string()));
+    let result = client
+        .rename_object(&bucket, &source_key, &dest_key, &rename_params_new)
+        .await;
+    assert!(result.is_err(), "Third rename should not work");
+}

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v0.5.0)
+
+* Add support for renaming files on buckets supporting the RenameObject API. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
 
 ## v0.4.0 (May 30, 2025)
 
@@ -7,7 +9,7 @@
 
 ## v0.3.0 (May 27, 2025)
 
-* Added ability to configure an error logger which can be used to report errors returned by fuse operations. Use method `MountpointConfig::error_logger` to configure the callback. ([#1416](https://github.com/awslabs/mountpoint-s3/pull/1416))  
+* Added ability to configure an error logger which can be used to report errors returned by fuse operations. Use method `MountpointConfig::error_logger` to configure the callback. ([#1416](https://github.com/awslabs/mountpoint-s3/pull/1416))
 * `PrefetchReadError::GetRequestFailed` error variant has changed. It now contains an additional field `metadata`. ([#1411](https://github.com/awslabs/mountpoint-s3/pull/1411))
 * Improve safety checks when reading disk cache blocks. ([#1427](https://github.com/awslabs/mountpoint-s3/pull/1427))
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased (v0.5.0)
 
-* Add support for renaming files on buckets supporting the RenameObject API. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
+* Add support for renaming files on buckets supporting the RenameObject API. ([#1468](https://github.com/awslabs/mountpoint-s3/pull/1468))
 
 ## v0.4.0 (May 30, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-fs"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.15.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"
@@ -43,6 +43,7 @@ supports-color = "3.0.2"
 sysinfo = "0.33.1"
 syslog = "7.0.0"
 tempfile = "3.15.0"
+syscalls = {version = "0.6.18", default-features = false}
 thiserror = "2.0.11"
 time = { version = "0.3.37", features = ["macros", "formatting", "serde-well-known"] }
 tracing = { version = "0.1.41", features = ["log"] }

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -29,6 +29,8 @@ pub struct S3FilesystemConfig {
     pub allow_delete: bool,
     /// Allow overwrite
     pub allow_overwrite: bool,
+    /// Allow renames
+    pub allow_rename: bool,
     /// Enable incremental uploads
     pub incremental_upload: bool,
     /// Storage class to be used for new object uploads
@@ -63,6 +65,7 @@ impl Default for S3FilesystemConfig {
             allow_delete: false,
             allow_overwrite: false,
             incremental_upload: false,
+            allow_rename: true,
             storage_class: None,
             s3_personality: S3Personality::default(),
             server_side_encryption: Default::default(),

--- a/mountpoint-s3-fs/src/fs/error.rs
+++ b/mountpoint-s3-fs/src/fs/error.rs
@@ -178,6 +178,11 @@ impl ToErrno for InodeError {
             InodeError::CorruptedMetadata(_) => libc::EIO,
             InodeError::SetAttrNotPermittedOnRemoteInode(_) => libc::EPERM,
             InodeError::StaleInode { .. } => libc::ESTALE,
+            InodeError::CannotRenameDirectory(_) => libc::EPERM,
+            InodeError::RenameDestinationExists { .. } => libc::EEXIST,
+            InodeError::RenameNotPermittedWhileWriting(_) => libc::EPERM,
+            InodeError::RenameNotSupported() => libc::ENOSYS,
+            InodeError::NameTooLong(_) => libc::ENAMETOOLONG,
             #[cfg(feature = "manifest")]
             InodeError::ManifestError { .. } => libc::EIO,
         }

--- a/mountpoint-s3-fs/src/fs/flags.rs
+++ b/mountpoint-s3-fs/src/fs/flags.rs
@@ -10,7 +10,7 @@
 ///         B,
 ///         C,
 ///     }
-/// }    
+/// }
 /// ```
 ///
 /// See [`OpenFlags`] for an example.
@@ -82,6 +82,21 @@ libc_flags! {
         O_DIRECT,
 
         // Incomplete list. To be integrated if/when required.
+    }
+}
+
+/// Flags used in [rename](super::S3Filesystem::rename).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RenameFlags(u32);
+
+libc_flags! {
+    RenameFlags : u32 {
+        #[cfg(target_os = "linux")]
+        RENAME_NOREPLACE,
+        #[cfg(target_os = "linux")]
+        RENAME_EXCHANGE,
+        #[cfg(target_os = "linux")]
+        RENAME_WHITEOUT,
     }
 }
 

--- a/mountpoint-s3-fs/src/fuse/session.rs
+++ b/mountpoint-s3-fs/src/fuse/session.rs
@@ -7,13 +7,11 @@ use fuser::MountOption;
 use fuser::{Filesystem, Session, SessionUnmounter};
 use tracing::{debug, error, trace, warn};
 
+use super::config::{FuseSessionConfig, MountPoint};
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::mpsc::{self, Sender};
 use crate::sync::thread::{self, JoinHandle};
 use crate::sync::Arc;
-
-use super::config::{FuseSessionConfig, MountPoint};
-
 /// A multi-threaded FUSE session that can be joined to wait for the FUSE filesystem to unmount or
 /// external shutdown.
 pub struct FuseSession {

--- a/mountpoint-s3-fs/src/s3.rs
+++ b/mountpoint-s3-fs/src/s3.rs
@@ -49,4 +49,12 @@ impl S3Personality {
             S3Personality::Outposts => false,
         }
     }
+
+    pub fn supports_rename_object(&self) -> bool {
+        match self {
+            S3Personality::Standard => false,
+            S3Personality::ExpressOneZone => true,
+            S3Personality::Outposts => false,
+        }
+    }
 }

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -236,6 +236,7 @@ pub mod mock_session {
             part_size: test_config.part_size,
             enable_backpressure: true,
             initial_read_window_size: test_config.initial_read_window_size,
+            enable_rename: test_config.filesystem_config.allow_rename,
             ..Default::default()
         };
         let client = Arc::new(MockClient::new(client_config));

--- a/mountpoint-s3-fs/tests/fuse_tests/mod.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/mod.rs
@@ -12,6 +12,7 @@ mod mkdir_test;
 mod prefetch_test;
 mod read_test;
 mod readdir_test;
+mod rename_test;
 mod rmdir_test;
 mod semantics_doc_test;
 mod setattr_test;

--- a/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
@@ -1,0 +1,2189 @@
+use crate::common::fuse::{self, read_dir_to_entry_names, TestSession, TestSessionConfig};
+use mountpoint_s3_fs::fs::CacheConfig;
+use mountpoint_s3_fs::s3::S3Personality;
+use mountpoint_s3_fs::S3FilesystemConfig;
+#[cfg(target_os = "linux")]
+use nix::fcntl::RenameFlags;
+use rand::distributions::Alphanumeric;
+use rand::thread_rng;
+use rand::Rng;
+use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::ffi::CString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
+use test_case::test_case;
+use tracing::{debug, info};
+
+/// Simple test cases, assuming a file isn't open for reading elsewhere.
+fn rename_basic_tests<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let nonexistent_path = main_dir.join("nonexistent.txt");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["source.txt"]);
+
+    let err =
+        fs::rename(&nonexistent_path, &destination_path).expect_err("file rename should fail as source doesn't exist");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+
+    fs::rename(&source_path, &destination_path).expect("should succeed if source exists and destination doesnt");
+    let err = fs::metadata(&source_path).expect_err("source should no longer exist after rename");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+    fs::metadata(&destination_path).expect("destination should exist after rename");
+
+    // readdir should now show the updated directory structure
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["destination.txt"]);
+
+    // S3 structure should match
+    assert!(
+        test_client.contains_key("dir/destination.txt").unwrap(),
+        "destination object must now exist in S3"
+    );
+    assert!(
+        !test_client.contains_key("dir/source.txt").unwrap(),
+        "source object must no longer exist in S3"
+    );
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_basic_tests_s3() {
+    rename_basic_tests(fuse::s3_session::new, "rename_basic_tests");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_basic_tests"; "prefix")]
+fn rename_basic_tests_mock(prefix: &str) {
+    rename_basic_tests(fuse::mock_session::new, prefix);
+}
+
+fn rename_simplewithcache_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            cache_config: CacheConfig {
+                serve_lookup_from_cache: true,
+                dir_ttl: Duration::from_secs(600),
+                file_ttl: Duration::from_secs(600),
+                ..Default::default()
+            },
+            s3_personality: S3Personality::ExpressOneZone,
+            allow_rename: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["source.txt"]);
+
+    fs::rename(&source_path, &destination_path).expect("should succeed if source exists and destination doesnt");
+    let err =
+        fs::metadata(&source_path).expect_err("source should no longer exist after rename even with cache enabled");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+    fs::metadata(&destination_path).expect("destination should exist after rename");
+
+    // readdir should now show the updated directory structure
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["destination.txt"]);
+
+    // S3 structure should match
+    assert!(
+        test_client.contains_key("dir/destination.txt").unwrap(),
+        "destination object must now exist in S3"
+    );
+    assert!(
+        !test_client.contains_key("dir/source.txt").unwrap(),
+        "source object must no longer exist in S3"
+    );
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_simplewithcache_test_s3() {
+    rename_simplewithcache_test(fuse::s3_session::new, "rename_simplewithcache_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_simplewithcache_test"; "prefix")]
+fn rename_simplewithcache_test_mock(prefix: &str) {
+    rename_simplewithcache_test(fuse::mock_session::new, prefix);
+}
+
+/// Covers where object is cached by MP but gone in S3.
+fn rename_srcremovedbutcached_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            cache_config: CacheConfig {
+                serve_lookup_from_cache: true,
+                dir_ttl: Duration::from_secs(600),
+                file_ttl: Duration::from_secs(600),
+                ..Default::default()
+            },
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path().to_owned();
+    const SOURCE_OBJ_KEY: &str = "dir/source.txt";
+
+    // Add a file directly to the bucket
+    test_client.put_object(SOURCE_OBJ_KEY, b"hello world").unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let nonexistent_path = main_dir.join("nonexistent.txt");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["source.txt"]);
+
+    test_client.remove_object(SOURCE_OBJ_KEY).unwrap();
+
+    fs::metadata(&source_path).expect("stat should succeed from cache");
+
+    let err = fs::rename(&nonexistent_path, &destination_path)
+        .expect_err("file rename should fail when src is missing in S3");
+    assert_eq!(
+        err.kind(),
+        ErrorKind::NotFound,
+        "rename should return ENOENT for the source no longer existing in S3"
+    );
+
+    let err = fs::metadata(&destination_path).expect_err("stat should fail for destination as rename failed");
+    assert_eq!(
+        err.kind(),
+        ErrorKind::NotFound,
+        "stat on destination should return ENOENT as rename failed"
+    );
+
+    // Assert expected S3 structure
+    assert!(
+        !test_client.contains_key("dir/source.txt").unwrap(),
+        "source object must no longer exist in S3 after removal"
+    );
+    assert!(
+        !test_client.contains_key("dir/destination.txt").unwrap(),
+        "destination object should not exist in S3"
+    );
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_srcremovedbutcached_test_s3() {
+    rename_srcremovedbutcached_test(fuse::s3_session::new, "rename_srcremovedbutcached_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_srcremovedbutcached_test"; "prefix")]
+fn rename_srcremovedbutcached_test_mock(prefix: &str) {
+    rename_srcremovedbutcached_test(fuse::mock_session::new, prefix);
+}
+
+fn rename_destexists_tests<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Prepare bucket content
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+    test_client.put_object("dir/destination.txt", b"foo bar").unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let mut dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    // Sort them
+    dir_entry_names.sort();
+    assert_eq!(dir_entry_names, vec!["destination.txt", "source.txt"]);
+
+    let err = fs::rename(&source_path, &destination_path).expect_err("should fail if destination exists");
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+
+    for s3_key in ["dir/source.txt", "dir/destination.txt"] {
+        assert!(
+            test_client.contains_key(s3_key).unwrap(),
+            "object with key {:?} should exist in S3",
+            s3_key
+        );
+    }
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_destexists_tests_s3() {
+    rename_destexists_tests(fuse::s3_session::new, "rename_destexists_tests");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_destexists_tests"; "prefix")]
+fn rename_destexists_tests_mock(prefix: &str) {
+    rename_destexists_tests(fuse::mock_session::new, prefix);
+}
+
+fn rename_destparentmissing_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Prepare bucket content
+    test_client.put_object("a/source.txt", b"hello world").unwrap();
+
+    let source_path = mount_point.join("a/source.txt");
+    let destination_path = mount_point.join("b/destination.txt");
+
+    let err = fs::rename(&source_path, &destination_path).expect_err("should fail if destination parent doesn't exist");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+
+    fs::create_dir(mount_point.join("b")).unwrap();
+    fs::rename(&source_path, &destination_path).expect("should succeed if destination parent now exists");
+
+    // S3 structure should match
+    assert!(
+        test_client.contains_key("b/destination.txt").unwrap(),
+        "destination object must now exist in S3"
+    );
+    assert!(
+        !test_client.contains_key("a/source.txt").unwrap(),
+        "source object must no longer exist in S3"
+    );
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_destparentmissing_test_s3() {
+    rename_destparentmissing_test(fuse::s3_session::new, "rename_destparentmissing_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_destparentmissing_test"; "prefix")]
+fn rename_destparentmissing_test_mock(prefix: &str) {
+    rename_destparentmissing_test(fuse::mock_session::new, prefix);
+}
+
+/// Testing behavior when a file is renamed in the middle of reading
+fn rename_readhandle_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    const B_IN_MB: usize = 1024 * 1024;
+    test_client.put_object("dir/source.txt", &[0u8; B_IN_MB * 128]).unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    let mut f = File::options()
+        .read(true)
+        .write(false)
+        .open(&source_path)
+        .expect("open should succeed");
+    f.read_exact(&mut [0u8; 1]).expect("read should succeed");
+
+    fs::rename(&source_path, &destination_path).expect("should succeed if source exists and destination doesnt");
+
+    // readdir should now show the file as gone (moved)
+    let read_dir_iter = fs::read_dir(main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["destination.txt"]);
+
+    let _new_pos = f.seek(SeekFrom::Start((B_IN_MB * 120) as u64)).unwrap(); // Seek far ahead in file, to exceed prefetcher's progress
+    let err = f
+        .read_exact(&mut [0u8; 1])
+        .expect_err("fresh read using open file handle should fail as object backing inode no longer exists");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EIO, "read should fail with OS err EIO");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_readhandle_test_s3() {
+    rename_readhandle_test(fuse::s3_session::new, "rename_readhandle_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_readhandle_test"; "prefix")]
+fn rename_readhandle_test_mock(prefix: &str) {
+    rename_readhandle_test(fuse::mock_session::new, prefix);
+}
+
+/// Testing behavior when a file is renamed during and after writing
+fn rename_writehandle_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/other.txt", &[0u8; 1024]).unwrap(); // Persist implicit directory for test
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("writing.txt");
+    let destination_path = main_dir.join("writing-after-move.txt");
+
+    let mut f = File::options()
+        .read(false)
+        .write(true)
+        .create_new(true)
+        .open(&source_path)
+        .expect("open for writing should succeed");
+
+    let err = fs::rename(&source_path, &destination_path).expect_err("rename of path open for writing should fail");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EPERM, "unlink should fail with OS err EPERM");
+
+    f.write_all(&[0u8; 1]).expect("write should succeed");
+
+    let err = fs::rename(&source_path, &destination_path)
+        .expect_err("rename of path partially written to should continue to fail");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::EPERM, "rename should fail with OS err EPERM");
+
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    let mut dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    dir_entry_names.sort();
+    assert_eq!(
+        dir_entry_names,
+        vec!["other.txt", "writing.txt"],
+        "file should be present in readdir"
+    );
+
+    f.sync_all().unwrap();
+    drop(f);
+
+    fs::rename(&source_path, &destination_path).expect("file can be renamed after being persisted remotely");
+    debug!("reading now --- a");
+    let read_dir_iter = fs::read_dir(&main_dir).unwrap();
+    debug!("read");
+    let mut dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    dir_entry_names.sort();
+    assert_eq!(
+        dir_entry_names,
+        vec!["other.txt", "writing-after-move.txt"],
+        "should only see existing files and new renamed file"
+    );
+    debug!("test successfull");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_writehandle_test_s3() {
+    rename_writehandle_test(fuse::s3_session::new, "rename_writehandle_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_writehandle_test"; "prefix")]
+fn rename_writehandle_test_mock(prefix: &str) {
+    rename_writehandle_test(fuse::mock_session::new, prefix);
+}
+
+fn rename_directory_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Prepare bucket content
+    test_client.put_object("source-dir/a.txt", b"hello world").unwrap();
+    test_client.put_object("source-dir/b.txt", b"foo bar").unwrap();
+
+    let src_dir_path = mount_point.join("source-dir");
+    let dest_dir_path = mount_point.join("destination-dir");
+
+    let err = fs::rename(&src_dir_path, &dest_dir_path).expect_err("should fail as directory rename is not supported");
+    assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+
+    // But we can still do other renames, right?
+    fs::rename(src_dir_path.join("a.txt"), src_dir_path.join("new-a.txt"))
+        .expect("rename of files should still succeed");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_directory_test_s3() {
+    rename_directory_test(fuse::s3_session::new, "rename_directory_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_directory_test"; "prefix")]
+fn rename_directory_test_mock(prefix: &str) {
+    rename_directory_test(fuse::mock_session::new, prefix);
+}
+
+/// Check that overwriting rename is forbidden when `allow_overwrites` is not passed as a flag.
+fn rename_overwrites_forbidden_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+    test_client.put_object("dir/destination.txt", b"hello world").unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    // files should be visible in readdir
+    let read_dir_iter = fs::read_dir(&main_dir).expect("directory should exist");
+    let mut dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    dir_entry_names.sort();
+    assert_eq!(dir_entry_names, vec!["destination.txt", "source.txt"]);
+
+    let err = fs::rename(source_path, destination_path)
+        .expect_err("overwriting file rename should fail if allow_overwrite was not provided");
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_overwrites_forbidden_s3() {
+    rename_overwrites_forbidden_test(fuse::s3_session::new, "rename_nodelete_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_nodelete_test"; "prefix")]
+fn rename_overwrites_forbidden_mock(prefix: &str) {
+    rename_overwrites_forbidden_test(fuse::mock_session::new, prefix);
+}
+
+// checks that renaming a file to it's current name succeeds
+// TODO: Maybe cut this test, as this is guaranteed by the rename implementations
+fn rename_no_op_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Put a object
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("source.txt");
+    fs::rename(source_path, destination_path).expect("rename of files should succeed");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_same_file_test_s3() {
+    rename_no_op_test(fuse::s3_session::new, "rename_nodelete_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_nodelete_test"; "prefix")]
+fn rename_same_file_test_mock(prefix: &str) {
+    rename_no_op_test(fuse::mock_session::new, prefix);
+}
+
+/**
+ * Semantics Issue: What hapens, when we call rename on a direcotry with itself as an argument?
+ */
+fn rename_dir_noop_accepted_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Put a object
+    test_client.put_object("dir/source.txt", b"hello world").unwrap();
+    let main_dir = mount_point.join("dir");
+
+    fs::rename(main_dir.clone(), main_dir.clone()).expect("rename of directory into itself should work");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_dir_noop_accepted_s3() {
+    crate::fuse_tests::rename_test::rename_dir_noop_accepted_test(fuse::s3_session::new, "rename_dir_rejected_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_dir_rejected"; "prefix")]
+fn rename_dir_noop_accepted_mock(prefix: &str) {
+    crate::fuse_tests::rename_test::rename_dir_noop_accepted_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(target_os = "linux")]
+/// Wrapper for renameat2, using a syscall instead of using nix::fcntl::renameat2.
+/// Needed, as glibc 2.26 does not support rename, and this version is shipped on CentOs 7 and Al2.
+pub fn renameat2_wrapper(old_path: &Path, new_path: &Path, flags: RenameFlags) -> Result<(), i32> {
+    let old_path_c = CString::new(old_path.as_os_str().as_encoded_bytes()).map_err(|_| libc::EINVAL)?;
+    let new_path_c = CString::new(new_path.as_os_str().as_encoded_bytes()).map_err(|_| libc::EINVAL)?;
+
+    // SAFETY: This is safe assuming renameat2 is implemented correctly.
+    //          We only pass in valid null terminated strings,
+    //          the constants are system defined and valid for this system call,
+    //          and `RenameFlags` can be passed to this system call.
+    let result: Result<usize, syscalls::Errno> = unsafe {
+        syscalls::syscall5(
+            syscalls::Sysno::renameat2,
+            libc::AT_FDCWD as usize,
+            old_path_c.as_ptr() as usize,
+            libc::AT_FDCWD as usize,
+            new_path_c.as_ptr() as usize,
+            flags.bits() as usize,
+        )
+    };
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) => Err(-err.into_raw()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn rename_exchange_rejected_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    test_client
+        .put_object("a.txt", b"hello world")
+        .expect("put object should succeed");
+    test_client
+        .put_object("b.txt", b"fun times")
+        .expect("put object should succeed");
+    let result_exchange = renameat2_wrapper(
+        &mount_point.join("a.txt"),
+        &mount_point.join("b.txt"),
+        nix::fcntl::RenameFlags::RENAME_EXCHANGE,
+    );
+    result_exchange.expect_err("Rename exchange rejected");
+    let result_noreplace = renameat2_wrapper(
+        &mount_point.join("a.txt"),
+        &mount_point.join("b.txt"),
+        nix::fcntl::RenameFlags::RENAME_NOREPLACE,
+    );
+    result_noreplace.expect_err("Rename noreplace not supported");
+    let result_whiteout = renameat2_wrapper(
+        &mount_point.join("a.txt"),
+        &mount_point.join("b.txt"),
+        nix::fcntl::RenameFlags::RENAME_WHITEOUT,
+    );
+    result_whiteout.expect_err("Rename noreplace not supported");
+}
+
+#[cfg(target_os = "linux")]
+#[test_case(""; "no prefix")]
+#[test_case("test_multiple_renames_deep_structure"; "prefix")]
+fn rename_exchange_rejected_mock(prefix: &str) {
+    rename_exchange_rejected_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(feature = "s3express_tests")]
+#[test_case("test_multiple_renames_deep_structure"; "prefix")]
+fn rename_exchange_rejected_s3(prefix: &str) {
+    rename_exchange_rejected_test(fuse::s3_session::new, prefix);
+}
+
+fn rename_key_too_long<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add an object
+    test_client
+        .put_object("dir/a.txt", b"hello world")
+        .expect("put object should succeed");
+
+    let too_long_key = "X".repeat(1027);
+    fs::rename(mount_point.join("dir/a.txt"), mount_point.join(&too_long_key)).expect_err("rename should not succeed");
+    //.expect_err("rename into a too long key should fail");
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test]
+fn rename_key_too_long_s3() {
+    rename_key_too_long(fuse::s3_session::new, "rename_dir_rejected_test");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_dir_rejected"; "prefix")]
+fn rename_key_too_long_mock(prefix: &str) {
+    rename_key_too_long(fuse::mock_session::new, prefix);
+}
+
+#[allow(clippy::too_many_arguments)]
+// Generic rename mounts a bucket as in the other tests (using prefix and creater_fn).
+// It then adds all the keys to the s3 bucket, with random content as description.
+// For each string pair in the ops, it then tries to execute rename on it.
+// If the success parameter is set to true, then each of these renames must succeed,
+// if it is false, it is required that at least one of the renames fails (i.e. track if one op failed using a boolean and check after all operations)
+// Then check that each file in the positive list is present and each file in the negative list is not present.
+fn generic_rename_test<F>(
+    creator_fn: F,
+    prefix: &str,
+    keys: Vec<&str>,
+    dirs: Vec<&str>,
+    ops: Vec<(&str, &str)>,
+    success: bool,
+    positive: Vec<&str>,
+    negative: Vec<&str>,
+) where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    // Create a test session configuration
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create a test session using the provided creator function
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add all the keys to the S3 bucket with random content
+    for key in keys.iter() {
+        let content = format!("Random content for {}", key);
+        test_client
+            .put_object(key, content.as_bytes())
+            .expect("PutObject should succeed");
+    }
+
+    // Create all the directories in dirs
+    for dir in dirs.iter() {
+        fs::create_dir_all(mount_point.join(dir))
+            .expect("error in a generic rename test, initial creation should succeed");
+    }
+
+    // Execute rename operations
+    let mut any_op_failed = false;
+    for (src, dst) in ops {
+        let result = fs::rename(mount_point.join(src), mount_point.join(dst));
+        if result.is_err() {
+            any_op_failed = true;
+            if success {
+                panic!(
+                    "Rename operation failed when it should have succeeded: {:?} to {:?}",
+                    src, dst
+                );
+            }
+        }
+    }
+
+    // Check if at least one operation failed when success is false
+    if !success && !any_op_failed {
+        panic!("Expected at least one rename operation to fail, but all succeeded");
+    }
+
+    // Check that each file in the positive list is present
+    for file in positive {
+        assert!(mount_point.join(file).exists(), "File should exist: {}", file);
+    }
+
+    // Check that each file in the negative list is not present
+    for file in negative {
+        assert!(!mount_point.join(file).exists(), "File should not exist: {}", file);
+    }
+}
+
+fn test_multiple_renames_deep_structure_success<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    generic_rename_test(
+        creator_fn,
+        prefix,
+        vec!["a/b/cc"],
+        vec!["a/b/c/d/e/f/g", "a/b/hg/sd/as/df/fd/kk"],
+        vec![("a/b/cc", "a/b/c/d/e/cc"), ("a/b/c/d/e/cc", "a/b/hg/sd/as/df/fd/assd")],
+        true,
+        vec!["a/b/hg/sd/as/df/fd/assd"],
+        vec!["a/b/cc"],
+    );
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_dir_rejected"; "prefix")]
+fn test_multiple_renames_deep_structure_mock(prefix: &str) {
+    test_multiple_renames_deep_structure_success(fuse::mock_session::new, prefix);
+}
+
+fn test_multiple_renames_deep_structure_failure<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    generic_rename_test(
+        creator_fn,
+        prefix,
+        vec!["a/b/cc"],
+        vec!["a/b/c/d/e/f/g", "a/b/hg/sd/as/df/fd/kk"],
+        vec![("a/b/cc", "a/b/c/d/e/cc"), ("a/b/c/d/f/cc", "a/b/hg/sd/as/df/fd/assd")],
+        false,
+        vec!["a/b/hg/sd/as/df/fd/kk"],
+        vec!["a/b/cc"],
+    );
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("test_multiple_renames_deep_structure"; "prefix")]
+fn test_multiple_renames_deep_structure_failure_mock(prefix: &str) {
+    test_multiple_renames_deep_structure_failure(fuse::mock_session::new, prefix);
+}
+
+fn test_rename_very_long_path<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let long_path = "a/".repeat(5) + "file.txt";
+    let new_long_dir = "b/".repeat(5);
+    let new_long_path = "b/".repeat(5) + "new_file.txt";
+
+    generic_rename_test(
+        creator_fn,
+        prefix,
+        vec![&long_path],
+        vec![&new_long_dir],
+        vec![(long_path.as_str(), new_long_path.as_str())],
+        true,
+        vec![&new_long_path],
+        vec![&long_path],
+    );
+}
+#[test_case(""; "no prefix")]
+#[test_case("test_hybridrename"; "prefix")]
+fn rename_very_long_mock(prefix: &str) {
+    test_rename_very_long_path(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case("test_hybridrename"; "prefix")]
+fn rename_very_long_s3(prefix: &str) {
+    test_rename_very_long_path(fuse::s3_session::new, prefix);
+}
+
+/// Tests that overwrites are enabled, if allow-overwrite is set.
+fn rename_allow_overwrites_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add an object
+    test_client
+        .put_object("dir/a.txt", b"key for a")
+        .expect("put object should succeed");
+
+    test_client
+        .put_object("dir/b.txt", b"key for b")
+        .expect("put object should succeed");
+
+    fs::rename(mount_point.join("dir/a.txt"), mount_point.join("dir/b.txt"))
+        .expect("overwriting rename should succeed");
+
+    // Check for the expected contents
+    let contents: String = fs::read_to_string(mount_point.join("dir/b.txt")).expect("file should be readable");
+    assert_eq!(contents, "key for a");
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("rename_allow_overwrites"; "prefix")]
+fn rename_allow_overwrites_mock(prefix: &str) {
+    rename_allow_overwrites_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case("rename_allow_overwrites"; "prefix")]
+fn rename_allow_overwrites_s3(prefix: &str) {
+    rename_allow_overwrites_test(fuse::s3_session::new, prefix);
+}
+#[cfg(target_os = "linux")]
+/// Tests that even in a mode where overwrites are be enabled, flag RENAME_NOREPLACE can prevent this.
+fn rename_flag_noreplace_disables_overwrites_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    test_client
+        .put_object("a.txt", b"hello world")
+        .expect("put object should succeed");
+    test_client
+        .put_object("b.txt", b"fun times")
+        .expect("put object should succeed");
+
+    let result_noreplace = renameat2_wrapper(
+        &mount_point.join("a.txt"),
+        &mount_point.join("b.txt"),
+        nix::fcntl::RenameFlags::RENAME_NOREPLACE,
+    );
+    result_noreplace.expect_err("RENAME_NOREPLACE not handled correctly, since rename succeded when it shouldn't have");
+
+    let result_noreplace = renameat2_wrapper(
+        &mount_point.join("a.txt"),
+        &mount_point.join("b.txt"),
+        RenameFlags::empty(),
+    );
+    result_noreplace.expect("Without RENAME_NOREPLACE overwriting rename should succeded");
+}
+
+#[cfg(target_os = "linux")]
+#[test_case(""; "no prefix")]
+#[test_case("rename_flag_noreplace_disables_overwrites"; "prefix")]
+fn rename_flag_noreplace_disables_overwrites_mock(prefix: &str) {
+    rename_flag_noreplace_disables_overwrites_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(feature = "s3express_tests")]
+#[test_case("rename_flag_noreplace_disables_overwrites"; "prefix")]
+fn rename_flag_noreplace_disables_overwrites_s3(prefix: &str) {
+    rename_flag_noreplace_disables_overwrites_test(fuse::s3_session::new, prefix);
+}
+
+/// This test aims at checking that concurrent renames work as expected.
+/// It locally creates two files "a.txt" and "b.txt" and then
+/// in two threads simultaneeously tries to rename "a.txt" to "b.txt"
+/// and "b.txt" to "a.txt".
+/// It then checks that only one of the files exists after the operations,
+/// and that the contents are as expected.
+///
+/// This test is repeated 100 times, to hopefully cover many
+/// possible interleavings.
+fn test_rename_concurrent<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let iterations = 10;
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            allow_delete: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let mount_point = test_session.mount_path().to_owned();
+
+    let mut wins = (0, 0);
+    for i in 0..iterations {
+        // Create initial files
+        debug!("Iteration #{i}");
+        {
+            let mut filea = File::create(mount_point.join("a.txt")).unwrap();
+            filea.write_all(b"a").unwrap();
+            filea.sync_all().unwrap();
+            filea.flush().unwrap();
+            let mut fileb = File::create(mount_point.join("b.txt")).unwrap();
+            fileb.write_all(b"b").unwrap();
+            fileb.flush().unwrap();
+            fileb.sync_all().unwrap();
+        }
+        // Create threads for concurrent rename operations
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mount_point_clone_thread_a = mount_point.clone();
+        let b1 = Arc::clone(&barrier);
+
+        let thread1 = std::thread::spawn(move || {
+            b1.wait();
+            fs::rename(
+                mount_point_clone_thread_a.join("a.txt"),
+                mount_point_clone_thread_a.join("b.txt"),
+            )
+        });
+        let mount_point_clone_thread_b = mount_point.clone();
+        let b2 = Arc::clone(&barrier);
+
+        let thread2 = std::thread::spawn(move || {
+            b2.wait();
+            fs::rename(
+                mount_point_clone_thread_b.join("b.txt"),
+                mount_point_clone_thread_b.join("a.txt"),
+            )
+        });
+        // Wait for both operations to complete
+        let result1 = thread1.join().expect("Thread 1 panicked");
+        let result2 = thread2.join().expect("Thread 2 panicked");
+        // Verify that at least one rename succeeded
+        assert!(result1.is_ok() && result2.is_ok(), "Both renames should succeed");
+
+        // Check file existence and contents
+        let files = vec!["a.txt", "b.txt"];
+        let mut found_files = 0;
+        let mut valid_content = true;
+
+        for file in files {
+            if let Ok(contents) = fs::read_to_string(mount_point.join(file)) {
+                found_files += 1;
+                if contents != "a" && contents != "b" {
+                    valid_content = false;
+                }
+                if contents == "a" {
+                    wins.0 += 1;
+                } else {
+                    wins.1 += 1;
+                }
+            }
+        }
+        assert!(found_files == 1);
+        let resa = fs::remove_file(mount_point.join("a.txt"));
+        let resb = fs::remove_file(mount_point.join("b.txt"));
+        if let (Err(_), Err(_)) = (resa, resb) {
+            panic!("Expected one file to be deletable");
+        }
+        // Verify that any remaining files have valid content
+        assert!(valid_content, "All remaining files should contain either 'a' or 'b'");
+    }
+    debug!("Finished {} {}", wins.0, wins.1);
+}
+
+#[test_case(""; "no prefix")]
+#[test_case("test_rename_concurrent"; "prefix")]
+fn test_rename_concurrent_mock(prefix: &str) {
+    test_rename_concurrent(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case("test_rename_concurrent"; "prefix")]
+fn test_rename_concurrent_simple_s3(prefix: &str) {
+    test_rename_concurrent(fuse::s3_session::new, prefix);
+}
+
+fn rename_file_contents_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_delete: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path().to_owned();
+
+    test_client
+        .put_object("dir/a.txt", b"hello world")
+        .expect("put object should succeed");
+
+    fs::rename(mount_point.join("dir/a.txt"), mount_point.join("dir/moved.txt")).expect("rename should succeed");
+
+    let contents =
+        fs::read_to_string(mount_point.join("dir/moved.txt")).expect("Should have been able to read the file");
+    assert_eq!(contents, "hello world");
+}
+
+#[test_case(""; "no prefix")]
+fn rename_file_contents_mock(prefix: &str) {
+    rename_file_contents_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case("test_rename_file_contents"; "prefix")]
+fn rename_file_contents_s3(prefix: &str) {
+    rename_file_contents_test(fuse::s3_session::new, prefix);
+}
+
+/// Ensure that inode number stay identical after a rename
+fn rename_same_ino_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    test_client
+        .put_object("dir/a.txt", b"key for a")
+        .expect("put object should succeed");
+    test_client
+        .put_object("dir/b.txt", b"key for b")
+        .expect("put object should succeed");
+
+    test_client
+        .put_object("dirtwo/b.txt", b"key for b in dir2")
+        .expect("put object should succeed");
+
+    // Get the inode number for mount_point.join("dir/a.txt")
+    let initial_inode = fs::metadata(mount_point.join("dir/a.txt")).unwrap().ino();
+    // Rename "dir/a.txt" to "dir/c.txt"
+    fs::rename(mount_point.join("dir/a.txt"), mount_point.join("dir/c.txt")).expect("rename should succeed");
+    assert_eq!(
+        fs::metadata(mount_point.join("dir/c.txt")).unwrap().ino(),
+        initial_inode
+    );
+    // Rename "dir/c.txt" to dir.b.txt ensure the inode number stays identical
+    fs::rename(mount_point.join("dir/c.txt"), mount_point.join("dir/b.txt")).expect("rename should succeed");
+    assert_eq!(
+        fs::metadata(mount_point.join("dir/b.txt")).unwrap().ino(),
+        initial_inode
+    );
+    // Rename "dir/b.txt" to "dirtwo/b.txt", ensure inode number stays identical
+    fs::rename(mount_point.join("dir/b.txt"), mount_point.join("dirtwo/b.txt")).expect("rename should succeed");
+    assert_eq!(
+        fs::metadata(mount_point.join("dirtwo/b.txt")).unwrap().ino(),
+        initial_inode
+    );
+    let read_dir_iter = fs::read_dir(mount_point.join("dirtwo")).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["b.txt"]);
+}
+
+#[test_case(""; "no prefix")]
+fn rename_same_ino_mock(prefix: &str) {
+    rename_same_ino_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_same_ino_s3(prefix: &str) {
+    rename_same_ino_test(fuse::s3_session::new, prefix);
+}
+
+/// Tests that a file can be appended after and before a rename, and that the content is as expected.
+fn rename_append_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let mount_point = test_session.mount_path();
+    fs::create_dir(mount_point.join("dir")).expect("should be able to create dir");
+    // Create file a.txt
+    {
+        let data = "Some data!";
+        let mut f = File::create(mount_point.join("a.txt")).expect("Unable to create file");
+        f.write_all(data.as_bytes()).expect("Unable to write data");
+        drop(f);
+    }
+    // Append to it
+    {
+        let data = "append";
+        let mut file = OpenOptions::new().append(true).open(mount_point.join("a.txt")).unwrap();
+        file.write_all(data.as_bytes()).expect("Unable to write data");
+        file.sync_all().unwrap();
+        drop(file);
+    }
+    // Rename it
+    {
+        fs::rename(mount_point.join("a.txt"), mount_point.join("dir/b.txt")).expect("rename successfull");
+    }
+    // Append to it again
+    {
+        let data = "append";
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(mount_point.join("dir/b.txt"))
+            .unwrap();
+        file.write_all(data.as_bytes()).expect("Unable to write data");
+        file.sync_all().unwrap();
+        drop(file);
+    }
+    fs::rename(mount_point.join("dir/b.txt"), mount_point.join("dir/c.txt")).expect("rename successfull");
+    // Verify the contents
+    // Wait for a few seconds
+    let contents = fs::read_to_string(mount_point.join("dir/c.txt")).expect("read should succeed");
+    assert_eq!(contents, "Some data!appendappend");
+}
+
+#[test_case(""; "no prefix")]
+fn rename_append_mock(prefix: &str) {
+    rename_append_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_append_s3(prefix: &str) {
+    rename_append_test(fuse::s3_session::new, prefix);
+}
+
+fn rename_out_of_topdir_regression<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+    // First place two objects in S3
+
+    test_client
+        .put_object("dir/a/b.txt", b"key for b nested")
+        .expect("put object should succeed");
+    test_client
+        .put_object("dir/b.txt", b"key for b")
+        .expect("put object should succeed");
+    // Try to rename
+    fs::rename(mount_point.join("dir/a/b.txt"), mount_point.join("dir/b.txt")).expect("Rename should work");
+    let contents = fs::read_to_string(mount_point.join("dir/b.txt")).expect("read should succeed");
+    assert_eq!(contents, "key for b nested");
+}
+
+#[test_case(""; "no prefix")]
+fn rename_out_of_topdir_regression_mock(prefix: &str) {
+    rename_out_of_topdir_regression(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_out_of_topdir_regression_s3(prefix: &str) {
+    rename_out_of_topdir_regression(fuse::s3_session::new, prefix);
+}
+
+fn compare_directories<P: AsRef<Path>>(dir1: P, dir2: P) {
+    let dir1 = dir1.as_ref();
+    let dir2 = dir2.as_ref();
+
+    // Helper function to get all files in a directory as a HashSet of relative paths
+    fn get_files(dir: &Path) -> HashSet<PathBuf> {
+        walkdir::WalkDir::new(dir)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+            .map(|entry| entry.path().strip_prefix(dir).unwrap().to_path_buf())
+            .collect()
+    }
+
+    let files1 = get_files(dir1);
+    let files2 = get_files(dir2);
+
+    // Check for files in dir1 that don't exist in dir2
+    let missing_in_dir2: Vec<_> = files1.difference(&files2).collect();
+    assert!(
+        missing_in_dir2.is_empty(),
+        "Files present in {:?} but missing in {:?}: {:?}",
+        dir1,
+        dir2,
+        missing_in_dir2
+    );
+
+    // Check for files in dir2 that don't exist in dir1
+    let missing_in_dir1: Vec<_> = files2.difference(&files1).collect();
+    assert!(
+        missing_in_dir1.is_empty(),
+        "Files present in {:?} but missing in {:?}: {:?}",
+        dir2,
+        dir1,
+        missing_in_dir1
+    );
+
+    // Compare contents of all files
+    for rel_path in &files1 {
+        let path1 = dir1.join(rel_path);
+        let path2 = dir2.join(rel_path);
+
+        let contents1 = std::fs::read(&path1).unwrap();
+        let contents2 = std::fs::read(&path2).unwrap();
+        assert_eq!(contents1, contents2, "Contents differ for file {:?}", rel_path);
+    }
+}
+
+fn compare_directories_only_readdir_on_dir1<P: AsRef<Path>>(dir1: P, dir2: P) {
+    let dir1 = dir1.as_ref();
+    let dir2 = dir2.as_ref();
+    fn get_files(dir: &Path) -> HashSet<PathBuf> {
+        walkdir::WalkDir::new(dir)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+            .map(|entry| entry.path().strip_prefix(dir).unwrap().to_path_buf())
+            .collect()
+    }
+
+    let files1 = get_files(dir1);
+    // Compare contents of all files
+    for rel_path in &files1 {
+        let path1 = dir1.join(rel_path);
+        let path2 = dir2.join(rel_path);
+
+        let contents1 = fs::read_to_string(&path1).unwrap();
+        let contents2 = fs::read_to_string(&path2).unwrap();
+        assert_eq!(contents1, contents2, "Contents differ for file {:?}", rel_path);
+    }
+}
+
+// This test starts with a directory structure
+//  - a
+//     - b
+//         - c
+//             - d.txt
+//             - e.txt
+//         - f.txt
+//         - g.txt
+//  - h
+//     - i.txt
+//  And performs the following moves:
+//     a/b/f.txt -> a/b/c/d.txt
+//     a/b/c/e.txt -> a/b/c/g.txt
+//     a/b/c/d.txt -> a/d.txt
+//     a/b/g.txt -> h/i.txt
+//  It performs this both on the MP and on a local directory and compares contents after each step.
+//  All of these renames are supposed to work.
+fn rename_complicated_structure_contents_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            cache_config: CacheConfig {
+                serve_lookup_from_cache: true,
+                dir_ttl: Duration::from_secs(6000),
+                file_ttl: Duration::from_secs(6000),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path();
+
+    let initial_files = [
+        ("a/b/c/d.txt", "d"),
+        ("a/b/c/e.txt", "e"),
+        ("a/b/f.txt", "f"),
+        ("a/b/g.txt", "g"),
+        ("h/i.txt", "i"),
+    ];
+
+    for (path, content) in &initial_files {
+        // Create in S3
+        test_client
+            .put_object(path, content.as_bytes())
+            .expect("put object should succeed");
+        // Create in local temp directory
+        let full_path = temp_path.join(path);
+        std::fs::create_dir_all(full_path.parent().unwrap()).expect("Failed to create directories");
+        std::fs::write(full_path, content.as_bytes()).expect("Failed to write file");
+    }
+
+    let renames = [
+        ("a/b/f.txt", "a/b/c/d.txt"),
+        ("a/b/c/e.txt", "a/b/g.txt"),
+        ("a/b/c/d.txt", "a/d.txt"),
+        ("a/b/g.txt", "h/i.txt"),
+    ];
+
+    for (i, (from, to)) in renames.iter().enumerate() {
+        debug!("Move {}", i + 1);
+        std::fs::rename(mount_point.join(from), mount_point.join(to)).expect("Move {i+1} failed");
+        std::fs::rename(temp_path.join(from), temp_path.join(to)).expect("Local move {i+1} failed");
+
+        compare_directories_only_readdir_on_dir1(temp_path, mount_point);
+    }
+
+    compare_directories(temp_path, mount_point);
+}
+
+#[test_case(""; "no prefix")]
+fn rename_complicated_structure_contents_mock(prefix: &str) {
+    rename_complicated_structure_contents_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_complicated_structure_contents_s3(prefix: &str) {
+    rename_complicated_structure_contents_test(fuse::s3_session::new, prefix);
+}
+
+fn rename_into_topdir_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+    // First place two objects in S3
+
+    test_client
+        .put_object("dir/a/b.txt", b"key for b nested")
+        .expect("put object should succeed");
+    test_client
+        .put_object("dir/b.txt", b"key for b")
+        .expect("put object should succeed");
+    // Try to rename
+    fs::rename(mount_point.join("dir/b.txt"), mount_point.join("dir/a/b.txt")).expect("Rename should work");
+    let contents = fs::read_to_string(mount_point.join("dir/a/b.txt")).expect("read should succeed");
+    assert_eq!(contents, "key for b");
+}
+
+#[test_case(""; "no prefix")]
+fn rename_into_topdir_mock(prefix: &str) {
+    rename_into_topdir_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_into_topdir_s3(prefix: &str) {
+    rename_into_topdir_test(fuse::s3_session::new, prefix);
+}
+
+fn cross_directory_rename_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            incremental_upload: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+    // First place three objects in S3
+
+    test_client
+        .put_object("dir/a/b.txt", b"dir/a/b.txt")
+        .expect("put object should succeed");
+    test_client
+        .put_object("dirb/b.txt", b"dirb/b.txt")
+        .expect("put object should succeed");
+    // Add a file so that the directory does not disappear after rename
+    test_client
+        .put_object("dir/a/static", b"dir/a/b.txt")
+        .expect("put object should succeed");
+    test_client
+        .put_object("dirb/c/d.txt", b"dirb/c/d.txt")
+        .expect("put object should succeed");
+
+    // Do two cross directory renames, then check the contents
+    fs::rename(mount_point.join("dir/a/b.txt"), mount_point.join("dirb/c/d.txt")).expect("rename should succeed");
+    fs::rename(mount_point.join("dirb/b.txt"), mount_point.join("dir/a/b.txt")).expect("rename should succeed");
+    // Check the contents
+    let contents = fs::read_to_string(mount_point.join("dir/a/b.txt")).expect("read should succeed");
+    assert_eq!(contents, "dirb/b.txt");
+
+    let contents = fs::read_to_string(mount_point.join("dirb/c/d.txt")).expect("read should succeed");
+    assert_eq!(contents, "dir/a/b.txt");
+}
+
+#[test_case(""; "no prefix")]
+fn cross_directory_rename_mock(prefix: &str) {
+    cross_directory_rename_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn cross_directory_rename_s3(prefix: &str) {
+    cross_directory_rename_test(fuse::s3_session::new, prefix);
+}
+
+fn rename_last_file_out_of_dir_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            incremental_upload: true,
+            cache_config: CacheConfig {
+                serve_lookup_from_cache: true,
+                dir_ttl: Duration::from_secs(0),
+                file_ttl: Duration::from_secs(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Place an object
+    test_client
+        .put_object("dir/a/b.txt", b"dir/a/b.txt")
+        .expect("put object should succeed");
+    fs::rename(mount_point.join("dir/a/b.txt"), mount_point.join("b.txt")).expect("Can move out of directory");
+
+    // Check that no more subdirectories
+    assert!(
+        !mount_point.join("dir/a").exists(),
+        "Directory 'dir/a' should no longer exist"
+    );
+    assert!(
+        !mount_point.join("dir").exists(),
+        "Directory 'dir' should no longer exist"
+    );
+
+    // Verify the file exists in the new location
+    assert!(mount_point.join("b.txt").exists(), "File should exist in new location");
+
+    // Verify the content of the moved file
+    let content = fs::read_to_string(mount_point.join("b.txt")).expect("Should be able to read file content");
+    assert_eq!(content, "dir/a/b.txt", "File content should remain unchanged");
+
+    // Verify with S3 client that the object has been moved
+    assert!(
+        test_client.contains_key("b.txt").unwrap(),
+        "Object should exist in new location"
+    );
+    assert!(
+        !test_client.contains_key("dir/a/b.txt").unwrap(),
+        "Object should not exist in old location"
+    );
+}
+
+#[test_case(""; "no prefix")]
+fn rename_last_file_out_of_dir_mock(prefix: &str) {
+    rename_last_file_out_of_dir_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_last_file_out_of_dir_s3(prefix: &str) {
+    rename_last_file_out_of_dir_test(fuse::s3_session::new, prefix);
+}
+
+/// Populates a bucket with two files "a.txt" and "b.txt", tries to spawn 20 threads that randomly rename one into the other
+/// Validates that at the end of the test, exactly one file is present, that at least one rename succeeded,
+/// and that the contents are either "a" or "b".
+fn many_simultaneous_renames_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    //
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            allow_delete: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path().to_owned();
+    let barrier = Arc::new(Barrier::new(20));
+    let success_counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    // Write both files
+    test_client
+        .put_object("a.txt", b"a")
+        .expect("put object should succeed");
+    test_client
+        .put_object("b.txt", b"b")
+        .expect("put object should succeed");
+
+    // Spawn 20 threads that try to rename files
+    for _ in 0..20 {
+        let mount_point = mount_point.clone();
+        let barrier = barrier.clone();
+        let success_counter = success_counter.clone();
+
+        let handle = std::thread::spawn(move || {
+            barrier.wait();
+            let result = if rand::random::<bool>() {
+                fs::rename(mount_point.join("a.txt"), mount_point.join("b.txt"))
+            } else {
+                fs::rename(mount_point.join("b.txt"), mount_point.join("a.txt"))
+            };
+            if result.is_ok() {
+                success_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all threads to complete
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    // Verify results
+    let success_count = success_counter.load(Ordering::SeqCst);
+    assert!(success_count > 0, "At least one rename should succeed");
+
+    // Check that exactly one file exists
+    let files_exist = [mount_point.join("a.txt").exists(), mount_point.join("b.txt").exists()];
+    assert_eq!(
+        files_exist.iter().filter(|&&x| x).count(),
+        1,
+        "Exactly one file should exist"
+    );
+
+    // Verify content is either "a" or "b"
+    let final_path = if mount_point.join("a.txt").exists() {
+        mount_point.join("a.txt")
+    } else {
+        mount_point.join("b.txt")
+    };
+    let content = fs::read_to_string(final_path).expect("Should be able to read file");
+    assert!(content == "a" || content == "b", "Content should be either 'a' or 'b'");
+}
+
+#[test_case(""; "no prefix")]
+fn many_simultaneous_renames_mock(prefix: &str) {
+    many_simultaneous_renames_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn many_simultaneous_renames_s3(prefix: &str) {
+    many_simultaneous_renames_test(fuse::s3_session::new, prefix);
+}
+
+/// Ensure that renaming to a file that is being written to fails
+fn rename_dest_open_for_writing_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            allow_delete: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path().to_owned();
+
+    test_client
+        .put_object("source.txt", b"source")
+        .expect("put object should succeed");
+
+    let _file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(mount_point.join("dest.txt"))
+        .expect("Should be able to open file for writing");
+
+    // Attempt to rename source to destination should fail
+    let result = fs::rename(mount_point.join("source.txt"), mount_point.join("dest.txt"));
+    assert!(
+        result.is_err(),
+        "Rename should fail when destination is open for writing"
+    );
+}
+
+#[test_case(""; "no prefix")]
+fn rename_dest_open_for_writing_mock(prefix: &str) {
+    rename_dest_open_for_writing_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_dest_open_for_writing_s3(prefix: &str) {
+    rename_dest_open_for_writing_test(fuse::s3_session::new, prefix);
+}
+
+/// Ensure overwriting to a file that is open for reading is possible, but read will fail at some point.
+fn rename_dest_open_for_reading_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            s3_personality: S3Personality::ExpressOneZone,
+            allow_overwrite: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    // Add a file directly to the bucket
+    const B_IN_MB: usize = 1024 * 1024;
+    test_client.put_object("dir/source.txt", &[0u8; B_IN_MB * 140]).unwrap();
+    test_client
+        .put_object("dir/destination.txt", &[3u8; B_IN_MB * 140])
+        .unwrap();
+
+    let main_dir = mount_point.join("dir");
+    let source_path = main_dir.join("source.txt");
+    let destination_path = main_dir.join("destination.txt");
+
+    let mut f = File::options()
+        .read(true)
+        .write(false)
+        .open(&destination_path)
+        .expect("open should succeed");
+    f.read_exact(&mut [0u8; 1]).expect("read should succeed");
+
+    fs::rename(&source_path, &destination_path).expect("should succeed if source exists and destination doesnt");
+
+    // readdir should now show the file as gone (moved)
+    let read_dir_iter = fs::read_dir(main_dir).unwrap();
+    let dir_entry_names = read_dir_to_entry_names(read_dir_iter);
+    assert_eq!(dir_entry_names, vec!["destination.txt"]);
+
+    let _new_pos = f.seek(SeekFrom::Start((B_IN_MB * 130) as u64)).unwrap(); // Seek far ahead in file, to exceed prefetcher's progress
+    let err = f
+        .read_exact(&mut [0u8; 1])
+        .expect_err("fresh read using open file handle should fail as object backing inode has been renamed");
+    let raw_os_err = err.raw_os_error().expect("err should be OS-level err");
+    assert_eq!(raw_os_err, libc::ESTALE, "read should fail with OS err ESTALE");
+}
+
+#[test_case(""; "no prefix")]
+fn rename_dest_open_for_reading_mock(prefix: &str) {
+    rename_dest_open_for_reading_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_dest_open_for_reading_s3(prefix: &str) {
+    rename_dest_open_for_reading_test(fuse::s3_session::new, prefix);
+}
+
+fn generate_random_filename() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8) // 8 character filenames
+        .map(char::from)
+        .collect()
+}
+
+fn generate_random_path(max_depth: usize) -> PathBuf {
+    let depth = thread_rng().gen_range(2..=max_depth);
+    let mut path = PathBuf::new();
+    for _ in 0..depth {
+        path.push(generate_random_filename());
+    }
+    path.set_extension("txt");
+    path
+}
+
+fn large_scale_random_rename_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    const INITIAL_FILES: usize = 600;
+    const RENAME_OPERATIONS: usize = 250;
+    const MAX_DEPTH: usize = 4;
+
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            cache_config: CacheConfig {
+                serve_lookup_from_cache: true,
+                dir_ttl: Duration::from_secs(6000),
+                file_ttl: Duration::from_secs(6000),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path();
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path();
+
+    info!("Generating and creating {} initial files...", INITIAL_FILES);
+
+    // Generate initial files
+    let mut files: Vec<(PathBuf, String)> = (0..INITIAL_FILES)
+        .map(|i| {
+            let path = generate_random_path(MAX_DEPTH);
+            let content = format!("content_{}", i);
+            (path, content)
+        })
+        .collect();
+
+    files.iter().for_each(|(path, content)| {
+        test_client
+            .put_object(path.to_str().unwrap(), content.as_bytes())
+            .expect("put object should succeed");
+
+        let full_path = temp_path.join(path);
+        std::fs::create_dir_all(full_path.parent().unwrap()).expect("Failed to create directories");
+        std::fs::write(full_path, content.as_bytes()).expect("Failed to write file");
+    });
+    // Perform rename operations
+    for i in 0..RENAME_OPERATIONS {
+        if i % 50 == 0 {
+            info!("Completed {} renames...", i);
+        }
+        let source_idx = thread_rng().gen_range(0..files.len());
+        let (source_path, _) = &files[source_idx];
+
+        // Different types of rename operations with weighted probabilities
+        let new_path = match thread_rng().gen_range(0..100) {
+            0..=40 => {
+                // 40% chance: Same directory, new name
+                source_path.with_file_name(format!("{}.txt", generate_random_filename()))
+            }
+            41..=70 => {
+                if let Some(parent) = source_path.parent() {
+                    parent.join(format!("{}.txt", generate_random_filename()))
+                } else {
+                    PathBuf::from(format!("{}.txt", generate_random_filename()))
+                }
+            }
+            _ => generate_random_path(MAX_DEPTH),
+        };
+
+        // Ensure parent directory exists for new path
+        if let Some(parent) = new_path.parent() {
+            let mp_parent = mount_point.join(parent);
+            let temp_parent = temp_path.join(parent);
+
+            if !mp_parent.exists() {
+                std::fs::create_dir_all(&mp_parent).expect("Failed to create parent directory in mountpoint");
+            }
+            if !temp_parent.exists() {
+                std::fs::create_dir_all(&temp_parent).expect("Failed to create parent directory in temp");
+            }
+        }
+
+        // Perform rename
+        std::fs::rename(mount_point.join(source_path), mount_point.join(&new_path)).expect("Move should succeed");
+
+        std::fs::rename(temp_path.join(source_path), temp_path.join(&new_path)).expect("Local move should succeed");
+
+        files[source_idx].0 = new_path;
+
+        // Compare directories periodically (every 10 operations)
+        if i % 10 == 0 {
+            compare_directories_only_readdir_on_dir1(temp_path, mount_point);
+        }
+    }
+    // Final comparison
+    compare_directories(temp_path, mount_point);
+}
+
+#[test_case(""; "no prefix")]
+fn large_scale_random_rename_mock(prefix: &str) {
+    large_scale_random_rename_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn large_scale_random_rename_s3(prefix: &str) {
+    large_scale_random_rename_test(fuse::s3_session::new, prefix);
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// Keeps track of the result of the three operations we try to run in parallel
+struct OperationResult {
+    mv_success: bool,
+    del_a_success: bool,
+    del_b_success: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+/// Keeps track of the part file system state that we care about for this test
+struct FsState {
+    a_exists: bool,
+    b_exists: bool,
+    b_has_a_content: bool, // true if b exists and has a's content
+}
+
+/// Takes a path and generates cooresponding FsState
+fn get_fs_state(mount_point: &Path) -> FsState {
+    let a_path = mount_point.join("a.txt");
+    let b_path = mount_point.join("b.txt");
+
+    let a_exists = a_path.exists();
+    let b_exists = b_path.exists();
+    let b_has_a_content = if b_exists {
+        match std::fs::read_to_string(&b_path) {
+            Ok(content) => content == "a_content",
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+
+    FsState {
+        a_exists,
+        b_exists,
+        b_has_a_content,
+    }
+}
+
+/// Simulate what would happen if operations occurred in a specific order
+fn simulate_sequence(ops: &[&str]) -> (OperationResult, FsState) {
+    let mut a_exists = true;
+    let mut b_exists = false;
+    let mut b_has_a_content = false;
+    let mut mv_success = false;
+    let mut del_a_success = false;
+    let mut del_b_success = false;
+
+    for &op in ops {
+        match op {
+            "mv" => {
+                if a_exists && !b_exists {
+                    mv_success = true;
+                    a_exists = false;
+                    b_exists = true;
+                    b_has_a_content = true;
+                }
+            }
+            "delA" => {
+                if a_exists {
+                    del_a_success = true;
+                    a_exists = false;
+                }
+            }
+            "delB" => {
+                if b_exists {
+                    del_b_success = true;
+                    b_exists = false;
+                    b_has_a_content = false;
+                }
+            }
+            _ => panic!("Unknown operation"),
+        }
+    }
+
+    (
+        OperationResult {
+            mv_success,
+            del_a_success,
+            del_b_success,
+        },
+        FsState {
+            a_exists,
+            b_exists,
+            b_has_a_content,
+        },
+    )
+}
+
+fn rename_concurrent_remove_test<F>(creator_fn: F, prefix: &str)
+where
+    F: FnOnce(&str, TestSessionConfig) -> TestSession,
+{
+    let test_session_config = TestSessionConfig {
+        filesystem_config: S3FilesystemConfig {
+            allow_overwrite: true,
+            allow_delete: true,
+            s3_personality: S3Personality::ExpressOneZone,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let test_session = creator_fn(prefix, test_session_config);
+    let test_client = test_session.client();
+    let mount_point = test_session.mount_path().to_owned();
+
+    // Run multiple iterations to increase chance of hitting different orderings
+    for iteration in 0..100 {
+        debug!("Starting iteration {}", iteration);
+
+        // Create initial state: only a.txt exists
+        test_client
+            .put_object("a.txt", b"a_content")
+            .expect("put object should succeed");
+
+        let barrier = Arc::new(Barrier::new(3));
+        let mv_success = Arc::new(AtomicBool::new(false));
+        let del_a_success = Arc::new(AtomicBool::new(false));
+        let del_b_success = Arc::new(AtomicBool::new(false));
+
+        // Thread 1: mv a -> b
+        let b1 = barrier.clone();
+        let mv_s = mv_success.clone();
+        let mp1 = mount_point.clone();
+        let mv_handle = std::thread::spawn(move || {
+            b1.wait();
+            let result = std::fs::rename(mp1.join("a.txt"), mp1.join("b.txt"));
+            mv_s.store(result.is_ok(), Ordering::SeqCst);
+        });
+
+        // Thread 2: remove a
+        let b2 = barrier.clone();
+        let del_a_s = del_a_success.clone();
+        let mp2 = mount_point.clone();
+        let del_a_handle = std::thread::spawn(move || {
+            b2.wait();
+            let result = std::fs::remove_file(mp2.join("a.txt"));
+            del_a_s.store(result.is_ok(), Ordering::SeqCst);
+        });
+
+        // Thread 3: remove b
+        let b3 = barrier.clone();
+        let del_b_s = del_b_success.clone();
+        let mp3 = mount_point.clone();
+        let del_b_handle = std::thread::spawn(move || {
+            b3.wait();
+            let result = std::fs::remove_file(mp3.join("b.txt"));
+            del_b_s.store(result.is_ok(), Ordering::SeqCst);
+        });
+
+        // Wait for all operations to complete
+        mv_handle.join().unwrap();
+        del_a_handle.join().unwrap();
+        del_b_handle.join().unwrap();
+
+        // Collect results
+        let actual_result = OperationResult {
+            mv_success: mv_success.load(Ordering::SeqCst),
+            del_a_success: del_a_success.load(Ordering::SeqCst),
+            del_b_success: del_b_success.load(Ordering::SeqCst),
+        };
+        let actual_fs_state = get_fs_state(&mount_point);
+
+        // Define all possible orderings
+        let possible_orderings = [
+            vec!["mv", "delA", "delB"],
+            vec!["mv", "delB", "delA"],
+            vec!["delA", "mv", "delB"],
+            vec!["delA", "delB", "mv"],
+            vec!["delB", "mv", "delA"],
+            vec!["delB", "delA", "mv"],
+        ];
+
+        // Check if actual result matches any possible ordering
+        let valid_outcome = possible_orderings.iter().any(|ordering| {
+            let (expected_result, expected_state) = simulate_sequence(ordering);
+            expected_result == actual_result && expected_state == actual_fs_state
+        });
+
+        assert!(
+            valid_outcome,
+            "Iteration {}: Result {:?} and state {:?} don't match any valid ordering",
+            iteration, actual_result, actual_fs_state
+        );
+
+        // Cleanup for next iteration
+        let _ = std::fs::remove_file(mount_point.join("a.txt"));
+        let _ = std::fs::remove_file(mount_point.join("b.txt"));
+    }
+}
+
+#[test_case(""; "no prefix")]
+fn rename_concurrent_remove_mock(prefix: &str) {
+    rename_concurrent_remove_test(fuse::mock_session::new, prefix);
+}
+
+#[cfg(feature = "s3express_tests")]
+#[test_case(""; "no prefix")]
+fn rename_concurrent_remove_s3(prefix: &str) {
+    rename_concurrent_remove_test(fuse::s3_session::new, prefix);
+}

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v1.19.0)
+
+* Add support for renaming files using the RenameObject API when mounting directory buckets in S3 Express One Zone. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
 
 ## v1.18.0 (May 30, 2025)
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased (v1.19.0)
 
-* Add support for renaming files using the RenameObject API when mounting directory buckets in S3 Express One Zone. ([#TODO](https://github.com/awslabs/mountpoint-s3/pull/TODO))
+* Add support for renaming files using the RenameObject API when mounting directory buckets in S3 Express One Zone. ([#1468](https://github.com/awslabs/mountpoint-s3/pull/1468))
 
 ## v1.18.0 (May 30, 2025)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.4.0" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.15.0" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.5.0" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 clap = { version = "4.5.27", features = ["derive"] }
@@ -34,6 +34,7 @@ futures = { version = "0.3.31", features = ["thread-pool"] }
 predicates = "3.1.3"
 proptest = "1.6.0"
 proptest-derive = "0.5.1"
+syscalls = "0.6.18"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Introduces support in Mountpoint for renaming files, using the [RenameObject API](https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-s3-express-one-zone-atomic-renaming-objects-api/), which is supported on directory buckets in S3 Express One Zone. 

File rename is enabled automatically when mounting a directory bucket in S3 Express One Zone. In order to replace an existing object through rename, the user must provide the `--allow-overwrite` flag at mount time. More details on Mountpoint's support for rename can be found in the semantics documentation `doc/SEMANTICS.md`. 

### Does this change impact existing behavior?

Yes, this change will enable rename object when a bucket with support for the new API is mounted.

### Does this change need a changelog entry? Does it require a version change?

Changelog entries for the crates are updated. Versions are increased.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
