### PR TITLE
Move object client into Superblock

### DIFF
--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -57,12 +57,12 @@ where
 {
     config: S3FilesystemConfig,
     client: Client,
-    superblock: Superblock,
+    superblock: Superblock<Client>,
     prefetcher: Prefetcher<Client>,
     uploader: Uploader<Client>,
     bucket: String,
     next_handle: AtomicU64,
-    dir_handles: AsyncRwLock<HashMap<u64, Arc<DirHandle>>>,
+    dir_handles: AsyncRwLock<HashMap<u64, Arc<DirHandle<Client>>>>,
     file_handles: AsyncRwLock<HashMap<u64, Arc<FileHandle<Client>>>>,
 }
 
@@ -163,7 +163,7 @@ where
             #[cfg(feature = "manifest")]
             manifest: config.manifest.clone(),
         };
-        let superblock = Superblock::new(bucket, prefix, superblock_config);
+        let superblock = Superblock::new(client.clone(), bucket, prefix, superblock_config);
         let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), config.mem_limit));
         let prefetcher = prefetch_builder.build(runtime.clone(), mem_limiter.clone(), config.prefetcher_config);
         let uploader = Uploader::new(
@@ -304,7 +304,7 @@ where
 
         let lookup = self
             .superblock
-            .lookup(&self.client, parent, name)
+            .lookup(parent, name)
             .await
             .map_err(|err| match err {
                 InodeError::FileDoesNotExist(_, _) => {
@@ -324,7 +324,7 @@ where
     pub async fn getattr(&self, ino: InodeNo) -> Result<Attr, Error> {
         trace!("fs:getattr with ino {:?}", ino);
 
-        let lookup = self.superblock.getattr(&self.client, ino, false).await?;
+        let lookup = self.superblock.getattr(ino, false).await?;
         let attr = self.make_attr(&lookup);
 
         Ok(Attr {
@@ -349,7 +349,7 @@ where
             mtime,
             size
         );
-        let setattr_result = self.superblock.setattr(&self.client, ino, atime, mtime).await;
+        let setattr_result = self.superblock.setattr(ino, atime, mtime).await;
         let lookup = match (setattr_result, size) {
             (Ok(lookup), _) => lookup,
             (Err(InodeError::SetAttrNotPermittedOnRemoteInode(_)), Some(0)) if !self.config.allow_overwrite => {
@@ -389,7 +389,7 @@ where
         }
 
         let force_revalidate = !self.config.cache_config.serve_lookup_from_cache || direct_io;
-        let lookup = self.superblock.getattr(&self.client, ino, force_revalidate).await?;
+        let lookup = self.superblock.getattr(ino, force_revalidate).await?;
 
         match lookup.inode.kind() {
             InodeKind::Directory => return Err(InodeError::IsDirectory(lookup.inode.err()).into()),
@@ -495,10 +495,7 @@ where
             ));
         }
 
-        let lookup = self
-            .superblock
-            .create(&self.client, parent, name, InodeKind::File)
-            .await?;
+        let lookup = self.superblock.create(parent, name, InodeKind::File).await?;
         debug!(ino = lookup.inode.ino(), "new inode created");
         let attr = self.make_attr(&lookup);
         Ok(Entry {
@@ -509,10 +506,7 @@ where
     }
 
     pub async fn mkdir(&self, parent: InodeNo, name: &OsStr, _mode: libc::mode_t, _umask: u32) -> Result<Entry, Error> {
-        let lookup = self
-            .superblock
-            .create(&self.client, parent, name, InodeKind::Directory)
-            .await?;
+        let lookup = self.superblock.create(parent, name, InodeKind::Directory).await?;
         let attr = self.make_attr(&lookup);
         Ok(Entry {
             ttl: lookup.validity(),
@@ -563,8 +557,8 @@ where
     }
 
     /// Creates a new ReaddirHandle for the provided parent and default page size
-    async fn readdir_handle(&self, parent: InodeNo) -> Result<ReaddirHandle, InodeError> {
-        self.superblock.readdir(&self.client, parent, 1000).await
+    async fn readdir_handle(&self, parent: InodeNo) -> Result<ReaddirHandle<Client>, InodeError> {
+        self.superblock.readdir(parent, 1000).await
     }
 
     pub async fn opendir(&self, parent: InodeNo, _flags: i32) -> Result<Opened, Error> {
@@ -676,7 +670,7 @@ where
         }
 
         impl<R: DirectoryReplier> Reply<R> {
-            async fn finish(self, offset: i64, dir_handle: &DirHandle) -> R {
+            async fn finish<O: ObjectClient + Send + Sync>(self, offset: i64, dir_handle: &DirHandle<O>) -> R {
                 *dir_handle.last_response.lock().await = Some((offset, self.entries));
                 self.reply
             }
@@ -695,7 +689,7 @@ where
         let mut reply = Reply { reply, entries: vec![] };
 
         if dir_handle.offset() < 1 {
-            let lookup = self.superblock.getattr(&self.client, parent, false).await?;
+            let lookup = self.superblock.getattr(parent, false).await?;
             let attr = self.make_attr(&lookup);
             let entry = DirectoryEntry {
                 ino: parent,
@@ -712,10 +706,7 @@ where
             dir_handle.next_offset();
         }
         if dir_handle.offset() < 2 {
-            let lookup = self
-                .superblock
-                .getattr(&self.client, readdir_handle.parent(), false)
-                .await?;
+            let lookup = self.superblock.getattr(readdir_handle.parent(), false).await?;
             let attr = self.make_attr(&lookup);
             let entry = DirectoryEntry {
                 ino: readdir_handle.parent(),
@@ -872,7 +863,7 @@ where
     }
 
     pub async fn rmdir(&self, parent_ino: InodeNo, name: &OsStr) -> Result<(), Error> {
-        self.superblock.rmdir(&self.client, parent_ino, name).await?;
+        self.superblock.rmdir(parent_ino, name).await?;
         Ok(())
     }
 
@@ -891,7 +882,7 @@ where
                 "Deletes are disabled. Use '--allow-delete' mount option to enable it."
             ));
         }
-        Ok(self.superblock.unlink(&self.client, parent_ino, name).await?)
+        Ok(self.superblock.unlink(parent_ino, name).await?)
     }
 
     pub async fn statfs(&self, _ino: InodeNo) -> Result<StatFs, Error> {
@@ -944,14 +935,7 @@ where
         }
 
         self.superblock
-            .rename(
-                &self.client,
-                old_parent_ino,
-                old_name,
-                new_parent_ino,
-                new_name,
-                overwrites_allowed,
-            )
+            .rename(old_parent_ino, old_name, new_parent_ino, new_name, overwrites_allowed)
             .await?;
         tracing::trace!("rename complete");
         Ok(())

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -56,7 +56,6 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     config: S3FilesystemConfig,
-    client: Client,
     superblock: Superblock<Client>,
     prefetcher: Prefetcher<Client>,
     uploader: Uploader<Client>,
@@ -178,7 +177,6 @@ where
 
         Self {
             config,
-            client,
             superblock,
             prefetcher,
             uploader,
@@ -724,7 +722,7 @@ where
         }
 
         loop {
-            let next = match readdir_handle.next(&self.client).await? {
+            let next = match readdir_handle.next().await? {
                 None => return Ok(reply.finish(offset, &dir_handle).await),
                 Some(next) => next,
             };

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -82,7 +82,7 @@ where
     ) -> Result<FileHandleState<Client>, Error> {
         let is_truncate = flags.contains(OpenFlags::O_TRUNC);
         let write_mode = fs.config.write_mode();
-        let handle = fs.superblock.write(&fs.client, ino, &write_mode, is_truncate).await?;
+        let handle = fs.superblock.write(ino, &write_mode, is_truncate).await?;
         let bucket = fs.bucket.clone();
         let key = fs.superblock.full_key_for_inode(&lookup.inode);
         let handle = if write_mode.incremental_upload {
@@ -122,7 +122,7 @@ where
                 "objects in flexible retrieval storage classes are not accessible",
             ));
         }
-        let handle = fs.superblock.read(&fs.client, lookup.inode.ino()).await?;
+        let handle = fs.superblock.read(lookup.inode.ino()).await?;
         let full_key = fs.superblock.full_key_for_inode(&lookup.inode);
         let object_size = lookup.stat.size as u64;
         let etag = match &lookup.stat.etag {

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -14,16 +14,16 @@ use crate::upload::{AppendUploadRequest, UploadRequest};
 use super::{DirectoryEntry, Error, InodeNo, OpenFlags, S3Filesystem, ToErrno};
 
 #[derive(Debug)]
-pub struct DirHandle {
+pub struct DirHandle<OC: ObjectClient + Send + Sync> {
     #[allow(unused)]
     ino: InodeNo,
-    pub handle: AsyncMutex<ReaddirHandle>,
+    pub handle: AsyncMutex<ReaddirHandle<OC>>,
     offset: AtomicI64,
     pub last_response: AsyncMutex<Option<(i64, Vec<DirectoryEntry>)>>,
 }
 
-impl DirHandle {
-    pub fn new(ino: InodeNo, readdir_handle: ReaddirHandle) -> Self {
+impl<OC: ObjectClient + Send + Sync> DirHandle<OC> {
+    pub fn new(ino: InodeNo, readdir_handle: ReaddirHandle<OC>) -> Self {
         Self {
             ino,
             handle: AsyncMutex::new(readdir_handle),
@@ -138,16 +138,16 @@ where
 }
 
 #[derive(Debug)]
-pub enum UploadState<Client: ObjectClient> {
+pub enum UploadState<Client: ObjectClient + Send + Sync> {
     AppendInProgress {
         request: AppendUploadRequest<Client>,
-        handle: WriteHandle,
+        handle: WriteHandle<Client>,
         initial_etag: Option<ETag>,
         written_bytes: usize,
     },
     MPUInProgress {
         request: UploadRequest<Client>,
-        handle: WriteHandle,
+        handle: WriteHandle<Client>,
     },
     Completed,
     // Remember the failure reason to respond to retries
@@ -321,7 +321,11 @@ where
         }
     }
 
-    async fn complete_upload(upload: UploadRequest<Client>, key: &str, handle: WriteHandle) -> Result<(), Error> {
+    async fn complete_upload(
+        upload: UploadRequest<Client>,
+        key: &str,
+        handle: WriteHandle<Client>,
+    ) -> Result<(), Error> {
         let size = upload.size();
         let (put_result, etag) = match upload.complete().await {
             Ok(result) => {
@@ -340,7 +344,7 @@ where
     async fn complete_append(
         upload: AppendUploadRequest<Client>,
         key: &str,
-        handle: WriteHandle,
+        handle: WriteHandle<Client>,
         initial_etag: Option<ETag>,
     ) -> Result<(), Error> {
         match Self::commit_append(upload, key).await {
@@ -369,7 +373,7 @@ where
         }
     }
 
-    fn finish(handle: WriteHandle, etag: Option<ETag>) {
+    fn finish(handle: WriteHandle<Client>, etag: Option<ETag>) {
         if let Err(err) = handle.finish(etag) {
             // Log the issue but still return put_result.
             error!(?err, "error updating the inode status");

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -57,17 +57,17 @@ use super::{InodeError, InodeKind, InodeKindData, InodeNo, InodeStat, LookedUp, 
 
 /// Handle for an inflight directory listing
 #[derive(Debug)]
-pub struct ReaddirHandle {
-    inner: Arc<SuperblockInner>,
+pub struct ReaddirHandle<OC: ObjectClient + Send + Sync> {
+    inner: Arc<SuperblockInner<OC>>,
     dir_ino: InodeNo,
     parent_ino: InodeNo,
     iter: AsyncMutex<ReaddirIter>,
     readded: Mutex<Option<LookedUp>>,
 }
 
-impl ReaddirHandle {
+impl<OC: ObjectClient + Send + Sync> ReaddirHandle<OC> {
     pub(super) fn new(
-        inner: Arc<SuperblockInner>,
+        inner: Arc<SuperblockInner<OC>>,
         dir_ino: InodeNo,
         parent_ino: InodeNo,
         full_path: String,
@@ -128,7 +128,7 @@ impl ReaddirHandle {
     /// Return the next inode for the directory stream. If the stream is finished, returns
     /// `Ok(None)`. Does not increment the lookup count of the returned inodes: the caller
     /// is responsible for calling [`remember()`] if required.
-    pub async fn next<OC: ObjectClient>(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
+    pub async fn next(&self, client: &OC) -> Result<Option<LookedUp>, InodeError> {
         if let Some(readded) = self.readded.lock().unwrap().take() {
             return Ok(Some(readded));
         }
@@ -212,7 +212,7 @@ impl ReaddirHandle {
     }
 
     #[cfg(test)]
-    pub(super) async fn collect<OC: ObjectClient>(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
+    pub(super) async fn collect(&self, client: &OC) -> Result<Vec<LookedUp>, InodeError> {
         let mut result = vec![];
         while let Some(entry) = self.next(client).await? {
             result.push(entry);


### PR DESCRIPTION
This PR moves the client into the Superblock, thus a superblock will always interact with the same instantiation of an `ObjectClient + Send + Sync`. 

### Does this change impact existing behavior?

No, this change does not impact existing behaviour, as is only an internal re-organisation. 

### Does this change need a changelog entry? Does it require a version change?

No, does not need a Changelog entry, as it only moves around where we store the client.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
