### PR TITLE
 Update prefetcher to increment client read window linearly with each read

### DIFF
--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adopt a unified memory pool to reduce overall memory usage. ([#1511](https://github.com/awslabs/mountpoint-s3/pull/1511))
 * Replace `S3Uri` with `S3Path` and consolidate related types like `Bucket` and `Prefix` into the `s3` module.
   ([#1535](https://github.com/awslabs/mountpoint-s3/pull/1535))
+* `PrefetchGetObject` now has an updated backpressure algorithm advancing the read window with each call to `PrefetchGetObject::read`, with the aim of higher sequential-read throughput. ([#1453](https://github.com/awslabs/mountpoint-s3/pull/1453))
 
 ## v0.6.0 (July 23, 2025)
 

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -126,40 +126,33 @@ impl BackpressureController {
             BackpressureFeedbackEvent::DataRead { offset, length } => {
                 self.next_read_offset = offset + length as u64;
                 self.mem_limiter.release(BufferArea::Prefetch, length as u64);
-                let remaining_window = self.read_window_end_offset.saturating_sub(self.next_read_offset) as usize;
 
-                // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
-                // When memory is low the `preferred_read_window_size` will be scaled down so we have to keep trying
-                // until we have enough read window.
-                while remaining_window < (self.preferred_read_window_size / 2)
-                    && self.read_window_end_offset < self.request_end_offset
-                {
+                loop {
                     let new_read_window_end_offset = self
                         .next_read_offset
                         .saturating_add(self.preferred_read_window_size as u64)
                         .min(self.request_end_offset);
-                    // We can skip if the new `read_window_end_offset` is less than or equal to the current one, this
-                    // could happen after the read window is scaled down.
-                    if new_read_window_end_offset <= self.read_window_end_offset {
-                        break;
-                    }
                     let to_increase = new_read_window_end_offset.saturating_sub(self.read_window_end_offset) as usize;
 
-                    // Force incrementing read window regardless of available memory when we are already at minimum
-                    // read window size.
+                    if to_increase == 0 {
+                        // There's nothing to increment, just accept the feedback.
+                        // This can happen with random read patterns or prefetcher scale down.
+                        break;
+                    }
+
+                    // Force incrementing window regardless of available memory when at minimum window size.
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         self.mem_limiter.reserve(BufferArea::Prefetch, to_increase as u64);
                         self.increment_read_window(to_increase).await;
                         break;
-                    }
-
-                    // Try to reserve the memory for the length we want to increase before sending the request,
-                    // scale down the read window if it fails.
-                    if self.mem_limiter.try_reserve(BufferArea::Prefetch, to_increase as u64) {
-                        self.increment_read_window(to_increase).await;
-                        break;
                     } else {
-                        self.scale_down();
+                        // Try to reserve memory and inc. read window, otherwise scale down and try again.
+                        if self.mem_limiter.try_reserve(BufferArea::Prefetch, to_increase as u64) {
+                            self.increment_read_window(to_increase).await;
+                            break;
+                        } else {
+                            self.scale_down();
+                        }
                     }
                 }
             }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -174,7 +174,10 @@ impl BackpressureController {
         let next_window_end_offset = prev_window_end_offset + len as u64;
         trace!(
             next_read_offset = self.next_read_offset,
-            prev_window_end_offset, next_window_end_offset, len, "incrementing read window",
+            prev_window_end_offset,
+            next_window_end_offset,
+            len,
+            "incrementing read window",
         );
 
         // This should not block since the channel is unbounded

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Add support for renaming files using the RenameObject API when mounting directory buckets in S3 Express One Zone. ([#1468](https://github.com/awslabs/mountpoint-s3/pull/1468))
 
+### Other changes
+
+* Mountpoint's prefetcher has an updated backpressure algorithm which advances the amount of data prefetched with each read rather than waiting for half of the read window to be consumed. The aim of the change is to achieve higher sequential-read throughput. ([#1453](https://github.com/awslabs/mountpoint-s3/pull/1453))
+
 ## v1.18.0 (May 30, 2025)
 
 ### New features


### PR DESCRIPTION
_Rebased version of https://github.com/awslabs/mountpoint-s3/pull/1453, PRed to run CI benchmarks and analyse performance/behaviour_

Mountpoint's S3 client has a backpressure mechanism to controlling how much data to fetch. This change updates the way Mountpoint's prefetcher signals to Mountpoint's S3 client (using the AWS CRT internally) to fetch more data ahead of where a consuming application is reading to accelerate throughput.

Before this change, Mountpoint would wait for 50% of the existing window to be consumed. For example with a window of 2GiB, 1GiB must be read by the kernel before Mountpoint would inform the S3 client to fetch more data up to 2GiB ahead of the current position.

After this change, Mountpoint now sends this signal with every read by the kernel. For example, a 128KiB read by the Kernel to fill a page in the page cache will result in the CRT being updated to be 2GiB ahead of the end offset of the 128KiB read, where the readahead window has a size of 2GiB.

We observe improved throughput for single file handle sequential reading with this approach. For random reading and for multiple file handle reading, we don't see an observable change in throughput. We expect this may be a prerequisite for driving higher throughput with multiple file handles, with this potentially being one bottleneck among others.

### Does this change impact existing behavior?

This improves the way Mountpoint signals progress to its S3 client. We expect improvements in throughput, but the end-user behavior hasn't changed in a meaningful way.

### Does this change need a changelog entry? Does it require a version change?

A changelog entry has been added to note the change in algorithm, alongside ensuring a minor version bump. This is added to communicate the change, in case any issue is raised around the change in behavior. However, we do not expect any regressions given the benchmarking performed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
