### PR TITLE
Add CLI option for publishing OTEL metrics to an endpoint 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,7 +920,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -2206,7 +2212,7 @@ dependencies = [
  "async-object-pool",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2311,11 +2317,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2323,7 +2343,9 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2462,6 +2484,22 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2956,10 +2994,15 @@ dependencies = [
  "mountpoint-s3-client",
  "mountpoint-s3-fuser",
  "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
  "predicates",
  "procfs",
  "proptest",
  "proptest-derive",
+ "prost 0.12.6",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -3163,6 +3206,83 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.5",
+ "serde",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "outref"
@@ -3533,6 +3653,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3893,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,7 +4080,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4100,6 +4300,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4341,6 +4553,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -4619,6 +4840,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,11 +4864,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -91,6 +91,7 @@ block_size = []
 event_log = []
 mem_limiter = []
 manifest = ["csv", "rusqlite"]
+otlp_integration = []
 # Features for choosing tests
 fips_tests = []
 fuse_tests = []

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -50,12 +50,17 @@ time = { version = "0.3.41", features = ["macros", "formatting", "serde-well-kno
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+opentelemetry = { version = "0.30.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.30.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.30.0", features = ["metrics", "http-proto"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17.0", default-features = false }
 
 [dev-dependencies]
 mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
+opentelemetry-proto = { version = "0.30.0", features = ["metrics", "gen-tonic"] }
+prost = "0.12.0"
 
 assert_cmd = "2.0.17"
 assert_fs = "1.1.3"

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -193,9 +193,7 @@ fn process_manifests(config: &ConfigOptions, database_directory: &Path) -> Resul
 
 fn setup_logging(config: &ConfigOptions) -> Result<(LoggingHandle, MetricsSinkHandle)> {
     let logging = init_logging(config.build_logging_config())?;
-
-    let metrics = metrics::install(None);
-
+    let metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
     Ok((logging, metrics))
 }
 

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -193,7 +193,9 @@ fn process_manifests(config: &ConfigOptions, database_directory: &Path) -> Resul
 
 fn setup_logging(config: &ConfigOptions) -> Result<(LoggingHandle, MetricsSinkHandle)> {
     let logging = init_logging(config.build_logging_config())?;
-    let metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
+
+    let metrics = metrics::install(None);
+
     Ok((logging, metrics))
 }
 

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -193,7 +193,7 @@ fn process_manifests(config: &ConfigOptions, database_directory: &Path) -> Resul
 
 fn setup_logging(config: &ConfigOptions) -> Result<(LoggingHandle, MetricsSinkHandle)> {
     let logging = init_logging(config.build_logging_config())?;
-    let metrics = metrics::install();
+    let metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
     Ok((logging, metrics))
 }
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -159,7 +159,7 @@ impl CliArgs {
 
 fn main() -> anyhow::Result<()> {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
 
     let args = CliArgs::parse();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -90,7 +90,7 @@ struct UploadBenchmarkArgs {
 
 fn main() {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install();
+    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
 
     let args = UploadBenchmarkArgs::parse();
     println!("starting upload benchmark with {:?}", &args);

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -90,9 +90,8 @@ struct UploadBenchmarkArgs {
 
 fn main() {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
-
     let args = UploadBenchmarkArgs::parse();
+
     println!("starting upload benchmark with {:?}", &args);
 
     let mut endpoint_config = EndpointConfig::new(&args.region);

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mem_limiter;
 pub mod memory;
 pub mod metablock;
 pub mod metrics;
+pub mod metrics_otel;
 pub mod object;
 pub mod prefetch;
 pub mod prefix;

--- a/mountpoint-s3-fs/src/metrics.rs
+++ b/mountpoint-s3-fs/src/metrics.rs
@@ -3,7 +3,8 @@
 //! This module hooks up the [metrics](https://docs.rs/metrics) facade to a metrics sink that
 //! currently just emits them to a tracing log entry.
 
-use crate::metrics_otel::{OtlpConfig, OtlpMetricsExporter};
+pub use crate::metrics_otel::OtlpConfig;
+use crate::metrics_otel::OtlpMetricsExporter;
 use opentelemetry::KeyValue;
 
 use std::thread::{self, JoinHandle};
@@ -17,6 +18,7 @@ use crate::sync::Arc;
 use crate::sync::mpsc::{RecvTimeoutError, Sender, channel};
 
 mod data;
+pub use data::MetricValue;
 use data::*;
 
 mod tracing_span;
@@ -160,7 +162,12 @@ impl MetricsSink {
         for mut entry in self.metrics.iter_mut() {
             let (key, metric) = entry.pair_mut();
 
-            // If OTLP export is enabled, also send metrics to OpenTelemetry
+            // Get both the value and string representation of the metric (this also resets the metric)
+            let Some((value, metric_str)) = metric.value_and_fmt_and_reset() else {
+                continue;
+            };
+
+            // If OTLP export is enabled, send metrics to OpenTelemetry
             if let Some(exporter) = &self.otlp_exporter {
                 // Convert labels to OpenTelemetry KeyValue pairs
                 let attributes: Vec<KeyValue> = key
@@ -168,30 +175,9 @@ impl MetricsSink {
                     .map(|label| KeyValue::new(label.key().to_string(), label.value().to_string()))
                     .collect();
 
-                // Record the metric based on its type
-                match metric {
-                    Metric::Counter(counter) => {
-                        if let Some((value, _)) = counter.load_and_reset() {
-                            exporter.record_counter(key, value, &attributes);
-                        }
-                    }
-                    Metric::Gauge(gauge) => {
-                        if let Some(value) = gauge.load_if_changed() {
-                            exporter.record_gauge(key, value, &attributes);
-                        }
-                    }
-                    Metric::Histogram(histogram) => {
-                        histogram.run_and_reset(|h| {
-                            let value = h.mean();
-                            exporter.record_histogram(key, value, &attributes);
-                        });
-                    }
-                }
+                // Record the metric using its value
+                exporter.record_metric(key, &value, &attributes);
             }
-
-            let Some(metric) = metric.fmt_and_reset() else {
-                continue;
-            };
             let labels = if key.labels().len() == 0 {
                 String::new()
             } else {
@@ -203,7 +189,7 @@ impl MetricsSink {
                         .join(",")
                 )
             };
-            metrics.push(format!("{}{}: {}", key.name(), labels, metric));
+            metrics.push(format!("{}{}: {}", key.name(), labels, metric_str));
         }
 
         metrics.sort();
@@ -497,7 +483,7 @@ mod tests {
         let error = result.unwrap_err().to_string();
         assert!(
             error.contains("Invalid OTLP endpoint configuration"),
-            "Error message should indicate invalid configuration: {error}"
+            "Error message should indicate invalid configuration: {error}",
         );
 
         // Test with no OTLP config (should succeed)

--- a/mountpoint-s3-fs/src/metrics/data.rs
+++ b/mountpoint-s3-fs/src/metrics/data.rs
@@ -1,6 +1,14 @@
 use crate::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use crate::sync::{Arc, Mutex};
 
+/// Represents the value of a metric
+#[derive(Debug, Clone)]
+pub enum MetricValue {
+    Counter(u64),
+    Gauge(f64),
+    Histogram(f64),
+}
+
 /// A single metric
 #[derive(Debug)]
 pub enum Metric {
@@ -43,34 +51,43 @@ impl Metric {
         metrics::Histogram::from_arc(inner.clone())
     }
 
-    /// Generate a string representation of this metric, or None if the metric has had no values
+    /// Generate both the value and string representation of this metric, or None if the metric has had no values
     /// emitted since the last call to this function.
-    pub fn fmt_and_reset(&self) -> Option<String> {
+    pub fn value_and_fmt_and_reset(&self) -> Option<(MetricValue, String)> {
         match self {
             Metric::Counter(inner) => {
                 let (sum, n) = inner.load_and_reset()?;
-                if n == 1 {
-                    Some(format!("{sum}"))
+                let fmt = if n == 1 {
+                    format!("{sum}")
                 } else {
-                    Some(format!("{sum} (n={n})"))
-                }
+                    format!("{sum} (n={n})")
+                };
+                Some((MetricValue::Counter(sum), fmt))
             }
             // Gauges can't reset because they can be incremented/decremented
-            Metric::Gauge(inner) => inner.load_if_changed().map(|value| format!("{value}")),
-            Metric::Histogram(histogram) => histogram.run_and_reset(|histogram| {
-                format!(
-                    "n={}: min={} p10={} p50={} avg={:.2} p90={} p99={} p99.9={} max={}",
-                    histogram.len(),
-                    histogram.min(),
-                    histogram.value_at_quantile(0.1),
-                    histogram.value_at_quantile(0.5),
-                    histogram.mean(),
-                    histogram.value_at_quantile(0.9),
-                    histogram.value_at_quantile(0.99),
-                    histogram.value_at_quantile(0.999),
-                    histogram.max(),
-                )
-            }),
+            Metric::Gauge(inner) => {
+                let value = inner.load_if_changed()?;
+                let fmt = format!("{value}");
+                Some((MetricValue::Gauge(value), fmt))
+            }
+            Metric::Histogram(histogram) => {
+                // run_and_reset already returns an Option, so we map it to our return type
+                histogram.run_and_reset(|histogram| {
+                    let fmt = format!(
+                        "n={}: min={} p10={} p50={} avg={:.2} p90={} p99={} p99.9={} max={}",
+                        histogram.len(),
+                        histogram.min(),
+                        histogram.value_at_quantile(0.1),
+                        histogram.value_at_quantile(0.5),
+                        histogram.mean(),
+                        histogram.value_at_quantile(0.9),
+                        histogram.value_at_quantile(0.99),
+                        histogram.value_at_quantile(0.999),
+                        histogram.max(),
+                    );
+                    (MetricValue::Histogram(histogram.max() as f64), fmt)
+                })
+            }
         }
     }
 }

--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -1,0 +1,213 @@
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use std::time::Duration;
+
+use metrics::Key;
+
+/// Configuration for OpenTelemetry metrics export
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// The endpoint URL to send metrics to
+    pub endpoint: String,
+    /// The export interval in seconds
+    pub interval_secs: u64,
+}
+
+impl OtlpConfig {
+    /// Create a new OtlpConfig with the specified endpoint and default interval
+    pub fn new(endpoint: &str) -> Self {
+        Self {
+            endpoint: endpoint.to_string(),
+            interval_secs: 5, // Default to 5 seconds
+        }
+    }
+
+    /// Set the export interval in seconds
+    pub fn with_interval_secs(mut self, secs: u64) -> Self {
+        self.interval_secs = secs;
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct OtlpMetricsExporter {
+    meter: opentelemetry::metrics::Meter,
+}
+
+impl OtlpMetricsExporter {
+    /// Create a new OtlpMetricsExporter with the specified configuration
+    /// Returns a Result containing the new exporter or an error if initialisation failed
+    pub fn new(config: &OtlpConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        // Initialise OTLP exporter using HTTP binary protocol with the specified endpoint
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(&config.endpoint)
+            .build()?;
+
+        // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
+        let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            // The default interval is 60 seconds so we use a PeriodicReader to allow us to specify a custom interval duration
+            .with_reader(
+                opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+                    .with_interval(Duration::from_secs(config.interval_secs))
+                    .build(),
+            )
+            .build();
+        // Set the configured SdkMeterProvider as the global meter provider making it the default provider that will be used throughout for all OpenTelemetry metrics
+        global::set_meter_provider(meter_provider);
+
+        // Obtain meter instance from global meter provider
+        // The meter will be used to create specific metric instruments (counters, gauges, histograms) and record values to them
+        let meter = global::meter("mountpoint-s3");
+
+        Ok(Self { meter })
+    }
+
+    /// Record a counter metric in OTel format
+    pub fn record_counter(&self, key: &Key, value: u64, attributes: &[KeyValue]) {
+        let counter = self.meter.u64_counter(key.name().to_string()).build();
+
+        counter.add(value, attributes);
+    }
+
+    /// Record a gauge metric in OTel format
+    pub fn record_gauge(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
+        let gauge = self.meter.f64_gauge(key.name().to_string()).build();
+
+        gauge.record(value, attributes);
+    }
+
+    /// Record a histogram metric in OTel format
+    pub fn record_histogram(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
+        let histogram = self.meter.f64_histogram(key.name().to_string()).build();
+
+        histogram.record(value, attributes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This is a manual test for verifying OpenTelemetry metrics export functionality.
+    /// It provides end-to-end verification of the metrics pipeline without needing to run the full mountpoint application.
+    ///
+    /// # Requirements
+    /// - An OpenTelemetry collector running at the specified endpoint (default: http://localhost:4318/v1/metrics)
+    ///
+    /// # How to run
+    /// ```bash
+    /// # Start the OpenTelemetry collector (e.g., using Docker)
+    /// docker run -p 4317:4317 -p 4318:4318 -v $(pwd)/collector-config.yaml:/etc/otel-collector-config.yaml \
+    ///   otel/opentelemetry-collector:latest --config=/etc/otel-collector-config.yaml
+    ///
+    /// # Run the test with default endpoint (ignored by default)
+    /// cargo test --package mountpoint-s3-fs --lib -- metrics_otel::tests::direct_otlp_test --exact --ignored
+    ///
+    /// # Or run with a custom endpoint by setting the MOUNTPOINT_TEST_OTLP_ENDPOINT environment variable
+    /// MOUNTPOINT_TEST_OTLP_ENDPOINT="http://custom-server:4318/v1/metrics" cargo test --package mountpoint-s3-fs --lib -- metrics_otel::tests::direct_otlp_test --exact --ignored
+    ///
+    /// # Verify metrics in collector logs
+    #[test]
+    #[ignore]
+    fn direct_otlp_test() {
+        use opentelemetry::global;
+        use opentelemetry_otlp::{Protocol, WithExportConfig};
+        use std::time::Duration;
+        use tracing::info;
+        use tracing_subscriber::fmt::format::FmtSpan;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        // Create and set the subscriber
+        tracing_subscriber::fmt()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(false)
+            .with_thread_ids(true)
+            .with_level(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_test_writer()
+            .set_default();
+
+        info!("Setting up direct OpenTelemetry test...");
+
+        // Get OTLP endpoint from environment variable or use default
+        let endpoint = std::env::var("MOUNTPOINT_TEST_OTLP_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:4318/v1/metrics".to_string());
+
+        info!("Using OTLP endpoint: {}", endpoint);
+
+        // Create a config with custom settings
+        let config = OtlpConfig::new(&endpoint).with_interval_secs(1);
+
+        // Initialize the OpenTelemetry SDK directly
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(&config.endpoint)
+            .with_timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to create exporter");
+
+        info!("Created exporter");
+
+        let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(1))
+            .build();
+
+        info!("Created reader");
+
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_reader(reader)
+            .build();
+
+        info!("Created provider");
+
+        global::set_meter_provider(provider.clone());
+
+        info!("Set meter provider");
+
+        let meter = global::meter("mountpoint-s3");
+
+        // Create and record multiple metrics to ensure visibility
+        let counter = meter
+            .u64_counter("test_counter")
+            .with_description("Test counter for direct OTLP export")
+            .with_unit("1")
+            .build();
+
+        info!("Created counter metric");
+
+        // Add multiple data points with different attributes
+        counter.add(
+            100,
+            &[
+                opentelemetry::KeyValue::new("test", "true"),
+                opentelemetry::KeyValue::new("source", "direct_test"),
+                opentelemetry::KeyValue::new("type", "counter"),
+            ],
+        );
+
+        info!("Recorded counter with value 100 to endpoint {}", endpoint);
+
+        // Add another data point to ensure we're seeing updates
+        counter.add(
+            150,
+            &[
+                opentelemetry::KeyValue::new("test", "true"),
+                opentelemetry::KeyValue::new("source", "direct_test"),
+                opentelemetry::KeyValue::new("type", "counter"),
+            ],
+        );
+
+        info!("Recorded counter with value 150 to endpoint {}", endpoint);
+        info!("Waiting for metrics to be exported...");
+
+        // Wait longer to ensure metrics are exported
+        std::thread::sleep(Duration::from_secs(10));
+
+        info!("Test complete. Check docker logs otel-collector for metrics with prefix 'mountpoint.'");
+    }
+}

--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -63,6 +63,9 @@ impl OtlpMetricsExporter {
             .with_endpoint(&endpoint_url)
             .build()?;
 
+        // Create a resource with no attributes to avoid default dimensions
+        let resource = opentelemetry_sdk::resource::Resource::builder_empty().build();
+
         // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
         let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             // The default interval is 60 seconds so we use a PeriodicReader to allow us to specify a custom interval duration
@@ -71,6 +74,7 @@ impl OtlpMetricsExporter {
                     .with_interval(Duration::from_secs(config.interval_secs))
                     .build(),
             )
+            .with_resource(resource)
             .build();
         // Set the configured SdkMeterProvider as the global meter provider making it the default provider that will be used throughout for all OpenTelemetry metrics
         global::set_meter_provider(meter_provider);

--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -3,7 +3,10 @@ use opentelemetry::global;
 use opentelemetry_otlp::{Protocol, WithExportConfig};
 use std::time::Duration;
 
+use crate::metrics::MetricValue;
 use metrics::Key;
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// Configuration for OpenTelemetry metrics export
 #[derive(Debug, Clone)]
@@ -19,7 +22,7 @@ impl OtlpConfig {
     pub fn new(endpoint: &str) -> Self {
         Self {
             endpoint: endpoint.to_string(),
-            interval_secs: 5, // Default to 5 seconds
+            interval_secs: 60, // Default to 60 seconds to align with the meter provider default interval
         }
     }
 
@@ -33,17 +36,31 @@ impl OtlpConfig {
 #[derive(Debug)]
 pub struct OtlpMetricsExporter {
     meter: opentelemetry::metrics::Meter,
+    counters: Mutex<HashMap<String, opentelemetry::metrics::Counter<u64>>>,
+    gauges: Mutex<HashMap<String, opentelemetry::metrics::Gauge<f64>>>,
+    histograms: Mutex<HashMap<String, opentelemetry::metrics::Histogram<f64>>>,
 }
 
 impl OtlpMetricsExporter {
     /// Create a new OtlpMetricsExporter with the specified configuration
     /// Returns a Result containing the new exporter or an error if initialisation failed
     pub fn new(config: &OtlpConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        // Ensure endpoint ends with /v1/metrics
+        let endpoint_url = if !config.endpoint.ends_with("/v1/metrics") {
+            if config.endpoint.ends_with('/') {
+                format!("{}v1/metrics", config.endpoint)
+            } else {
+                format!("{}/v1/metrics", config.endpoint)
+            }
+        } else {
+            config.endpoint.to_string()
+        };
+
         // Initialise OTLP exporter using HTTP binary protocol with the specified endpoint
         let exporter = opentelemetry_otlp::MetricExporter::builder()
             .with_http()
             .with_protocol(Protocol::HttpBinary)
-            .with_endpoint(&config.endpoint)
+            .with_endpoint(&endpoint_url)
             .build()?;
 
         // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
@@ -62,28 +79,54 @@ impl OtlpMetricsExporter {
         // The meter will be used to create specific metric instruments (counters, gauges, histograms) and record values to them
         let meter = global::meter("mountpoint-s3");
 
-        Ok(Self { meter })
+        Ok(Self {
+            meter,
+            counters: Mutex::new(HashMap::new()),
+            gauges: Mutex::new(HashMap::new()),
+            histograms: Mutex::new(HashMap::new()),
+        })
     }
 
     /// Record a counter metric in OTel format
     pub fn record_counter(&self, key: &Key, value: u64, attributes: &[KeyValue]) {
-        let counter = self.meter.u64_counter(key.name().to_string()).build();
-
+        let name = format!("mountpoint.{}", key.name());
+        let mut counters = self.counters.lock().unwrap();
+        let counter = counters
+            .entry(name.clone())
+            .or_insert_with(|| self.meter.u64_counter(name).build());
         counter.add(value, attributes);
     }
 
     /// Record a gauge metric in OTel format
     pub fn record_gauge(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
-        let gauge = self.meter.f64_gauge(key.name().to_string()).build();
-
+        let name = format!("mountpoint.{}", key.name());
+        let mut gauges = self.gauges.lock().unwrap();
+        let gauge = gauges
+            .entry(name.clone())
+            .or_insert_with(|| self.meter.f64_gauge(name).build());
         gauge.record(value, attributes);
     }
 
     /// Record a histogram metric in OTel format
     pub fn record_histogram(&self, key: &Key, value: f64, attributes: &[KeyValue]) {
-        let histogram = self.meter.f64_histogram(key.name().to_string()).build();
-
+        let name = format!("mountpoint.{}", key.name());
+        let mut histograms = self.histograms.lock().unwrap();
+        let histogram = histograms
+            .entry(name.clone())
+            .or_insert_with(|| self.meter.f64_histogram(name).build());
         histogram.record(value, attributes);
+    }
+
+    /// Record a metric using its MetricValue
+    pub fn record_metric(&self, key: &Key, value: &MetricValue, attributes: &[KeyValue]) {
+        match value {
+            MetricValue::Counter(count) => self.record_counter(key, *count, attributes),
+            MetricValue::Gauge(val) => self.record_gauge(key, *val, attributes),
+            MetricValue::Histogram(_mean) => {
+                // Do nothing for histograms for now
+                // Will be implemented later
+            }
+        }
     }
 }
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -51,6 +51,7 @@ built = { version = "0.8.0", features = ["git2"] }
 block_size = ["mountpoint-s3-fs/block_size"]
 event_log = ["mountpoint-s3-fs/event_log"]
 mem_limiter = ["mountpoint-s3-fs/mem_limiter"]
+otlp_integration = ["mountpoint-s3-fs/otlp_integration"]
 # Features for choosing tests
 s3_tests = ["mountpoint-s3-fs/s3_tests"]
 fuse_tests = ["mountpoint-s3-fs/fuse_tests"]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -280,6 +280,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
     #[clap(long, help = "Enable logging of summarized performance metrics", help_heading = LOGGING_OPTIONS_HEADER)]
     pub log_metrics: bool,
 
+    #[cfg(feature = "otlp_integration")]
     #[clap(
         long,
         help = "Enable OTLP metrics export to the specified endpoint",
@@ -288,6 +289,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
     )]
     pub log_metrics_otlp: Option<String>,
 
+    #[cfg(feature = "otlp_integration")]
     #[clap(
         long,
         help = "OTLP metrics export interval in seconds [default: 5]",

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -280,6 +280,24 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
     #[clap(long, help = "Enable logging of summarized performance metrics", help_heading = LOGGING_OPTIONS_HEADER)]
     pub log_metrics: bool,
 
+    #[clap(
+        long,
+        help = "Enable OTLP metrics export to the specified endpoint",
+        help_heading = LOGGING_OPTIONS_HEADER,
+        value_name = "ENDPOINT"
+    )]
+    pub log_metrics_otlp: Option<String>,
+
+    #[clap(
+        long,
+        help = "OTLP metrics export interval in seconds [default: 5]",
+        help_heading = LOGGING_OPTIONS_HEADER,
+        value_name = "SECONDS",
+        value_parser = value_parser!(u64).range(1..),
+        requires = "log_metrics_otlp"
+    )]
+    pub log_metrics_otlp_interval: Option<u64>,
+
     #[clap(short, long, help = "Enable debug logging for Mountpoint", help_heading = LOGGING_OPTIONS_HEADER)]
     pub debug: bool,
 

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -30,7 +30,7 @@ pub fn run(client_builder: impl ClientBuilder, args: CliArgs) -> anyhow::Result<
     if args.foreground {
         let _logging = init_logging(args.make_logging_config()).context("failed to initialize logging")?;
 
-        let _metrics = metrics::install();
+        let _metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
         create_pid_file()?;
 
@@ -62,7 +62,7 @@ pub fn run(client_builder: impl ClientBuilder, args: CliArgs) -> anyhow::Result<
                 let args = parse_cli_args(false);
                 let _logging = init_logging(logging_config).context("failed to initialize logging")?;
 
-                let _metrics = metrics::install();
+                let _metrics = metrics::install(None).map_err(|e| anyhow!("Failed to initialize metrics: {}", e))?;
 
                 create_pid_file()?;
 


### PR DESCRIPTION
This PR adds a CLI argument which enables users to run Mountpoint with the functionality of publishing metrics to a specified endpoint.

No impact on existing behavior. This CLI option is under a compile time flag.

Added functionality:
Run Mountpoint with --log-metrics-otlp http://localhost:4318 flag to enable publishing metrics to port 4318 (otlp port)
Optionally you can also specify the exporting interval with the --log-metrics-otlp-interval flag.

To verify the implementation I ran a docker container running the OpenTelemetry Collector at the default port, and ran Mountpoint with the new flag with endpoint specified.
I verified that the Mountpoint metrics were visible in the collector logs. Here is a screenshot of an example Mountpoint metric collected at the endpoint:

<img width="416" height="217" alt="Screenshot 2025-07-31 at 17 39 57" src="https://github.com/user-attachments/assets/565f6ae9-84dc-49e4-a80a-6383ede913f4" />

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
