### PR TITLE
Avoid copy of data returned by GetObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Reduce memory fragmentation and peak usage by avoiding copying data returned by GetObject into newly allocated buffers.
   Callers of the `get_object` method are now responsible for returning the buffers to the internal memory pool by dropping
-  the received `Bytes` instances after use. Failure to do so may eventually lead to reduced throughput when the memory pool
-  reaches capacity.
+  the received `Bytes` instances after use. Failure to do so may eventually lead to reduced or zero throughput when the
+  memory pool reaches capacity.
   ([#1481](https://github.com/awslabs/mountpoint-s3/pull/1481))
 
 ## v0.16.0 (Jun 19, 2025)

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,6 +1,12 @@
-## Unreleased (v0.16.1)
+## Unreleased (v0.17.0)
 
-* Update to latest CRT dependencies.
+### Breaking changes
+
+* Reduce memory fragmentation and peak usage by avoiding copying data returned by GetObject into newly allocated buffers.
+  Callers of the `get_object` method are now responsible for returning the buffers to the internal memory pool by dropping
+  the received `Bytes` instances after use. Failure to do so may eventually lead to reduced throughput when the memory pool
+  reaches capacity.
+  ([#1481](https://github.com/awslabs/mountpoint-s3/pull/1481))
 
 ## v0.16.0 (Jun 19, 2025)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -60,6 +60,7 @@ supports-color = "3.0.2"
 built = { version = "0.7.5", features = ["git2"] }
 
 [features]
+restore_buffer_copy = []
 mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand", "dep:rand_chacha"]
 # Features for choosing tests
 s3_tests = []

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -26,6 +26,7 @@ pub use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 use mountpoint_s3_crt::io::host_resolver::{AddressKinds, HostResolver, HostResolverDefaultOptions};
 use mountpoint_s3_crt::io::retry_strategy::{ExponentialBackoffJitterMode, RetryStrategy, StandardRetryOptions};
 use mountpoint_s3_crt::io::stream::InputStream;
+use mountpoint_s3_crt::s3::buffer::Buffer;
 use mountpoint_s3_crt::s3::client::{
     init_signing_config, BufferPoolUsageStats, ChecksumConfig, Client, ClientConfig, MetaRequest, MetaRequestOptions,
     MetaRequestResult, MetaRequestType, RequestMetrics, RequestType,
@@ -534,7 +535,7 @@ impl S3CrtClientInner {
         request_span: Span,
         on_request_finish: impl Fn(&RequestMetrics) + Send + 'static,
         mut on_headers: impl FnMut(&Headers, i32) + Send + 'static,
-        mut on_body: impl FnMut(u64, &[u8]) + Send + 'static,
+        mut on_body: impl FnMut(u64, &Buffer) + Send + 'static,
         parse_meta_request_error: impl FnOnce(&MetaRequestResult) -> Option<E> + Send + 'static,
         on_meta_request_result: impl FnOnce(ObjectClientResult<(), E, S3RequestError>) + Send + 'static,
     ) -> Result<CancellingMetaRequest, S3RequestError> {

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -102,7 +102,10 @@ impl S3CrtClient {
                 move |offset, data| {
                     _ = part_sender.unbounded_send(S3GetObjectEvent::BodyPart(GetBodyPart {
                         offset,
-                        data: Bytes::copy_from_slice(data),
+                        data: Bytes::from_owner(
+                            data.to_owned_buffer()
+                                .expect("can acquire ownership of buffers from GetObject"),
+                        ),
                     }));
                 },
                 parse_get_object_error,

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -149,12 +149,12 @@ impl S3CrtClient {
 
 #[cfg(not(feature = "restore_buffer_copy"))]
 fn make_body_part(offset: u64, data: &Buffer) -> GetBodyPart {
+    let owned_buffer = data
+        .to_owned_buffer()
+        .expect("buffers returned from GetObject can always be acquired");
     GetBodyPart {
         offset,
-        data: Bytes::from_owner(
-            data.to_owned_buffer()
-                .expect("can acquire ownership of buffers from GetObject"),
-        ),
+        data: Bytes::from_owner(owned_buffer),
     }
 }
 

--- a/mountpoint-s3-crt/examples/download_crt.rs
+++ b/mountpoint-s3-crt/examples/download_crt.rs
@@ -17,6 +17,7 @@ use mountpoint_s3_crt::io::channel_bootstrap::{ClientBootstrap, ClientBootstrapO
 use mountpoint_s3_crt::io::event_loop::EventLoopGroup;
 use mountpoint_s3_crt::io::host_resolver::{HostResolver, HostResolverDefaultOptions};
 use mountpoint_s3_crt::io::retry_strategy::{ExponentialBackoffJitterMode, RetryStrategy, StandardRetryOptions};
+use mountpoint_s3_crt::s3::buffer::Buffer;
 use mountpoint_s3_crt::s3::client::{init_signing_config, Client, ClientConfig, MetaRequestOptions, MetaRequestType};
 use mountpoint_s3_crt::s3::endpoint_resolver::{RequestContext, RuleEngine};
 use tracing::trace;
@@ -144,7 +145,7 @@ impl CrtClient {
         &self,
         bucket: &str,
         key: &str,
-        body_callback: impl FnMut(u64, &[u8]) + Send + 'static,
+        body_callback: impl FnMut(u64, &Buffer) + Send + 'static,
     ) -> anyhow::Result<()> {
         let endpoint = Endpoint::resolve(&self.config.region, bucket)?;
 

--- a/mountpoint-s3-crt/src/s3.rs
+++ b/mountpoint-s3-crt/src/s3.rs
@@ -8,6 +8,7 @@ pub use mountpoint_s3_crt_sys::aws_s3_errors as ErrorCode;
 
 use crate::common::allocator::Allocator;
 
+pub mod buffer;
 pub mod client;
 pub mod endpoint_resolver;
 

--- a/mountpoint-s3-crt/src/s3/buffer.rs
+++ b/mountpoint-s3-crt/src/s3/buffer.rs
@@ -1,0 +1,136 @@
+//! Data buffers used by the S3 Client.
+
+use std::ptr::NonNull;
+use std::{mem::ManuallyDrop, ops::Deref};
+
+use mountpoint_s3_crt_sys::{
+    aws_byte_cursor, aws_s3_buffer_ticket, aws_s3_buffer_ticket_acquire, aws_s3_buffer_ticket_release,
+};
+
+use crate::aws_byte_cursor_as_slice;
+
+/// A slice of a data buffer.
+///
+/// Wrapper for a [aws_byte_cursor] pointing to (part of) the body returned by
+/// a meta request. It can optionally hold a reference to a [BufferTicket] which
+/// can be used to acquire ownership of the underlying memory pool buffer.
+#[derive(Debug)]
+pub struct Buffer<'slice> {
+    slice: &'slice aws_byte_cursor,
+    ticket: Option<&'slice BufferTicket>,
+}
+
+impl<'slice> Buffer<'slice> {
+    /// Create a new instance from a [aws_byte_cursor] and optional associated [aws_s3_buffer_ticket].
+    ///
+    /// SAFETY: slice must be a valid `aws_byte_cursor`.
+    pub(crate) fn new_unchecked(slice: &'slice aws_byte_cursor, ticket: Option<&'slice BufferTicket>) -> Self {
+        Self { slice, ticket }
+    }
+
+    /// Acquire ownership of the underlying memory pool buffer and return an [OwnedBuffer].
+    ///
+    /// Fails and returns [None] if no [BufferTicket] was provided.
+    pub fn to_owned_buffer(&self) -> Option<OwnedBuffer> {
+        let ticket = self.ticket?.clone();
+        Some(OwnedBuffer::new(*self.slice, ticket))
+    }
+}
+
+impl Deref for Buffer<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `self.slice` is valid for the lifetime of self.
+        unsafe { aws_byte_cursor_as_slice(self.slice) }
+    }
+}
+
+impl AsRef<[u8]> for Buffer<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+/// An owned data buffer from the memory pool.
+#[derive(Debug, Clone)]
+pub struct OwnedBuffer {
+    slice: aws_byte_cursor,
+    _ticket: BufferTicket,
+}
+
+impl OwnedBuffer {
+    /// Create a new instance.
+    fn new(slice: aws_byte_cursor, ticket: BufferTicket) -> Self {
+        Self { slice, _ticket: ticket }
+    }
+}
+
+// SAFETY: `self.slice` is valid for the lifetime of `self._ticket`
+unsafe impl Send for OwnedBuffer {}
+// SAFETY: `self.slice` is valid for the lifetime of `self._ticket`
+unsafe impl Sync for OwnedBuffer {}
+
+impl Deref for OwnedBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `self.slice` is valid as for the lifetime of `self.ticket`.
+        unsafe { aws_byte_cursor_as_slice(&self.slice) }
+    }
+}
+
+impl AsRef<[u8]> for OwnedBuffer {
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+/// Wraps a valid [aws_s3_buffer_ticket].
+#[derive(Debug)]
+pub(crate) struct BufferTicket {
+    inner: NonNull<aws_s3_buffer_ticket>,
+}
+
+impl BufferTicket {
+    /// Create a new instance.
+    ///
+    /// # Safety
+    /// `ticket` must be a valid `aws_s3_buffer_ticket`.
+    pub unsafe fn new(ticket: NonNull<aws_s3_buffer_ticket>) -> Self {
+        aws_s3_buffer_ticket_acquire(ticket.as_ptr());
+        Self { inner: ticket }
+    }
+
+    /// Create an instance without incrementing the reference count of the underlying ticket.
+    /// Returns `None` if `ticket` is `null`.
+    ///
+    /// # Safety
+    /// `ticket` must be valid for the lifetime of the returned `Self`.
+    pub unsafe fn new_unowned(ticket: *mut aws_s3_buffer_ticket) -> Option<ManuallyDrop<Self>> {
+        let inner = NonNull::new(ticket)?;
+        Some(ManuallyDrop::new(Self { inner }))
+    }
+}
+
+// SAFETY: `aws_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Send for BufferTicket {}
+// SAFETY: `aws_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Sync for BufferTicket {}
+
+impl Drop for BufferTicket {
+    fn drop(&mut self) {
+        // SAFETY: `self.ticket` is a valid `aws_s3_buffer_ticket`, and we're dropping a reference to it
+        // so it's safe to call release (which will decrement the refcnt).
+        unsafe {
+            aws_s3_buffer_ticket_release(self.inner.as_ptr());
+        }
+    }
+}
+
+impl Clone for BufferTicket {
+    fn clone(&self) -> Self {
+        // SAFETY: `self.inner` is a valid `aws_s3_buffer_ticket`.
+        unsafe { Self::new(self.inner) }
+    }
+}

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -9,7 +9,6 @@ use crate::common::uri::Uri;
 use crate::http::request_response::{Headers, Message};
 use crate::io::channel_bootstrap::ClientBootstrap;
 use crate::io::retry_strategy::RetryStrategy;
-use crate::s3::buffer::BufferTicket;
 use crate::s3::s3_library_init;
 use crate::{aws_byte_cursor_as_slice, CrtError, ToAwsByteCursor};
 use futures::Future;
@@ -572,8 +571,7 @@ unsafe extern "C" fn meta_request_receive_body_callback_ex(
     let user_data = MetaRequestOptionsInner::from_user_data_ptr(user_data);
 
     if let Some(callback) = user_data.on_body_ex.as_mut() {
-        let ticket = BufferTicket::new_unowned(meta.ticket);
-        let buffer = Buffer::new_unchecked(&*body, ticket.as_deref());
+        let buffer = Buffer::new_unchecked(&*body, &meta.ticket);
         callback(meta.range_start, &buffer);
     }
 

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -571,7 +571,8 @@ unsafe extern "C" fn meta_request_receive_body_callback_ex(
     let user_data = MetaRequestOptionsInner::from_user_data_ptr(user_data);
 
     if let Some(callback) = user_data.on_body_ex.as_mut() {
-        let buffer = Buffer::new_unchecked(&*body, &meta.ticket);
+        // SAFETY: `body` and `meta.ticket` outlive `buffer`.
+        let buffer = unsafe { Buffer::new_unchecked(&*body, &meta.ticket) };
         callback(meta.range_start, &buffer);
     }
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.1", features = ["restore_buffer_copy"] }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.1", features = ["restore_buffer_copy"] }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.17.0", features = ["restore_buffer_copy"] }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.5.1" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.16.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.17.0" }
 
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 clap = { version = "4.5.27", features = ["derive"] }


### PR DESCRIPTION
Reduce memory fragmentation and peak usage by avoiding copying data returned by GetObject into newly allocated buffers. This change relies on the new CRT API integrated in #1430, which allows `S3CrtClient` to extend the lifetime of the buffers from the CRT memory pool when they are returned by GetObject. Callers of the `get_object` method are now responsible for dropping the returned `Bytes` instances in order for the buffers to be released back to the CRT memory pool. 

At the moment, the memory-limiting strategy used in the prefetcher component in Mountpoint does not cope well with the change and may end up starving the CRT of available buffers. For this specific use case, we introduced a temporary feature flag in the `mountpoint-s3-client` crate, `restore_buffer_copy` which restores the previous behavior, i.e. GetObject allocates and returns new buffers with a copy of the object content. As we rework this aspect of the prefetcher, we will likely remove the feature flag.

### Does this change impact existing behavior?

Yes. The buffers returned by GetObject will be borrowed from the internal memory pool.

### Does this change need a changelog entry? Does it require a version change?

Yes. Entry and new version number for the client crate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
