### PR TITLE
Fewer Iterations in rename tests

### DIFF
--- a/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
@@ -1875,9 +1875,9 @@ fn large_scale_random_rename_test<F>(creator_fn: F, prefix: &str)
 where
     F: FnOnce(&str, TestSessionConfig) -> TestSession,
 {
-    const INITIAL_FILES: usize = 600;
-    const RENAME_OPERATIONS: usize = 250;
-    const MAX_DEPTH: usize = 4;
+    const INITIAL_FILES: usize = 200;
+    const RENAME_OPERATIONS: usize = 50;
+    const MAX_DEPTH: usize = 3;
 
     let test_session_config = TestSessionConfig {
         filesystem_config: S3FilesystemConfig {
@@ -2093,7 +2093,7 @@ where
     let mount_point = test_session.mount_path().to_owned();
 
     // Run multiple iterations to increase chance of hitting different orderings
-    for iteration in 0..100 {
+    for iteration in 0..30 {
         debug!("Starting iteration {}", iteration);
 
         // Create initial state: only a.txt exists


### PR DESCRIPTION
Two randomised tests for rename take > 40 minutes to execute on our CI. This PR reduces those parameters so that integrationn tests should execute faster again.

### Does this change impact existing behavior?

No, only affects integration tests.



### Does this change need a changelog entry? Does it require a version change?

Requires neither changelog entry nor version change, as only tests are affected.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
