### PR TITLE
Clarify that rename is atomic

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -246,7 +246,7 @@ Delete operations are immediately actioned against the object in S3, even if the
 
 File rename is supported for objects stored in the S3 Express One Zone storage class.
 Renames that would replace the destination file are only enabled when the `--allow-overwrite` flag is set.
-Rename operations are immediately actioned against the objects in S3, even where the source or any destination file is being read from.
+Rename operations are performed atomically and immediately actioned against the objects in S3, even where the source or any destination file is being read from.
 
 If you want to allow overwriting existing files, use the `--allow-overwrite` flag at mount time. The file must be opened with the `O_TRUNC` flag which will truncate the existing file. All writes must start from the beginning of the file and must be made sequentially.
 

--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -19,7 +19,7 @@ By default, Mountpoint does not allow deleting existing objects with commands li
 
 For objects stored in S3 Express One Zone, Mountpoint supports appending to files. If the `--incremental-upload` flag is set at startup time, Mountpoint allows opening existing files without specifying the `O_TRUNC` flag. All writes must still be sequential and start from the end of the file. In this mode, Mountpoint will always upload data to S3 in sequential increments and offer the same throughput of a single PUT API call on S3. Moreover, partial writes will be visible to other S3 clients before the file is closed. Applications can call `fsync` to guarantee that the data written so far is uploaded to S3 and are then allowed to continue writing to the file.
 
-Mountpoint supports file rename for objects stored in the S3 Express One Zone storage class.
+Mountpoint supports atomic file rename for objects stored in the S3 Express One Zone storage class.
 Attempting to rename files where unsupported by S3 will result in the operation being rejected.
 Mountpoint distinguishes between rename operations that move to an empty destination (non-replacing) and those that replace an existing object at the destination (replacing).
 While non-replacing renames do not require further flags to be set, replacing rename require passing the `--allow-overwrite` flag to Mountpoint at startup time.


### PR DESCRIPTION
Clarified that rename in Express OneZone is atomic.

### Does this change impact existing behavior?

Doc update, no impact on existing behaviour.

### Does this change need a changelog entry? Does it require a version change?

No, just a small doc update.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
