### PR TITLE
Add trace for block reads in disk data cache

### DIFF
--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -327,6 +327,12 @@ impl DiskDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        trace!(
+            key = ?cache_key.key(),
+            offset = block_offset,
+            path = ?path.as_ref(),
+            "reading cache block",
+        );
         let mut file = match fs::File::open(path.as_ref()) {
             Ok(file) => file,
             Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),


### PR DESCRIPTION
Add a trace for block reads, useful for performance and memory analysis.

### Does this change impact existing behavior?

Adds a new trace log on block reading.

### Does this change need a changelog entry? Does it require a version change?

No, trace log addition only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
