### PR TITLE
Implement integrity checks for the metadata store

### DIFF
--- a/mountpoint-s3-crt/src/checksums/crc32c.rs
+++ b/mountpoint-s3-crt/src/checksums/crc32c.rs
@@ -42,6 +42,11 @@ impl Hasher {
         self.state = Crc32c(Self::crc32c(buf, self.state.0));
     }
 
+    /// Return the computed CRC32C checksum value without finalizing the hasher.
+    pub fn current_value(&self) -> Crc32c {
+        self.state
+    }
+
     /// Finalize the hash state and return the computed CRC32C checksum value.
     pub fn finalize(self) -> Crc32c {
         self.state

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -98,6 +98,10 @@ second_account_tests = []
 name = "mount_from_config"
 required-features = ["manifest", "event_log"]
 
+[[example]]
+name = "create_manifest"
+required-features = ["manifest"]
+
 [[bench]]
 name = "cache_serialization"
 harness = false

--- a/mountpoint-s3-fs/examples/config.json.example
+++ b/mountpoint-s3-fs/examples/config.json.example
@@ -9,7 +9,8 @@
         {
             "directory_name": "example_dir",
             "bucket_name": "amzn-s3-demo-bucket",
-            "manifest_path": "../output.csv"
+            "manifest_path": "../output.csv",
+            "manifest_checksum": 880485757
         }
     ],
     "loglevel": "debug,awscrt=off",

--- a/mountpoint-s3-fs/examples/create_manifest.rs
+++ b/mountpoint-s3-fs/examples/create_manifest.rs
@@ -1,0 +1,176 @@
+use std::{
+    fs::File,
+    hash::Hasher,
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::{Client, config::Region, operation::list_objects_v2::ListObjectsV2Output};
+use clap::Parser;
+use crc32c::{self, Crc32cHasher, crc32c_combine};
+use csv::WriterBuilder;
+use serde::Serialize;
+
+#[derive(Debug, Parser)]
+#[clap(
+    name = "Mountpoint Manifest Creator",
+    about = "A helper to create a CSV manifest of a bucket using ListObjectsV2 requests."
+)]
+struct Opt {
+    /// The AWS Region.
+    #[clap(long)]
+    region: String,
+
+    /// The name of the bucket.
+    #[clap(long)]
+    bucket: String,
+
+    /// The prefix to list [must include '/' if not empty].
+    #[clap(long, default_value = "")]
+    prefix: String,
+
+    /// Whether to remove prefix from the keys in the output.
+    #[clap(long, default_value_t = false)]
+    remove_prefix: bool,
+
+    /// Where to write the manifest.
+    #[clap(long)]
+    output_file: PathBuf,
+}
+
+#[derive(Serialize)]
+struct CsvEntry {
+    /// Partial key of the S3 object.
+    ///
+    /// Must not contain S3 prefix, when the prefix is mounted.
+    /// May hold a directory marker (e.g. "dir1/dir2/"), which will be skipped
+    /// and won't affect the file system structure.
+    partial_key: String,
+    /// Etag of the S3 object.
+    etag: String,
+    /// Size of the S3 object.
+    size: usize,
+    /// CRC32C checksum of the fields.
+    checksum: u32,
+}
+
+impl CsvEntry {
+    fn new(partial_key: String, etag: String, size: usize) -> Self {
+        let checksum = Self::compute_checksum(&partial_key, &etag, size);
+        Self {
+            partial_key,
+            etag,
+            size,
+            checksum,
+        }
+    }
+
+    fn compute_checksum(partial_key: &str, etag: &str, size: usize) -> u32 {
+        let mut hasher = Crc32cHasher::new(0);
+        hasher.write(partial_key.as_bytes());
+        hasher.write(etag.as_bytes());
+        // we encode size with big endian byte order and with a fixed width of 8 bytes (rust: u64, java: long)
+        let size = size as u64;
+        hasher.write(size.to_be_bytes().as_ref());
+        hasher.finish() as u32
+    }
+
+    fn total_size(&self) -> usize {
+        const SIZE_LEN: usize = 8; // size is always 8 bytes
+        self.partial_key.len() + self.etag.len() + SIZE_LEN
+    }
+}
+
+fn write_to_manifest<W: Write>(
+    resp: &ListObjectsV2Output,
+    prefix: &str,
+    remove_prefix: bool,
+    writer: &mut csv::Writer<W>,
+    running_checksum: &mut u32,
+) -> Result<()> {
+    for object in resp.contents() {
+        let relative_key = if remove_prefix && !prefix.is_empty() {
+            &object.key().unwrap()[prefix.len() + 1..]
+        } else {
+            object.key().unwrap()
+        };
+
+        // Create a CsvEntry instance
+        let entry = CsvEntry::new(
+            relative_key.to_string(),
+            object.e_tag().unwrap().to_string().replace("\"", ""), // remove quotes (that's the default behavior in Java SDK)
+            object.size().unwrap() as usize,
+        );
+
+        // Update running_checksum using crc32c_combine (this may not be available in all libraries, alternatively re-compute checksum for each field)
+        *running_checksum = crc32c_combine(*running_checksum, entry.checksum, entry.total_size());
+
+        // Write the entry to the CSV writer
+        writer.serialize(entry)?;
+    }
+    Ok(())
+}
+
+async fn list_objects(
+    client: &Client,
+    bucket: &str,
+    prefix: &str,
+    remove_prefix: bool,
+    output_file: &Path,
+) -> Result<()> {
+    // Create a CSV writer
+    let file = File::options().write(true).create_new(true).open(output_file)?;
+    let writer = BufWriter::new(file);
+    let mut writer = WriterBuilder::new().has_headers(false).from_writer(writer);
+
+    // Running checksum of all entries in the manifest
+    let mut running_checksum: u32 = 0;
+
+    // Make ListObjectsV2 requests and write output to the CSV file
+    let mut resp = client.list_objects_v2().bucket(bucket).prefix(prefix).send().await?;
+    write_to_manifest(&resp, prefix, remove_prefix, &mut writer, &mut running_checksum)?;
+
+    while let Some(token) = resp.next_continuation_token {
+        resp = client
+            .list_objects_v2()
+            .bucket(bucket)
+            .continuation_token(token)
+            .prefix(prefix)
+            .send()
+            .await?;
+        write_to_manifest(&resp, prefix, remove_prefix, &mut writer, &mut running_checksum)?;
+    }
+
+    // Flush the writer to ensure all data is written
+    writer.flush()?;
+
+    // Print the final running checksum to stdout
+    println!("Running checksum of all entries: {running_checksum}");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        region,
+        bucket,
+        prefix,
+        remove_prefix,
+        output_file,
+    } = Opt::parse();
+
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(Region::new(region))
+        .load()
+        .await;
+    let client = Client::new(&sdk_config);
+
+    list_objects(&client, &bucket, &prefix, remove_prefix, output_file.as_path()).await?;
+
+    Ok(())
+}

--- a/mountpoint-s3-fs/src/manifest/builder.rs
+++ b/mountpoint-s3-fs/src/manifest/builder.rs
@@ -3,11 +3,12 @@ use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 use std::{collections::HashMap, fs::File};
 
+use mountpoint_s3_client::checksums::Crc32c;
 use serde::Deserialize;
 use thiserror::Error;
 
 use crate::fs::InodeKind;
-use crate::metablock::{ROOT_INODE_NO, ValidKey, ValidKeyError};
+use crate::metablock::{ROOT_INODE_NO, ValidKey, ValidKeyError, ValidName};
 use crate::s3::{Bucket, Prefix, PrefixError, S3Path, S3PathError};
 
 use super::{
@@ -38,6 +39,12 @@ pub enum InputManifestError {
     DbError(#[from] rusqlite::Error),
     #[error("s3 key provided in the csv manifest is invalid")]
     InvalidKey(#[from] ValidKeyError),
+    #[error("invalid checksum for the entry with key {0}, computed {1}, received {2}")]
+    InvalidChecksum(String, u32, u32),
+    #[error("invalid checksum for the manifest file for channel {0}, computed {1}, received {2}")]
+    InvalidFileChecksum(String, u32, u32),
+    #[error("invalid etag {0} for the entry with key {1}")]
+    InvalidEtag(String, String),
 }
 
 /// ChannelConfig represents per-channel configuration, when multiple buckets are mounted.
@@ -48,6 +55,7 @@ pub struct ChannelConfig {
     #[serde(default)]
     pub prefix: String,
     pub manifest_path: PathBuf,
+    pub manifest_checksum: u32,
 }
 
 /// ChannelManifest is a helper struct, primarily exposed for usage in tests.
@@ -70,13 +78,17 @@ pub struct InputManifestEntry {
     partial_key: ValidKey,
     etag: String,
     size: usize,
+    // Checksum as computed by the creator of the manifest; we will validate it before storing to DB.
+    checksum: Crc32c,
 }
 
 impl InputManifestEntry {
+    /// Creates an InputManifestEntry and stores the expected checksum for later validation.
     pub fn new(
         partial_key: impl Into<String>,
         etag: impl Into<String>,
         size: usize,
+        checksum: u32,
     ) -> Result<Self, InputManifestError> {
         let partial_key = ValidKey::try_from(partial_key.into())?;
         if partial_key.is_empty() {
@@ -87,25 +99,63 @@ impl InputManifestEntry {
         if partial_key.kind() != InodeKind::File {
             return Err(InputManifestError::DirectoryMarker(partial_key.to_string()));
         }
+        let etag = etag.into();
+        if etag.is_empty() {
+            return Err(InputManifestError::InvalidEtag(partial_key.to_string(), etag));
+        }
         Ok(Self {
             partial_key,
-            etag: etag.into(),
+            etag,
             size,
+            checksum: Crc32c::new(checksum),
         })
     }
 
-    fn into_db_entry(self, id: u64, parent_id: u64, channel_id: usize, parent_partial_key: ValidKey) -> DbEntry {
+    /// Creates an InputManifestEntry and computes the checksum.
+    ///
+    /// This is only useful in tests.
+    pub fn new_without_checksum(
+        partial_key: impl Into<String>,
+        etag: impl Into<String>,
+        size: usize,
+    ) -> Result<Self, InputManifestError> {
+        let mut hasher = mountpoint_s3_client::checksums::crc32c::Hasher::new();
+
+        let partial_key: String = partial_key.into();
+        hasher.update(partial_key.as_bytes());
+        let etag: String = etag.into();
+        hasher.update(etag.as_bytes());
+        // we encode size with big endian byte order and with a fixed width of 8 bytes (rust: u64, java: long)
+        hasher.update((size as u64).to_be_bytes().as_ref());
+        let checksum = hasher.finalize();
+
+        Self::new(partial_key, etag, size, checksum.value())
+    }
+
+    /// Creates a [DbEntry] from self. The checksum is validated here.
+    fn into_db_entry(
+        self,
+        id: u64,
+        parent_id: u64,
+        channel_id: usize,
+        parent_partial_key: ValidKey,
+        s3_path: &S3Path,
+    ) -> Result<DbEntry, InputManifestError> {
         debug_assert_eq!(self.partial_key.kind(), InodeKind::File);
 
-        DbEntry {
+        DbEntry::new_with_partial_checksum(
             id,
             parent_id,
             channel_id,
-            parent_partial_key: Some(parent_partial_key.to_string()),
-            name: self.partial_key.name().to_string(),
-            etag: Some(self.etag),
-            size: Some(self.size),
-        }
+            Some(parent_partial_key),
+            self.partial_key
+                .valid_name()
+                .expect("files guaranteed to have a valid name"),
+            Some(self.etag),
+            Some(self.size),
+            s3_path,
+            self.checksum,
+        )
     }
 }
 
@@ -113,9 +163,10 @@ impl InputManifestEntry {
 ///
 /// Accepts a slice of [ChannelConfig], with each channel having a dedicated CSV manifest.
 ///
-/// For each manifest, the expected file format is CSV with no header and 3 columns: partial_key, etag, size.
+/// For each manifest, the expected file format is CSV with no header and 4 columns: partial_key, etag, size, checksum.
 /// The field `partial_key` must not contain S3 prefix, when the prefix is mounted.
 /// The field `etag` may contain enclosing quotes, just as it is returned by S3 ListObjectsV2 API.
+/// The fields `checksum` must contain the CRC32C checksum of the other 3 fields of the entry.
 /// All fields must be properly escaped.
 pub fn ingest_manifest(channel_configs: &[ChannelConfig], db_path: &Path) -> Result<(), InputManifestError> {
     if db_path.exists() {
@@ -133,7 +184,11 @@ pub fn ingest_manifest(channel_configs: &[ChannelConfig], db_path: &Path) -> Res
     for config in channel_configs {
         let csv_path = &config.manifest_path;
         let file = File::open(csv_path).map_err(|err| InputManifestError::CsvOpenError(csv_path.to_path_buf(), err))?;
-        let csv_reader = CsvReader::new(BufReader::new(file));
+        let csv_reader = CsvReader::new(
+            BufReader::new(file),
+            csv_path.to_string_lossy().as_ref(),
+            config.manifest_checksum,
+        );
         channel_manifest_readers.push(ChannelManifest {
             directory_name: config.directory_name.clone(),
             s3_path: S3Path::new(Bucket::new(&config.bucket_name)?, Prefix::new(&config.prefix)?),
@@ -216,15 +271,18 @@ impl ManifestBuilder {
         for (channel_id, channel_manifest) in channel_manifests.into_iter().enumerate() {
             // insert synthetic channel dir
             let channel_root_id = self.next_id;
-            self.insert_buffer.push(DbEntry {
-                id: channel_root_id,
-                parent_id: ROOT_INODE_NO,
+            let channel_directory_name = ValidName::try_from(channel_manifest.directory_name.as_str())
+                .map_err(|_| InputManifestError::InvalidChannel(channel_manifest.directory_name.clone()))?;
+            self.insert_buffer.push(DbEntry::new(
+                channel_root_id,
+                ROOT_INODE_NO,
                 channel_id,
-                parent_partial_key: None,
-                name: channel_manifest.directory_name.clone(),
-                etag: None,
-                size: None,
-            });
+                None,
+                channel_directory_name,
+                None,
+                None,
+                &channel_manifest.s3_path,
+            )?);
             self.next_id += 1;
 
             // insert keys from the manifest (and corresponding dirs)
@@ -240,11 +298,21 @@ impl ManifestBuilder {
                 let entry = entry?;
 
                 // insert the parent directories
-                let (parent_id, parent_partial_key) =
-                    self.ensure_dirs_inserted(&entry.partial_key, channel_id, channel_root_id)?;
+                let (parent_id, parent_partial_key) = self.ensure_dirs_inserted(
+                    &entry.partial_key,
+                    channel_id,
+                    channel_root_id,
+                    &channel_manifest.s3_path,
+                )?;
 
                 // push new file entry to the insert_buffer
-                let db_entry = entry.into_db_entry(self.next_id, parent_id, channel_id, parent_partial_key);
+                let db_entry = entry.into_db_entry(
+                    self.next_id,
+                    parent_id,
+                    channel_id,
+                    parent_partial_key,
+                    &channel_manifest.s3_path,
+                )?;
                 self.insert_buffer.push(db_entry);
                 self.next_id += 1;
 
@@ -270,6 +338,7 @@ impl ManifestBuilder {
         object_key: &ValidKey,
         channel_id: usize,
         channel_root_id: u64,
+        s3_path: &S3Path,
     ) -> Result<(u64, ValidKey), InputManifestError> {
         debug_assert_eq!(object_key.kind(), InodeKind::File);
 
@@ -283,15 +352,16 @@ impl ManifestBuilder {
                 *dir_id
             } else {
                 let id = self.next_id;
-                self.insert_buffer.push(DbEntry {
+                self.insert_buffer.push(DbEntry::new(
                     id,
                     parent_id,
                     channel_id,
-                    parent_partial_key: Some(parent_partial_key.to_string()),
-                    name: component.to_string(),
-                    etag: None,
-                    size: None,
-                });
+                    Some(parent_partial_key.clone()),
+                    *component,
+                    None,
+                    None,
+                    s3_path,
+                )?);
                 self.dir_ids.insert(partial_key.to_string(), id);
                 self.next_id += 1;
                 id
@@ -339,7 +409,7 @@ mod tests {
         let db_path = db_dir.path().join("s3_keys.db3");
         let entries = manifest_keys
             .iter()
-            .map(|key| Ok(InputManifestEntry::new(*key, DUMMY_ETAG, DUMMY_SIZE).unwrap()));
+            .map(|key| Ok(InputManifestEntry::new_without_checksum(*key, DUMMY_ETAG, DUMMY_SIZE).unwrap()));
         let err = create_db(
             &db_path,
             vec![ChannelManifest {
@@ -373,6 +443,7 @@ mod tests {
                 bucket_name: "bucket".to_string(),
                 prefix: "".to_string(),
                 manifest_path: PathBuf::new(),
+                manifest_checksum: 0,
             })
             .collect();
         let err = ingest_manifest(&configs, &db_path).expect_err("must be an error");
@@ -398,5 +469,28 @@ mod tests {
             1000,
         )
         .expect("db creation must succeed");
+    }
+
+    #[test]
+    fn test_invalid_file_checksum() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("s3_keys.db3");
+        let entries = [Err(InputManifestError::InvalidFileChecksum(
+            "manifest1.csv".to_string(),
+            0,
+            0,
+        ))]
+        .into_iter();
+        let err = create_db(
+            &db_path,
+            vec![ChannelManifest {
+                directory_name: "channel_0".to_string(),
+                s3_path: S3Path::new(Bucket::new("bucket").unwrap(), Default::default()),
+                entries,
+            }],
+            1000,
+        )
+        .expect_err("must be an error");
+        assert!(matches!(err, InputManifestError::InvalidFileChecksum(_, _, _)));
     }
 }

--- a/mountpoint-s3-fs/src/manifest/csv_reader.rs
+++ b/mountpoint-s3-fs/src/manifest/csv_reader.rs
@@ -1,4 +1,5 @@
 use csv::{DeserializeRecordsIntoIter, ReaderBuilder};
+use mountpoint_s3_client::checksums::crc32c::Hasher;
 use serde::Deserialize;
 use std::io::Read;
 
@@ -7,26 +8,65 @@ use super::builder::InputManifestEntry;
 
 pub struct CsvReader<R: Read> {
     reader: DeserializeRecordsIntoIter<R, CsvEntry>,
+    file_path: String,
+    hasher: Option<Hasher>,
+    expected_checksum: u32,
 }
 
 impl<R: Read> CsvReader<R> {
-    pub fn new(reader: R) -> Self {
+    pub fn new(reader: R, file_path: &str, expected_checksum: u32) -> Self {
         let reader = ReaderBuilder::new()
             .has_headers(false)
             .from_reader(reader)
             .into_deserialize();
-        Self { reader }
+        Self {
+            reader,
+            file_path: file_path.to_string(),
+            hasher: Some(Hasher::new()),
+            expected_checksum,
+        }
+    }
+
+    fn update_running_checksum(&mut self, csv_entry: &CsvEntry) {
+        // we re-compute checksum of each entry, because `Hasher` doesn't support combining pre-computed checksums
+        if let Some(hasher) = self.hasher.as_mut() {
+            hasher.update(csv_entry.partial_key.as_bytes());
+            hasher.update(csv_entry.etag.as_bytes());
+            // we encode size with big endian byte order and with a fixed width of 8 bytes (rust: u64, java: long)
+            let size = csv_entry.size as u64;
+            hasher.update(size.to_be_bytes().as_ref());
+        }
     }
 }
 
 impl<R: Read> Iterator for CsvReader<R> {
     type Item = Result<InputManifestEntry, InputManifestError>;
 
+    /// Returns next validated [InputManifestEntry] or [InputManifestError].
+    ///
+    /// This method will compare the manifest checksum after the final CSV entry is processed.
+    /// An error [InputManifestError::InvalidFileChecksum] will be returned as a last item in
+    /// the stream if validation fails.
     fn next(&mut self) -> Option<Self::Item> {
         match self.reader.next() {
-            Some(Ok(csv_entry)) => Some(csv_entry.try_into()),
+            Some(Ok(csv_entry)) => {
+                self.update_running_checksum(&csv_entry);
+                Some(csv_entry.try_into())
+            }
             Some(Err(err)) => Some(Err(InputManifestError::from(err))),
-            None => None,
+            None => {
+                if let Some(hasher) = self.hasher.take() {
+                    let computed_checksum = hasher.finalize().value();
+                    if computed_checksum != self.expected_checksum {
+                        return Some(Err(InputManifestError::InvalidFileChecksum(
+                            self.file_path.clone(),
+                            computed_checksum,
+                            self.expected_checksum,
+                        )));
+                    }
+                }
+                None
+            }
         }
     }
 }
@@ -47,13 +87,15 @@ struct CsvEntry {
     etag: String,
     /// Size of the S3 object.
     size: usize,
+    /// CRC32C checksum of the fields.
+    checksum: u32,
 }
 
 impl TryInto<InputManifestEntry> for CsvEntry {
     type Error = InputManifestError;
 
     fn try_into(self) -> Result<InputManifestEntry, Self::Error> {
-        InputManifestEntry::new(self.partial_key, self.etag, self.size)
+        InputManifestEntry::new(self.partial_key, self.etag, self.size, self.checksum)
     }
 }
 
@@ -62,60 +104,102 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    const CSV_ENTRY: &str = r#""{}","""etag1""",1024"#;
+    const CSV_ENTRY: &str = r#""key1","""etag1""",1024,2462020494"#;
 
-    const CSV_2_ENTRIES: &str = r#""key1","""etag1""",1024
-"key2","""etag2""",2048"#;
+    const CSV_2_ENTRIES: &str = r#""key1","""etag1""",1024,2462020494
+"key2","""etag2""",2048,181357319"#;
 
     const CSV_MULTILINE_ENTRY: &str = r#""ke"",
-y1","""etag1""",1024"#;
+y1","""etag1""",1024,978391088"#;
 
-    #[test_case(&CSV_ENTRY.replace("{}", "key1"), &[
-        InputManifestEntry::new("key1", "\"etag1\"", 1024).unwrap(),
+    const CSV_ENTRY_PATTERN: &str = r#""__KEY__","""etag1""",1024,__CHECKSUM__"#;
+
+    #[test_case(&CSV_ENTRY, 2462020494, &[
+        InputManifestEntry::new("key1", "\"etag1\"", 1024, 2462020494).unwrap(),
     ]; "1 full entry")]
-    #[test_case(CSV_2_ENTRIES, &[
-        InputManifestEntry::new("key1", "\"etag1\"", 1024).unwrap(),
-        InputManifestEntry::new("key2", "\"etag2\"", 2048).unwrap(),
+    #[test_case(CSV_2_ENTRIES, 2007214548, &[
+        InputManifestEntry::new("key1", "\"etag1\"", 1024, 2462020494).unwrap(),
+        InputManifestEntry::new("key2", "\"etag2\"", 2048, 181357319).unwrap(),
     ]; "2 full entries")]
-    #[test_case(r#""key1","",1024"#, &[
-        InputManifestEntry::new("key1", "", 1024).unwrap(),
-    ]; "no etag")]
-    #[test_case(CSV_MULTILINE_ENTRY, &[
-        InputManifestEntry::new("ke\",\ny1", "\"etag1\"", 1024).unwrap()
+    #[test_case(CSV_MULTILINE_ENTRY, 978391088, &[
+        InputManifestEntry::new("ke\",\ny1","\"etag1\"", 1024, 978391088).unwrap()
     ]; "with special chars")]
-    #[test_case("", &[]; "empty")]
-    fn test_csv_parsing_ok(csv_str: &str, expected: &[InputManifestEntry]) {
-        let actual: Vec<_> = CsvReader::new(csv_str.as_bytes())
+    #[test_case("", 0, &[]; "empty")]
+    fn test_csv_parsing_ok(csv_str: &str, manifest_checksum: u32, expected: &[InputManifestEntry]) {
+        let actual: Vec<_> = CsvReader::new(csv_str.as_bytes(), "manifest.csv", manifest_checksum)
             .map(|item| item.expect("parsing must succeed"))
             .collect();
         assert_eq!(&actual, expected);
     }
 
-    #[test_case(r#""key1","""etag1""","#; "no size")]
+    #[test_case(r#""key1","""etag1""",,0"#; "no size")]
     #[test_case(r#""key","""etag1""""#; "incomplete row")]
+    #[test_case(r#""key","""etag1""",18446744073709551616,0"#; "size overflow")]
     fn test_csv_parsing_err(csv_str: &str) {
-        let mut reader = CsvReader::new(csv_str.as_bytes());
+        let mut reader = CsvReader::new(csv_str.as_bytes(), "manifest.csv", 0);
         let err = reader.next().expect("must be some").expect_err("must be an error");
         assert!(matches!(err, InputManifestError::CsvError(_)));
     }
 
-    #[test_case("dir1/./a.txt"; "with dot")]
-    #[test_case("dir1/../a.txt"; "with 2 dots")]
-    #[test_case("dir1//a.txt"; "with 2 slashes")]
-    #[test_case(""; "empty")]
-    #[test_case("dir1/a\0.txt"; "with 0")]
-    fn test_csv_parsing_err_key(key: &str) {
-        let csv_string = CSV_ENTRY.replace("{}", key);
-        let mut reader = CsvReader::new(csv_string.as_bytes());
+    #[test_case("dir1/./a.txt", 0; "with dot")]
+    #[test_case("dir1/../a.txt", 0; "with 2 dots")]
+    #[test_case("dir1//a.txt", 0; "with 2 slashes")]
+    #[test_case("", 0; "empty")]
+    #[test_case("dir1/a\0.txt", 0; "with 0")]
+    fn test_csv_parsing_err_key(key: &str, checksum: u32) {
+        let csv_string = CSV_ENTRY_PATTERN
+            .replace("__KEY__", key)
+            .replace("__CHECKSUM__", &checksum.to_string());
+        let mut reader = CsvReader::new(csv_string.as_bytes(), "manifest.csv", checksum);
         let err = reader.next().expect("must be some").expect_err("must be an error");
         assert!(matches!(err, InputManifestError::InvalidKey(_)));
     }
 
     #[test]
+    fn test_csv_parsing_err_etag() {
+        let csv_string = r#""key1","",1024,2946291887"#;
+        let expected_checksum = 2946291887;
+        let mut reader = CsvReader::new(csv_string.as_bytes(), "manifest.csv", expected_checksum);
+        let err = reader.next().expect("must be some").expect_err("must be an error");
+        assert!(matches!(err, InputManifestError::InvalidEtag(_, _)));
+    }
+
+    #[test]
     fn test_csv_parsing_err_folder_marker() {
-        let csv_string = CSV_ENTRY.replace("{}", "dir1/dir2/dir3/");
-        let mut reader = CsvReader::new(csv_string.as_bytes());
+        let csv_string = r#""dir1/dir2/dir3/","""etag1""",1024,0"#;
+        let mut reader = CsvReader::new(csv_string.as_bytes(), "manifest.csv", 0);
         let err = reader.next().expect("must be some").expect_err("must be an error");
         assert!(matches!(err, InputManifestError::DirectoryMarker(_)));
+    }
+
+    #[test]
+    fn test_csv_parsing_checksum() {
+        let csv_string = r#"
+"1/file1","cab383756633321927cbbcdae674eade-1","1048576","2073902617"
+"1/file2","13ae585d58e207aff2ae65d2297c6828-1","1048576","2479809313"
+"2/file1","eb18c122dd77776ec5b88470f8c9a8b6-1","1048576","810936535"
+"2/file2","12cb9855bc16ba97271f429697013854-1","1048576","807927593""#;
+        let expected_checksum = 880485757;
+
+        // first try with wrong checksum
+        let entries: Vec<_> = CsvReader::new(csv_string.as_bytes(), "manifest.csv", 123456789).collect();
+        assert!(matches!(
+            entries.last().expect("non empty iterator"),
+            Err(InputManifestError::InvalidFileChecksum(_, _, _))
+        ));
+
+        // now try with good checksum
+        let entries: Vec<_> = CsvReader::new(csv_string.as_bytes(), "manifest.csv", expected_checksum)
+            .map(|item| item.expect("parsing must succeed"))
+            .collect();
+        assert_eq!(
+            entries,
+            &[
+                InputManifestEntry::new("1/file1", "cab383756633321927cbbcdae674eade-1", 1048576, 2073902617).unwrap(),
+                InputManifestEntry::new("1/file2", "13ae585d58e207aff2ae65d2297c6828-1", 1048576, 2479809313).unwrap(),
+                InputManifestEntry::new("2/file1", "eb18c122dd77776ec5b88470f8c9a8b6-1", 1048576, 810936535).unwrap(),
+                InputManifestEntry::new("2/file2", "12cb9855bc16ba97271f429697013854-1", 1048576, 807927593).unwrap(),
+            ]
+        );
     }
 }

--- a/mountpoint-s3-fs/src/metablock/path.rs
+++ b/mountpoint-s3-fs/src/metablock/path.rs
@@ -84,6 +84,14 @@ impl ValidKey {
         }
     }
 
+    /// The name for this key, i.e. the last path component.
+    ///
+    /// This returns a [ValidName] or [None] if name is empty.
+    pub fn valid_name(&self) -> Option<ValidName> {
+        let name = self.name();
+        if name.is_empty() { None } else { Some(ValidName(name)) }
+    }
+
     /// The kind of [Inode](super::Inode) associated with this key.
     pub fn kind(&self) -> InodeKind {
         match self.key.as_bytes().last() {


### PR DESCRIPTION
Introduce checksum verification of:

1. entries provided in the input CSV manifest (and for the whole file)
2. entries stored in the metadata store

Slightly refactored `ManifestEntry` in order to avoid huge `match` blocks. This PR also adds an example of the manifest creation.

### Does this change impact existing behavior?

No, only `mount_from_config` example.

### Does this change need a changelog entry? Does it require a version change?

Yes, an entry for `mountpoint-s3-fs` crate, and a minor version bump of this crate. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
