### PR TITLE
Remove last bucket usage

### DIFF
--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -59,7 +59,6 @@ where
     metablock: Arc<dyn Metablock>,
     prefetcher: Prefetcher<Client>,
     uploader: Uploader<Client>,
-    bucket: String,
     next_handle: AtomicU64,
     file_handles: AsyncRwLock<HashMap<u64, Arc<FileHandle<Client>>>>,
 }
@@ -178,7 +177,6 @@ where
             metablock: Arc::new(superblock),
             prefetcher,
             uploader,
-            bucket: bucket.to_string(),
             next_handle: AtomicU64::new(1),
             file_handles: AsyncRwLock::new(HashMap::new()),
         }


### PR DESCRIPTION
Removes a left over usage of bucket in `Filesystem`.

No behaviour change.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
