### PR TITLE
Make ObjectClient part sizes no longer optional

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -73,11 +73,11 @@ where
     type PutObjectRequest = FailurePutObjectRequest<Client, GetWrapperState>;
     type ClientError = Client::ClientError;
 
-    fn read_part_size(&self) -> Option<usize> {
+    fn read_part_size(&self) -> usize {
         self.client.read_part_size()
     }
 
-    fn write_part_size(&self) -> Option<usize> {
+    fn write_part_size(&self) -> usize {
         self.client.write_part_size()
     }
 

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -834,12 +834,12 @@ impl ObjectClient for MockClient {
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
-    fn read_part_size(&self) -> Option<usize> {
-        Some(self.config.part_size)
+    fn read_part_size(&self) -> usize {
+        self.config.part_size
     }
 
-    fn write_part_size(&self) -> Option<usize> {
-        Some(self.config.part_size)
+    fn write_part_size(&self) -> usize {
+        self.config.part_size
     }
 
     fn initial_read_window_size(&self) -> Option<usize> {
@@ -1532,7 +1532,7 @@ mod tests {
             .initial_read_window_size(256)
             .build();
 
-        let part_size = client.read_part_size().unwrap();
+        let part_size = client.read_part_size();
         let size = part_size * 2;
         let range = 0..(part_size + 1) as u64;
 

--- a/mountpoint-s3-client/src/mock_client/throughput_client.rs
+++ b/mountpoint-s3-client/src/mock_client/throughput_client.rs
@@ -123,11 +123,11 @@ impl ObjectClient for ThroughputMockClient {
     type PutObjectRequest = MockPutObjectRequest;
     type ClientError = MockClientError;
 
-    fn read_part_size(&self) -> Option<usize> {
+    fn read_part_size(&self) -> usize {
         self.inner.read_part_size()
     }
 
-    fn write_part_size(&self) -> Option<usize> {
+    fn write_part_size(&self) -> usize {
         self.inner.write_part_size()
     }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -33,13 +33,11 @@ pub trait ObjectClient {
     type PutObjectRequest: PutObjectRequest<ClientError = Self::ClientError>;
     type ClientError: std::error::Error + ProvideErrorMetadata + Send + Sync + 'static;
 
-    /// Query the part size this client uses for GET operations to the object store. This
-    /// can be `None` if the client does not do multi-part operations.
-    fn read_part_size(&self) -> Option<usize>;
+    /// Query the part size this client uses for GET operations to the object store.
+    fn read_part_size(&self) -> usize;
 
-    /// Query the part size this client uses for PUT operations to the object store. This
-    /// can be `None` if the client does not do multi-part operations.
-    fn write_part_size(&self) -> Option<usize>;
+    /// Query the part size this client uses for PUT operations to the object store.
+    fn write_part_size(&self) -> usize;
 
     /// Query the initial read window size this client uses for backpressure GetObject requests.
     /// This can be `None` if backpressure is disabled.

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1414,16 +1414,16 @@ impl ObjectClient for S3CrtClient {
     type PutObjectRequest = S3PutObjectRequest;
     type ClientError = S3RequestError;
 
-    fn read_part_size(&self) -> Option<usize> {
-        Some(self.inner.read_part_size)
+    fn read_part_size(&self) -> usize {
+        self.inner.read_part_size
     }
 
-    fn write_part_size(&self) -> Option<usize> {
+    fn write_part_size(&self) -> usize {
         // TODO: the CRT does some clamping to a max size rather than just swallowing the part size
         // we configured it with, so this might be wrong. Right now the only clamping is to the max
         // S3 part size (5GiB), so this shouldn't affect the result.
         // https://github.com/awslabs/aws-c-s3/blob/94e3342c12833c5199/source/s3_client.c#L337-L344
-        Some(self.inner.write_part_size)
+        self.inner.write_part_size
     }
 
     fn initial_read_window_size(&self) -> Option<usize> {

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -101,7 +101,7 @@ async fn test_get_object_backpressure(size: usize, range: Option<Range<u64>>) {
 async fn verify_backpressure_get_object() {
     let initial_window_size = 256;
     let client: S3CrtClient = get_test_backpressure_client(initial_window_size, None);
-    let part_size = client.read_part_size().unwrap();
+    let part_size = client.read_part_size();
 
     let size = part_size * 2;
     let range = 0..(part_size + 1) as u64;
@@ -631,7 +631,7 @@ async fn stress_test_get_object() {
             .endpoint_config(get_test_endpoint_config())
             .event_loop_threads(100),
     );
-    assert!(client.read_part_size().unwrap() > size);
+    assert!(client.read_part_size() > size);
 
     let mut tasks = tokio::task::JoinSet::new();
     for t in 0..10000 {

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -236,7 +236,7 @@ async fn test_put_object_write_cancelled() {
         .expect("put_object should succeed");
 
     // Write a multiple of `part_size` to ensure it will not complete immediately.
-    let full_size = client.write_part_size().unwrap() * 10;
+    let full_size = client.write_part_size() * 10;
     let buffer = vec![0u8; full_size];
 
     // Complete one write to ensure the MPU was created and the buffer for the upload request is available.

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -159,7 +159,7 @@ where
             runtime,
             pool,
             mem_limiter,
-            UploaderConfig::new(client.write_part_size().unwrap())
+            UploaderConfig::new(client.write_part_size())
                 .storage_class(config.storage_class.to_owned())
                 .server_side_encryption(config.server_side_encryption.clone())
                 .default_checksum_algorithm(config.use_upload_checksums.then_some(ChecksumAlgorithm::Crc32c)),

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -355,7 +355,7 @@ where
     ) -> Result<RequestTask<Client>, PrefetchReadError<Client::ClientError>> {
         let start = self.next_sequential_read_offset;
         let object_size = self.size as usize;
-        let read_part_size = self.part_stream.client().read_part_size().unwrap_or(8 * 1024 * 1024);
+        let read_part_size = self.part_stream.client().read_part_size();
         let range = RequestRange::new(object_size, start, object_size);
 
         // The prefetcher now relies on backpressure mechanism so it must be enabled
@@ -542,8 +542,7 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool =
-            PagedPool::new_with_candidate_sizes([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
+        let pool = PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()]);
         let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let builder = match prefetcher_type {

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -484,8 +484,7 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool =
-            PagedPool::new_with_candidate_sizes([client.read_part_size().unwrap(), client.write_part_size().unwrap()]);
+        let pool = PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()]);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let mem_limiter = MemoryLimiter::new(pool.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(


### PR DESCRIPTION
The `ObjectClient` trait currently defines `read_part_size` and `write_part_size` as optional. This abstraction does not apply to any of the existing implementations of the trait and we currently have no plans of using it. This change removes this unnecessary abstraction, simplifying the code and avoiding possible confusion.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
