### PR TITLE
Extend prefetcher benchmarks to test multiple object downloads

### DIFF
--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -230,7 +230,12 @@ fn make_s3_client_from_args(args: &CliArgs) -> anyhow::Result<S3CrtClient> {
         client_config = client_config.part_size(part_size as usize);
     }
     if let Some(interfaces) = &args.bind {
-        client_config = client_config.network_interface_names(interfaces.clone());
+        let nics: Vec<String> = interfaces
+            .iter()
+            .flat_map(|iface| iface.split(',').map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect();
+        client_config = client_config.network_interface_names(nics);
     }
     Ok(S3CrtClient::new(client_config)?)
 }


### PR DESCRIPTION
With this change, we can benchmark concurrent downloads of multiple objects at prefetcher.

This change also allows passing NICs as a comma separated list and adds a new parameter to limit the run time of the test 

### Does this change impact existing behavior?

No, only extends prefetch benchmarks.

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
