### PR TITLE
Add unused `CredentialsProvider::new_delegate` provider

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased (v0.16.1)
+## Unreleased (v0.17.0)
 
 * Update to latest CRT dependencies.
+* Add `CredentialsProvider::new_delegate`, which can be used to implement custom credential providers in Rust.
 
 ## v0.16.0 (Jun 19, 2025)
 

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -18,8 +18,9 @@ use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
 use mountpoint_s3_client::types::GetObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
+use mountpoint_s3_crt::auth::credentials::{Credentials, CredentialsProvider, CredentialsProviderStaticOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
+use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 
 /// Test creating a client with the static credentials provider
 #[tokio::test]
@@ -369,6 +370,54 @@ rusty_fork_test! {
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         runtime.block_on(test_credential_process_behind_source_profile_async());
     }
+}
+
+/// Test creating a client with the static credentials provider
+#[tokio::test]
+async fn test_delegate_provider() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_delegate_provider");
+
+    let key = format!("{prefix}/hello");
+    let body = b"hello world!";
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(Bytes::from_static(body)))
+        .send()
+        .await
+        .unwrap();
+
+    let event_loop_group = EventLoopGroup::new_default(&Allocator::default(), None, || {}).unwrap();
+
+    // Get some static credentials by just using the SDK's default provider, which we know works
+    let credentials = get_sdk_default_chain_creds().await;
+
+    // Build a S3CrtClient that uses a delegate credentials provider with the creds we just got, passing through static credentials
+    let provider = CredentialsProvider::new_delegate(&Allocator::default(), event_loop_group, move || {
+        let credentials = credentials.clone();
+        async move {
+            let credentials = Credentials::build_credentials(
+                credentials.access_key_id(),
+                credentials.secret_access_key(),
+                credentials.session_token(),
+                credentials.expiry(),
+            );
+            Some(credentials)
+        }
+    })
+    .unwrap();
+    let config = S3ClientConfig::new()
+        .auth_config(S3ClientAuthConfig::Provider(provider))
+        .endpoint_config(get_test_endpoint_config());
+    let client = S3CrtClient::new(config).unwrap();
+
+    let result = client
+        .get_object(&bucket, &key, &GetObjectParams::new())
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body[..]).await;
 }
 
 /// Test using a client with scoped-down credentials

--- a/mountpoint-s3-crt/src/auth/credentials.rs
+++ b/mountpoint-s3-crt/src/auth/credentials.rs
@@ -1,22 +1,29 @@
 //! AWS credentials providers
 
-use std::fmt::Debug;
-use std::ptr::NonNull;
-
 use mountpoint_s3_crt_sys::{
-    aws_credentials_provider, aws_credentials_provider_acquire, aws_credentials_provider_cached_options,
-    aws_credentials_provider_chain_default_options, aws_credentials_provider_new_anonymous,
+    aws_credentials, aws_credentials_new, aws_credentials_provider, aws_credentials_provider_acquire,
+    aws_credentials_provider_cached_options, aws_credentials_provider_chain_default_options,
+    aws_credentials_provider_delegate_options, aws_credentials_provider_new_anonymous,
     aws_credentials_provider_new_cached, aws_credentials_provider_new_chain_default,
-    aws_credentials_provider_new_profile, aws_credentials_provider_new_static,
+    aws_credentials_provider_new_delegate, aws_credentials_provider_new_profile, aws_credentials_provider_new_static,
     aws_credentials_provider_profile_options, aws_credentials_provider_release,
-    aws_credentials_provider_static_options,
+    aws_credentials_provider_static_options, aws_credentials_release, aws_on_get_credentials_callback_fn, AWS_OP_ERR,
+    AWS_OP_SUCCESS,
 };
+use std::ffi::OsStr;
+use std::fmt::Debug;
+use std::future::Future;
+use std::ptr::NonNull;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::auth::auth_library_init;
 use crate::common::allocator::Allocator;
 use crate::common::error::Error;
 use crate::io::channel_bootstrap::ClientBootstrap;
-use crate::{CrtError as _, ToAwsByteCursor as _};
+use crate::io::event_loop::EventLoopGroup;
+use crate::io::futures::FutureSpawner;
+use crate::{CrtError as _, ToAwsByteCursor};
 
 /// Options for creating a default credentials provider
 #[derive(Debug)]
@@ -54,11 +61,113 @@ impl Debug for CredentialsProviderStaticOptions<'_> {
     }
 }
 
+/// Options for creating an owned set of credentials
+pub struct Credentials {
+    credentials: *mut aws_credentials,
+    expiration: u64,
+}
+
+impl Debug for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field("access_key_id", &"** redacted **")
+            .field("secret_access_key", &"** redacted **")
+            .field("expiration", &self.expiration)
+            .finish()
+    }
+}
+
+impl Credentials {
+    /// Builds some credentials from access_key, secret_access_key, and an optional session token + expiration.
+    pub fn build_credentials<S: AsRef<OsStr>>(
+        access_key_id: S,
+        secret_access_key: S,
+        session_token: Option<S>,
+        expiration: Option<SystemTime>,
+    ) -> Credentials {
+        // SAFETY: aws_credentials_new copies all the arguments and takes ownership of them.
+        unsafe {
+            let session_token = session_token
+                .map(|session_token| session_token.as_aws_byte_cursor())
+                .unwrap_or_default();
+            let expiration = expiration
+                .map(|expiration| {
+                    let since_epoch = expiration.duration_since(UNIX_EPOCH).expect("Should be after epoch");
+                    since_epoch.as_secs()
+                })
+                .unwrap_or(u64::MAX);
+            let aws_credentials = aws_credentials_new(
+                Allocator::default().inner.as_ptr(),
+                access_key_id.as_aws_byte_cursor(),
+                secret_access_key.as_aws_byte_cursor(),
+                session_token,
+                expiration,
+            );
+            Credentials {
+                credentials: aws_credentials,
+                expiration,
+            }
+        }
+    }
+
+    fn as_ptr(&self) -> &*mut aws_credentials {
+        &self.credentials
+    }
+}
+
+impl Drop for Credentials {
+    fn drop(&mut self) {
+        // SAFETY: There's at least one reference until here
+        unsafe {
+            aws_credentials_release(self.credentials);
+        }
+    }
+}
+
+type OnGetCredentialsCallbackFn =
+    unsafe extern "C" fn(credentials: *mut aws_credentials, error_code: libc::c_int, user_data: *mut libc::c_void);
+
+struct DelegateOnGetCredentialsReplier {
+    callback: OnGetCredentialsCallbackFn,
+    user_data: *mut libc::c_void,
+}
+
+impl DelegateOnGetCredentialsReplier {
+    fn reply_with_credentials(&self, credentials: Option<Credentials>) {
+        let (aws_creds, error_code) = match &credentials {
+            Some(credentials) => (credentials.as_ptr(), AWS_OP_SUCCESS),
+            None => (&std::ptr::null_mut(), AWS_OP_ERR),
+        };
+        // SAFETY: user_data is passed through without modification, and is thread-safe.
+        // aws_creds is a raw pointer to the credentials, and is only used whilst credentials lives.
+        // credentials is reference counted, and knows how to decrement a reference when it's dropped.
+        // `self.callback` can take ownership if it wants by incrementing the reference counter.
+        unsafe {
+            (self.callback)(*aws_creds, error_code, self.user_data);
+        }
+        drop(credentials);
+    }
+}
+
+// SAFETY: Whilst the CRT doesn't explicitly say `callback_user_data` and `callback` are usable between threads,
+// the sts provider (and others) use the `user_data` in other threads via an event loop.
+unsafe impl Send for DelegateOnGetCredentialsReplier {}
+
+type OnGetCredentials = Box<dyn Fn(DelegateOnGetCredentialsReplier) + Send + Sync + 'static>;
+struct OnDelegateCallback(OnGetCredentials);
+
+impl Debug for OnDelegateCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnDelegateCallback").finish()
+    }
+}
+
 /// A credentials provider is an object that has an asynchronous query function for retrieving AWS
 /// credentials
 #[derive(Debug)]
 pub struct CredentialsProvider {
     pub(crate) inner: NonNull<aws_credentials_provider>,
+    on_delegate_callback: Option<Arc<OnDelegateCallback>>,
 }
 
 // SAFETY: aws_credentials_provider is thread-safe.
@@ -84,7 +193,10 @@ impl CredentialsProvider {
             aws_credentials_provider_new_chain_default(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
         };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            on_delegate_callback: None,
+        })
     }
 
     /// Creates the anonymous credential provider.
@@ -97,7 +209,10 @@ impl CredentialsProvider {
             aws_credentials_provider_new_anonymous(allocator.inner.as_ptr(), std::ptr::null_mut()).ok_or_last_error()?
         };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            on_delegate_callback: None,
+        })
     }
 
     /// Creates the profile credential provider.
@@ -133,7 +248,10 @@ impl CredentialsProvider {
             cached_provider
         };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            on_delegate_callback: None,
+        })
     }
 
     /// Creates a static credential provider that always returns the given credentials
@@ -155,7 +273,50 @@ impl CredentialsProvider {
             aws_credentials_provider_new_static(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
         };
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            on_delegate_callback: None,
+        })
+    }
+
+    /// Creates a delegate credential provider that always returns the given credentials
+    pub fn new_delegate<F, Fut>(
+        allocator: &Allocator,
+        event_loop_group: EventLoopGroup,
+        callback: F,
+    ) -> Result<Self, Error>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Option<Credentials>> + Send,
+    {
+        auth_library_init(allocator);
+        let user_callback_arc = Arc::new(callback);
+        let future_spawner = move |credentials_replier: DelegateOnGetCredentialsReplier| {
+            let user_callback_inner = user_callback_arc.clone();
+            event_loop_group.spawn_future(async move {
+                let credentials = user_callback_inner().await;
+                credentials_replier.reply_with_credentials(credentials);
+            });
+        };
+
+        let callback_wrapper = Arc::new(OnDelegateCallback(Box::new(future_spawner)));
+        let callback_raw = Arc::as_ptr(&callback_wrapper);
+        let inner_options = aws_credentials_provider_delegate_options {
+            get_credentials: Some(delegate_callback),
+            delegate_user_data: callback_raw as *mut libc::c_void,
+            ..Default::default()
+        };
+
+        // SAFETY: aws_credentials_provider_new_delegate keeps pointers to `delegate_callback` and `callback_raw`.
+        // `delegate_callback` is a constant pointer, and callback_raw is kept alive through ownership of callback_wrapper in Self
+        let inner = unsafe {
+            aws_credentials_provider_new_delegate(allocator.inner.as_ptr(), &inner_options).ok_or_last_error()?
+        };
+
+        Ok(Self {
+            inner,
+            on_delegate_callback: Some(callback_wrapper),
+        })
     }
 }
 
@@ -166,7 +327,10 @@ impl Clone for CredentialsProvider {
             aws_credentials_provider_acquire(self.inner.as_ptr());
         }
 
-        Self { inner: self.inner }
+        Self {
+            inner: self.inner,
+            on_delegate_callback: self.on_delegate_callback.clone(),
+        }
     }
 }
 
@@ -177,5 +341,25 @@ impl Drop for CredentialsProvider {
         unsafe {
             aws_credentials_provider_release(self.inner.as_ptr());
         }
+    }
+}
+
+unsafe extern "C" fn delegate_callback(
+    delegate_user_data: *mut libc::c_void,
+    callback: aws_on_get_credentials_callback_fn,
+    callback_user_data: *mut libc::c_void,
+) -> i32 {
+    let on_delegate_cb = delegate_user_data as *mut OnDelegateCallback;
+
+    match callback {
+        Some(callback) => {
+            let on_get_credentials_replier = DelegateOnGetCredentialsReplier {
+                callback,
+                user_data: callback_user_data,
+            };
+            (*on_delegate_cb).0(on_get_credentials_replier);
+            AWS_OP_SUCCESS
+        }
+        None => AWS_OP_ERR,
     }
 }


### PR DESCRIPTION
Add unused `CredentialsProvider::new_delegate` provider.

`new_delegate` takes a closure which returns a future for credentials. This can be used to implement other credentials providers in the future.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Changelog entry written for mountpoint-s3-client.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
