### PR TITLE
Extract meta request type when reserving buffers

### DIFF
--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -82,6 +82,7 @@ pub mod config {
     #[doc(hidden)]
     pub use mountpoint_s3_crt::s3::s3_library_init;
 
+    pub use mountpoint_s3_crt::s3::client::MetaRequestType;
     pub use mountpoint_s3_crt::s3::pool::{MemoryPool, MemoryPoolFactory, MemoryPoolFactoryOptions};
 }
 

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -1,4 +1,4 @@
-use mountpoint_s3_client::config::MemoryPool;
+use mountpoint_s3_client::config::{MemoryPool, MetaRequestType};
 
 /// Creates a memory pool to use in tests.
 pub fn new_for_tests() -> impl MemoryPool {
@@ -12,7 +12,7 @@ struct NoReusePool();
 impl MemoryPool for NoReusePool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, _type: MetaRequestType) -> Self::Buffer {
         vec![0u8; size].into_boxed_slice()
     }
 

--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -60,7 +60,10 @@ const CRT_HEADERS: &[&str] = &[
 const PRIVATE_CRT_HEADERS: &[&str] = &[
     // To access S3 client stats
     "aws-c-s3/include/aws/s3/private/s3_client_impl.h",
+    // To get usage state from the default pool
     "aws-c-s3/include/aws/s3/private/s3_default_buffer_pool.h",
+    // To get meta request type
+    "aws-c-s3/include/aws/s3/private/s3_meta_request_impl.h",
 ];
 
 /// Get the OS name we are compiling to
@@ -181,6 +184,7 @@ fn generate_bindings(include_dir: &Path, output_path: &Path) -> Result<(), Bindg
         builder = builder.header(header_path.to_str().unwrap());
     }
 
+    builder = builder.clang_args(&["-I", Path::new(CRT_PATH).join("aws-c-s3/include").to_str().unwrap()]);
     for header in PRIVATE_CRT_HEADERS {
         let header_path = Path::new(CRT_PATH).join(header);
         if !header_path.exists() {

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -537,6 +537,18 @@ impl From<MetaRequestType> for aws_s3_meta_request_type {
     }
 }
 
+impl From<aws_s3_meta_request_type> for MetaRequestType {
+    fn from(value: aws_s3_meta_request_type) -> Self {
+        match value {
+            aws_s3_meta_request_type::AWS_S3_META_REQUEST_TYPE_DEFAULT => MetaRequestType::Default,
+            aws_s3_meta_request_type::AWS_S3_META_REQUEST_TYPE_COPY_OBJECT => MetaRequestType::CopyObject,
+            aws_s3_meta_request_type::AWS_S3_META_REQUEST_TYPE_GET_OBJECT => MetaRequestType::GetObject,
+            aws_s3_meta_request_type::AWS_S3_META_REQUEST_TYPE_PUT_OBJECT => MetaRequestType::PutObject,
+            _ => panic!("unknown meta request type {value:?}"),
+        }
+    }
+}
+
 /// SAFETY: Don't call this function directly, only called by the CRT as a callback.
 unsafe extern "C" fn meta_request_telemetry_callback(
     _request: *mut aws_s3_meta_request,


### PR DESCRIPTION
Modify the new `MemoryPool` trait (and the CRT bridge) to propagate the type of the meta request which is reserving the buffer. Requires extending bindings to an additional private header from `aws-c-s3` in order to access the type of a `aws_s3_meta_request` pointer.

### Does this change impact existing behavior?

No, the new type information is not used yet.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
