### PR TITLE
Explicitly edit fstab file when running on Github runners to avoid a failure

### DIFF
--- a/mountpoint-s3/tests/fstab/basic_checks.sh
+++ b/mountpoint-s3/tests/fstab/basic_checks.sh
@@ -3,6 +3,11 @@
 # Exit on errors
 set -e
 
+# Edit the Github Actions fstab file to not mount some azure disk which times out and fails the CI.
+if [[ "${GITHUB_ACTIONS}" ]]; then
+  sudo sed -i -E 's/^(\/dev\/disk\/cloud\/azure_resource-part1)/#\1/g' /etc/fstab
+fi
+
 source "$(dirname "$(which "$0")")/spawn_mounts.sh"
 
 build_out=$(cargo build --bin mount-s3 --release --message-format=json-render-diagnostics)

--- a/mountpoint-s3/tests/fstab/spawn_mounts.sh
+++ b/mountpoint-s3/tests/fstab/spawn_mounts.sh
@@ -34,7 +34,7 @@ function spawn_mounts() {
     sudo systemctl daemon-reload
 
     # Emit logs only if Mountpoint fails to start
-    trap "sudo journalctl -u \"$unit\" --since \"$(date '+%Y-%m-%d %H:%M:%S')\" | cat" ERR
+    trap "sudo journalctl -u \"$unit\" --since \"$(date '+%Y-%m-%d %H:%M:%S')\" | cat; journalctl -xe" ERR
     sudo systemctl start "$unit"
 
     echo -e "\nStatus of systemd unit $unit:"


### PR DESCRIPTION
In the fstab CI tests, comment out a fstab entry for `\dev/disk/cloud/azure_resource-part1` if we're running in Github Actions.

### Does this change impact existing behavior?

Fixes a failure in Github CI.

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
