### PR TITLE
Decouple mem_limiter from client

### DIFF
--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -124,15 +124,37 @@ fn parse_duration(arg: &str) -> Result<Duration, String> {
         .map_err(|e| format!("Invalid duration: {e}"))
 }
 
-fn create_memory_limiter(args: &CliArgs, client: &S3CrtClient) -> Arc<MemoryLimiter<S3CrtClient>> {
-    let max_memory_target = if let Some(target) = args.max_memory_target {
-        target * 1024 * 1024
-    } else {
-        // Default to 95% of total system memory
-        let sys = System::new_with_specifics(RefreshKind::everything());
-        (sys.total_memory() as f64 * 0.95) as u64
-    };
-    Arc::new(MemoryLimiter::new(client.clone(), max_memory_target))
+impl CliArgs {
+    fn memory_target(&self) -> u64 {
+        if let Some(target) = self.max_memory_target {
+            target * 1024 * 1024
+        } else {
+            // Default to 95% of total system memory
+            let sys = System::new_with_specifics(RefreshKind::everything());
+            (sys.total_memory() as f64 * 0.95) as u64
+        }
+    }
+
+    fn s3_client_config(&self) -> S3ClientConfig {
+        let initial_read_window_size = 1024 * 1024 + 128 * 1024;
+        let mut client_config = S3ClientConfig::new()
+            .read_backpressure(true)
+            .initial_read_window(initial_read_window_size)
+            .endpoint_config(EndpointConfig::new(self.region.as_str()));
+        if let Some(throughput_target_gbps) = self.maximum_throughput_gbps {
+            client_config = client_config.throughput_target_gbps(throughput_target_gbps as f64);
+        }
+        if let Some(limit_gib) = self.crt_memory_limit_gib {
+            client_config = client_config.memory_limit_in_bytes(limit_gib * 1024 * 1024 * 1024);
+        }
+        if let Some(part_size) = self.part_size {
+            client_config = client_config.part_size(part_size as usize);
+        }
+        if let Some(nics) = &self.bind {
+            client_config = client_config.network_interface_names(nics.to_vec());
+        }
+        client_config
+    }
 }
 
 fn main() -> anyhow::Result<()> {
@@ -142,8 +164,9 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     let bucket = args.bucket.as_str();
-    let client = make_s3_client_from_args(&args).context("failed to create S3 CRT client")?;
-    let mem_limiter = create_memory_limiter(&args, &client);
+    let client_config = args.s3_client_config();
+    let client = S3CrtClient::new(client_config).context("failed to create S3 CRT client")?;
+    let mem_limiter = Arc::new(MemoryLimiter::new(client.clone(), args.memory_target()));
     let runtime = Runtime::new(client.event_loop_group());
 
     // Verify if all objects exist and collect metadata
@@ -257,25 +280,4 @@ async fn wait_for_download(
         total_bytes_read += bytes_read;
     }
     Ok(total_bytes_read)
-}
-
-fn make_s3_client_from_args(args: &CliArgs) -> anyhow::Result<S3CrtClient> {
-    let initial_read_window_size = 1024 * 1024 + 128 * 1024;
-    let mut client_config = S3ClientConfig::new()
-        .read_backpressure(true)
-        .initial_read_window(initial_read_window_size)
-        .endpoint_config(EndpointConfig::new(args.region.as_str()));
-    if let Some(throughput_target_gbps) = args.maximum_throughput_gbps {
-        client_config = client_config.throughput_target_gbps(throughput_target_gbps as f64);
-    }
-    if let Some(limit_gib) = args.crt_memory_limit_gib {
-        client_config = client_config.memory_limit_in_bytes(limit_gib * 1024 * 1024 * 1024);
-    }
-    if let Some(part_size) = args.part_size {
-        client_config = client_config.part_size(part_size as usize);
-    }
-    if let Some(nics) = &args.bind {
-        client_config = client_config.network_interface_names(nics.to_vec());
-    }
-    Ok(S3CrtClient::new(client_config)?)
 }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use async_channel::{Receiver, RecvError, Sender, unbounded};
 use humansize::make_format;
-use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
@@ -35,7 +34,7 @@ pub struct BackpressureConfig {
 /// It is used to send feedback ([Self::send_feedback]) to its corresponding [BackpressureLimiter],
 /// the counterpart which should be leveraged by the stream producer.
 #[derive(Debug)]
-pub struct BackpressureController<Client: ObjectClient> {
+pub struct BackpressureController {
     /// Sender for the [BackpressureLimiter] to receive size increments from the controller.
     read_window_updater: Sender<usize>,
     /// Amount by which the producer should be producing data ahead of [Self::next_read_offset].
@@ -58,7 +57,7 @@ pub struct BackpressureController<Client: ObjectClient> {
     /// Memory limiter is used to guide decisions on how much data to prefetch.
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
 }
 
 /// The [BackpressureLimiter] is used on producer side of a stream, for example,
@@ -81,10 +80,10 @@ pub struct BackpressureLimiter {
 ///
 /// This pair allows a consumer to send feedback ([BackpressureFeedbackEvent]) when starved or bytes are consumed,
 /// informing a producer (a holder of the [BackpressureLimiter]) when it should provide data more aggressively.
-pub fn new_backpressure_controller<Client: ObjectClient>(
+pub fn new_backpressure_controller(
     config: BackpressureConfig,
-    mem_limiter: Arc<MemoryLimiter<Client>>,
-) -> (BackpressureController<Client>, BackpressureLimiter) {
+    mem_limiter: Arc<MemoryLimiter>,
+) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
@@ -114,7 +113,7 @@ pub fn new_backpressure_controller<Client: ObjectClient>(
     (controller, limiter)
 }
 
-impl<Client: ObjectClient> BackpressureController<Client> {
+impl BackpressureController {
     pub fn read_window_end_offset(&self) -> u64 {
         self.read_window_end_offset
     }
@@ -234,7 +233,7 @@ impl<Client: ObjectClient> BackpressureController<Client> {
     }
 }
 
-impl<Client: ObjectClient> Drop for BackpressureController<Client> {
+impl Drop for BackpressureController {
     fn drop(&mut self) {
         debug_assert!(
             self.next_read_offset <= self.request_end_offset,
@@ -435,7 +434,7 @@ mod tests {
 
     fn new_backpressure_controller_for_test(
         backpressure_config: BackpressureConfig,
-    ) -> (BackpressureController<MockClient>, BackpressureLimiter) {
+    ) -> (BackpressureController, BackpressureLimiter) {
         let client = MockClient::config()
             .bucket("test-bucket")
             .part_size(8 * 1024 * 1024)

--- a/mountpoint-s3-fs/src/prefetch/builder.rs
+++ b/mountpoint-s3-fs/src/prefetch/builder.rs
@@ -38,7 +38,7 @@ where
     pub fn build(
         self,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
+        mem_limiter: Arc<MemoryLimiter>,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         self.inner.build(runtime, mem_limiter, prefetcher_config)
@@ -58,7 +58,7 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
+        mem_limiter: Arc<MemoryLimiter>,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client>;
 }
@@ -74,7 +74,7 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
+        mem_limiter: Arc<MemoryLimiter>,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = ClientPartStream::new(runtime, self.client, mem_limiter);
@@ -95,7 +95,7 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
+        mem_limiter: Arc<MemoryLimiter>,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = CachingPartStream::new(runtime, self.client, mem_limiter, self.cache);

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -29,11 +29,11 @@ pub struct CachingPartStream<Cache, Client: ObjectClient + Clone + Send + Sync +
     cache: Arc<Cache>,
     runtime: Runtime,
     client: Client,
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
 }
 
 impl<Cache, Client: ObjectClient + Clone + Send + Sync + 'static> CachingPartStream<Cache, Client> {
-    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter<Client>>, cache: Cache) -> Self {
+    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter>, cache: Cache) -> Self {
         Self {
             cache: Arc::new(cache),
             runtime,

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -23,7 +23,7 @@ pub struct PartQueue<Client: ObjectClient> {
     failed: bool,
     /// The total number of bytes sent to the underlying queue of `self.receiver`
     bytes_received: Arc<AtomicUsize>,
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
 }
 
 /// Producer side of the queue of [Part]s.
@@ -36,7 +36,7 @@ pub struct PartQueueProducer<E: std::error::Error> {
 
 /// Creates an unbounded [PartQueue] and its related [PartQueueProducer].
 pub fn unbounded_part_queue<Client: ObjectClient>(
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
 ) -> (PartQueue<Client>, PartQueueProducer<Client::ClientError>) {
     let (sender, receiver) = unbounded();
     let bytes_counter = Arc::new(AtomicUsize::new(0));

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -195,11 +195,11 @@ impl<Client> Debug for PartStream<Client> {
 pub struct ClientPartStream<Client: ObjectClient + Clone + Send + Sync + 'static> {
     runtime: Runtime,
     client: Client,
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
 }
 
 impl<Client: ObjectClient + Clone + Send + Sync + 'static> ClientPartStream<Client> {
-    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter<Client>>) -> Self {
+    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter>) -> Self {
         Self {
             runtime,
             client,

--- a/mountpoint-s3-fs/src/prefetch/task.rs
+++ b/mountpoint-s3-fs/src/prefetch/task.rs
@@ -17,7 +17,7 @@ pub struct RequestTask<Client: ObjectClient> {
     remaining: usize,
     range: RequestRange,
     part_queue: PartQueue<Client>,
-    backpressure_controller: BackpressureController<Client>,
+    backpressure_controller: BackpressureController,
 }
 
 impl<Client: ObjectClient> RequestTask<Client> {
@@ -25,7 +25,7 @@ impl<Client: ObjectClient> RequestTask<Client> {
         task_handle: RemoteHandle<()>,
         range: RequestRange,
         part_queue: PartQueue<Client>,
-        backpressure_controller: BackpressureController<Client>,
+        backpressure_controller: BackpressureController,
     ) -> Self {
         Self {
             _task_handle: task_handle,

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -269,7 +269,7 @@ impl TargetThroughputSetting {
 //
 // Note the CRT does not respect this value right now, they always return chunks of part size
 // but this is the first window size we prefer.
-const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 + 128 * 1024;
+pub const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 + 128 * 1024;
 
 impl ClientConfig {
     /// Create an [S3CrtClient]

--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -28,7 +28,7 @@ pub use incremental::AppendUploadRequest;
 pub struct Uploader<Client: ObjectClient> {
     client: Client,
     runtime: Runtime,
-    mem_limiter: Arc<MemoryLimiter<Client>>,
+    mem_limiter: Arc<MemoryLimiter>,
     storage_class: Option<String>,
     server_side_encryption: ServerSideEncryption,
     buffer_size: usize,
@@ -104,12 +104,7 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     /// Create a new [Uploader] that will make requests to the given client.
-    pub fn new(
-        client: Client,
-        runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter<Client>>,
-        config: UploaderConfig,
-    ) -> Self {
+    pub fn new(client: Client, runtime: Runtime, mem_limiter: Arc<MemoryLimiter>, config: UploaderConfig) -> Self {
         Self {
             client,
             runtime,


### PR DESCRIPTION
Minor refactor to decouple the memory limiter from the client implementation. The memory limiter only requires the client to retrieve information about its internal memory pool utilization. This change wraps that request in a type-erased closure and drop the generic parameter from the memory limiter and all related types.

### Does this change impact existing behavior?

No. Internal refactor only.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
