### PR TITLE
Unaligned

### DIFF
--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -339,7 +339,8 @@ where
             if response.is_empty() && part_bytes.len() == to_read as usize {
                 return Ok(part_bytes);
             }
-
+            // Emit a metric here, since we have consumed an unaligned part
+            counter!("prefetch.unaligned_part").increment(1);
             let part_len = part_bytes.len() as u64;
             response.extend(part_bytes)?;
             to_read -= part_len;

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -264,12 +264,12 @@ impl TargetThroughputSetting {
 // FUSE doesn't know the difference between regular reads and readahead reads, it will
 // send us a READ request for that 128k, so we'll have to block waiting for it even if
 // the application doesn't want it. This is all in the noise for sequential IO, but
-// waiting for the readahead hurts random IO. So we add 128k to the first request size
-// to avoid the latency hit of the second request.
+// waiting for the readahead hurts random IO.
+// So we request 2MB to stay aligned with the part size (8MB).
 //
 // Note the CRT does not respect this value right now, they always return chunks of part size
 // but this is the first window size we prefer.
-pub const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 * 8;
+pub const INITIAL_READ_WINDOW_SIZE: usize = 2 * 1024 * 1024;
 
 impl ClientConfig {
     /// Create an [S3CrtClient]

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -269,7 +269,7 @@ impl TargetThroughputSetting {
 //
 // Note the CRT does not respect this value right now, they always return chunks of part size
 // but this is the first window size we prefer.
-pub const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 + 128 * 1024;
+pub const INITIAL_READ_WINDOW_SIZE: usize = 1024 * 1024 * 8;
 
 impl ClientConfig {
     /// Create an [S3CrtClient]


### PR DESCRIPTION
Adds a metric to track and sets initial read window size to 2MB so that reads are aligned with the standard S3 part size and less reads cross part boundaries.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
