### PR TITLE
Introduce builder pattern for mockclientconfig

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use futures::StreamExt;
 use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::mock_client::throughput_client::ThroughputMockClient;
-use mountpoint_s3_client::mock_client::{MockClientConfig, MockObject};
+use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::types::{ETag, GetObjectParams};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
@@ -157,11 +157,10 @@ fn main() {
             const BUCKET: &str = "bucket";
             const KEY: &str = "key";
 
-            let config = MockClientConfig::builder()
+            let config = MockClient::config()
                 .bucket(BUCKET)
                 .part_size(args.part_size)
-                .unordered_list_seed(None)
-                .build();
+                .unordered_list_seed(None);
             let client = ThroughputMockClient::new(config, args.throughput_target_gbps);
             let client = Arc::new(client);
 

--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -449,7 +449,7 @@ pub fn countdown_failure_client<Client: ObjectClient>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject};
+    use crate::mock_client::{MockClient, MockClientError, MockObject};
     use crate::types::ETag;
     use std::collections::HashSet;
 
@@ -458,7 +458,7 @@ mod tests {
         let bucket = "test_bucket";
         let key = "foo";
 
-        let client = MockClient::new(MockClientConfig::builder().bucket(bucket).part_size(128).build());
+        let client = MockClient::config().bucket(bucket).part_size(128).build();
 
         let body = vec![0u8; 50];
         client.add_object(key, MockObject::from_bytes(&body, ETag::for_tests()));
@@ -507,7 +507,7 @@ mod tests {
         let bucket = "test_bucket";
         let key = "foo";
 
-        let client = MockClient::new(MockClientConfig::builder().bucket(bucket).build());
+        let client = MockClient::config().bucket(bucket).build();
 
         let mut put_single_failures = HashMap::new();
         put_single_failures.insert(2, ObjectClientError::ClientError(MockClientError("error".into())));

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -255,10 +255,7 @@ mod tests {
 
         for rate_gbps in [0.5, 1.0, 2.0] {
             for _ in 0..ITERATIONS {
-                let config = MockClientConfig::builder()
-                    .part_size(8 * 1024 * 1024)
-                    .bucket("test_bucket")
-                    .build();
+                let config = MockClient::config().part_size(8 * 1024 * 1024).bucket("test_bucket");
                 let client = ThroughputMockClient::new(config, rate_gbps);
 
                 client

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -267,20 +267,18 @@ macro_rules! object_client_test {
     ($test_fn_identifier:ident) => {
         mod $test_fn_identifier {
             use super::$test_fn_identifier;
-            use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+            use mountpoint_s3_client::mock_client::MockClient;
             use $crate::{get_test_bucket_and_prefix, get_test_client};
 
             #[tokio::test]
             async fn mock() {
                 let (bucket, prefix) = get_test_bucket_and_prefix(stringify!($test_fn_identifier));
 
-                let client = MockClient::new(
-                    MockClientConfig::builder()
-                        .bucket(&bucket)
-                        .part_size(1024)
-                        .unordered_list_seed(None)
-                        .build(),
-                );
+                let client = MockClient::config()
+                    .bucket(&bucket)
+                    .part_size(1024)
+                    .unordered_list_seed(None)
+                    .build();
 
                 let key = format!("{prefix}hello");
                 $test_fn_identifier(&client, &bucket, &key, Default::default()).await;

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -492,7 +492,7 @@ mod tests {
     use proptest::{prop_assert, proptest};
 
     use mountpoint_s3_client::failure_client::{CountdownFailureConfig, countdown_failure_client};
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError};
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientError};
     use mountpoint_s3_client::types::ETag;
     use test_case::test_case;
 
@@ -501,13 +501,14 @@ mod tests {
     #[tokio::test]
     async fn test_put_get(part_size: usize, block_size: u64) {
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(part_size)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(part_size)
+                .build(),
+        );
 
         let config = ExpressDataCacheConfig::new(bucket, "unique source description").block_size(block_size);
         let cache = ExpressDataCache::new(client, config);
@@ -598,13 +599,14 @@ mod tests {
     #[tokio::test]
     async fn large_object_bypassed() {
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(8 * 1024 * 1024)
-            .enable_backpressure(true)
-            .initial_read_window_size(8 * 1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(8 * 1024 * 1024)
+                .enable_backpressure(true)
+                .initial_read_window_size(8 * 1024 * 1024)
+                .build(),
+        );
         let cache = ExpressDataCache::new(
             client.clone(),
             ExpressDataCacheConfig::new(bucket, "unique source description"),
@@ -629,13 +631,14 @@ mod tests {
     async fn test_get_validate_failure() {
         let source_bucket = "source-bucket";
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(8 * 1024 * 1024)
-            .enable_backpressure(true)
-            .initial_read_window_size(8 * 1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(8 * 1024 * 1024)
+                .enable_backpressure(true)
+                .initial_read_window_size(8 * 1024 * 1024)
+                .build(),
+        );
         let config = ExpressDataCacheConfig::new(bucket, source_bucket);
         let block_size = config.block_size;
         let cache = ExpressDataCache::new(client.clone(), config);
@@ -755,13 +758,14 @@ mod tests {
     async fn test_verify_cache_valid_success() {
         let source_bucket = "source-bucket";
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(8 * 1024 * 1024)
-            .enable_backpressure(true)
-            .initial_read_window_size(8 * 1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(8 * 1024 * 1024)
+                .enable_backpressure(true)
+                .initial_read_window_size(8 * 1024 * 1024)
+                .build(),
+        );
         let cache = ExpressDataCache::new(client.clone(), ExpressDataCacheConfig::new(bucket, source_bucket));
 
         cache.verify_cache_valid().await.expect("cache should work");
@@ -771,13 +775,14 @@ mod tests {
     async fn test_verify_cache_valid_failure() {
         let source_bucket = "source-bucket";
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(8 * 1024 * 1024)
-            .enable_backpressure(true)
-            .initial_read_window_size(8 * 1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(8 * 1024 * 1024)
+                .enable_backpressure(true)
+                .initial_read_window_size(8 * 1024 * 1024)
+                .build(),
+        );
 
         let mut put_single_failures = HashMap::new();
         put_single_failures.insert(1, MockClientError("error".to_owned().into()).into());

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig, ExpressDataCache, ExpressDataCacheConfig};
 
     use futures::executor::ThreadPool;
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+    use mountpoint_s3_client::mock_client::MockClient;
     use mountpoint_s3_client::types::ETag;
     use tempfile::TempDir;
     use test_case::test_case;
@@ -138,13 +138,12 @@ mod tests {
 
     fn create_express_cache() -> (MockClient, ExpressDataCache<MockClient>) {
         let bucket = "test_bucket";
-        let config = MockClientConfig::builder()
+        let client = MockClient::config()
             .bucket(bucket.to_string())
             .part_size(PART_SIZE)
             .enable_backpressure(true)
             .initial_read_window_size(PART_SIZE)
             .build();
-        let client = MockClient::new(config);
         let cache = ExpressDataCache::new(
             client.clone(),
             ExpressDataCacheConfig::new(bucket, "unique source description"),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -802,19 +802,19 @@ mod tests {
 
     use fuser::FileType;
     use futures::executor::ThreadPool;
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockObject};
+    use mountpoint_s3_client::mock_client::{MockClient, MockObject};
     use mountpoint_s3_client::types::ETag;
 
     #[tokio::test]
     async fn test_open_with_corrupted_sse() {
         let bucket = "bucket";
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder()
+        let client = Arc::new(
+            MockClient::config()
                 .bucket(bucket)
                 .enable_backpressure(true)
                 .initial_read_window_size(1024 * 1024)
                 .build(),
-        ));
+        );
         // Create "dir1" in the client to avoid creating it locally
         client.add_object("dir1/file1.bin", MockObject::constant(0xa1, 15, ETag::for_tests()));
 

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -554,13 +554,14 @@ mod tests {
     }
 
     fn run_sequential_read_test(prefetcher_type: PrefetcherType, size: u64, read_size: usize, test_config: TestConfig) {
-        let config = MockClientConfig::builder()
-            .bucket("test-bucket")
-            .part_size(test_config.client_part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(test_config.initial_read_window_size)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test-bucket")
+                .part_size(test_config.client_part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(test_config.initial_read_window_size)
+                .build(),
+        );
         let object = MockObject::ramp(0xaa, size as usize, ETag::for_tests());
         let etag = object.etag();
 
@@ -675,11 +676,10 @@ mod tests {
         };
 
         // backpressure is not enabled for the client
-        let config = MockClientConfig::builder()
+        let config = MockClient::config()
             .bucket("test-bucket")
             .part_size(test_config.client_part_size)
-            .enable_backpressure(false)
-            .build();
+            .enable_backpressure(false);
 
         fail_with_backpressure_precondition_test(prefetcher_type, test_config, config);
     }
@@ -698,12 +698,11 @@ mod tests {
         };
 
         // backpressure is enabled but initial read window size is zero
-        let config = MockClientConfig::builder()
+        let config = MockClient::config()
             .bucket("test-bucket")
             .part_size(test_config.client_part_size)
             .enable_backpressure(true)
-            .initial_read_window_size(0)
-            .build();
+            .initial_read_window_size(0);
 
         fail_with_backpressure_precondition_test(prefetcher_type, test_config, config);
     }
@@ -715,13 +714,12 @@ mod tests {
         test_config: TestConfig,
         get_failures: HashMap<usize, GetObjectFailureMode<MockClientError>>,
     ) {
-        let config = MockClientConfig::builder()
+        let client = MockClient::config()
             .bucket("test-bucket")
             .part_size(test_config.client_part_size)
             .enable_backpressure(true)
             .initial_read_window_size(test_config.initial_read_window_size)
             .build();
-        let client = MockClient::new(config);
         let object = MockObject::ramp(0xaa, size as usize, ETag::for_tests());
         let etag = object.etag();
 
@@ -850,13 +848,14 @@ mod tests {
         reads: Vec<(u64, usize)>,
         test_config: TestConfig,
     ) {
-        let config = MockClientConfig::builder()
-            .bucket("test-bucket")
-            .part_size(test_config.client_part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(test_config.initial_read_window_size)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test-bucket")
+                .part_size(test_config.client_part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(test_config.initial_read_window_size)
+                .build(),
+        );
         let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
         let etag = object.etag();
 
@@ -997,14 +996,12 @@ mod tests {
         const PART_SIZE: usize = 8192;
         const OBJECT_SIZE: usize = 2 * PART_SIZE;
 
-        let config = MockClientConfig::builder()
+        let client = MockClient::config()
             .bucket("test-bucket")
             .part_size(PART_SIZE)
             .enable_backpressure(true)
             .initial_read_window_size(OBJECT_SIZE)
             .build();
-
-        let client = MockClient::new(config);
         let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
         let etag = object.etag();
         client.add_object("hello", object);
@@ -1067,13 +1064,12 @@ mod tests {
         const PART_SIZE: usize = 8192;
         const OBJECT_SIZE: usize = 2 * PART_SIZE;
 
-        let config = MockClientConfig::builder()
+        let client = MockClient::config()
             .bucket("test-bucket")
             .part_size(PART_SIZE)
             .enable_backpressure(true)
             .initial_read_window_size(PART_SIZE)
             .build();
-        let client = MockClient::new(config);
         let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
         let etag = object.etag();
         client.add_object("hello", object);
@@ -1133,13 +1129,14 @@ mod tests {
         const OBJECT_SIZE: usize = 200;
         const FIRST_REQUEST_SIZE: usize = 100;
 
-        let config = MockClientConfig::builder()
-            .bucket("test-bucket")
-            .part_size(part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(FIRST_REQUEST_SIZE)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test-bucket")
+                .part_size(part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(FIRST_REQUEST_SIZE)
+                .build(),
+        );
         let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
         let etag = object.etag();
 
@@ -1167,13 +1164,14 @@ mod tests {
     fn test_backward_seek(first_read_size: usize, part_size: usize) {
         const OBJECT_SIZE: usize = 200;
 
-        let config = MockClientConfig::builder()
-            .bucket("test-bucket")
-            .part_size(part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(part_size)
-            .build();
-        let client = Arc::new(MockClient::new(config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test-bucket")
+                .part_size(part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(part_size)
+                .build(),
+        );
         let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
         let etag = object.etag();
 
@@ -1221,13 +1219,14 @@ mod tests {
             let max_forward_seek_wait_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
             let max_backward_seek_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
 
-            let config = MockClientConfig::builder()
-                .bucket("test-bucket")
-                .part_size(part_size)
-                .enable_backpressure(true)
-                .initial_read_window_size(initial_read_window_size)
-                .build();
-            let client = Arc::new(MockClient::new(config));
+            let client = Arc::new(
+                MockClient::config()
+                    .bucket("test-bucket")
+                    .part_size(part_size)
+                    .enable_backpressure(true)
+                    .initial_read_window_size(initial_read_window_size)
+                    .build(),
+            );
             let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT));
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
@@ -1280,13 +1279,14 @@ mod tests {
             let max_object_size = initial_read_window_size.min(max_read_window_size) * 20;
             let object_size = rng.gen_range(1u64..(64 * 1024).min(max_object_size) as u64);
 
-            let config = MockClientConfig::builder()
-                .bucket("test-bucket")
-                .part_size(part_size)
-                .enable_backpressure(true)
-                .initial_read_window_size(initial_read_window_size)
-                .build();
-            let client = Arc::new(MockClient::new(config));
+            let client = Arc::new(
+                MockClient::config()
+                    .bucket("test-bucket")
+                    .part_size(part_size)
+                    .enable_backpressure(true)
+                    .initial_read_window_size(initial_read_window_size)
+                    .build(),
+            );
             let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), MINIMUM_MEM_LIMIT));
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -328,7 +328,7 @@ mod tests {
     use std::sync::Arc;
 
     use futures::executor::block_on;
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError};
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientError};
     use test_case::test_case;
 
     use crate::mem_limiter::MemoryLimiter;
@@ -436,14 +436,12 @@ mod tests {
     fn new_backpressure_controller_for_test(
         backpressure_config: BackpressureConfig,
     ) -> (BackpressureController<MockClient>, BackpressureLimiter) {
-        let config = MockClientConfig::builder()
+        let client = MockClient::config()
             .bucket("test-bucket")
             .part_size(8 * 1024 * 1024)
             .enable_backpressure(true)
             .initial_read_window_size(backpressure_config.initial_read_window_size)
             .build();
-
-        let client = MockClient::new(config);
         let mem_limiter = Arc::new(MemoryLimiter::new(
             client,
             backpressure_config.max_read_window_size as u64,

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -402,7 +402,7 @@ mod tests {
 
     use futures::executor::{ThreadPool, block_on};
     use mountpoint_s3_client::{
-        mock_client::{MockClient, MockClientConfig, MockObject, Operation},
+        mock_client::{MockClient, MockObject, Operation},
         types::ETag,
     };
     use test_case::test_case;
@@ -444,14 +444,15 @@ mod tests {
 
         let cache = InMemoryDataCache::new(block_size as u64);
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(client_part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(initial_read_window_size)
-            .build();
 
-        let mock_client = Arc::new(MockClient::new(config));
+        let mock_client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(client_part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(initial_read_window_size)
+                .build(),
+        );
         let mem_limiter = Arc::new(MemoryLimiter::new(mock_client.clone(), MINIMUM_MEM_LIMIT));
         mock_client.add_object(key, object.clone());
 
@@ -525,14 +526,15 @@ mod tests {
 
         let cache = InMemoryDataCache::new(block_size as u64);
         let bucket = "test-bucket";
-        let config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(client_part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(initial_read_window_size)
-            .build();
 
-        let mock_client = Arc::new(MockClient::new(config));
+        let mock_client = Arc::new(
+            MockClient::config()
+                .bucket(bucket)
+                .part_size(client_part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(initial_read_window_size)
+                .build(),
+        );
         let mem_limiter = Arc::new(MemoryLimiter::new(mock_client.clone(), MINIMUM_MEM_LIMIT));
         mock_client.add_object(key, object.clone());
 

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     async fn run_test(ops: Vec<Op>) {
-        let client = MockClient::new(Default::default());
+        let client = MockClient::config().build();
         let mem_limiter = MemoryLimiter::new(client, MINIMUM_MEM_LIMIT);
         let part_id = ObjectId::new("key".to_owned(), ETag::for_tests());
         let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>(mem_limiter.into());

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -1970,7 +1970,7 @@ impl InodeError {
 mod tests {
 
     use mountpoint_s3_client::{
-        mock_client::{MockClient, MockClientConfig, MockObject},
+        mock_client::{MockClient, MockObject},
         types::ETag,
     };
     use std::str::FromStr;
@@ -1997,11 +1997,7 @@ mod tests {
     #[tokio::test]
     async fn test_lookup(prefix: &str) {
         let bucket = "test_bucket";
-        let client_config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(1024 * 1024).build());
 
         let keys = &[
             format!("{prefix}dir0/file0.txt"),
@@ -2123,11 +2119,7 @@ mod tests {
     async fn test_lookup_with_caching(cached: bool) {
         let bucket = "test_bucket";
         let prefix = "prefix/";
-        let client_config = MockClientConfig::builder()
-            .bucket(bucket)
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(1024 * 1024).build());
 
         let keys = &[
             format!("{prefix}file0.txt"),
@@ -2189,8 +2181,7 @@ mod tests {
     async fn test_negative_lookup_with_caching(cached: bool) {
         let bucket = "test_bucket";
         let prefix = "prefix/";
-        let client_config = MockClientConfig::builder().bucket(bucket).part_size(32).build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let ttl = if cached {
@@ -2246,11 +2237,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_readdir(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         let keys = &[
             format!("{prefix}dir0/file0.txt"),
@@ -2400,11 +2392,7 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_readdir_no_remote_keys(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(MockClient::config().bucket("test_bucket").part_size(32).build());
 
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
@@ -2436,11 +2424,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_readdir_local_keys_after_remote_keys(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
@@ -2483,11 +2472,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_create_local_dir(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 
@@ -2519,11 +2509,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_readdir_lookup_after_rmdir(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 
@@ -2574,14 +2565,22 @@ mod tests {
     #[test_case("test_prefix/", false; "prefixed unordered")]
     #[tokio::test]
     async fn test_readdir_unordered(prefix: &str, ordered: bool) {
-        let mut builder = MockClientConfig::builder().bucket("test_bucket").part_size(1024 * 1024);
-
-        if !ordered {
-            builder = builder.unordered_list_seed(Some(123456));
-        }
-
-        let client_config = builder.build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = if ordered {
+            Arc::new(
+                MockClient::config()
+                    .bucket("test_bucket")
+                    .part_size(1024 * 1024)
+                    .build(),
+            )
+        } else {
+            Arc::new(
+                MockClient::config()
+                    .bucket("test_bucket")
+                    .part_size(1024 * 1024)
+                    .unordered_list_seed(Some(123456))
+                    .build(),
+            )
+        };
 
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let s3_personality = if ordered {
@@ -2694,11 +2693,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_rmdir_delete_status(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 
@@ -2745,11 +2745,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_parent_readdir_after_rmdir(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 
@@ -2781,11 +2782,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_lookup_after_unlink(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket".to_string())
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket".to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 
@@ -2814,12 +2816,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_finish_writing_convert_parent_local_dirs_to_remote() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket".to_string())
-            .part_size(1024 * 1024)
-            .build();
-
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket".to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let superblock = Superblock::new(client.clone(), "test_bucket", &Default::default(), Default::default());
 
         let nested_dirs = (0..5).map(|i| format!("level{i}")).collect::<Vec<_>>();
@@ -2867,12 +2869,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_inode_reuse() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket".to_string())
-            .part_size(1024 * 1024)
-            .build();
-
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket".to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
         client.add_object("dir1/file1.txt", MockObject::constant(0xaa, 30, ETag::for_tests()));
 
         let superblock = Superblock::new(client.clone(), "test_bucket", &Default::default(), Default::default());
@@ -2892,12 +2894,12 @@ mod tests {
     #[test_case("subdir/"; "with subdirectory")]
     #[tokio::test]
     async fn test_lookup_directory_overlap(subdir: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket".to_string())
-            .part_size(1024 * 1024)
-            .build();
-
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket".to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
         // In this test the `/` delimiter comes back to bite us. `dir-1/` comes before `dir/` in
         // lexicographical order (- is ASCII 0x2d, / is ASCII 0x2f), so `dir-1` will be the first
         // common prefix when we do ListObjects with prefix = 'dir'. But `dir` comes before `dir-1`
@@ -2926,12 +2928,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_names() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         // The only valid key here is "dir1/a", so we should see a directory called "dir1" and a
         // file inside it called "a".
@@ -2975,12 +2977,12 @@ mod tests {
     #[test_case("test_prefix/"; "prefixed")]
     #[tokio::test]
     async fn test_setattr(prefix: &str) {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let prefix = Prefix::new(prefix).expect("valid prefix");
         let superblock = Superblock::new(client.clone(), "test_bucket", &prefix, Default::default());
 

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -476,18 +476,19 @@ mod tests {
     use super::*;
     use crate::superblock::Superblock;
     use mountpoint_s3_client::{
-        mock_client::{MockClient, MockClientConfig, MockObject},
+        mock_client::{MockClient, MockObject},
         types::ETag,
     };
     use time::Duration;
 
     #[tokio::test]
     async fn test_forget() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         let superblock = Superblock::new(client.clone(), "test_bucket", &Default::default(), Default::default());
         let ino = 42;
@@ -529,11 +530,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_forget_can_remove_inodes() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         let name = "foo";
         client.add_object(name, b"foo".into());
@@ -562,11 +564,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_forget_shadowed_inode() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
 
         let name = "foo";
         client.add_object(name, b"foo".into());
@@ -594,11 +597,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_unlink_verify_checksum() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let file_name = "corrupted";
         client.add_object(file_name.as_ref(), MockObject::constant(0xaa, 30, ETag::for_tests()));
 
@@ -652,11 +656,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_setattr_invalid_stat() {
-        let client_config = MockClientConfig::builder()
-            .bucket("test_bucket")
-            .part_size(1024 * 1024)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test_bucket")
+                .part_size(1024 * 1024)
+                .build(),
+        );
         let superblock = Superblock::new(client.clone(), "test_bucket", &Default::default(), Default::default());
 
         let ino: u64 = 42;
@@ -705,18 +710,19 @@ mod tests {
     mod shuttle_tests {
         use super::*;
         use crate::fs::FUSE_ROOT_INODE;
-        use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+        use mountpoint_s3_client::mock_client::MockClient;
         use shuttle::{check_dfs, check_pct, check_random, thread};
         use shuttle::{future::block_on, sync::Arc};
 
         #[test]
         fn test_create_and_forget_race_condition() {
             async fn test_helper() {
-                let client_config = MockClientConfig::builder()
-                    .bucket("test_bucket")
-                    .part_size(1024 * 1024)
-                    .build();
-                let client = Arc::new(MockClient::new(client_config));
+                let client = Arc::new(
+                    MockClient::config()
+                        .bucket("test_bucket")
+                        .part_size(1024 * 1024)
+                        .build(),
+                );
 
                 let name = "foo";
                 client.add_object(name, b"foo".into());
@@ -757,12 +763,13 @@ mod tests {
         #[test]
         fn test_concurrent_rename_different_files() {
             async fn test_helper() {
-                let client_config = MockClientConfig::builder()
-                    .bucket("test_bucket")
-                    .part_size(1024 * 1024)
-                    .enable_rename(true)
-                    .build();
-                let client = Arc::new(MockClient::new(client_config));
+                let client = Arc::new(
+                    MockClient::config()
+                        .bucket("test_bucket")
+                        .part_size(1024 * 1024)
+                        .enable_rename(true)
+                        .build(),
+                );
 
                 // Create directories first
                 let superblock = Arc::new(Superblock::new(
@@ -855,12 +862,11 @@ mod tests {
         #[test]
         fn test_concurrent_rename_and_lookup() {
             async fn test_helper() {
-                let client_config = MockClientConfig::builder()
+                let client = MockClient::config()
                     .bucket("test_bucket")
                     .part_size(1024 * 1024)
                     .enable_rename(true)
                     .build();
-                let client = Arc::new(MockClient::new(client_config));
 
                 let source_name = "source";
                 client.add_object(source_name, b"foo".into());

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -206,7 +206,7 @@ mod tests {
 
     use futures::executor::ThreadPool;
     use mountpoint_s3_client::failure_client::{CountdownFailureConfig, countdown_failure_client};
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError};
+    use mountpoint_s3_client::mock_client::{MockClient, MockClientError};
     use mountpoint_s3_client::types::ChecksumAlgorithm;
     use test_case::test_case;
 
@@ -241,9 +241,7 @@ mod tests {
         let name = "hello";
         let key = name;
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         let uploader = new_uploader_for_test(client.clone(), None, ServerSideEncryption::default(), true);
         let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
@@ -265,9 +263,7 @@ mod tests {
         let key = name;
         let storage_class = "INTELLIGENT_TIERING";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         let uploader = new_uploader_for_test(
             client.clone(),
             Some(storage_class.to_owned()),
@@ -304,9 +300,7 @@ mod tests {
         let name = "hello";
         let key = name;
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let mut put_failures = HashMap::new();
         put_failures.insert(1, Ok((1, MockClientError("error".to_owned().into()))));
@@ -356,9 +350,7 @@ mod tests {
         let name = "hello";
         let key = name;
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(PART_SIZE).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(PART_SIZE).build());
         let uploader = new_uploader_for_test(client.clone(), None, ServerSideEncryption::default(), true);
         let mut request = uploader.start_atomic_upload(bucket.to_owned(), key.to_owned()).unwrap();
 
@@ -388,7 +380,7 @@ mod tests {
     #[test_case(Some("aws:kms"), None)]
     #[tokio::test]
     async fn put_with_corrupted_sse_test(sse_type_corrupted: Option<&str>, key_id_corrupted: Option<&str>) {
-        let client = Arc::new(MockClient::new(MockClientConfig::builder().build()));
+        let client = Arc::new(MockClient::config().build());
         let mut uploader = new_uploader_for_test(
             client,
             None,
@@ -413,9 +405,7 @@ mod tests {
         let name = "hello";
         let key = name;
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         let uploader = new_uploader_for_test(
             client,
             None,

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -457,7 +457,7 @@ mod tests {
     use futures::executor::ThreadPool;
     use mountpoint_s3_client::error::{ObjectClientError, PutObjectError};
     use mountpoint_s3_client::failure_client::{CountdownFailureConfig, countdown_failure_client};
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockObject};
+    use mountpoint_s3_client::mock_client::{MockClient, MockObject};
     use mountpoint_s3_client::types::{ChecksumAlgorithm, ETag, GetObjectParams, GetObjectResponse};
     use test_case::test_case;
 
@@ -499,9 +499,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         // Create the "before append" object for the test
         let mut existing_object = existing_object;
@@ -572,9 +570,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let mut existing_object = existing_object;
         if let Some(object) = &mut existing_object {
@@ -644,9 +640,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let mut expected_checksum_algorithm = default_checksum_algorithm.as_slice();
         let mut expected_content = Vec::new();
@@ -711,9 +705,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let mut existing_object = existing_object;
         if let Some(object) = &mut existing_object {
@@ -747,9 +739,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
         client.add_object(key, existing_object.clone());
@@ -781,9 +771,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let mut put_single_failures = HashMap::new();
         put_single_failures.insert(2, ObjectClientError::ServiceError(PutObjectError::BadChecksum));
@@ -833,9 +821,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
         client.add_object(key, existing_object.clone());
@@ -887,9 +873,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let mut put_single_failures = HashMap::new();
         put_single_failures.insert(2, ObjectClientError::ServiceError(PutObjectError::BadChecksum));
@@ -961,12 +945,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder()
-                .bucket(bucket.to_owned())
-                .part_size(32)
-                .build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket.to_owned()).part_size(32).build());
         // Create the "before append" object for the test
         let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
         client.add_object(key, existing_object.clone());
@@ -1026,9 +1005,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         let buffer_size = 256;
         let uploader = new_uploader_for_test(client.clone(), buffer_size, None, None);
@@ -1060,9 +1037,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
         client.add_object(key, existing_object.clone());
@@ -1101,9 +1076,7 @@ mod tests {
         let key = "hello";
         let mut expected_content = Vec::new();
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(32).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Create the "before append" object for the test
         let existing_object = MockObject::from([0xbb; 20]).with_computed_checksums(&[ChecksumAlgorithm::Crc32c]);
         client.add_object(key, existing_object.clone());
@@ -1146,9 +1119,7 @@ mod tests {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::new(
-            MockClientConfig::builder().bucket(bucket).part_size(part_size).build(),
-        ));
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
 
         // Use a memory limiter with 0 limit
         let mem_limiter = MemoryLimiter::new(client.clone(), 0);

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -215,7 +215,7 @@ pub mod mock_session {
     use super::*;
 
     use futures::executor::ThreadPool;
-    use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+    use mountpoint_s3_client::mock_client::MockClient;
     use mountpoint_s3_client::types::{HeadObjectParams, ObjectAttribute};
     use mountpoint_s3_fs::prefetch::Prefetcher;
 
@@ -231,14 +231,15 @@ pub mod mock_session {
             format!("{test_name}/")
         };
 
-        let client_config = MockClientConfig::builder()
-            .bucket(BUCKET_NAME)
-            .part_size(test_config.part_size)
-            .enable_backpressure(true)
-            .initial_read_window_size(test_config.initial_read_window_size)
-            .enable_rename(test_config.filesystem_config.allow_rename)
-            .build();
-        let client = Arc::new(MockClient::new(client_config));
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(BUCKET_NAME)
+                .part_size(test_config.part_size)
+                .enable_backpressure(true)
+                .initial_read_window_size(test_config.initial_read_window_size)
+                .enable_rename(test_config.filesystem_config.allow_rename)
+                .build(),
+        );
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let (session, mount) = create_fuse_session(
@@ -271,13 +272,14 @@ pub mod mock_session {
                 format!("{test_name}/")
             };
 
-            let client_config = MockClientConfig::builder()
-                .bucket(BUCKET_NAME)
-                .part_size(test_config.part_size)
-                .enable_backpressure(true)
-                .initial_read_window_size(test_config.initial_read_window_size)
-                .build();
-            let client = Arc::new(MockClient::new(client_config));
+            let client = Arc::new(
+                MockClient::config()
+                    .bucket(BUCKET_NAME)
+                    .part_size(test_config.part_size)
+                    .enable_backpressure(true)
+                    .initial_read_window_size(test_config.initial_read_window_size)
+                    .build(),
+            );
             let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
             let prefetcher_builder = Prefetcher::caching_builder(cache, client.clone());
             let (session, mount) = create_fuse_session(

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -22,7 +22,7 @@ use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::{
     Allocator, CredentialsProvider, CredentialsProviderStaticOptions, RustLogAdapter, S3ClientAuthConfig,
 };
-use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig};
+use mountpoint_s3_client::mock_client::MockClient;
 use mountpoint_s3_fs::fs::{DirectoryEntry, DirectoryReplier};
 use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::prefix::Prefix;
@@ -36,14 +36,14 @@ pub fn make_test_filesystem(
     prefix: &Prefix,
     config: S3FilesystemConfig,
 ) -> (Arc<MockClient>, S3Filesystem<Arc<MockClient>>) {
-    let client_config = MockClientConfig::builder()
-        .bucket(bucket)
-        .part_size(1024 * 1024)
-        .enable_backpressure(true)
-        .initial_read_window_size(256 * 1024)
-        .build();
-
-    let client = Arc::new(MockClient::new(client_config));
+    let client = Arc::new(
+        MockClient::config()
+            .bucket(bucket)
+            .part_size(1024 * 1024)
+            .enable_backpressure(true)
+            .initial_read_window_size(256 * 1024)
+            .build(),
+    );
     let fs = make_test_filesystem_with_client(client.clone(), bucket, prefix, config);
     (client, fs)
 }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -11,7 +11,7 @@ use mountpoint_s3_client::config::S3ClientConfig;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3_client::error_metadata::ClientErrorMetadata;
 use mountpoint_s3_client::failure_client::{CountdownFailureConfig, countdown_failure_client};
-use mountpoint_s3_client::mock_client::{MockClient, MockClientConfig, MockClientError, MockObject, Operation};
+use mountpoint_s3_client::mock_client::{MockClient, MockClientError, MockObject, Operation};
 use mountpoint_s3_client::types::{ETag, GetObjectParams, PutObjectSingleParams, RestoreStatus};
 #[cfg(feature = "s3_tests")]
 use mountpoint_s3_fs::fs::error_metadata::MOUNTPOINT_ERROR_LOOKUP_NONEXISTENT;
@@ -708,14 +708,14 @@ async fn test_upload_aborted_on_write_failure() {
     const BUCKET_NAME: &str = "test_upload_aborted_on_write_failure";
     const FILE_NAME: &str = "foo.bin";
 
-    let client_config = MockClientConfig::builder()
-        .bucket(BUCKET_NAME)
-        .part_size(1024 * 1024)
-        .enable_backpressure(true)
-        .initial_read_window_size(256 * 1024)
-        .build();
-
-    let client = Arc::new(MockClient::new(client_config));
+    let client = Arc::new(
+        MockClient::config()
+            .bucket(BUCKET_NAME)
+            .part_size(1024 * 1024)
+            .enable_backpressure(true)
+            .initial_read_window_size(256 * 1024)
+            .build(),
+    );
     let mut put_failures = HashMap::new();
     put_failures.insert(1, Ok((2, MockClientError("error".to_owned().into()))));
 
@@ -782,14 +782,14 @@ async fn test_upload_aborted_on_fsync_failure() {
     const BUCKET_NAME: &str = "test_upload_aborted_on_fsync_failure";
     const FILE_NAME: &str = "foo.bin";
 
-    let client_config = MockClientConfig::builder()
-        .bucket(BUCKET_NAME)
-        .part_size(1024 * 1024)
-        .enable_backpressure(true)
-        .initial_read_window_size(256 * 1024)
-        .build();
-
-    let client = Arc::new(MockClient::new(client_config));
+    let client = Arc::new(
+        MockClient::config()
+            .bucket(BUCKET_NAME)
+            .part_size(1024 * 1024)
+            .enable_backpressure(true)
+            .initial_read_window_size(256 * 1024)
+            .build(),
+    );
     let mut put_failures = HashMap::new();
     put_failures.insert(1, Ok((2, MockClientError("error".to_owned().into()))));
 
@@ -841,14 +841,14 @@ async fn test_upload_aborted_on_release_failure() {
     const BUCKET_NAME: &str = "test_upload_aborted_on_fsync_failure";
     const FILE_NAME: &str = "foo.bin";
 
-    let client_config = MockClientConfig::builder()
-        .bucket(BUCKET_NAME)
-        .part_size(1024 * 1024)
-        .enable_backpressure(true)
-        .initial_read_window_size(256 * 1024)
-        .build();
-
-    let client = Arc::new(MockClient::new(client_config));
+    let client = Arc::new(
+        MockClient::config()
+            .bucket(BUCKET_NAME)
+            .part_size(1024 * 1024)
+            .enable_backpressure(true)
+            .initial_read_window_size(256 * 1024)
+            .build(),
+    );
     let mut put_failures = HashMap::new();
     put_failures.insert(1, Ok((2, MockClientError("error".to_owned().into()))));
 
@@ -1635,15 +1635,15 @@ async fn test_rename_support_is_cached() {
     const BUCKET_NAME: &str = "test_rename_support_cached_general_purpose";
     const FILE_NAME: &str = "a.txt";
 
-    let client_config = MockClientConfig::builder()
-        .bucket(BUCKET_NAME)
-        .part_size(1024 * 1024)
-        .enable_backpressure(true)
-        .initial_read_window_size(256 * 1024)
-        .enable_rename(false)
-        .build();
-
-    let client = Arc::new(MockClient::new(client_config));
+    let client = Arc::new(
+        MockClient::config()
+            .bucket(BUCKET_NAME)
+            .part_size(1024 * 1024)
+            .enable_backpressure(true)
+            .initial_read_window_size(256 * 1024)
+            .enable_rename(false)
+            .build(),
+    );
 
     // Put one object into the bucket
     let params = PutObjectSingleParams::new();

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -16,7 +16,7 @@ use futures::executor::ThreadPool;
 
 use mountpoint_s3::CliArgs;
 use mountpoint_s3_client::mock_client::throughput_client::ThroughputMockClient;
-use mountpoint_s3_client::mock_client::{MockClientConfig, MockObject};
+use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_fs::Runtime;
 use mountpoint_s3_fs::s3::S3Personality;
@@ -57,14 +57,13 @@ fn create_mock_client(args: &CliArgs) -> anyhow::Result<(Arc<ThroughputMockClien
         S3Personality::Standard
     };
 
-    let config = MockClientConfig::builder()
+    let config = MockClient::config()
         .bucket(&bucket_name)
         .part_size(part_size as usize)
         .unordered_list_seed(None)
         .enable_backpressure(true)
         .initial_read_window_size(1024 * 1024 + 128 * 1024) // matching real MP
-        .enable_rename(s3_personality.supports_rename_object())
-        .build();
+        .enable_rename(s3_personality.supports_rename_object());
 
     let client = if let Some(max_throughput_gbps) = args.maximum_throughput_gbps {
         tracing::info!("mock client limited to {max_throughput_gbps} Gb/s download throughput");


### PR DESCRIPTION
Use a builder pattern for MockClientConfig.

### Does this change impact existing behavior?

Does not impact existing behaviour as it only changes the way we build the structure.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
