### PR TITLE
Prepare for release of the fs crate v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-io",
  "async-lock",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,8 @@
-## Unreleased (v0.18.1)
+## Unreleased (v0.19.0)
 
+### Breaking changes
+
+* Make `ObjectClient` part sizes no longer optional. ([#1542](https://github.com/awslabs/mountpoint-s3/pull/1542))
 * Remove `restore_buffer_copy` feature flag. ([#1511](https://github.com/awslabs/mountpoint-s3/pull/1511))
 
 ## v0.18.0 (July 23, 2025)

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.19.0)
+## Unreleased
+
+## v0.19.0 (July 28, 2025)
 
 ### Breaking changes
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.18.1"
+version = "0.19.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.7.0)
+## Unreleased
+
+## v0.7.0 (July 28, 2025)
 
 * Adopt a unified memory pool to reduce overall memory usage. ([#1511](https://github.com/awslabs/mountpoint-s3/pull/1511))
 * Replace `S3Uri` with `S3Path` and consolidate related types like `Bucket` and `Prefix` into the `s3` module.

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.18.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.0" }
 
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.7.0" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.18.1" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.0" }
 
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 clap = { version = "4.5.40", features = ["derive"] }


### PR DESCRIPTION
Update changelogs of the `fs` and `client` crates to prepare for release.

Also include previously missing entry in `client` changelog for #1542, and increase the crate version number. 

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

See above.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
