### PR TITLE
Add non-zero check for incremental upload buffer sizes

### DIFF
--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -116,6 +116,7 @@ where
         mem_limiter: Arc<MemoryLimiter>,
         config: UploaderConfig,
     ) -> Self {
+        assert!(config.buffer_size > 0, "buffer_size should be greater than 0 for uploads");
         Self {
             client,
             runtime,
@@ -152,7 +153,6 @@ where
         initial_offset: u64,
         initial_etag: Option<ETag>,
     ) -> AppendUploadRequest<Client> {
-        assert!(self.buffer_size > 0, "write-part-size should be greater than 0 for incremental uploads");
         // Limit the queue capacity to hold buffers for a total of at most
         // MAX_BYTES_IN_QUEUE, but ensure it allows at least 1 buffer.
         let capacity = (MAX_BYTES_IN_QUEUE / self.buffer_size).max(1);

--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -152,6 +152,7 @@ where
         initial_offset: u64,
         initial_etag: Option<ETag>,
     ) -> AppendUploadRequest<Client> {
+        assert!(self.buffer_size > 0, "write-part-size should be greater than 0 for incremental uploads");
         // Limit the queue capacity to hold buffers for a total of at most
         // MAX_BYTES_IN_QUEUE, but ensure it allows at least 1 buffer.
         let capacity = (MAX_BYTES_IN_QUEUE / self.buffer_size).max(1);


### PR DESCRIPTION
Add non-zero check for upload buffer-sizes.

This is done so that we avoid runtime exceptions for invalid sized buffers and division by 0 during capacity calculations in current or future incremental uploads. The buffer_size currently is derived from `write-part-size`. We have a check for read/write part-sizes being in the range [5MiB, 5GiB] in the `CrtClientConfig`. However, there are some tests and testing trait-implementations which don't do the same validation and hence need explicit checks in the upload constructor.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No, minor code enhancement entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
