### PR TITLE
Add mock option to prefetcher benchmark

### DIFF
--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -59,6 +59,9 @@ class PrefetchBenchmark(BaseBenchmark):
         read_size = self.common_config['read_size']
         subprocess_args.extend(["--read-size", str(read_size)])
 
+        if self.prefetch_config.get('mock_client', False):
+            subprocess_args.append("--mock-client")
+
         for interface in self.common_config['network_interfaces']:
             subprocess_args.extend(["--bind", interface])
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -2,79 +2,80 @@
 # as well as some which will be 'swept' over for experiments.
 
 defaults:
-  - _self_
+    - _self_
 
 # ===== Common parameters for all benchmarks =====
 s3_bucket: ???
 application_workers: 1
 iteration: 0
 iterations: 1
-run_time: 30  # Default run time in seconds
+run_time: 30 # Default run time in seconds
 read_size: 262144 # Defaults to 256KiB, can go up to 1MiB.
 read_part_size: !!null
 region: "us-east-1"
-write_part_size: 16777216  # 16 MiB, to allow for uploads of large files
-object_size_in_gib: 100  # Size of the object to benchmark
+write_part_size: 16777216 # 16 MiB, to allow for uploads of large files
+object_size_in_gib: 100 # Size of the object to benchmark
 benchmark_type: "fio" # fio, prefetch, client, client-bp, crt
-s3_keys: !!null
+s3_keys: !!null # Network configuration
 
-# Network configuration
 network:
-  interface_names: []
-  maximum_throughput_gbps: !!null
+    interface_names: []
+    maximum_throughput_gbps:
+        !!null # Monitoring options (common to all benchmarks)
 
-# Monitoring options (common to all benchmarks)
 monitoring:
-  with_bwm: false
-  with_perf_stat: false
+    with_bwm: false
+    with_perf_stat: false
 
 # ===== Mountpoint configuration =====
 mountpoint:
-  fuse_threads: !!null
-  prefix: !!null
-  metadata_ttl: "indefinite"
-  mountpoint_max_background: !!null
-  mountpoint_congestion_threshold: !!null
-  mountpoint_binary: !!null
-  upload_checksums: !!null
-  stub_mode: "off"  # Options: "off", "fs_handler", "s3_client"
-  mountpoint_debug: false
-  mountpoint_debug_crt: false
+    fuse_threads: !!null
+    prefix: !!null
+    metadata_ttl: "indefinite"
+    mountpoint_max_background: !!null
+    mountpoint_congestion_threshold: !!null
+    mountpoint_binary: !!null
+    upload_checksums: !!null
+    stub_mode: "off" # Options: "off", "fs_handler", "s3_client"
+    mountpoint_debug: false
+    mountpoint_debug_crt: false
 
 # ===== Benchmark-specific configurations =====
 benchmarks:
-  fio:
-    direct_io: false
-    fio_benchmarks:
-      - sequential_read
-    fio_benchmark: "${benchmarks.fio.fio_benchmarks[0]}"
-    fio_io_engine: "psync"
-  
-  prefetch:
-    max_memory_target: !!null
-  
-  crt:
-    crt_benchmarks_path: !!null
+    fio:
+        direct_io: false
+        fio_benchmarks:
+            - sequential_read
+        fio_benchmark: "${benchmarks.fio.fio_benchmarks[0]}"
+        fio_io_engine: "psync"
 
-  client:  
-    # None 
+    prefetch:
+        max_memory_target: !!null
+        mock_client: false
 
-  client_backpressure:
-    read_window_size: !!null #2147483648 
+    crt:
+        crt_benchmarks_path: !!null
+
+    client:
+        # None
+
+    client_backpressure:
+        read_window_size: !!null #2147483648
+
 
 hydra:
-  help:
-    app_name: "Mountpoint benchmark runner"
-  mode: MULTIRUN
-  job:
-    chdir: true
-  sweeper:
-    # Global sweeper params - use this for common parameters across all benchmarks
-    # For specific parameter use sweep params under the specific benchmark type config
-    params:
-      'application_workers': 1, 4, 16, 64, 128
-      'iteration': "range(${iterations})"
-      'mountpoint.fuse_threads': 1, 16, 64
-      'benchmarks.fio.direct_io': false, true
-      # 'benchmarks.prefetch.max_memory_target': !!null, 1073741824, 2147483648  # null, 1GB, 2GB
-      #'benchmarks.client_backpressure.read_window_size': 8388608, 2147483648
+    help:
+        app_name: "Mountpoint benchmark runner"
+    mode: MULTIRUN
+    job:
+        chdir: true
+    sweeper:
+        # Global sweeper params - use this for common parameters across all benchmarks
+        # For specific parameter use sweep params under the specific benchmark type config
+        params:
+            "application_workers": 1, 4, 16, 64, 128
+            "iteration": "range(${iterations})"
+            "mountpoint.fuse_threads": 1, 16, 64
+            "benchmarks.fio.direct_io": false, true
+            # 'benchmarks.prefetch.max_memory_target': !!null, 1073741824, 2147483648  # null, 1GB, 2GB
+            #'benchmarks.client_backpressure.read_window_size': 8388608, 2147483648


### PR DESCRIPTION
Add possibility to run the prefetcher benchmark with the mock client, this is helpful for judging the effect a certain change has. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
