### PR TITLE
Split up client and fs integration tests in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,18 +58,18 @@ jobs:
         bucket-type:
         - name: S3
           feature: 
-        - name: S3 Express One Zone
+        - name: S3XOZ
           feature: s3express_tests
         fuseVersion: [2, 3]
         runner:
         - name: Ubuntu x86
           tags: [ubuntu-22.04] # GitHub-hosted
-        - name: Amazon Linux arm
+        - name: AL2 arm
           tags: [self-hosted, linux, arm64]
         exclude:
           # fuse3 is not available on Amazon Linux 2
           - runner:
-              name: Amazon Linux arm
+              name: AL2 arm
               tags: [self-hosted, linux, arm64]
             fuseVersion: 3
 
@@ -100,7 +100,7 @@ jobs:
     - name: Run tests
       run: cargo test ${{ env.packages }} --features '${{ env.features }}'
     - name: Save dump files
-      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      if: ${{ failure() && matrix.runner.name == 'AL2 arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
   client-test:
@@ -118,12 +118,12 @@ jobs:
         bucket-type:
         - name: S3
           feature: 
-        - name: S3 Express One Zone
+        - name: S3XOZ
           feature: s3express_tests
         runner:
         - name: Ubuntu x86
           tags: [ubuntu-22.04] # GitHub-hosted
-        - name: Amazon Linux arm
+        - name: AL2 arm
           tags: [self-hosted, linux, arm64]
         pool:
         - name: Default Pool
@@ -159,7 +159,7 @@ jobs:
     - name: Run tests
       run: cargo test ${{ env.packages }} --features '${{ env.features }}'
     - name: Save dump files
-      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      if: ${{ failure() && matrix.runner.name == 'AL2 arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
   fstab:
@@ -175,7 +175,7 @@ jobs:
         runner:
           - name: Ubuntu x86
             tags: [ubuntu-22.04] # GitHub-hosted
-          - name: Amazon Linux arm
+          - name: AL2 arm
             tags: [self-hosted, linux, arm64]
 
     steps:


### PR DESCRIPTION
Organize the integration test workflows in two groups:

1. Client tests, for the `mountpoint-s3-client` crate (and its dependencies: `mountpoint-s3-crt` and `mountpoint-s3-crt-sys`) 
2. FS tests, for `mountpoint-s3-fs` and `mountpoint-s3`

Both groups define a matrix strategy across runners and S3 buckets. Additionally, the first group adds a dimension for the memory pool (currently default and test pool), while the second runs tests with FUSE 2 and 3.

### Does this change impact existing behavior?

No, CI change only.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
