### PR TITLE
Add option to disable download checksums in performance tests

### DIFF
--- a/benchmark/benchmarks/benchmark_config_parser.py
+++ b/benchmark/benchmarks/benchmark_config_parser.py
@@ -42,6 +42,7 @@ class BenchmarkConfigParser:
             'with_bwm': getattr(self.cfg.monitoring, 'with_bwm', False),
             'write_part_size': getattr(self.cfg, 'write_part_size', 16777216),  # 16 MiB
             'with_perf_stat': getattr(self.cfg.monitoring, 'with_perf_stat', False),
+            'download_checksums': getattr(self.cfg, 'download_checksums', True),
         }
 
     def get_mountpoint_config(self) -> Dict[str, Any]:

--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import os
 from typing import Dict, Any
 
 from benchmarks.base_benchmark import BaseBenchmark
@@ -70,8 +71,16 @@ class ClientBenchmark(BaseBenchmark):
         else:
             raise ValueError("Seeing fewer objects than app workers. So cannot proceed with the run.")
 
+        client_env = {}
+        if not self.common_config['download_checksums']:
+            client_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
+
+        subprocess_env = os.environ.copy()
+        subprocess_env.update(client_env)
+        log.debug("Subprocess env: %s", subprocess_env)
+
         log.info("Running client benchmark with args: %s", subprocess_args)
-        subprocess.run(subprocess_args, check=True, capture_output=True, text=True)
+        subprocess.run(subprocess_args, check=True, capture_output=True, text=True, env=client_env)
         log.info("Client benchmark completed successfully.")
 
     def post_process(self) -> Dict[str, Any]:

--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -75,12 +75,11 @@ class ClientBenchmark(BaseBenchmark):
         if not self.common_config['download_checksums']:
             client_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
 
-        subprocess_env = os.environ.copy()
-        subprocess_env.update(client_env)
+        subprocess_env = os.environ.copy() | client_env
         log.debug("Subprocess env: %s", subprocess_env)
 
         log.info("Running client benchmark with args: %s", subprocess_args)
-        subprocess.run(subprocess_args, check=True, capture_output=True, text=True, env=client_env)
+        subprocess.run(subprocess_args, check=True, capture_output=True, text=True, env=subprocess_env)
         log.info("Client benchmark completed successfully.")
 
     def post_process(self) -> Dict[str, Any]:

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -111,6 +111,8 @@ def mount_mp(cfg: DictConfig, mount_dir: str) -> Dict[str, Any]:
         mp_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(mp_config["mountpoint_congestion_threshold"])
 
     mp_env["UNSTABLE_MOUNTPOINT_PID_FILE"] = f"{mount_dir}.pid"
+    if not common_config['download_checksums']:
+        mp_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
 
     if stub_mode != "off" and mp_config["mountpoint_binary"] is not None:
         raise ValueError("Cannot use `stub_mode` with `mountpoint_binary`, `stub_mode` requires recompilation")

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -72,8 +72,7 @@ class PrefetchBenchmark(BaseBenchmark):
         if not self.common_config['download_checksums']:
             prefetch_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
 
-        subprocess_env = os.environ.copy()
-        subprocess_env.update(prefetch_env)
+        subprocess_env = os.environ.copy() | prefetch_env
         log.debug("Subprocess env: %s", subprocess_env)
 
         log.info("Running prefetch benchmark with args: %s", subprocess_args)

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 from typing import Dict, Any
 
@@ -67,9 +68,16 @@ class PrefetchBenchmark(BaseBenchmark):
             subprocess_args.extend(["--max-duration", str(run_time)])
 
         subprocess_args.extend(["--output-file", "prefetch-output.json"])
+        prefetch_env = {}
+        if not self.common_config['download_checksums']:
+            prefetch_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
+
+        subprocess_env = os.environ.copy()
+        subprocess_env.update(prefetch_env)
+        log.debug("Subprocess env: %s", subprocess_env)
 
         log.info("Running prefetch benchmark with args: %s", subprocess_args)
-        subprocess.run(subprocess_args, check=True, capture_output=True, text=True)
+        subprocess.run(subprocess_args, check=True, capture_output=True, text=True, env=subprocess_env)
         log.info("Prefetch benchmark completed successfully.")
 
     def post_process(self) -> None:

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -18,13 +18,12 @@ write_part_size: 16777216  # 16 MiB, to allow for uploads of large files
 object_size_in_gib: 100  # Size of the object to benchmark
 benchmark_type: "fio" # fio, prefetch, client, client-bp, crt
 s3_keys: !!null
+download_checksums: true
 
-# Network configuration
 network:
   interface_names: []
   maximum_throughput_gbps: !!null
 
-# Monitoring options (common to all benchmarks)
 monitoring:
   with_bwm: false
   with_perf_stat: false
@@ -60,8 +59,6 @@ benchmarks:
   client:  
     # None 
 
-  client_backpressure:
-    read_window_size: !!null #2147483648 
 
 hydra:
   help:

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -20,10 +20,12 @@ benchmark_type: "fio" # fio, prefetch, client, client-bp, crt
 s3_keys: !!null
 download_checksums: true
 
+# Network configuration
 network:
   interface_names: []
   maximum_throughput_gbps: !!null
 
+# Monitoring options (common to all benchmarks)
 monitoring:
   with_bwm: false
   with_perf_stat: false
@@ -58,6 +60,9 @@ benchmarks:
 
   client:  
     # None 
+
+  client_backpressure:
+    read_window_size: !!null #2147483648 
 
 
 hydra:


### PR DESCRIPTION

Adds an option to our benchmarking code to disable verification of downloaded objects integrity.

Does not change existing behaviour, as it is only enabled when `EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION ` is set, and thus does not need a changelog entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
