### PR TITLE
Remove default OpenTelemetry SDK dimensions

### DIFF
--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -63,6 +63,9 @@ impl OtlpMetricsExporter {
             .with_endpoint(&endpoint_url)
             .build()?;
 
+        // Create a resource with no attributes to avoid default dimensions
+        let resource = opentelemetry_sdk::resource::Resource::builder_empty().build();
+
         // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
         let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             // The default interval is 60 seconds so we use a PeriodicReader to allow us to specify a custom interval duration
@@ -71,6 +74,7 @@ impl OtlpMetricsExporter {
                     .with_interval(Duration::from_secs(config.interval_secs))
                     .build(),
             )
+            .with_resource(resource)
             .build();
         // Set the configured SdkMeterProvider as the global meter provider making it the default provider that will be used throughout for all OpenTelemetry metrics
         global::set_meter_provider(meter_provider);


### PR DESCRIPTION

This PR removes unnecessary default dimensions which are published by the OpenTelemetry SDK. This is to make the published metrics on CloudWatch more readable and focused on specific Mountpoint metrics dimensions.

### Does this change impact existing behavior?
No impact on existing behaviour. 

No breaking change.

Tested by checking metrics published to CloudWatch - the OpenTelemetry SDK dimensions are no longer published. 
The specific dimensions that you want to aggregate can be configured in the CloudWatch Agent configuration file.

Before:

<img width="1221" alt="Screenshot 2025-07-02 at 18 22 10" src="https://github.com/user-attachments/assets/0ea75255-a279-432c-b6fd-cad0174aa7d3" />

After:

<img width="1222" alt="Screenshot 2025-07-02 at 18 22 32" src="https://github.com/user-attachments/assets/76b6f597-f13d-491e-aebd-45035037b649" />


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
