### PR TITLE
Extend prefetcher benchmarks to test multiple objects

### DIFF
--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -208,7 +208,12 @@ fn make_s3_client_from_args(args: &CliArgs) -> anyhow::Result<S3CrtClient> {
         client_config = client_config.part_size(part_size as usize);
     }
     if let Some(interfaces) = &args.bind {
-        client_config = client_config.network_interface_names(interfaces.clone());
+        let nics: Vec<String> = interfaces
+            .iter()
+            .flat_map(|iface| iface.split(',').map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect();
+        client_config = client_config.network_interface_names(nics);
     }
     Ok(S3CrtClient::new(client_config)?)
 }

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -39,11 +39,11 @@ fn init_tracing_subscriber() {
     about = "Run workloads against the prefetcher component of Mountpoint. Fetched data is discarded."
 )]
 pub struct CliArgs {
-    #[clap(help = "S3 bucket name containing the S3 object to fetch")]
+    #[clap(help = "S3 bucket name containing the S3 objects to fetch")]
     pub bucket: String,
 
-    #[clap(help = "S3 object key to fetch")]
-    pub s3_key: String,
+    #[clap(help = "List of S3 object keys to fetch", num_args = 1.., value_delimiter = ',')]
+    pub s3_keys: Vec<String>,
 
     #[clap(
         long,
@@ -93,8 +93,13 @@ pub struct CliArgs {
     #[arg(long, help = "Number of times to download the S3 object", default_value_t = 1)]
     iterations: usize,
 
-    #[arg(long, help = "Number of concurrent downloads", default_value_t = 1, value_name = "N")]
-    downloads: usize,
+    #[arg(
+        long,
+        help = "Number of concurrent downloads per object",
+        default_value_t = 1,
+        value_name = "N"
+    )]
+    downloads_per_object: usize,
 
     #[clap(
         long,
@@ -104,6 +109,17 @@ pub struct CliArgs {
     pub bind: Option<Vec<String>>,
 }
 
+fn create_memory_limiter(args: &CliArgs, client: &S3CrtClient) -> Arc<MemoryLimiter<S3CrtClient>> {
+    let max_memory_target = if let Some(target) = args.max_memory_target {
+        target * 1024 * 1024
+    } else {
+        // Default to 95% of total system memory
+        let sys = System::new_with_specifics(RefreshKind::everything());
+        (sys.total_memory() as f64 * 0.95) as u64
+    };
+    Arc::new(MemoryLimiter::new(client.clone(), max_memory_target))
+}
+
 fn main() -> anyhow::Result<()> {
     init_tracing_subscriber();
     let _metrics_handle = mountpoint_s3_fs::metrics::install();
@@ -111,54 +127,55 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     let bucket = args.bucket.as_str();
-    let key = args.s3_key.as_str();
-
     let client = make_s3_client_from_args(&args).context("failed to create S3 CRT client")?;
-
-    let mem_limiter = {
-        let max_memory_target = if let Some(target) = args.max_memory_target {
-            target * 1024 * 1024
-        } else {
-            // Default to 95% of total system memory
-            let sys = System::new_with_specifics(RefreshKind::everything());
-            (sys.total_memory() as f64 * 0.95) as u64
-        };
-        Arc::new(MemoryLimiter::new(client.clone(), max_memory_target))
-    };
-
-    let head_object_result = block_on(client.head_object(bucket, key, &HeadObjectParams::new()))
-        .context("initial HeadObject to fetch object metadata before benchmark failed")?;
-    let size = head_object_result.size;
-    let object_id = ObjectId::new(key.to_string(), head_object_result.etag);
-
+    let mem_limiter = create_memory_limiter(&args, &client);
     let runtime = Runtime::new(client.event_loop_group());
 
-    for iteration in 0..args.iterations {
-        let manager = Prefetcher::default_builder(client.clone()).build(
-            runtime.clone(),
-            mem_limiter.clone(),
-            PrefetcherConfig::default(),
-        );
+    // Verify if all objects exist and collect metadata
+    let object_metadata: Vec<(ObjectId, u64)> = args
+        .s3_keys
+        .iter()
+        .map(|key| {
+            let head_result = block_on(client.head_object(bucket, key, &HeadObjectParams::new()))
+                .with_context(|| format!("HeadObject failed for {key}"))?;
+            Ok((ObjectId::new(key.to_string(), head_result.etag), head_result.size))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
+    for iteration in 0..args.iterations {
         let received_bytes = Arc::new(AtomicU64::new(0));
         let start = Instant::now();
 
         thread::scope(|scope| {
-            for _ in 0..args.downloads {
-                let received_bytes = received_bytes.clone();
-                let mut request = manager.prefetch(bucket.to_string(), object_id.clone(), size);
+            let mut download_tasks = Vec::new();
 
-                scope.spawn(|| {
-                    futures::executor::block_on(async move {
-                        let mut offset = 0;
-                        while offset < size {
-                            let bytes = request.read(offset, args.read_size).await.unwrap();
-                            let length = bytes.len() as u64;
-                            offset += length;
-                            received_bytes.fetch_add(length, Ordering::SeqCst);
-                        }
-                    })
-                });
+            for (object_id, size) in &object_metadata {
+                for _ in 0..args.downloads_per_object {
+                    let received_bytes = received_bytes.clone();
+                    let object_id = object_id.clone();
+                    let manager = Prefetcher::default_builder(client.clone()).build(
+                        runtime.clone(),
+                        mem_limiter.clone(),
+                        PrefetcherConfig::default(),
+                    );
+                    let mut request = manager.prefetch(bucket.to_string(), object_id.clone(), *size);
+
+                    download_tasks.push(scope.spawn(move || {
+                        futures::executor::block_on(async move {
+                            let mut offset = 0;
+                            while offset < *size {
+                                let bytes = request.read(offset, args.read_size).await.unwrap();
+                                let length = bytes.len() as u64;
+                                offset += length;
+                                received_bytes.fetch_add(length, Ordering::SeqCst);
+                            }
+                        })
+                    }));
+                }
+            }
+
+            for task in download_tasks {
+                task.join().unwrap();
             }
         });
 
@@ -166,9 +183,7 @@ fn main() -> anyhow::Result<()> {
 
         let received_size = received_bytes.load(Ordering::SeqCst);
         println!(
-            "{}: received {} bytes in {:.2}s: {:.2} Gib/s",
-            iteration,
-            received_size,
+            "{iteration}: received {received_size} bytes in {:.2}s: {:.2} Gib/s",
             elapsed.as_secs_f64(),
             (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024 * 1024 / 8) as f64
         );


### PR DESCRIPTION
With this change, we can benchmark concurrent downloads of multiple objects at prefetcher.


### Does this change impact existing behavior?

No, only extends prefetch benchmarks. 

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
