### PR TITLE
Release crates, mountpoint-s3-fs 0.6.0

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.18.0)
+## Unreleased
+
+## v0.18.0 (July 23, 2025)
 
 * Add support for custom memory pools. ([#1516](https://github.com/awslabs/mountpoint-s3/pull/1516))
 * Upgrade to Rust 2024. ([#1498](https://github.com/awslabs/mountpoint-s3/pull/1498))

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.15.0)
+## Unreleased
+
+## v0.15.0 (July 23, 2025)
 
 * Upgrade to Rust 2024. ([#1498](https://github.com/awslabs/mountpoint-s3/pull/1498))
 

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.13.0)
+## Unreleased
+
+## v0.13.0 (July 23, 2025)
 
 * Upgrade to Rust 2024. ([#1498](https://github.com/awslabs/mountpoint-s3/pull/1498))
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.6.0)
+## Unreleased
+
+## v0.6.0 (July 23, 2025)
 
 * Introduce `Metablock` abstraction and adjust the interface between `S3Filesystem` and implementors of `Metablock`. ([#1500](https://github.com/awslabs/mountpoint-s3/pull/1500), [#1488](https://github.com/awslabs/mountpoint-s3/pull/1488))
 * Upgrade to Rust 2024. ([#1498](https://github.com/awslabs/mountpoint-s3/pull/1498))


### PR DESCRIPTION
Update changelogs in preparation for crates release. Crates to be released:
- mountpoint-s3-crt-sys
- mountpoint-s3-crt
- mountpoint-s3-client
- mountpoint-s3-fs

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
