### PR TITLE
Explicitly specify opt-level, use link-time optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ resolver = "2"
 
 [profile.release]
 debug = 2
+opt-level = 3
+lto = true # Link-time optimization
+codegen-units = 1  # Single compilation unit for better optimization


### PR DESCRIPTION
Explicitly set the optimisation level for our release builds to 3, additionally enables link time optimisations and uses a single compilation unit -- this enables more optimisations across the full linked codebase. 

Does not need a changelog entry, as it does not change mountpoint's behaviour.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
