### PR TITLE
Set `mem_limit` in `mount_from_config` example

### DIFF
--- a/mountpoint-s3-fs/examples/config.json.example
+++ b/mountpoint-s3-fs/examples/config.json.example
@@ -14,5 +14,6 @@
     "loglevel": "debug,awscrt=off",
     "throughput_config": {
         "type": "IMDSAutoConfigure"
-    }
+    },
+    "memory_limit_bytes": 2147483648
 }

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -58,6 +58,8 @@ struct ConfigOptions {
     auto_unmount: Option<bool>,
     user_agent_prefix: Option<String>,
     part_size: Option<usize>,
+    /// Target memory limit (in bytes) that Mountpoint will try to enforce
+    memory_limit_bytes: Option<u64>,
 
     // File system options
     dir_mode: Option<u16>,
@@ -96,6 +98,9 @@ impl ConfigOptions {
         }
         if let Some(gid) = self.gid {
             fs_config.uid = gid;
+        }
+        if let Some(memory_limit_bytes) = self.memory_limit_bytes {
+            fs_config.mem_limit = memory_limit_bytes;
         }
         Ok(fs_config)
     }


### PR DESCRIPTION
Set `mem_limit` in `mount_from_config` example. The value is retrieved from a json config.

### Does this change impact existing behavior?

No, only the example.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
