### PR TITLE
Enforce valid buffer sizes for the memory pool

### DIFF
--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -80,7 +80,7 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
 
     #[cfg(feature = "fs_pool_tests")]
     let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
-        mountpoint_s3_fs::memory::PagedPool::new([options.part_size()])
+        mountpoint_s3_fs::memory::PagedPool::new_with_candidate_sizes([options.part_size()])
     });
 
     config

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -40,7 +40,7 @@ fn cache_read_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Pat
         block_size: BLOCK_SIZE,
         limit: mountpoint_s3_fs::data_cache::CacheLimit::Unbounded,
     };
-    let pool = PagedPool::new([BLOCK_SIZE as usize]);
+    let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE as usize]);
     let cache = DiskDataCache::new(config, pool);
     let cache_key = ObjectId::new("a".into(), ETag::for_tests());
     let bytes = ChecksummedBytes::new(data.to_owned().into());

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -141,7 +141,7 @@ fn mount_file_system(
     region: &str,
     throughput_target_gbps: Option<f64>,
 ) -> BackgroundSession {
-    let pool = PagedPool::new([8 * 1024 * 1024]);
+    let pool = PagedPool::new_with_candidate_sizes([8 * 1024 * 1024]);
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
     let initial_read_window_size = 1024 * 1024 + 128 * 1024;
     config = config

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -219,7 +219,7 @@ fn mount_filesystem(
 
     // Create the client and runtime
     let client_config = config.build_client_config()?;
-    let pool = PagedPool::new([client_config.part_config.read_size_bytes]);
+    let pool = PagedPool::new_with_candidate_sizes([client_config.part_config.read_size_bytes]);
     let client = client_config
         .create_client(pool.clone(), None)
         .context("Failed to create S3 client")?;

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -165,7 +165,7 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     let bucket = args.bucket.as_str();
-    let pool = PagedPool::new([args.part_size.unwrap_or(8 * 1024 * 1024) as usize]);
+    let pool = PagedPool::new_with_candidate_sizes([args.part_size.unwrap_or(8 * 1024 * 1024) as usize]);
     let client_config = args.s3_client_config().memory_pool(pool.clone());
     let client = S3CrtClient::new(client_config).context("failed to create S3 CRT client")?;
     let mem_limiter = Arc::new(MemoryLimiter::new(pool, args.memory_target_in_bytes()));

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -101,7 +101,7 @@ fn main() {
         let endpoint_uri = Uri::new_from_str(&Allocator::default(), url).expect("Failed to parse endpoint URL");
         endpoint_config = endpoint_config.endpoint(endpoint_uri);
     }
-    let pool = PagedPool::new([args.write_part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([args.write_part_size]);
     let mut config = S3ClientConfig::new()
         .endpoint_config(endpoint_config)
         .throughput_target_gbps(args.throughput_target_gbps as f64)

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn get_path_for_block_key() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new([1024]);
+        let pool = PagedPool::new_with_candidate_sizes([1024]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     fn get_path_for_block_key_huge_block_index() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new([1024]);
+        let pool = PagedPool::new_with_candidate_sizes([1024]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -734,7 +734,7 @@ mod tests {
         let object_2_size = data_2.len();
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new([pool_buffer_size]);
+        let pool = PagedPool::new_with_candidate_sizes([pool_buffer_size]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -821,7 +821,7 @@ mod tests {
         let slice = data.slice(1..5);
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new([8 * 1024 * 1024]);
+        let pool = PagedPool::new_with_candidate_sizes([8 * 1024 * 1024]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -903,7 +903,7 @@ mod tests {
         let small_object_key = ObjectId::new("small".into(), ETag::for_tests());
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new([BLOCK_SIZE]);
+        let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -1086,7 +1086,7 @@ mod tests {
         // "Corrupt" the serialized value with an invalid length.
         replace_u64_at(&mut buf, offset, u64::MAX);
 
-        let pool = PagedPool::new([MAX_LENGTH as usize]);
+        let pool = PagedPool::new_with_candidate_sizes([MAX_LENGTH as usize]);
         let err = DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool).expect_err("deserialization should fail");
         match length_to_corrupt {
             "key" | "etag" => assert!(matches!(
@@ -1102,7 +1102,7 @@ mod tests {
     fn test_concurrent_access() {
         let block_size = 1024 * 1024;
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new([block_size]);
+        let pool = PagedPool::new_with_candidate_sizes([block_size]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -129,7 +129,7 @@ mod tests {
 
     fn create_disk_cache() -> (TempDir, Arc<DiskDataCache>) {
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new([BLOCK_SIZE as usize, PART_SIZE]);
+        let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE as usize, PART_SIZE]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -812,7 +812,7 @@ mod tests {
         client.add_object("dir1/file1.bin", MockObject::constant(0xa1, 15, ETag::for_tests()));
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let pool = PagedPool::new([32]);
+        let pool = PagedPool::new_with_candidate_sizes([32]);
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let server_side_encryption =
             ServerSideEncryption::new(Some("aws:kms".to_owned()), Some("some_key_alias".to_owned()));

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -542,7 +542,8 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool = PagedPool::new([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
+        let pool =
+            PagedPool::new_with_candidate_sizes([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
         let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let builder = match prefetcher_type {
@@ -1229,7 +1230,7 @@ mod tests {
                     .initial_read_window_size(initial_read_window_size)
                     .build(),
             );
-            let pool = PagedPool::new([part_size]);
+            let pool = PagedPool::new_with_candidate_sizes([part_size]);
             let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
@@ -1290,7 +1291,7 @@ mod tests {
                     .initial_read_window_size(initial_read_window_size)
                     .build(),
             );
-            let pool = PagedPool::new([part_size]);
+            let pool = PagedPool::new_with_candidate_sizes([part_size]);
             let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -436,7 +436,7 @@ mod tests {
     fn new_backpressure_controller_for_test(
         backpressure_config: BackpressureConfig,
     ) -> (BackpressureController, BackpressureLimiter) {
-        let pool = PagedPool::new([8 * 1024 * 1024]);
+        let pool = PagedPool::new_with_candidate_sizes([8 * 1024 * 1024]);
         let mem_limiter = Arc::new(MemoryLimiter::new(
             pool,
             backpressure_config.max_read_window_size as u64,

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -454,7 +454,7 @@ mod tests {
                 .initial_read_window_size(initial_read_window_size)
                 .build(),
         );
-        let pool = PagedPool::new([block_size, client_part_size]);
+        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size]);
         let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
         mock_client.add_object(key, object.clone());
 
@@ -537,7 +537,7 @@ mod tests {
                 .initial_read_window_size(initial_read_window_size)
                 .build(),
         );
-        let pool = PagedPool::new([block_size, client_part_size]);
+        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size]);
         let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
         mock_client.add_object(key, object.clone());
 

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -173,7 +173,7 @@ mod tests {
     }
 
     async fn run_test(ops: Vec<Op>) {
-        let pool = PagedPool::new([1024]);
+        let pool = PagedPool::new_with_candidate_sizes([1024]);
         let mem_limiter = MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT);
         let part_id = ObjectId::new("key".to_owned(), ETag::for_tests());
         let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>(mem_limiter.into());

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -223,7 +223,7 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let buffer_size = client.write_part_size().unwrap();
-        let pool = PagedPool::new([buffer_size]);
+        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let mem_limiter = MemoryLimiter::new(pool.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -484,7 +484,8 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool = PagedPool::new([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
+        let pool =
+            PagedPool::new_with_candidate_sizes([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let mem_limiter = MemoryLimiter::new(pool.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(
@@ -1135,7 +1136,7 @@ mod tests {
         let key = "hello";
 
         let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
-        let pool = PagedPool::new([32]);
+        let pool = PagedPool::new_with_candidate_sizes([32]);
 
         // Use a memory limiter with 0 limit
         let mem_limiter = MemoryLimiter::new(pool.clone(), 0);

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -289,7 +289,7 @@ pub mod mock_session {
         };
 
         let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-        let pool = PagedPool::new([test_config.part_size]);
+        let pool = PagedPool::new_with_candidate_sizes([test_config.part_size]);
         let client = Arc::new(
             MockClient::config()
                 .bucket(s3_path.bucket.to_string())
@@ -330,7 +330,7 @@ pub mod mock_session {
             };
 
             let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-            let pool = PagedPool::new([test_config.cache_block_size, test_config.part_size]);
+            let pool = PagedPool::new_with_candidate_sizes([test_config.cache_block_size, test_config.part_size]);
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = Arc::new(
@@ -478,7 +478,7 @@ pub mod s3_session {
     pub fn new_with_test_client(test_config: TestSessionConfig, sdk_client: Client, s3_path: S3Path) -> TestSession {
         let mount_dir = tempfile::tempdir().unwrap();
 
-        let pool = PagedPool::new([test_config.part_size]);
+        let pool = PagedPool::new_with_candidate_sizes([test_config.part_size]);
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
             .endpoint_config(get_test_endpoint_config())
@@ -518,7 +518,7 @@ pub mod s3_session {
             let s3_path = get_test_s3_path(test_name);
             let region = get_test_region();
 
-            let pool = PagedPool::new([test_config.cache_block_size, test_config.part_size]);
+            let pool = PagedPool::new_with_candidate_sizes([test_config.cache_block_size, test_config.part_size]);
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = create_crt_client(

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -46,7 +46,7 @@ pub fn make_test_filesystem(
             .initial_read_window_size(256 * 1024)
             .build(),
     );
-    let pool = PagedPool::new([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
     let fs = make_test_filesystem_with_client(client.clone(), pool, bucket, prefix, config);
     (client, fs)
 }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -729,7 +729,7 @@ async fn test_upload_aborted_on_write_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -805,7 +805,7 @@ async fn test_upload_aborted_on_fsync_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -866,7 +866,7 @@ async fn test_upload_aborted_on_release_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -1530,7 +1530,7 @@ async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
     let client_config = S3ClientConfig::default()
         .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true)
@@ -1567,7 +1567,7 @@ async fn test_lookup_forbidden() {
     let policy = deny_single_object_access_policy(&bucket, &key);
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
@@ -1650,7 +1650,7 @@ async fn test_rename_support_is_cached() {
     const FILE_NAME: &str = "a.txt";
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
     let client = Arc::new(
         MockClient::config()
             .bucket(BUCKET_NAME)

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -44,7 +44,7 @@ async fn express_invalid_block_read() {
     let prefix = get_test_prefix("express_invalid_block_read");
 
     // Mount the bucket
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let cache = CacheTestWrapper::new(ExpressDataCache::new(
         client.clone(),
@@ -106,7 +106,7 @@ async fn express_invalid_block_read() {
 fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -131,7 +131,7 @@ fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) 
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let cache = DiskDataCache::new(cache_config, pool.clone());
 
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -152,7 +152,7 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
     use mountpoint_s3_fs::data_cache::ExpressDataCacheConfig;
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let config = ExpressDataCacheConfig::new(&cache_bucket, &bucket_name)
@@ -167,7 +167,7 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
 #[tokio::test]
 #[cfg(feature = "s3express_tests")]
 async fn express_cache_read_empty() {
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -184,7 +184,7 @@ async fn disk_cache_read_empty() {
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize]);
     let cache = DiskDataCache::new(cache_config, pool);
 
     cache_read_empty(cache, "disk_cache_read_empty").await;
@@ -195,7 +195,7 @@ async fn disk_cache_read_empty() {
 async fn express_cache_verify_fail_non_express() {
     use mountpoint_s3_fs::data_cache::DataCacheError;
 
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let cache_bucket_name = get_standard_bucket();
@@ -244,7 +244,7 @@ async fn express_cache_verify_fail_forbidden() {
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
 
-    let pool = PagedPool::new([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(
         CLIENT_PART_SIZE,
         CLIENT_PART_SIZE,
@@ -348,7 +348,7 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
     let bucket = get_standard_bucket();
     let prefix = get_test_prefix("express_expected_bucket_owner");
     let cache_config = ExpressDataCacheConfig::new(&cache_bucket, &bucket);
-    let pool = PagedPool::new([cache_config.block_size as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes([cache_config.block_size as usize, CLIENT_PART_SIZE]);
     let cache = ExpressDataCache::new(client.clone(), cache_config);
     let cache_valid = block_on(cache.verify_cache_valid());
     if owner_checked && !owner_matches {

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -205,7 +205,7 @@ fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, MockServe
         .addressing_style(AddressingStyle::Path) // mock server responds to path style requests only
         .endpoint(endpoint);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
     let client_config = S3ClientConfig::default()
         .endpoint_config(endpoint_config)
         .auth_config(S3ClientAuthConfig::NoSigning)

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -176,7 +176,7 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let client_config = args.client_config(build_info::FULL_VERSION);
 
     // Set up a paged memory pool
-    let pool = PagedPool::new([
+    let pool = PagedPool::new_with_candidate_sizes([
         args.cache_block_size_in_bytes() as usize,
         client_config.part_config.read_size_bytes,
         client_config.part_config.write_size_bytes,


### PR DESCRIPTION
The memory pool will only accept buffer sizes in the range (0, 64MiB] for the primary memory (i.e. allocated in pages of 16 buffers). For larger sizes, it will only use secondary memory (i.e. ad-hoc allocation for a single buffer).

The 64MiB cap reproduces the behavior of the internal CRT memory pool.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No - part of the memory pool change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
