### PR TITLE
Use release flag for prefetcher benchmark

### DIFF
--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -23,6 +23,7 @@ class PrefetchBenchmark(BaseBenchmark):
         subprocess_args = [
             "cargo",
             "run",
+            "--release",
             "--example",
             "prefetch_benchmark",
             self.common_config['s3_bucket'],


### PR DESCRIPTION
Harmonises the use of `--release` compile time flag across benchmarks.

Does not need a Changelog entry, as it neither changes existing behaviour nor is customer-facing. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
