### PR TITLE
Improve tracing for prefetcher read window increments

### DIFF
--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -173,8 +173,12 @@ impl BackpressureController {
         let prev_window_end_offset = self.read_window_end_offset;
         let next_window_end_offset = prev_window_end_offset + len as u64;
         trace!(
+            controller_addr = format!("{:p}", self),
             next_read_offset = self.next_read_offset,
-            prev_window_end_offset, next_window_end_offset, len, "incrementing read window",
+            prev_window_end_offset,
+            next_window_end_offset,
+            len,
+            "incrementing read window",
         );
 
         // This should not block since the channel is unbounded


### PR DESCRIPTION
Changes the BackpressureHandle to include the address of the backpressure handle so that we can easily match tracing about read window increments to the file handle.


Does not impact existing behaviour, no changelog entry or version change required.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
