### PR TITLE
Replace full key with S3Location in file handles

### DIFF
--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -686,14 +686,14 @@ where
         };
 
         let complete_result = write_state
-            .complete_if_in_progress(self, file_handle.ino, &file_handle.location.full_key())
+            .complete_if_in_progress(self, file_handle.ino, &file_handle.location)
             .await;
         metrics::gauge!("fs.current_handles", "type" => "write").decrement(1.0);
 
         match complete_result {
             Ok(upload_completed_async) => {
                 if upload_completed_async {
-                    debug!(key = ?&file_handle.location.full_key(), "upload completed async after file was closed");
+                    debug!(key = %file_handle.location, "upload completed async after file was closed");
                 }
                 Ok(())
             }

--- a/mountpoint-s3-fs/src/metablock/path.rs
+++ b/mountpoint-s3-fs/src/metablock/path.rs
@@ -183,6 +183,16 @@ impl S3Location {
     }
 }
 
+impl Display for S3Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{} (bucket: {})",
+            self.path.prefix, self.partial_key, self.path.bucket
+        )
+    }
+}
+
 /// A valid name for an [Inode](super::Inode).
 #[derive(Debug, Clone, Copy)]
 pub struct ValidName<'a>(&'a str);


### PR DESCRIPTION
Internal change to directly propagate `S3Location` in file handles rather than the derived `full_key` string. The value is used for logging and error report, so we can postpone formatting the string until it is needed.

### Does this change impact existing behavior?

Minor change in string formatting in logs.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
