### PR TITLE
Add custom memory pool implementation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,6 +130,8 @@ jobs:
           feature:
         - name: Test Pool
           feature: pool_tests
+        - name: FS Pool
+          feature: fs_pool_tests
 
     steps:
     - name: Configure AWS credentials

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,7 @@ dependencies = [
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
+ "mountpoint-s3-fs",
  "percent-encoding",
  "pin-project",
  "platform-info",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -56,6 +56,9 @@ tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 mountpoint-s3-client = { path = ".", features = ["mock"] }
 
+# Required to run the tests using the custom memory pool from the fs crate.
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs" }
+
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2"] }
 
@@ -67,6 +70,7 @@ s3_tests = []
 fips_tests = []
 s3express_tests = []
 pool_tests = []
+fs_pool_tests = []
 
 [lib]
 doctest = false

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -78,6 +78,11 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
     #[cfg(feature = "pool_tests")]
     let config = config.memory_pool(memory_pool::new_for_tests());
 
+    #[cfg(feature = "fs_pool_tests")]
+    let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
+        mountpoint_s3_fs::memory::PagedPool::new([options.part_size()])
+    });
+
     config
 }
 

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::undocumented_unsafe_blocks)]
+
 mod async_util;
 pub mod autoconfigure;
 mod checksums;
@@ -9,6 +11,7 @@ pub mod logging;
 #[cfg(feature = "manifest")]
 pub mod manifest;
 pub mod mem_limiter;
+pub mod memory;
 pub mod metablock;
 pub mod metrics;
 pub mod object;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,0 +1,8 @@
+mod buffers;
+mod pages;
+mod pool;
+mod stats;
+
+pub use buffers::{PoolBuffer, PoolBufferMut};
+pub use pool::PagedPool;
+pub use stats::BufferKind;

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -1,0 +1,223 @@
+use bytes::Bytes;
+
+use crate::sync::Arc;
+
+use super::pages::PagedBufferPtr;
+use super::stats::{BufferKind, PoolStats};
+
+/// Pool buffer.
+#[derive(Debug)]
+pub struct PoolBuffer(PoolBufferInner);
+
+#[derive(Debug)]
+enum PoolBufferInner {
+    /// Buffer from the paged pool.
+    Primary { buffer_ptr: PagedBufferPtr, size: usize },
+    /// Buffer allocated independently.
+    Secondary(FreeBuffer),
+}
+
+impl PoolBuffer {
+    pub(super) fn new_primary(buffer_ptr: PagedBufferPtr, size: usize) -> Self {
+        assert!(size <= buffer_ptr.size());
+        Self(PoolBufferInner::Primary { buffer_ptr, size })
+    }
+
+    pub(super) fn new_secondary(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
+        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats)))
+    }
+
+    pub fn capacity(&self) -> usize {
+        match &self.0 {
+            PoolBufferInner::Primary { size, .. } => *size,
+            PoolBufferInner::Secondary(boxed) => boxed.data.len(),
+        }
+    }
+
+    pub fn into_bytes(self) -> Bytes {
+        Bytes::from_owner(self)
+    }
+}
+
+impl AsMut<[u8]> for PoolBuffer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match &mut self.0 {
+            PoolBufferInner::Primary { buffer_ptr, size } => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts_mut(buffer_ptr.as_raw_ptr(), *size) }
+            }
+            PoolBufferInner::Secondary(boxed) => &mut boxed.data,
+        }
+    }
+}
+
+impl AsRef<[u8]> for PoolBuffer {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            PoolBufferInner::Primary { buffer_ptr, size } => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts(buffer_ptr.as_raw_ptr(), *size) }
+            }
+            PoolBufferInner::Secondary(boxed) => &boxed.data,
+        }
+    }
+}
+
+/// A mutable buffer backed by the pool.
+#[derive(Debug)]
+pub struct PoolBufferMut {
+    buffer: PoolBuffer,
+    len: usize,
+}
+
+impl PoolBufferMut {
+    pub fn new(buffer: PoolBuffer) -> Self {
+        Self { buffer, len: 0 }
+    }
+
+    /// Append data from a slice to the end of this buffer. If reaching the buffer capacity,
+    /// split off the overflowing subslice.
+    ///
+    /// Returns the overflowing subslice.
+    pub fn append_from_slice<'a>(&mut self, slice: &mut &'a [u8]) -> &'a [u8] {
+        let available = self.buffer.capacity() - self.len;
+        let overflow = slice.split_off(available.min(slice.len())..).unwrap();
+        let new_len = self.len + slice.len();
+        self.buffer.as_mut()[self.len..new_len].copy_from_slice(slice);
+        self.len = new_len;
+        overflow
+    }
+
+    /// Set the length of this buffer, up to its capacity. When extending the
+    /// current length, exposes uninitialized data.
+    ///
+    /// Returns the resulting length of the buffer (<= capacity).
+    pub fn set_len_uninit(&mut self, length: usize) -> usize {
+        self.len = self.buffer.capacity().min(length);
+        self.len
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.len == self.buffer.capacity()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.buffer.capacity()
+    }
+
+    pub fn into_bytes(self) -> Bytes {
+        Bytes::from_owner(self)
+    }
+}
+
+impl AsRef<[u8]> for PoolBufferMut {
+    fn as_ref(&self) -> &[u8] {
+        &self.buffer.as_ref()[..self.len]
+    }
+}
+
+impl AsMut<[u8]> for PoolBufferMut {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer.as_mut()[..self.len]
+    }
+}
+
+#[derive(Debug)]
+struct FreeBuffer {
+    data: Box<[u8]>,
+    kind: BufferKind,
+    stats: Arc<PoolStats>,
+}
+
+impl FreeBuffer {
+    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
+        let data = vec![0u8; size].into_boxed_slice();
+        stats.reserve_bytes(data.len(), kind);
+        Self { data, kind, stats }
+    }
+}
+
+impl Drop for FreeBuffer {
+    fn drop(&mut self) {
+        self.stats.release_bytes(self.data.len(), self.kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::pages::tests::create_page;
+
+    use super::*;
+
+    use test_case::{test_case, test_matrix};
+
+    fn primary(buffer_size: usize) -> PoolBuffer {
+        let page = create_page(buffer_size);
+        let buffer_ptr = page
+            .try_reserve(BufferKind::Other)
+            .expect("should be able to reserve a buffer from a new page");
+
+        PoolBuffer::new_primary(buffer_ptr, buffer_size)
+    }
+
+    fn secondary(buffer_size: usize) -> PoolBuffer {
+        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, Arc::new(PoolStats::default()))
+    }
+
+    #[test_case(primary)]
+    #[test_case(secondary)]
+    fn test_pool_buffer(create_fn: fn(usize) -> PoolBuffer) {
+        const BUFFER_SIZE: usize = 1024;
+        let mut pool_buffer = create_fn(BUFFER_SIZE);
+
+        assert_eq!(pool_buffer.capacity(), BUFFER_SIZE);
+
+        let data = &[42u8; BUFFER_SIZE];
+        pool_buffer.as_mut().copy_from_slice(data);
+
+        assert_eq!(pool_buffer.as_ref(), data);
+
+        let bytes = pool_buffer.into_bytes();
+        assert_eq!(bytes.as_ref(), data);
+    }
+
+    const BUFFER_SIZE: usize = 1024;
+    const SMALL_WRITE_SIZE: usize = 512;
+    const LARGE_WRITE_SIZE: usize = 1280;
+
+    #[test_matrix([primary, secondary], [SMALL_WRITE_SIZE, BUFFER_SIZE, LARGE_WRITE_SIZE])]
+    fn test_pool_buffer_mut(create_fn: fn(usize) -> PoolBuffer, write_size: usize) {
+        let mut pool_buffer = PoolBufferMut::new(create_fn(BUFFER_SIZE));
+
+        assert_eq!(pool_buffer.capacity(), BUFFER_SIZE);
+        assert_eq!(pool_buffer.len(), 0);
+        assert!(pool_buffer.is_empty());
+        assert!(!pool_buffer.is_full());
+
+        let slice = pool_buffer.as_ref();
+        assert!(slice.is_empty());
+
+        let data = vec![42u8; write_size];
+        let mut slice = &data[..];
+        let remaining = pool_buffer.append_from_slice(&mut slice);
+
+        let overflow_size = write_size.saturating_sub(BUFFER_SIZE);
+        let appended_size = write_size - overflow_size;
+        assert_eq!(remaining.len(), overflow_size);
+        assert_eq!(slice.len(), appended_size);
+
+        assert_eq!(pool_buffer.len(), appended_size);
+        assert_eq!(pool_buffer.as_ref(), &data[..appended_size]);
+
+        let bytes = pool_buffer.into_bytes();
+        assert_eq!(bytes.as_ref(), &data[..appended_size]);
+    }
+}

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -268,14 +268,14 @@ mod tests {
         let result = pool_buffer.fill_from_reader(&data[..]);
         if read_size + INITIAL_SIZE >= BUFFER_SIZE {
             result.expect("fill from large enough slice should succeed");
-            assert_eq!(&pool_buffer.as_ref()[0..INITIAL_SIZE], &initial[..]);
+            assert_eq!(&pool_buffer.as_ref()[..INITIAL_SIZE], &initial[..]);
             assert_eq!(
                 &pool_buffer.as_ref()[INITIAL_SIZE..],
                 &data[..BUFFER_SIZE - INITIAL_SIZE]
             );
         } else {
             result.expect_err("fill from small slice should fail");
-            assert_eq!(pool_buffer.len(), INITIAL_SIZE);
+            assert_eq!(pool_buffer.as_ref(), &initial[..]);
         }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -127,7 +127,7 @@ impl Page {
             return false;
         }
         self.inner.stats.remove_empty_page();
-        // Mark the page as full, even if no buffer is currently reserved. If a new request
+        // Mark the page as full, even though no buffer is currently reserved. If a new request
         // arrives before the page is removed from the pool, it will be denied.
         *bitmask = FULL_MASK;
         true

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -105,8 +105,8 @@ impl PagedPool {
                 let buffer_ptr = pool.reserve(kind);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
-                let slack = pool.buffer_size() - size;
-                metrics::histogram!("pool.slack_bytes", "kind" => kind.as_str()).record(slack as f64);
+                metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
+                    .record((pool.buffer_size() - size) as f64);
                 PoolBuffer::new_primary(buffer_ptr, size)
             }
             None => {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -1,0 +1,345 @@
+use std::time::Duration;
+
+use mountpoint_s3_client::config::{MemoryPool, MetaRequestType};
+
+use crate::sync::{Arc, RwLock};
+
+use super::buffers::{PoolBuffer, PoolBufferMut};
+use super::pages::{Page, PagedBufferPtr};
+use super::stats::{BufferKind, PoolStats, SizePoolStats};
+
+/// A pool of reusable fixed-size buffers allocated in large pages.
+///
+/// This type implements [MemoryPool] and can be configured as a custom memory pool
+/// for a [S3CrtClient](mountpoint_s3_client::S3CrtClient).
+/// It can also return mutable buffers ([PoolBufferMut]) to use in other scenarios,
+/// such as reading cache blocks from disk or buffering incremental uploads.
+///
+/// The pool is configured by providing a set of sizes for the buffers, e.g. read
+/// and write part sizes, cache block size. For each of these sizes, the pool will
+/// maintain a [SizePool] instance, which will allocate "pages" of
+/// [BUFFERS_PER_PAGE](super::pages::Page::BUFFERS_PER_PAGE) (16) buffers on demand.
+///
+/// When a buffer of a given size is requested, the pool will return a buffer from one
+/// of 2 logical areas: **primary** and **secondary**:
+///
+/// - **primary**: the [SizePool] with the smallest buffer size large enough to contain
+///   the requested size is selected. If any of its existing pages has a free buffer,
+///   it is marked as reserved and returned, otherwise a new page is allocated.
+/// - **secondary**: if the requested size is larger than the maximum buffer size in
+///   [SizePool]s, a buffer of the exact size is allocated and returned.
+///
+/// When a primary buffer is dropped, it will automatically be released back to the pool,
+/// so it can be reused. Secondary buffers will also notify the pool on drop, but only
+/// for tracking.
+///
+/// The [`trim`](Self::trim) method can be invoked to free all empty pages, i.e. with no
+/// currently reserved buffers, across [SizePool]s.
+///
+/// When reserving a buffer, a [BufferKind] parameter is required to keep track of the
+/// usage. Requests through the [MemoryPool] interface will map the originating
+/// [MetaRequestType] to [BufferKind].
+#[derive(Debug, Clone)]
+pub struct PagedPool {
+    inner: Arc<PagedPoolInner>,
+}
+
+impl PagedPool {
+    /// Creates a new pool with the given set of buffer sizes.
+    ///
+    /// Duplicate sizes are ignored.
+    pub fn new(buffer_sizes: impl Into<Vec<usize>>) -> Self {
+        let mut buffer_sizes: Vec<_> = buffer_sizes.into();
+        buffer_sizes.sort();
+        buffer_sizes.dedup();
+
+        let stats = Arc::new(PoolStats::default());
+        let size_pools = buffer_sizes
+            .iter()
+            .map(|&buffer_size| SizePool {
+                pages: Default::default(),
+                stats: Arc::new(SizePoolStats::new(buffer_size, stats.clone())),
+            })
+            .collect();
+
+        let inner = PagedPoolInner { size_pools, stats };
+        Self { inner: Arc::new(inner) }
+    }
+
+    /// Trim empty pages in the pool.
+    pub fn trim(&self) -> bool {
+        self.inner.trim()
+    }
+
+    /// Schedule recurring calls to [trim](Self::trim).
+    pub fn schedule_trim(&self, recurring_time: Duration) {
+        let weak = Arc::downgrade(&self.inner);
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(recurring_time);
+                let Some(pool) = weak.upgrade() else {
+                    return;
+                };
+                pool.trim();
+            }
+        });
+    }
+
+    /// Return the reserved memory in bytes for the given kind of buffer.
+    pub fn reserved_bytes(&self, kind: BufferKind) -> usize {
+        self.inner.stats.reserved_bytes(kind)
+    }
+
+    /// Get a new empty mutable buffer from the pool with the requested capacity.
+    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind) -> PoolBufferMut {
+        let buffer = self.get_buffer(capacity, kind);
+        PoolBufferMut::new(buffer)
+    }
+
+    fn get_buffer(&self, size: usize, kind: BufferKind) -> PoolBuffer {
+        match self.inner.get_pool_for_size(size) {
+            Some(pool) => {
+                let buffer_ptr = pool.reserve(kind);
+                metrics::histogram!("pool.reserve", "type" => "primary", "kind" => kind.as_str()).record(size as f64);
+                let slack = pool.buffer_size() - size;
+                metrics::histogram!("pool.slack", "kind" => kind.as_str()).record(slack as f64);
+                PoolBuffer::new_primary(buffer_ptr, size)
+            }
+            None => {
+                metrics::histogram!("pool.reserve", "type" => "secondary", "kind" => kind.as_str()).record(size as f64);
+                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn page_count(&self) -> usize {
+        self.inner
+            .size_pools
+            .iter()
+            .map(|pool| pool.pages.read().unwrap().len())
+            .sum()
+    }
+
+    #[cfg(test)]
+    fn used_buffer_count(&self, kind: BufferKind) -> usize {
+        self.inner
+            .size_pools
+            .iter()
+            .map(|pool| pool.stats.used_buffers(kind))
+            .sum()
+    }
+}
+
+impl MemoryPool for PagedPool {
+    type Buffer = PoolBuffer;
+
+    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType) -> Self::Buffer {
+        self.get_buffer(size, meta_request_type.into())
+    }
+
+    fn trim(&self) -> bool {
+        self.trim()
+    }
+}
+
+#[derive(Debug)]
+struct PagedPoolInner {
+    size_pools: Vec<SizePool>,
+    stats: Arc<PoolStats>,
+}
+
+impl PagedPoolInner {
+    fn get_pool_for_size(&self, size: usize) -> Option<&SizePool> {
+        if size == 0 {
+            return None;
+        }
+
+        let index = self.size_pools.partition_point(|p| p.stats.buffer_size < size);
+        if index == self.size_pools.len() {
+            return None;
+        }
+
+        Some(&self.size_pools[index])
+    }
+
+    fn trim(&self) -> bool {
+        let mut removed = false;
+        for pool in &self.size_pools {
+            if pool.stats.empty_pages() == 0 {
+                continue;
+            }
+            let mut write = pool.pages.write().unwrap();
+            let len = write.len();
+            write.retain(|p| !p.invalidate_if_empty());
+
+            let pages_freed = len - write.len();
+            if pages_freed > 0 {
+                tracing::trace!(
+                    size = pool.stats.buffer_size,
+                    pages_freed,
+                    "free empty memory pool pages"
+                );
+                removed = true;
+            }
+            metrics::histogram!("pool.trim", "size" => format!("{}", pool.stats.buffer_size))
+                .record(pages_freed as f64);
+        }
+
+        removed
+    }
+}
+
+#[derive(Debug)]
+struct SizePool {
+    pages: RwLock<Vec<Page>>,
+    stats: Arc<SizePoolStats>,
+}
+
+impl SizePool {
+    fn reserve(&self, kind: BufferKind) -> PagedBufferPtr {
+        {
+            let read_pages = self.pages.read().unwrap();
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
+                return buffer_ptr;
+            }
+        }
+
+        let mut write_pages = self.pages.write().unwrap();
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
+            return buffer_ptr;
+        }
+
+        tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
+        let page = Page::new(self.stats.clone());
+        let buffer_ptr = page.try_reserve(kind).unwrap();
+        write_pages.push(page);
+        buffer_ptr
+    }
+
+    fn try_get_buffer_ptr<'a>(
+        &self,
+        mut pages: impl Iterator<Item = &'a Page>,
+        kind: BufferKind,
+    ) -> Option<PagedBufferPtr> {
+        pages.find_map(|page| page.try_reserve(kind))
+    }
+
+    fn buffer_size(&self) -> usize {
+        self.stats.buffer_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::ops::Deref;
+    use std::thread::{self, sleep};
+    use std::time::Duration;
+
+    use super::*;
+
+    use bytes::Bytes;
+    use rand::Rng;
+    use test_case::{test_case, test_matrix};
+
+    fn copy_from_slice(pool: &PagedPool, original: &[u8]) -> Bytes {
+        let mut buffer = pool.get_buffer(original.len(), BufferKind::Other);
+        buffer.as_mut().clone_from_slice(original);
+        buffer.into_bytes()
+    }
+
+    #[test_case(&[1, 2, 3], &[5, 10])]
+    #[test_case(&vec![42u8; 1000], &[128, 1024])]
+    fn test_from_slice(original: &[u8], buffer_sizes: &[usize]) {
+        let pool = PagedPool::new(buffer_sizes);
+        let bytes = copy_from_slice(&pool, original);
+        assert_eq!(original, bytes.as_ref());
+    }
+
+    #[test_case(&[5, 10, 1024])]
+    fn test_pages(buffer_sizes: &[usize]) {
+        let pool = PagedPool::new(buffer_sizes);
+
+        for &size in buffer_sizes {
+            let original = vec![1u8; size];
+
+            assert_eq!(pool.page_count(), 0);
+            assert_eq!(pool.used_buffer_count(BufferKind::Other), 0);
+
+            let mut buffers = Vec::new();
+            for _ in 0..16 {
+                buffers.push(copy_from_slice(&pool, &original));
+            }
+            assert_eq!(pool.page_count(), 1);
+            assert_eq!(pool.used_buffer_count(BufferKind::Other), 16);
+
+            buffers.push(copy_from_slice(&pool, &original));
+            assert_eq!(pool.page_count(), 2);
+            assert_eq!(pool.used_buffer_count(BufferKind::Other), 17);
+
+            assert!(!pool.trim());
+
+            drop(buffers);
+
+            assert_eq!(pool.page_count(), 2);
+            assert_eq!(pool.used_buffer_count(BufferKind::Other), 0);
+
+            assert!(pool.trim());
+            assert_eq!(pool.page_count(), 0);
+            assert_eq!(pool.used_buffer_count(BufferKind::Other), 0);
+        }
+    }
+
+    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [None, Some(Duration::from_millis(1))])]
+    #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
+    #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
+    fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
+        let pool = PagedPool::new(buffer_sizes);
+        if let Some(duration) = schedule {
+            pool.schedule_trim(duration);
+        }
+
+        let num_threads = 10000;
+        thread::scope(|scope| {
+            for i in 0..num_threads {
+                let pool = pool.clone();
+                scope.spawn(move || {
+                    let len = rand::thread_rng().gen_range(1..original.len());
+                    let original = &original[..len];
+                    let bytes = copy_from_slice(&pool, &original[..len]);
+                    assert_eq!(original, bytes.deref());
+
+                    sleep(Duration::from_millis(i as u64 % 10));
+
+                    let bytes = copy_from_slice(&pool, &bytes);
+                    assert_eq!(original, bytes.deref());
+                });
+            }
+        });
+
+        let page_count = pool.page_count();
+        if page_count > 0 {
+            pool.trim();
+            assert_eq!(pool.page_count(), 0);
+        }
+    }
+
+    #[test]
+    fn test_reserved_bytes() {
+        let buffer_size = 1024;
+        let reservations = HashMap::from([(BufferKind::GetObject, 10), (BufferKind::Other, 20)]);
+        let pool = PagedPool::new([buffer_size]);
+        let mut buffers = Vec::new();
+        for (&kind, &count) in &reservations {
+            for _ in 0..count {
+                buffers.push(pool.get_buffer(buffer_size, kind).into_bytes());
+            }
+        }
+
+        for (&kind, &count) in &reservations {
+            let reserved = pool.reserved_bytes(kind);
+            assert_eq!(reserved, count * buffer_size);
+        }
+    }
+}

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,0 +1,113 @@
+use std::ops::Index;
+
+use mountpoint_s3_client::config::MetaRequestType;
+
+use crate::sync::Arc;
+use crate::sync::atomic::{AtomicUsize, Ordering};
+
+/// Usage stats for a pool.
+#[derive(Debug, Default)]
+pub struct PoolStats {
+    reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+}
+
+impl PoolStats {
+    pub fn reserved_bytes(&self, kind: BufferKind) -> usize {
+        self.reserved_bytes[kind].load(Ordering::SeqCst)
+    }
+
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
+        self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
+    }
+
+    pub(super) fn release_bytes(&self, bytes: usize, kind: BufferKind) {
+        self.reserved_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
+    }
+}
+
+/// Usage stats for a specific size pool.
+#[derive(Debug)]
+pub struct SizePoolStats {
+    pub buffer_size: usize,
+    empty_pages: AtomicUsize,
+    used_buffers: [AtomicUsize; BUFFER_KIND_COUNT],
+    pool_stats: Arc<PoolStats>,
+}
+
+impl SizePoolStats {
+    pub(super) fn new(buffer_size: usize, pool_stats: Arc<PoolStats>) -> Self {
+        Self {
+            buffer_size,
+            empty_pages: Default::default(),
+            used_buffers: Default::default(),
+            pool_stats,
+        }
+    }
+
+    pub fn empty_pages(&self) -> usize {
+        self.empty_pages.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn add_empty_page(&self) {
+        self.empty_pages.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn remove_empty_page(&self) {
+        self.empty_pages.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    #[allow(unused)]
+    pub fn used_buffers(&self, kind: BufferKind) -> usize {
+        self.used_buffers[kind].load(Ordering::SeqCst)
+    }
+
+    pub(super) fn add_used_buffer(&self, kind: BufferKind) {
+        self.used_buffers[kind].fetch_add(1, Ordering::SeqCst);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind);
+    }
+
+    pub(super) fn remove_used_buffer(&self, kind: BufferKind) {
+        self.used_buffers[kind].fetch_sub(1, Ordering::SeqCst);
+        self.pool_stats.release_bytes(self.buffer_size, kind);
+    }
+}
+
+/// Classify buffers by their usage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BufferKind {
+    GetObject,
+    PutObject,
+    DiskCache,
+    Append,
+    Other,
+}
+const BUFFER_KIND_COUNT: usize = BufferKind::Other as usize + 1;
+
+impl<T> Index<BufferKind> for [T; BUFFER_KIND_COUNT] {
+    type Output = T;
+    fn index(&self, idx: BufferKind) -> &Self::Output {
+        &self[idx as usize]
+    }
+}
+
+impl BufferKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BufferKind::GetObject => "get_object",
+            BufferKind::PutObject => "put_object",
+            BufferKind::DiskCache => "disk_cache",
+            BufferKind::Append => "append",
+            BufferKind::Other => "other",
+        }
+    }
+}
+
+impl From<MetaRequestType> for BufferKind {
+    fn from(value: MetaRequestType) -> Self {
+        match value {
+            MetaRequestType::Default | MetaRequestType::CopyObject => Self::Other,
+            MetaRequestType::GetObject => Self::GetObject,
+            MetaRequestType::PutObject => Self::PutObject,
+        }
+    }
+}


### PR DESCRIPTION
Introduce a custom implementation of a `MemoryPool` which can be used by the CRT S3 client. The new pool will eventually be adopted in Mountpoint, which will also use it to replace the allocations for disk cache blocks and incremental upload buffers.

This change extends the integration tests on the client crate to run with this pool implementation.

See docs in `memory/pool.rs` for more details on the new memory pool.

### Does this change impact existing behavior?

No, the new pool is only used in tests for now. 

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
