### PR TITLE
Fix issue preventing incremental upload to handle very large write part sizes

### DIFF
--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -140,6 +140,9 @@ where
         initial_offset: u64,
         initial_etag: Option<ETag>,
     ) -> AppendUploadRequest<Client> {
+        // Limit the queue capacity to hold buffers for a total of at most
+        // MAX_BYTES_IN_QUEUE, but ensure it allows at least 1 buffer.
+        let capacity = (MAX_BYTES_IN_QUEUE / self.buffer_size).max(1);
         let params = AppendUploadQueueParams {
             bucket,
             key,
@@ -147,7 +150,7 @@ where
             initial_etag,
             server_side_encryption: self.server_side_encryption.clone(),
             default_checksum_algorithm: self.default_checksum_algorithm.clone(),
-            capacity: MAX_BYTES_IN_QUEUE / self.buffer_size,
+            capacity,
         };
         AppendUploadRequest::new(
             &self.runtime,

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -163,6 +163,7 @@ where
         mem_limiter: Arc<MemoryLimiter>,
         params: AppendUploadQueueParams,
     ) -> Self {
+        assert!(params.capacity > 0, "append queue capacity must be greater than 0");
         let span = debug_span!("append", key = params.key, initial_offset = params.initial_offset);
         let (request_sender, request_receiver) = bounded(params.capacity);
         let (response_sender, response_receiver) = unbounded();

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update underlying S3 client version and file system core library version.
 * Log messages now include the thread ID that logged the message, like "ThreadId(01)", after the level. ([#1460](https://github.com/awslabs/mountpoint-s3/pull/1460))
+* Fix issue preventing incremental upload to handle very large write part sizes. ([#1538](https://github.com/awslabs/mountpoint-s3/pull/1538))
 
 ## v1.19.0 (Jun 19, 2025)
 


### PR DESCRIPTION
The append upload queue tries to limit the total memory used to buffer the data to write to 2 GiB. However, when setting  `--write-part-size` to values greater than 2 GiB, it would incorrectly set the queue capacity to 0 buffers and panic.

This change ensures that the queue allows for at least 1 buffer, even if that means exceeding the 2 GiB cap.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Bug fix entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
