### PR TITLE
Add support for custom memory pools

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -148,6 +148,64 @@ jobs:
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
+
+  client-test:
+    name: Client Tests (${{ matrix.bucket-type.name }}, ${{ matrix.runner.name }}, ${{ matrix.pool.name }})
+    runs-on: ${{ matrix.runner.tags }}
+
+    environment: ${{ inputs.environment }}
+    env:
+      features: s3_tests,fips_tests,${{ matrix.pool.feature }},${{ matrix.bucket-type.feature }}
+      packages: --package mountpoint-s3-client --package mountpoint-s3-crt --package mountpoint-s3-crt-sys
+
+    strategy:
+      fail-fast: false
+      matrix:
+        bucket-type:
+        - name: S3
+          feature: 
+        - name: S3 Express One Zone
+          feature: s3express_tests
+        runner:
+        - name: Ubuntu x86
+          tags: [ubuntu-22.04] # GitHub-hosted
+        - name: Amazon Linux arm
+          tags: [self-hosted, linux, arm64]
+        pool:
+        - name: Test Pool
+          feature: pool_tests
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Set up Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        # setup-rust-toolchain sets "-D warnings" by default, and Rust treats any warning as compile error.
+        # We need to this currently because `mountpoint-s3-fuser` contains some warnings and it breaks the build.
+        rustflags: ""
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        # not required for client tests. TODO: make it optional.
+        fuseVersion: 2
+    - name: Build tests
+      run: cargo test ${{ env.packages }} --features '${{ env.features }}' --no-run
+    - name: Run tests
+      run: cargo test ${{ env.packages }} --features '${{ env.features }}'
+    - name: Save dump files
+      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      run: ./.github/actions/scripts/save-coredump.sh
+
   fstab:
     name: fstab tests (${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.tags }}

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased (v0.18.0)
 
+* Add support for custom memory pools. ([#1516](https://github.com/awslabs/mountpoint-s3/pull/1516))
 * Upgrade to Rust 2024. ([#1498](https://github.com/awslabs/mountpoint-s3/pull/1498))
 * Fix a race condition in the internal memory pool that in some cases could result in a deadlock.
   ([#1515](https://github.com/awslabs/mountpoint-s3/issues/1515))

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -66,6 +66,7 @@ mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand", "dep:rand_chac
 s3_tests = []
 fips_tests = []
 s3express_tests = []
+pool_tests = []
 
 [lib]
 doctest = false

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -40,6 +40,7 @@
 //!
 //! [awscrt]: https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html
 
+#![deny(clippy::undocumented_unsafe_blocks)]
 // Make async trait docs not-ugly on docs.rs (https://github.com/dtolnay/async-trait/issues/213)
 #![cfg_attr(docsrs, feature(async_fn_in_trait))]
 
@@ -79,6 +80,8 @@ pub mod config {
     pub use mountpoint_s3_crt::io::io_library_init;
     #[doc(hidden)]
     pub use mountpoint_s3_crt::s3::s3_library_init;
+
+    pub use mountpoint_s3_crt::s3::pool::{MemoryPool, MemoryPoolFactory, MemoryPoolFactoryOptions};
 }
 
 /// Types used by all object clients

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -63,7 +63,8 @@ pub mod error_metadata;
 pub use object_client::{ObjectClient, PutObjectRequest};
 
 pub use s3_crt_client::{
-    OnTelemetry, S3CrtClient, S3RequestError, get_object::S3GetObjectResponse, put_object::S3PutObjectRequest,
+    NewClientError, OnTelemetry, S3CrtClient, S3RequestError, get_object::S3GetObjectResponse,
+    put_object::S3PutObjectRequest,
 };
 
 /// Configuration for the S3 client

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -14,10 +14,10 @@ use tempfile::NamedTempFile;
 use common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
 use common::*;
 
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
 use mountpoint_s3_client::types::GetObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
 
@@ -51,7 +51,7 @@ async fn test_static_provider() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -71,7 +71,7 @@ async fn test_static_provider() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -129,7 +129,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -145,7 +145,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -158,7 +158,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
+    let _result = create_client_with_config(config).expect_err("profile doesn't exist");
 }
 
 async fn test_profile_provider_assume_role_async() {
@@ -206,7 +206,7 @@ async fn test_profile_provider_assume_role_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -219,7 +219,7 @@ async fn test_profile_provider_assume_role_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -335,7 +335,7 @@ async fn test_credential_process_behind_source_profile_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(correct_profile.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
     let _result = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}foo/"))
         .await
@@ -345,7 +345,7 @@ async fn test_credential_process_behind_source_profile_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(incorrect_profile.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
     let err = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}/"))
         .await
@@ -419,7 +419,7 @@ async fn test_scoped_credentials() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     // Inside the prefix, things should be fine
     let _result = client

--- a/mountpoint-s3-client/tests/client.rs
+++ b/mountpoint-s3-client/tests/client.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use common::*;
+use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::config::S3ClientConfig;
+
+#[tokio::test]
+async fn test_create_client_twice() {
+    let config = set_up_client_config(S3ClientConfig::new().endpoint_config(get_test_endpoint_config()));
+
+    // Attempt to create the client twice.
+    for _i in 0..2 {
+        let _client = S3CrtClient::new(config.clone()).expect("could not create test client");
+    }
+}

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -1,0 +1,23 @@
+use mountpoint_s3_client::config::MemoryPool;
+
+/// Creates a memory pool to use in tests.
+pub fn new_for_tests() -> impl MemoryPool {
+    NoReusePool()
+}
+
+/// Trivial memory pool implementation that always allocates new buffers.
+#[derive(Debug, Clone)]
+struct NoReusePool();
+
+impl MemoryPool for NoReusePool {
+    type Buffer = Box<[u8]>;
+
+    fn get_buffer(&self, size: usize) -> Self::Buffer {
+        vec![0u8; size].into_boxed_slice()
+    }
+
+    fn trim(&self) -> bool {
+        // Nothing to do.
+        false
+    }
+}

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -24,6 +24,7 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
 
 pub mod creds;
+pub mod memory_pool;
 pub mod tracing_test;
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3-client/tests/endpoint_config.rs
+++ b/mountpoint-s3-client/tests/endpoint_config.rs
@@ -5,9 +5,9 @@ pub mod common;
 use aws_sdk_s3::primitives::ByteStream;
 use bytes::Bytes;
 use common::*;
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::types::GetObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use test_case::test_case;
 
 async fn run_test(endpoint_config: EndpointConfig, prefix: &str, bucket: String) {
@@ -26,7 +26,7 @@ async fn run_test(endpoint_config: EndpointConfig, prefix: &str, bucket: String)
         .unwrap();
 
     let config = S3ClientConfig::new().endpoint_config(endpoint_config.clone());
-    let client = S3CrtClient::new(config).expect("could not create test client");
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -123,7 +123,7 @@ async fn test_single_region_access_point(addressing_style: AddressingStyle, arn:
 // For multi region access points, Rust SDK is not supported. Hence different helper method for these tests.
 async fn run_list_objects_test(endpoint_config: EndpointConfig, prefix: &str, bucket: &str) {
     let config = S3ClientConfig::new().endpoint_config(endpoint_config.clone());
-    let client = S3CrtClient::new(config).expect("could not create test client");
+    let client = get_test_client_with_config(config);
 
     client
         .list_objects(bucket, None, "/", 10, prefix)

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -359,8 +359,7 @@ async fn test_get_object_wrong_region() {
     let key = format!("{prefix}/nonexistent_key");
 
     let endpoint_config = EndpointConfig::new(&get_secondary_test_region());
-    let client =
-        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("must create a client");
+    let client = get_test_client_with_config(S3ClientConfig::new().endpoint_config(endpoint_config));
 
     let err = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -627,12 +626,11 @@ async fn stress_test_get_object() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = S3CrtClient::new(
+    let client = get_test_client_with_config(
         S3ClientConfig::new()
             .endpoint_config(get_test_endpoint_config())
             .event_loop_threads(100),
-    )
-    .expect("could not create test client");
+    );
     assert!(client.read_part_size().unwrap() > size);
 
     let mut tasks = tokio::task::JoinSet::new();

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -3,11 +3,7 @@
 pub mod common;
 
 use common::*;
-#[cfg(not(feature = "s3express_tests"))]
-use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_client::S3RequestError;
-#[cfg(not(feature = "s3express_tests"))]
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{HeadBucketError, ObjectClientError};
 
 #[tokio::test]
@@ -21,10 +17,11 @@ async fn test_head_bucket_correct_region() {
 #[tokio::test]
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_head_bucket_wrong_region() {
+    use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let endpoint_config = EndpointConfig::new(&get_secondary_test_region());
-    let client =
-        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client");
+    let client = get_test_client_with_config(S3ClientConfig::new().endpoint_config(endpoint_config));
     let expected_region = get_test_region();
 
     let result = client.head_bucket(&bucket).await;

--- a/mountpoint-s3-client/tests/network_interface_config.rs
+++ b/mountpoint-s3-client/tests/network_interface_config.rs
@@ -5,10 +5,10 @@ pub mod common;
 use test_case::test_case;
 
 use common::*;
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError::ServiceError};
 use mountpoint_s3_client::types::HeadObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 
 #[tokio::test]
 async fn test_empty_list() {
@@ -19,7 +19,7 @@ async fn test_empty_list() {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    let client = S3CrtClient::new(config).expect("client should create OK");
+    let client = create_client_with_config(config).expect("client should create OK");
 
     let err = client
         .head_object(&bucket, &key, &HeadObjectParams::new())
@@ -41,7 +41,7 @@ async fn test_one_interface_ok() {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    let client = S3CrtClient::new(config).expect("client should create OK");
+    let client = create_client_with_config(config).expect("client should create OK");
 
     let err = client
         .head_object(&bucket, &key, &HeadObjectParams::new())
@@ -68,7 +68,7 @@ async fn test_nonexistent(with_valid_interface: bool) {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    S3CrtClient::new(config).expect_err(
+    create_client_with_config(config).expect_err(
         "CRT should return an error during client creation if provided with non-existent network interface",
     );
 }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -18,7 +18,7 @@ use mountpoint_s3_client::types::{
     ChecksumAlgorithm, GetObjectParams, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
     PutObjectTrailingChecksums,
 };
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3RequestError};
 
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
 // contents are correct with a GET.
@@ -315,10 +315,11 @@ async fn test_put_object_initiate_failure() {
 async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
     const PART_SIZE: usize = 5 * 1024 * 1024;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
-    let client_config = S3ClientConfig::new()
-        .part_size(PART_SIZE)
-        .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(
+        S3ClientConfig::new()
+            .part_size(PART_SIZE)
+            .endpoint_config(get_test_endpoint_config()),
+    );
     let key = format!("{prefix}hello");
 
     let mut rng = rand::thread_rng();
@@ -384,8 +385,7 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
 #[tokio::test]
 async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_happy");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let key = format!("{prefix}hello");
 
     let params = PutObjectParams::new().object_metadata(object_metadata.clone());
@@ -415,8 +415,7 @@ async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, St
 #[tokio::test]
 async fn test_put_user_object_metadata_bad_header(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_bad_header");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let key = format!("{prefix}hello");
 
     let params = PutObjectParams::new().object_metadata(object_metadata.clone());
@@ -436,7 +435,7 @@ async fn test_put_review(pass_review: bool) {
     let client_config = S3ClientConfig::new()
         .part_size(PART_SIZE)
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(client_config);
     let key = format!("{prefix}hello");
 
     let mut rng = rand::thread_rng();
@@ -602,8 +601,7 @@ async fn check_sse(
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {
     let bucket = get_test_bucket();
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let request_params = PutObjectParams::new()
         .server_side_encryption(sse_type.map(|value| value.to_owned()))
         .ssekms_key_id(kms_key_id.to_owned());
@@ -639,7 +637,7 @@ async fn test_concurrent_put_objects(throughput_target_gbps: f64, max_concurrent
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .throughput_target_gbps(throughput_target_gbps);
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(client_config);
     let not_existing_key = format!("{prefix}not-there");
     let request_params = PutObjectParams::new();
 

--- a/mountpoint-s3-client/tests/rename_object.rs
+++ b/mountpoint-s3-client/tests/rename_object.rs
@@ -1,26 +1,24 @@
 #![cfg(feature = "s3express_tests")]
 
-use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{ObjectClientError, RenameObjectError};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::types::{
     HeadObjectParams, PutObjectParams, PutObjectSingleParams, RenameObjectParams, RenamePreconditionTypes,
     UploadChecksum,
 };
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient};
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
 use mountpoint_s3_crt::checksums::crc64nvme;
 use tracing::debug;
 use uuid::Uuid;
 
 pub mod common;
-use common::{get_test_bucket_and_prefix, get_test_endpoint_config};
+use common::{get_test_bucket_and_prefix, get_test_client};
 
 // Test that rename with source matching works as expected
 #[tokio::test]
 async fn simple_rename() {
     let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -53,8 +51,7 @@ async fn simple_rename() {
 #[tokio::test]
 async fn put_append_rename_append_test() {
     let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -110,8 +107,7 @@ async fn put_append_rename_append_test() {
 #[tokio::test]
 async fn rename_destination_does_not_match() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_destination_does_not_match");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -160,8 +156,7 @@ async fn rename_destination_does_not_match() {
 #[tokio::test]
 async fn rename_overwrite_error() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_overwrite_error");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -203,8 +198,7 @@ async fn rename_overwrite_error() {
 #[tokio::test]
 async fn rename_double_error() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_double_error");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -255,8 +249,7 @@ async fn rename_double_error() {
 #[tokio::test]
 async fn rename_source_does_not_match() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_source_does_not_match");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -303,8 +296,7 @@ async fn rename_source_does_not_match() {
 #[tokio::test]
 async fn rename_idempotency_test() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_idempotency_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 

--- a/mountpoint-s3-crt/src/common/allocator.rs
+++ b/mountpoint-s3-crt/src/common/allocator.rs
@@ -83,3 +83,12 @@ impl Default for Allocator {
         Self { inner, traced: false }
     }
 }
+
+impl From<NonNull<aws_allocator>> for Allocator {
+    fn from(value: NonNull<aws_allocator>) -> Self {
+        Self {
+            inner: value,
+            traced: false,
+        }
+    }
+}

--- a/mountpoint-s3-crt/src/s3.rs
+++ b/mountpoint-s3-crt/src/s3.rs
@@ -11,6 +11,7 @@ use crate::common::allocator::Allocator;
 pub mod buffer;
 pub mod client;
 pub mod endpoint_resolver;
+pub mod pool;
 
 static S3_LIBRARY_INIT: Once = Once::new();
 

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -1,0 +1,429 @@
+//! Bridge custom memory pool implementations to the CRT S3 Client interface.
+
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{fmt::Debug, ptr::NonNull};
+
+use mountpoint_s3_crt_sys::{
+    aws_allocator, aws_byte_buf, aws_byte_buf_from_empty_array, aws_byte_cursor, aws_future_s3_buffer_ticket,
+    aws_future_s3_buffer_ticket_acquire, aws_future_s3_buffer_ticket_new, aws_future_s3_buffer_ticket_release,
+    aws_future_s3_buffer_ticket_set_result_by_move, aws_ref_count_init, aws_s3_buffer_pool, aws_s3_buffer_pool_config,
+    aws_s3_buffer_pool_factory_fn, aws_s3_buffer_pool_reserve_meta, aws_s3_buffer_pool_vtable, aws_s3_buffer_ticket,
+    aws_s3_buffer_ticket_vtable,
+};
+
+use crate::ToAwsByteCursor as _;
+use crate::common::allocator::Allocator;
+
+/// A custom memory pool.
+pub trait MemoryPool: Clone + Send + Sync {
+    /// Associated buffer type.
+    type Buffer: AsMut<[u8]>;
+
+    /// Get a buffer of at least the requested size.
+    fn get_buffer(&self, size: usize) -> Self::Buffer;
+
+    /// Trim the pool.
+    ///
+    /// Return `true` if the pool freed any memory.
+    fn trim(&self) -> bool;
+}
+
+/// Factory for a custom memory pool.
+pub trait MemoryPoolFactory {
+    /// The [MemoryPool] implementation created by this factory.
+    type Pool: MemoryPool;
+
+    /// Create a memory pool instance.
+    fn create(&self, options: MemoryPoolFactoryOptions) -> Self::Pool;
+}
+
+impl<F, P> MemoryPoolFactory for F
+where
+    F: Fn(MemoryPoolFactoryOptions) -> P,
+    P: MemoryPool,
+{
+    type Pool = P;
+
+    fn create(&self, options: MemoryPoolFactoryOptions) -> Self::Pool {
+        self(options)
+    }
+}
+
+/// Options to create a [MemoryPool].
+#[derive(Debug)]
+pub struct MemoryPoolFactoryOptions {
+    part_size: usize,
+    max_part_size: usize,
+    memory_limit: usize,
+}
+
+impl MemoryPoolFactoryOptions {
+    /// The default part size set on the client.
+    pub fn part_size(&self) -> usize {
+        self.part_size
+    }
+    /// The max part size for the client.
+    pub fn max_part_size(&self) -> usize {
+        self.max_part_size
+    }
+    /// The memory limit set on the client.
+    pub fn memory_limit(&self) -> usize {
+        self.memory_limit
+    }
+}
+
+/// Factory used by [Client](`super::client::Client`) to create CRT wrappers for [MemoryPool] implementations.
+#[derive(Debug, Clone)]
+pub struct CrtBufferPoolFactory(Arc<CrtBufferPoolFactoryInner>);
+
+#[derive(Debug)]
+struct CrtBufferPoolFactoryInner {
+    factory_ptr: NonNull<libc::c_void>,
+    factory_fn: aws_s3_buffer_pool_factory_fn,
+    drop_fn: fn(*mut ::libc::c_void),
+}
+
+// SAFETY: `CrtBufferPoolFactoryInner` is safe to transfer across threads because it wraps a [MemoryPoolFactory] implementation that is [Send].
+unsafe impl Send for CrtBufferPoolFactoryInner {}
+// SAFETY: `CrtBufferPoolFactoryInner` is safe to share across threads because it wraps a [MemoryPoolFactory] implementation that is [Sync].
+unsafe impl Sync for CrtBufferPoolFactoryInner {}
+
+impl Drop for CrtBufferPoolFactoryInner {
+    fn drop(&mut self) {
+        (self.drop_fn)(self.factory_ptr.as_ptr());
+    }
+}
+
+impl CrtBufferPoolFactory {
+    /// Builds a factory for the given pool.
+    pub fn new<PoolFactory: MemoryPoolFactory>(pool_factory: PoolFactory) -> Self {
+        let factory = Box::pin(pool_factory);
+        // SAFETY: The pointer to the factory will only be used in `buffer_pool_factory` and
+        // `drop_pool_factory`, which will treat it as pinned.
+        let leaked = Box::leak(unsafe { Pin::into_inner_unchecked(factory) });
+        // SAFETY: `leaked` is not null.
+        let factory_ptr = unsafe { NonNull::new_unchecked(leaked as *mut PoolFactory as *mut libc::c_void) };
+        Self(Arc::new(CrtBufferPoolFactoryInner {
+            factory_ptr,
+            factory_fn: Some(buffer_pool_factory::<PoolFactory>),
+            drop_fn: drop_pool_factory::<PoolFactory>,
+        }))
+    }
+
+    /// Returns the factory callback and user_data pointer to pass to the CRT.
+    pub(crate) fn as_inner(&self) -> (aws_s3_buffer_pool_factory_fn, *mut ::libc::c_void) {
+        (self.0.factory_fn, self.0.factory_ptr.as_ptr())
+    }
+}
+
+unsafe extern "C" fn buffer_pool_factory<PoolFactory: MemoryPoolFactory>(
+    allocator: *mut aws_allocator,
+    config: aws_s3_buffer_pool_config,
+    user_data: *mut libc::c_void,
+) -> *mut aws_s3_buffer_pool {
+    // SAFETY: `user_data` references a `Box` owned by the `CrtBufferPoolFactory` instance.
+    let pool_factory = unsafe { &*(user_data as *mut PoolFactory) };
+
+    // SAFETY: `allocator` is a non-null pointer to a `aws_allocator` instance.
+    let allocator = unsafe { NonNull::new_unchecked(allocator).into() };
+
+    let options = MemoryPoolFactoryOptions {
+        part_size: config.part_size,
+        max_part_size: config.max_part_size,
+        memory_limit: config.memory_limit,
+    };
+    let pool = pool_factory.create(options);
+
+    let crt_pool = CrtBufferPool::new(pool.clone(), allocator);
+
+    // SAFETY: the CRT will only use the pool through its vtable and refcount.
+    unsafe { crt_pool.leak() }
+}
+
+fn drop_pool_factory<PoolFactory: MemoryPoolFactory>(factory_ptr: *mut libc::c_void) {
+    // SAFETY: `factory_ptr` was leaked in `CrtBufferPoolFactory::new`.
+    _ = unsafe { Pin::new_unchecked(Box::from_raw(factory_ptr as *mut PoolFactory)) };
+}
+
+/// Internal wrapper to bridge the [MemoryPool] implementation to
+/// the `aws_s3_buffer_pool` to provide to the CRT.
+///
+/// Instances of this type also hold the vtables to set up both
+/// the `aws_s3_buffer_pool` itself and the `aws_s3_buffer_ticket`s
+/// it returns. Notably, all the functions in the vtables are generic
+/// in the same [MemoryPool] implementation as [CrtBufferPool], so
+/// that the CRT can handle different implementations and there is
+/// no need for dynamic dispatch on the Rust side.
+struct CrtBufferPool<Pool: MemoryPool> {
+    /// Inner struct to pass to CRT functions.
+    inner: aws_s3_buffer_pool,
+    /// [MemoryPool] implementation.
+    pool: Pool,
+    /// Holds the vtable to point to in `inner`.
+    pool_vtable: aws_s3_buffer_pool_vtable,
+    /// Holds the vtable for the `aws_s3_buffer_ticket` instances.
+    ticket_vtable: aws_s3_buffer_ticket_vtable,
+    /// CRT allocator.
+    allocator: Allocator,
+    /// Pin this struct because inner.impl_ will be a pointer to this object.
+    _pinned: PhantomPinned,
+}
+
+impl<Pool: MemoryPool> CrtBufferPool<Pool> {
+    fn new(pool: Pool, allocator: Allocator) -> Pin<Box<Self>> {
+        // `inner` will be initialized after pinning because its fields require pinned addresses.
+        let mut crt_pool = Box::pin(CrtBufferPool {
+            inner: Default::default(),
+            pool,
+            pool_vtable: aws_s3_buffer_pool_vtable {
+                reserve: Some(pool_reserve::<Pool>),
+                trim: Some(pool_trim::<Pool>),
+                acquire: None,
+                release: None,
+            },
+            ticket_vtable: aws_s3_buffer_ticket_vtable {
+                claim: Some(ticket_claim::<Pool::Buffer>),
+                acquire: None,
+                release: None,
+            },
+            allocator,
+            _pinned: Default::default(),
+        });
+
+        // Set up the vtable and `impl_` to the pinned addresses (self-referential) and initialize ref-counting.
+        // SAFETY: We're setting up the struct to be self-referential, and we're not moving out
+        // of the struct, so the unchecked deref of the pinned pointer is okay.
+        unsafe {
+            let pool_ref = Pin::get_unchecked_mut(Pin::as_mut(&mut crt_pool));
+            pool_ref.inner.vtable = &raw mut pool_ref.pool_vtable;
+            pool_ref.inner.impl_ = pool_ref as *mut CrtBufferPool<Pool> as *mut libc::c_void;
+            aws_ref_count_init(
+                &mut pool_ref.inner.ref_count,
+                &mut pool_ref.inner as *mut aws_s3_buffer_pool as *mut libc::c_void,
+                Some(pool_destroy::<Pool>),
+            );
+        }
+
+        crt_pool
+    }
+
+    /// Leak a pinned instance and returns a raw pointer.
+    ///
+    /// # Safety
+    /// The returned pointer must eventually be passed to [from_raw] and can
+    /// additionally only used in [ref_from_raw].
+    unsafe fn leak(self: Pin<Box<Self>>) -> *mut aws_s3_buffer_pool {
+        // SAFETY: the resulting pointer will be only used in `pool_reserve`, `pool_trim`, and `pool_destroy`.
+        let pool = Box::leak(unsafe { Pin::into_inner_unchecked(self) });
+        &raw mut pool.inner
+    }
+
+    /// Returns a reference to original instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn ref_from_raw(pool: &*mut aws_s3_buffer_pool) -> &Self {
+        // SAFETY: `pool` points to the `inner` field of a pinned instance.
+        unsafe {
+            let impl_ptr = (**pool).impl_;
+            &*(impl_ptr as *mut Self)
+        }
+    }
+
+    /// Re-constructs the original pinned instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn from_raw(pool: *mut aws_s3_buffer_pool) -> Pin<Box<Self>> {
+        // SAFETY: `pool` points to the `inner` field of a pinned instance.
+        unsafe { Pin::new_unchecked(Box::from_raw((*pool).impl_ as *mut Self)) }
+    }
+
+    fn trim(&self) {
+        self.pool.trim();
+    }
+
+    fn reserve(&self, size: usize) -> CrtTicketFuture {
+        let future = CrtTicketFuture::new(&self.allocator);
+
+        // Get a buffer from the pool, build its ticket, and immediately fullfil the future.
+        // This will likely change later, when we make the method on the pool async.
+        let buffer = self.pool.get_buffer(size);
+        let ticket = self.make_ticket(buffer);
+        future.set(ticket);
+
+        future
+    }
+
+    fn make_ticket(&self, buffer: Pool::Buffer) -> Pin<Box<CrtTicket<Pool::Buffer>>> {
+        // Set up the vtable by pointing into the pool pinned address, but leave `impl_`
+        // and `ref_count` to be initialized after pinning the ticket.
+        let mut ticket = Box::pin(CrtTicket {
+            inner: aws_s3_buffer_ticket {
+                vtable: (&raw const self.ticket_vtable).cast_mut(),
+                ref_count: Default::default(),
+                impl_: std::ptr::null_mut(),
+            },
+            buffer,
+            _pinned: Default::default(),
+        });
+
+        // Set `impl_` to the pinned address (self-referential) and initialize ref-counting.
+        // SAFETY: We're setting up the struct to be self-referential, and we're not moving out
+        // of the struct, so the unchecked deref of the pinned pointer is okay.
+        unsafe {
+            let ticket_ref = Pin::get_unchecked_mut(Pin::as_mut(&mut ticket));
+            ticket_ref.inner.impl_ = ticket_ref as *mut CrtTicket<Pool::Buffer> as *mut libc::c_void;
+            aws_ref_count_init(
+                &mut ticket_ref.inner.ref_count,
+                &mut ticket_ref.inner as *mut aws_s3_buffer_ticket as *mut libc::c_void,
+                Some(ticket_destroy::<Pool::Buffer>),
+            );
+        }
+
+        ticket
+    }
+}
+
+unsafe extern "C" fn pool_reserve<Pool: MemoryPool>(
+    pool: *mut aws_s3_buffer_pool,
+    meta: aws_s3_buffer_pool_reserve_meta,
+) -> *mut aws_future_s3_buffer_ticket {
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
+    let future = crt_pool.reserve(meta.size);
+
+    // SAFETY: the CRT will take ownership of the future.
+    unsafe { future.into_inner_ptr() }
+}
+
+unsafe extern "C" fn pool_trim<Pool: MemoryPool>(pool: *mut aws_s3_buffer_pool) {
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
+    crt_pool.trim();
+}
+
+unsafe extern "C" fn pool_destroy<Pool: MemoryPool>(data: *mut libc::c_void) {
+    let pool = data as *mut aws_s3_buffer_pool;
+
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    _ = unsafe { CrtBufferPool::<Pool>::from_raw(pool) };
+}
+
+/// Wrapper for [aws_s3_buffer_ticket].
+struct CrtTicket<Buffer: AsMut<[u8]>> {
+    /// Inner struct to pass to CRT functions.
+    inner: aws_s3_buffer_ticket,
+    /// Buffer implementing [AsMut<\[u8\]>].
+    buffer: Buffer,
+    /// Pin this struct because inner.impl_ will be a pointer to this object.
+    _pinned: PhantomPinned,
+}
+
+impl<Buffer: AsMut<[u8]>> CrtTicket<Buffer> {
+    /// Leak a pinned instance and returns a raw pointer.
+    ///
+    /// # Safety
+    /// The returned pointer must eventually be passed to [from_raw] and can
+    /// additionally only used in [ref_mut_from_raw].
+    unsafe fn leak(self: Pin<Box<Self>>) -> *mut aws_s3_buffer_ticket {
+        // SAFETY: the resulting pointer will be only used in `ticket_claim` and `ticket_destroy`.
+        let boxed = unsafe { Pin::into_inner_unchecked(self) };
+        let pool = Box::leak(boxed);
+        &raw mut pool.inner
+    }
+
+    /// Returns a reference to original instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn ref_mut_from_raw(ticket: &mut *mut aws_s3_buffer_ticket) -> &mut Self {
+        // SAFETY: `ticket` points to the `inner` field of a pinned instance.
+        unsafe {
+            let impl_ptr = (**ticket).impl_;
+            &mut *(impl_ptr as *mut Self)
+        }
+    }
+
+    /// Re-constructs the original pinned instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn from_raw(ticket: *mut aws_s3_buffer_ticket) -> Pin<Box<Self>> {
+        // SAFETY: `ticket` points to the `inner` field of a pinned instance.
+        unsafe { Pin::new_unchecked(Box::from_raw((*ticket).impl_ as *mut Self)) }
+    }
+}
+
+unsafe extern "C" fn ticket_claim<Buffer: AsMut<[u8]>>(mut ticket: *mut aws_s3_buffer_ticket) -> aws_byte_buf {
+    // SAFETY: `ticket` was obtained through `Ticket::leak`.
+    let ticket = unsafe { CrtTicket::<Buffer>::ref_mut_from_raw(&mut ticket) };
+
+    // SAFETY: the CRT guarantees to only use the returned buffer while holding the ticket.
+    let aws_byte_cursor { len, ptr } = unsafe { ticket.buffer.as_mut().as_aws_byte_cursor() };
+
+    // SAFETY: `ptr` is a valid buffer with capacity >= `size`.
+    unsafe { aws_byte_buf_from_empty_array(ptr as *mut libc::c_void, len) }
+}
+
+unsafe extern "C" fn ticket_destroy<Buffer: AsMut<[u8]>>(data: *mut libc::c_void) {
+    let ticket = data as *mut aws_s3_buffer_ticket;
+    // SAFETY: `ticket` was obtained through `Ticket::leak`.
+    _ = unsafe { CrtTicket::<Buffer>::from_raw(ticket) };
+}
+
+/// Wrapper for [aws_future_s3_buffer_ticket].
+#[derive(Debug)]
+struct CrtTicketFuture {
+    inner: *mut aws_future_s3_buffer_ticket,
+}
+
+// SAFETY: `aws_future_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Send for CrtTicketFuture {}
+
+// SAFETY: `aws_future_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Sync for CrtTicketFuture {}
+
+impl CrtTicketFuture {
+    fn new(allocator: &Allocator) -> Self {
+        // SAFETY: aws_future_s3_buffer_ticket_new return a non-null pointer to a new aws_future_s3_buffer_ticket with a reference count of 1.
+        let inner = unsafe { aws_future_s3_buffer_ticket_new(allocator.inner.as_ptr()) };
+        Self { inner }
+    }
+
+    fn set<Buffer: AsMut<[u8]>>(&self, ticket: Pin<Box<CrtTicket<Buffer>>>) {
+        // SAFETY: `ticket` will be passed to the CRT which will only use it through its vtable and refcount.
+        let mut ticket = unsafe { ticket.leak() };
+        // SAFETY: `self.inner` is a valid future and we are setting it to `ticket`.
+        unsafe {
+            aws_future_s3_buffer_ticket_set_result_by_move(self.inner, &mut ticket);
+        }
+    }
+
+    /// Return the pointer to the inner `aws_future_s3_buffer_ticket` instance.
+    ///
+    /// # Safety
+    /// The returned pointer follows ref-counting rules and must be eventually released.
+    unsafe fn into_inner_ptr(mut self) -> *mut aws_future_s3_buffer_ticket {
+        std::mem::replace(&mut self.inner, std::ptr::null_mut())
+    }
+}
+
+impl Clone for CrtTicketFuture {
+    fn clone(&self) -> Self {
+        // SAFETY: `self.inner` is a valid `aws_future_s3_buffer_ticket`, and we increment its
+        // reference count on Clone and decrement it on Drop.
+        let inner = unsafe { aws_future_s3_buffer_ticket_acquire(self.inner) };
+        Self { inner }
+    }
+}
+
+impl Drop for CrtTicketFuture {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` is a valid `aws_future_s3_buffer_ticket`, and on Drop it's safe to decrement
+        // the reference count since this is balancing the `acquire` in `new`.
+        unsafe { aws_future_s3_buffer_ticket_release(self.inner) };
+    }
+}

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -31,7 +31,7 @@ pub trait MemoryPool: Clone + Send + Sync {
 }
 
 /// Factory for a custom memory pool.
-pub trait MemoryPoolFactory {
+pub trait MemoryPoolFactory: Send + Sync {
     /// The [MemoryPool] implementation created by this factory.
     type Pool: MemoryPool;
 
@@ -41,7 +41,7 @@ pub trait MemoryPoolFactory {
 
 impl<F, P> MemoryPoolFactory for F
 where
-    F: Fn(MemoryPoolFactoryOptions) -> P,
+    F: Fn(MemoryPoolFactoryOptions) -> P + Send + Sync,
     P: MemoryPool,
 {
     type Pool = P;

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -367,7 +367,7 @@ unsafe extern "C" fn ticket_claim<Buffer: AsMut<[u8]>>(mut ticket: *mut aws_s3_b
     // SAFETY: the CRT guarantees to only use the returned buffer while holding the ticket.
     let aws_byte_cursor { len, ptr } = unsafe { ticket.buffer.as_mut().as_aws_byte_cursor() };
 
-    // Build the `aws_byte_buf` required by the CRT from the pointer and length of the buffer.
+    // Use `aws_byte_buf_from_empty_array` to build an `aws_byte_buf` with 0 length and `len` capacity.
     // SAFETY: `ptr` is a valid buffer with capacity >= `len`.
     unsafe { aws_byte_buf_from_empty_array(ptr as *mut libc::c_void, len) }
 }


### PR DESCRIPTION
Introduces a `MemoryPool` trait in the client crate which allows users to provide their own memory pool implementation. This is part of the broader effort to use a unified memory pool in Mountpoint (see draft PR #1511).

This change introduces:
* The required code to bridge implementations of the new Rust trait to the CRT pool interface.
* A simple `MemoryPool` implementation to be used in tests.
* The `pool_tests` feature flags to use the above pool in the client tests, replacing the CRT default pool.
* A new CI workflow to run the client tests with the custom pool.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Entry in the client changelog.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
