### PR TITLE
Add versioning of the configuration format in mount_from_config example

### DIFF
--- a/mountpoint-s3-fs/examples/config.json.example
+++ b/mountpoint-s3-fs/examples/config.json.example
@@ -1,4 +1,5 @@
 {
+    "config_version": "0.0.1",
     "mountpoint": "/exmpl/mountpoint",
     "metadata_store_dir": "/exmpl/tmpdir",
     "event_log_dir": "/exmpl/event_log_dir",


### PR DESCRIPTION
Example binary `mount_from_config` now accepts `config_version` parameter. This may be used to ensure that user is aware of updates to the configuration format and prevent from silent failures.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
