### PR TITLE
Minor fixes to client and prefetch benchmarks for consistency

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -44,9 +44,8 @@ fn run_benchmark(
     let total_start = Instant::now();
     let mut iter_results = Vec::new();
     let mut iteration = 0;
-    let timeout: Instant = total_start
-        .checked_add(max_duration.unwrap_or(Duration::from_secs(86400)))
-        .expect("Duration overflow error");
+    let duration = max_duration.unwrap_or(Duration::from_secs(86400));
+    let timeout: Instant = total_start.checked_add(duration).expect("Duration overflow error");
 
     while iteration < num_iterations && Instant::now() < timeout {
         let iter_start = Instant::now();
@@ -146,7 +145,7 @@ fn run_benchmark(
             "summary": {
                 "total_bytes": total_bytes,
                 "total_elapsed_seconds": total_elapsed.as_secs_f64(),
-                "max_duration_seconds": max_duration,
+                "max_duration_seconds": duration,
                 "iterations": iter_results.len(),
             },
             "iterations": iter_results

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -18,6 +18,8 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 
+const SECONDS_PER_DAY: u64 = 86400;
+
 /// Like `tracing_subscriber::fmt::init` but sends logs to stderr
 fn init_tracing_subscriber() {
     RustLogAdapter::try_init().expect("unable to install CRT log adapter");
@@ -44,7 +46,7 @@ fn run_benchmark(
     let total_start = Instant::now();
     let mut iter_results = Vec::new();
     let mut iteration = 0;
-    let duration = max_duration.unwrap_or(Duration::from_secs(86400));
+    let duration = max_duration.unwrap_or(Duration::from_secs(SECONDS_PER_DAY));
     let timeout: Instant = total_start.checked_add(duration).expect("Duration overflow error");
 
     while iteration < num_iterations && Instant::now() < timeout {

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -21,6 +21,8 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 
+const SECONDS_PER_DAY: u64 = 86400;
+
 /// Like `tracing_subscriber::fmt::init` but sends logs to stderr
 fn init_tracing_subscriber() {
     RustLogAdapter::try_init().expect("should succeed as first and only adapter init call");
@@ -159,7 +161,7 @@ fn main() -> anyhow::Result<()> {
     let mut iteration = 0;
     let mut total_bytes = 0;
     let mut iter_results = Vec::new();
-    let max_duration = args.max_duration.unwrap_or(Duration::from_secs(86400));
+    let max_duration = args.max_duration.unwrap_or(Duration::from_secs(SECONDS_PER_DAY));
     let timeout: Instant = total_start.checked_add(max_duration).expect("Duration overflow error");
     while iteration < args.iterations && Instant::now() < timeout {
         let received_bytes = Arc::new(AtomicU64::new(0));


### PR DESCRIPTION
This change makes prefetch and client benchmarks consistent simplifying the automation

### Does this change impact existing behavior?

No, client and prefetch benchmarks only

### Does this change need a changelog entry? Does it require a version change?

No, client and prefetch benchmarks only

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
