### PR TITLE
Move `reader_count` out of inode

### DIFF
--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -63,7 +63,7 @@ where
 {
     /// The file handle has been assigned as a read handle
     Read {
-        handle: ReadHandle,
+        handle: ReadHandle<Client>,
         request: PrefetchGetObject<Client>,
     },
     /// The file handle has been assigned as a write handle

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -404,7 +404,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
 
     /// Create a new handle for a file being read. The handle can be used to update the state of
     /// the inflight read and commit it once finished.
-    pub async fn read(&self, ino: InodeNo) -> Result<ReadHandle, InodeError> {
+    pub async fn read(&self, ino: InodeNo) -> Result<ReadHandle<OC>, InodeError> {
         trace!(?ino, "read");
 
         let inode = self.inner.get(ino)?;
@@ -1187,7 +1187,7 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
         name: ValidName,
         remote: Option<RemoteLookup>,
     ) -> Result<LookedUp, InodeError> {
-        let mut parent_state = parent.get_mut_inode_state()?.state;
+        let mut parent_state = parent.get_mut_inode_state()?;
         let inode = match &parent_state.kind_data {
             InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
             InodeKindData::Directory { children, .. } => children.get(name.as_ref()).cloned(),

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -1399,6 +1399,8 @@ impl InodeMap {
 }
 
 #[derive(Debug, Default)]
+/// A wrapper around a `HashMap<InodeNo, u32>` to manage reader counts for Inodes
+/// Ensures that the inodes are locked for writing while performing these operations.
 struct ReaderCountMap {
     map: HashMap<InodeNo, u32>,
 }

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -242,7 +242,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
             bucket: bucket.to_owned(),
             prefix: prefix.clone(),
             inodes: RwLock::new(inodes),
-            reader_counts: RwLock::new(ReaderCountMap::new()),
+            reader_counts: Default::default(),
             negative_cache,
             next_ino: AtomicU64::new(2),
             mount_time,
@@ -1404,11 +1404,7 @@ struct ReaderCountMap {
 }
 
 impl ReaderCountMap {
-    fn new() -> Self {
-        ReaderCountMap { map: HashMap::new() }
-    }
-
-    fn is_anyone_reading(&self, locked_inode: &InodeLockedForWriting) -> bool {
+    fn has_readers(&self, locked_inode: &InodeLockedForWriting) -> bool {
         self.map.get(&locked_inode.ino).is_some_and(|&count| count > 0)
     }
 

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -44,6 +44,7 @@ use crate::logging;
 use crate::manifest::{Manifest, ManifestEntry, ManifestError};
 use crate::prefix::Prefix;
 use crate::s3::S3Personality;
+use crate::superblock::inode::InodeLockedForWriting;
 use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::{Arc, RwLock, RwLockWriteGuard};
 mod expiry;
@@ -138,14 +139,14 @@ impl<'a> PendingRenameGuard<'a> {
     /// Take an inode and, if (and only if) currently in Remote state, transition into `PendingRename`.
     fn try_transition(inode: &'a Inode) -> Result<Self, InodeError> {
         let mut locked = inode.get_mut_inode_state()?;
-        match locked.write_status {
+        match locked.state.write_status {
             WriteStatus::LocalUnopened | WriteStatus::LocalOpen | WriteStatus::PendingRename => {
                 return Err(InodeError::RenameNotPermittedWhileWriting(inode.err()))
             }
             WriteStatus::Remote => {} // All OK.
         }
 
-        locked.write_status = WriteStatus::PendingRename;
+        locked.state.write_status = WriteStatus::PendingRename;
         drop(locked);
         Ok(PendingRenameGuard { inode: Some(inode) })
     }
@@ -161,8 +162,8 @@ impl Drop for PendingRenameGuard<'_> {
     fn drop(&mut self) {
         if let Some(inode) = self.inode {
             let mut inode_locked = inode.get_mut_inode_state().unwrap();
-            if inode_locked.write_status == WriteStatus::PendingRename {
-                inode_locked.write_status = WriteStatus::Remote;
+            if inode_locked.state.write_status == WriteStatus::PendingRename {
+                inode_locked.state.write_status = WriteStatus::Remote;
             }
         }
     }
@@ -185,7 +186,7 @@ impl<'a> RenameLockGuard<'a> {
 
         if src_ino == dst_ino {
             return Ok(RenameLockGuard {
-                src_parent_lock: source_parent.get_mut_inode_state()?,
+                src_parent_lock: source_parent.get_mut_inode_state()?.state,
                 dst_parent_lock: None,
             });
         }
@@ -195,11 +196,11 @@ impl<'a> RenameLockGuard<'a> {
         // Take read lock
         let ancestor_check = Self::dst_is_ancestor(&superblock_inner.inodes.read().unwrap(), source_parent, dst_ino);
         if ancestor_check || src_ino > dst_ino {
-            dst_parent_lock = Some(dest_parent.get_mut_inode_state()?);
-            src_parent_lock = source_parent.get_mut_inode_state()?;
+            dst_parent_lock = Some(dest_parent.get_mut_inode_state()?.state);
+            src_parent_lock = source_parent.get_mut_inode_state()?.state;
         } else {
-            src_parent_lock = source_parent.get_mut_inode_state()?;
-            dst_parent_lock = Some(dest_parent.get_mut_inode_state()?);
+            src_parent_lock = source_parent.get_mut_inode_state()?.state;
+            dst_parent_lock = Some(dest_parent.get_mut_inode_state()?.state);
         }
         Ok(RenameLockGuard {
             src_parent_lock,
@@ -304,9 +305,9 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
             }
             writing_children.remove(&ino);
 
-            if let Ok(state) = inode.get_inode_state() {
+            if let Ok(locked) = inode.get_inode_state() {
                 metrics::counter!("metadata_cache.inode_forgotten_before_expiry")
-                    .increment(state.stat.is_valid().into());
+                    .increment(locked.state.stat.is_valid().into());
             };
         }
     }
@@ -329,7 +330,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
         logging::record_name(inode.name());
 
         if !force_revalidate {
-            let sync = inode.get_inode_state()?;
+            let sync = inode.get_inode_state()?.state;
             if sync.stat.is_valid() {
                 let stat = sync.stat.clone();
                 drop(sync);
@@ -361,7 +362,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
     ) -> Result<LookedUp, InodeError> {
         let inode = self.inner.get(ino)?;
         logging::record_name(inode.name());
-        let mut sync = inode.get_mut_inode_state()?;
+        let mut sync = inode.get_mut_inode_state()?.state;
 
         if sync.write_status == WriteStatus::Remote {
             return Err(InodeError::SetAttrNotPermittedOnRemoteInode(inode.err()));
@@ -447,7 +448,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
         // Put inode creation in a block so we don't hold the lock on the parent state longer than needed.
         let lookup = {
             let parent_inode = self.inner.get(dir)?;
-            let mut parent_state = parent_inode.get_mut_inode_state()?;
+            let mut parent_state = parent_inode.get_mut_inode_state()?.state;
 
             // Check again for the child now that the parent is locked, since we might have lost to a
             // racing lookup. (It would be nice to lock the parent and *then* lookup, but we'd have to
@@ -498,8 +499,8 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
         }
 
         let parent = self.inner.get(parent_ino)?;
-        let mut parent_state = parent.get_mut_inode_state()?;
-        let mut inode_state = inode.get_mut_inode_state()?;
+        let mut parent_state = parent.get_mut_inode_state()?.state;
+        let mut inode_state = inode.get_mut_inode_state()?.state;
 
         match &inode_state.write_status {
             WriteStatus::LocalOpen => unreachable!("A directory cannot be in Local open state"),
@@ -563,7 +564,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
         }
 
         let write_status = {
-            let inode_state = inode.get_inode_state()?;
+            let inode_state = inode.get_inode_state()?.state;
             inode_state.write_status
         };
 
@@ -597,7 +598,7 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
             }
         }
 
-        let mut parent_state = parent.get_mut_inode_state()?;
+        let mut parent_state = parent.get_mut_inode_state()?.state;
         match &mut parent_state.kind_data {
             InodeKindData::File { .. } => {
                 debug_assert!(false, "inodes never change kind");
@@ -904,11 +905,11 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
             parent: Inode,
             name: &str,
         ) -> Option<Result<LookedUp, InodeError>> {
-            match &parent.get_inode_state().ok()?.kind_data {
+            match &parent.get_inode_state().ok()?.state.kind_data {
                 InodeKindData::File { .. } => unreachable!("parent should be a directory!"),
                 InodeKindData::Directory { children, .. } => {
                     if let Some(inode) = children.get(name) {
-                        let inode_stat = &inode.get_inode_state().ok()?.stat;
+                        let inode_stat = &inode.get_inode_state().ok()?.state.stat;
                         if inode_stat.is_valid() {
                             let lookup = LookedUp {
                                 inode: inode.clone(),
@@ -1149,7 +1150,7 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
         remote: &Option<RemoteLookup>,
     ) -> Result<Option<LookedUp>, InodeError> {
         let parent_state = parent.get_inode_state()?;
-        let inode = match &parent_state.kind_data {
+        let inode = match &parent_state.state.kind_data {
             InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
             InodeKindData::Directory { children, .. } => children.get(name),
         };
@@ -1157,13 +1158,13 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
             (None, None) => Err(InodeError::FileDoesNotExist(name.to_owned(), parent.err())),
             (Some(remote), Some(existing_inode)) => {
                 let mut existing_state = existing_inode.get_mut_inode_state()?;
-                let existing_is_remote = existing_state.write_status == WriteStatus::Remote;
+                let existing_is_remote = existing_state.state.write_status == WriteStatus::Remote;
                 if remote.kind == existing_inode.kind()
                     && existing_is_remote
-                    && existing_state.stat.etag == remote.stat.etag
+                    && existing_state.state.stat.etag == remote.stat.etag
                 {
                     trace!(parent=?existing_inode.parent(), name=?existing_inode.name(), ino=?existing_inode.ino(), "updating inode in place");
-                    existing_state.stat = remote.stat.clone();
+                    existing_state.state.stat = remote.stat.clone();
                     Ok(Some(LookedUp {
                         inode: existing_inode.clone(),
                         stat: remote.stat.clone(),
@@ -1185,7 +1186,7 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
         name: ValidName,
         remote: Option<RemoteLookup>,
     ) -> Result<LookedUp, InodeError> {
-        let mut parent_state = parent.get_mut_inode_state()?;
+        let mut parent_state = parent.get_mut_inode_state()?.state;
         let inode = match &parent_state.kind_data {
             InodeKindData::File { .. } => unreachable!("we know parent is a directory"),
             InodeKindData::Directory { children, .. } => children.get(name.as_ref()).cloned(),
@@ -1208,8 +1209,8 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
                         InodeKind::File => self.config.cache_config.file_ttl,
                         InodeKind::Directory => self.config.cache_config.dir_ttl,
                     };
-                    sync.stat.update_validity(validity);
-                    let stat = sync.stat.clone();
+                    sync.state.stat.update_validity(validity);
+                    let stat = sync.state.stat.clone();
                     drop(sync);
 
                     Ok(LookedUp {
@@ -1237,7 +1238,7 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
                 // remote. Our goal here is for the behavior to be as unsurprising as possible while
                 // being consistent with our stated semantics about implicit directories and how
                 // directories shadow files.
-                let mut existing_state = existing_inode.get_mut_inode_state()?;
+                let mut existing_state = existing_inode.get_mut_inode_state()?.state;
                 let existing_is_remote = existing_state.write_status == WriteStatus::Remote;
 
                 // Remote files are always shadowed by existing local files/directories, so do
@@ -1406,21 +1407,21 @@ impl ReaderCountMap {
         ReaderCountMap { map: HashMap::new() }
     }
 
-    fn is_anyone_reading(&self, ino: InodeNo, _lockguard: &RwLockWriteGuard<'_, InodeState>) -> bool {
-        self.map.get(&ino).is_some_and(|&count| count > 0)
+    fn is_anyone_reading(&self, locked_inode: &InodeLockedForWriting) -> bool {
+        self.map.get(&locked_inode.ino).is_some_and(|&count| count > 0)
     }
 
-    fn increase_reader_count(&mut self, ino: InodeNo, _lockguard: &RwLockWriteGuard<'_, InodeState>) {
-        *self.map.entry(ino).or_insert(0) += 1;
+    fn increase_reader_count(&mut self, locked_inode: &InodeLockedForWriting) {
+        *self.map.entry(locked_inode.ino).or_insert(0) += 1;
     }
 
-    fn decrease_reader_count(&mut self, ino: InodeNo, _lockguard: &RwLockWriteGuard<'_, InodeState>) {
-        if let Some(count) = self.map.get_mut(&ino) {
+    fn decrease_reader_count(&mut self, locked_inode: &InodeLockedForWriting) {
+        if let Some(count) = self.map.get_mut(&locked_inode.ino) {
             if *count > 0 {
                 *count -= 1;
             }
             if *count == 0 {
-                self.map.remove(&ino);
+                self.map.remove(&locked_inode.ino);
             }
         }
     }
@@ -1996,6 +1997,7 @@ mod tests {
                 .inode
                 .get_inode_state()
                 .expect("should get Inode state with read lock")
+                .state
                 .write_status,
             WriteStatus::LocalUnopened
         );
@@ -2200,7 +2202,8 @@ mod tests {
         let parent = superblock.inner.get(FUSE_ROOT_INODE).unwrap();
         let parent_state = parent
             .get_inode_state()
-            .expect("should get parent state with read lock");
+            .expect("should get parent state with read lock")
+            .state;
         match &parent_state.kind_data {
             InodeKindData::File {} => unreachable!("Parent can only be a Directory"),
             InodeKindData::Directory {
@@ -2318,6 +2321,7 @@ mod tests {
                         .inode
                         .get_inode_state()
                         .expect("should get inode state with read lock")
+                        .state
                         .write_status,
                     WriteStatus::LocalUnopened
                 );

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -611,14 +611,14 @@ impl<OC: ObjectClient + Send + Sync> WriteHandle<OC> {
 
 /// Handle for a file being read
 #[derive(Debug)]
-pub struct ReadHandle {
-    inner: Arc<SuperblockInner>,
+pub struct ReadHandle<OC: ObjectClient + Send + Sync> {
+    inner: Arc<SuperblockInner<OC>>,
     inode: Inode,
 }
 
-impl ReadHandle {
+impl<OC: ObjectClient + Send + Sync> ReadHandle<OC> {
     /// Create a new read handle
-    pub(super) fn new(inner: Arc<SuperblockInner>, inode: Inode) -> Result<Self, InodeError> {
+    pub(super) fn new(inner: Arc<SuperblockInner<OC>>, inode: Inode) -> Result<Self, InodeError> {
         let locked_inode = inode.get_mut_inode_state()?;
         if !matches!(
             locked_inode.write_status,

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -525,7 +525,7 @@ impl<OC: ObjectClient + Send + Sync> WriteHandle<OC> {
         is_truncate: bool,
     ) -> Result<Self, InodeError> {
         let mut state = inode.get_mut_inode_state()?;
-        if inner.reader_counts.read().unwrap().is_anyone_reading(&state) {
+        if inner.reader_counts.read().unwrap().has_readers(&state) {
             return Err(InodeError::InodeNotWritableWhileReading(inode.err()));
         }
 

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -165,7 +165,6 @@ impl Inode {
                 write_status: WriteStatus::Remote,
                 kind_data: InodeKindData::default_for(InodeKind::Directory),
                 lookup_count: 1,
-                reader_count: 0,
             },
         )
     }
@@ -199,7 +198,6 @@ impl Inode {
             // We can NOT protect from later changes to the old inode's lookup count
             // by concurrent operations, when the VFS lock does not prohibit this.
             lookup_count: old_inode_state.lookup_count,
-            reader_count: 0,
         };
 
         Ok(Self::new(self.ino(), new_parent, new_key, prefix, new_inode_state))
@@ -269,8 +267,6 @@ pub(super) struct InodeState {
     /// Number of references the kernel is holding to the [Inode].
     /// A number of FS operations increment this, while the kernel calls [`Inode::forget(ino, n)`] to decrement.
     lookup_count: u64,
-    /// Number of active prefetching streams on the [Inode].
-    reader_count: u64,
 }
 
 impl InodeState {
@@ -280,7 +276,6 @@ impl InodeState {
             kind_data: InodeKindData::default_for(kind),
             write_status,
             lookup_count: 0,
-            reader_count: 0,
         }
     }
 }
@@ -480,7 +475,12 @@ impl<OC: ObjectClient + Send + Sync> WriteHandle<OC> {
         is_truncate: bool,
     ) -> Result<Self, InodeError> {
         let mut state = inode.get_mut_inode_state()?;
-        if state.reader_count > 0 {
+        if inner
+            .reader_counts
+            .read()
+            .unwrap()
+            .is_anyone_reading(inode.ino(), &state)
+        {
             return Err(InodeError::InodeNotWritableWhileReading(inode.err()));
         }
         match state.write_status {
@@ -572,26 +572,35 @@ impl<OC: ObjectClient + Send + Sync> WriteHandle<OC> {
 /// Handle for a file being read
 #[derive(Debug)]
 pub struct ReadHandle {
+    inner: Arc<SuperblockInner>,
     inode: Inode,
 }
 
 impl ReadHandle {
     /// Create a new read handle
-    pub(super) fn new(inode: Inode) -> Result<Self, InodeError> {
-        let mut state = inode.get_mut_inode_state()?;
+    pub(super) fn new(inner: Arc<SuperblockInner>, inode: Inode) -> Result<Self, InodeError> {
+        let state = inode.get_mut_inode_state()?;
         if !matches!(state.write_status, WriteStatus::Remote | WriteStatus::PendingRename) {
             return Err(InodeError::InodeNotReadableWhileWriting(inode.err()));
         }
-        state.reader_count += 1;
+        inner
+            .reader_counts
+            .write()
+            .unwrap()
+            .increase_reader_count(inode.ino(), &state);
         drop(state);
-        Ok(Self { inode })
+        Ok(Self { inner, inode })
     }
 
     /// Update status of the inode to reflect the read being finished
     pub fn finish(self) -> Result<(), InodeError> {
         // Decrease reader count for the inode
-        let mut state = self.inode.get_mut_inode_state()?;
-        state.reader_count -= 1;
+        let state = self.inode.get_mut_inode_state()?;
+        self.inner
+            .reader_counts
+            .write()
+            .unwrap()
+            .decrease_reader_count(self.inode.ino(), &state);
         Ok(())
     }
 }
@@ -631,7 +640,6 @@ mod tests {
                 stat: InodeStat::for_file(0, OffsetDateTime::now_utc(), None, None, None, Default::default()),
                 kind_data: InodeKindData::File {},
                 lookup_count: 5,
-                reader_count: 0,
             },
         );
         superblock.inner.inodes.write().unwrap().insert(ino, inode.clone());
@@ -771,7 +779,6 @@ mod tests {
                     write_status: WriteStatus::Remote,
                     kind_data: InodeKindData::File {},
                     lookup_count: 1,
-                    reader_count: 0,
                 }),
             }),
         };
@@ -825,7 +832,6 @@ mod tests {
                     stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, None, None, Default::default()),
                     kind_data: InodeKindData::File {},
                     lookup_count: 5,
-                    reader_count: 0,
                 }),
             }),
         };

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -75,12 +75,12 @@ impl<OC: ObjectClient + Send + Sync> ReaddirHandle<OC> {
     ) -> Result<Self, InodeError> {
         let local_entries = {
             let inode = inner.get(dir_ino)?;
-            let kind_data = &inode.get_inode_state()?.state.kind_data;
+            let kind_data = &inode.get_inode_state()?.kind_data;
             let local_files = match kind_data {
                 InodeKindData::File { .. } => return Err(InodeError::NotADirectory(inode.err())),
                 InodeKindData::Directory { writing_children, .. } => writing_children.iter().map(|ino| {
                     let inode = inner.get(*ino)?;
-                    let stat = inode.get_inode_state()?.state.stat.clone();
+                    let stat = inode.get_inode_state()?.stat.clone();
                     Ok(ReaddirEntry::LocalInode {
                         lookup: LookedUp { inode, stat },
                     })

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -75,12 +75,12 @@ impl<OC: ObjectClient + Send + Sync> ReaddirHandle<OC> {
     ) -> Result<Self, InodeError> {
         let local_entries = {
             let inode = inner.get(dir_ino)?;
-            let kind_data = &inode.get_inode_state()?.kind_data;
+            let kind_data = &inode.get_inode_state()?.state.kind_data;
             let local_files = match kind_data {
                 InodeKindData::File { .. } => return Err(InodeError::NotADirectory(inode.err())),
                 InodeKindData::Directory { writing_children, .. } => writing_children.iter().map(|ino| {
                     let inode = inner.get(*ino)?;
-                    let stat = inode.get_inode_state()?.stat.clone();
+                    let stat = inode.get_inode_state()?.state.stat.clone();
                     Ok(ReaddirEntry::LocalInode {
                         lookup: LookedUp { inode, stat },
                     })


### PR DESCRIPTION
Moves the reader count out of the inode and instead stores the reader counts for all inodes with non-zero reader count in a HashMap (that is protected by a lock).

### Does this change impact existing behavior?

This should not have breaking changes, it could potentially reduce unlikely issues with the reader count getting messed up in highly concurrent scenarios involving re-creation of inodes with the same number.


### Does this change need a changelog entry? Does it require a version change?

Does not need a Changelog entry or version change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
