### PR TITLE
Add usages of INITIAL_READ_WINDOW_SIZE

### DIFF
--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -10,6 +10,7 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_fs::fuse::S3FuseFilesystem;
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::prefetch::Prefetcher;
+use mountpoint_s3_fs::s3::config::INITIAL_READ_WINDOW_SIZE;
 use mountpoint_s3_fs::s3::{Bucket, S3Path};
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig, Superblock, SuperblockConfig};
 use tempfile::tempdir;
@@ -143,10 +144,9 @@ fn mount_file_system(
 ) -> BackgroundSession {
     let pool = PagedPool::new([8 * 1024 * 1024]);
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
-    let initial_read_window_size = 1024 * 1024 + 128 * 1024;
     config = config
         .read_backpressure(true)
-        .initial_read_window(initial_read_window_size)
+        .initial_read_window(INITIAL_READ_WINDOW_SIZE)
         .memory_pool(pool.clone());
     if let Some(throughput_target_gbps) = throughput_target_gbps {
         config = config.throughput_target_gbps(throughput_target_gbps);

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -16,6 +16,7 @@ use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
+use mountpoint_s3_fs::s3::config::INITIAL_READ_WINDOW_SIZE;
 use serde_json::{json, to_writer};
 use sysinfo::{RefreshKind, System};
 use tracing_subscriber::EnvFilter;
@@ -140,7 +141,7 @@ impl CliArgs {
         // Set up backpressure with the same initial window used in Mountpoint.
         let mut client_config = S3ClientConfig::new()
             .read_backpressure(true)
-            .initial_read_window(mountpoint_s3_fs::s3::config::INITIAL_READ_WINDOW_SIZE)
+            .initial_read_window(INITIAL_READ_WINDOW_SIZE)
             .endpoint_config(EndpointConfig::new(self.region.as_str()));
         if let Some(throughput_target_gbps) = self.maximum_throughput_gbps {
             client_config = client_config.throughput_target_gbps(throughput_target_gbps as f64);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -1203,6 +1203,8 @@ mod tests {
         use shuttle::rand::Rng;
         use shuttle::{check_pct, check_random};
 
+        use crate::s3::config::INITIAL_READ_WINDOW_SIZE;
+
         struct ShuttleRuntime;
         impl Spawn for ShuttleRuntime {
             fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
@@ -1216,8 +1218,8 @@ mod tests {
             let object_size = rng.gen_range(1u64..1 * 1024 * 1024);
             let max_read_window_size = rng.gen_range(16usize..1 * 1024 * 1024);
             let sequential_prefetch_multiplier = rng.gen_range(2usize..16);
-            let part_size = rng.gen_range(16usize..1 * 1024 * 1024 + 128 * 1024);
-            let initial_read_window_size = rng.gen_range(16usize..1 * 1024 * 1024 + 128 * 1024);
+            let part_size = rng.gen_range(16usize..1 * INITIAL_READ_WINDOW_SIZE);
+            let initial_read_window_size = rng.gen_range(16usize..1 * INITIAL_READ_WINDOW_SIZE);
             let max_forward_seek_wait_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
             let max_backward_seek_distance = rng.gen_range(16u64..1 * 1024 * 1024 + 256 * 1024);
 

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -332,8 +332,9 @@ mod tests {
 
     use crate::mem_limiter::MemoryLimiter;
     use crate::memory::PagedPool;
+    use crate::s3::config::INITIAL_READ_WINDOW_SIZE;
 
-    #[test_case(1024 * 1024 + 128 * 1024, 2)] // real config
+    #[test_case(INITIAL_READ_WINDOW_SIZE, 2)] // real config
     #[test_case(3 * 1024 * 1024, 4)]
     #[test_case(8 * 1024 * 1024, 8)]
     #[test_case(2 * 1024 * 1024 * 1024, 2)]

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -20,7 +20,7 @@ use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_fs::Runtime;
 use mountpoint_s3_fs::memory::PagedPool;
-use mountpoint_s3_fs::s3::config::{ClientConfig, TargetThroughputSetting};
+use mountpoint_s3_fs::s3::config::{ClientConfig, INITIAL_READ_WINDOW_SIZE, TargetThroughputSetting};
 use mountpoint_s3_fs::s3::{S3Path, S3Personality};
 
 fn main() -> anyhow::Result<()> {
@@ -57,7 +57,7 @@ pub fn create_mock_client(
         .part_size(part_size as usize)
         .unordered_list_seed(None)
         .enable_backpressure(true)
-        .initial_read_window_size(1024 * 1024 + 128 * 1024) // matching real MP
+        .initial_read_window_size(INITIAL_READ_WINDOW_SIZE) // matching real MP
         .enable_rename(s3_personality.supports_rename_object());
 
     let client = if let TargetThroughputSetting::User {


### PR DESCRIPTION
Replaces hard-coded initial read window sizes with usages of the constant `INITIAL_READ_WINDOW_SIZE`.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
