### PR TITLE
Add max_memory_target configuration to Mountpoint benchmarks

### DIFF
--- a/benchmark/benchmarks/benchmark_config_parser.py
+++ b/benchmark/benchmarks/benchmark_config_parser.py
@@ -58,6 +58,7 @@ class BenchmarkConfigParser:
             'prefix': getattr(mp_cfg, 'prefix', None),
             'stub_mode': getattr(mp_cfg, 'stub_mode', 'off'),
             'upload_checksums': getattr(mp_cfg, 'upload_checksums', None),
+            'max_memory_target': getattr(mp_cfg, 'max_memory_target', None),
         }
 
     def get_fio_config(self) -> Dict[str, Any]:

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -40,7 +40,7 @@ def mount_mp(cfg: DictConfig, mount_dir: str) -> Dict[str, Any]:
             "run",
             "--quiet",
             "--release",
-            "--features=mock",
+            "--features=mock,mem_limiter",
         ]
 
         if stub_mode == "s3_client":
@@ -89,6 +89,9 @@ def mount_mp(cfg: DictConfig, mount_dir: str) -> Dict[str, Any]:
 
     if mp_config['upload_checksums'] is not None:
         subprocess_args.append(f"--upload-checksums={mp_config['upload_checksums']}")
+
+    if (max_memory_target := mp_config['max_memory_target']) is not None:
+        subprocess_args.append(f"--max-memory-target={max_memory_target}")
 
     if (fuse_threads := mp_config['fuse_threads']) is not None:
         subprocess_args.append(f"--max-threads={fuse_threads}")

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -39,6 +39,7 @@ mountpoint:
   mountpoint_congestion_threshold: !!null
   mountpoint_binary: !!null
   upload_checksums: !!null
+  max_memory_target: !!null # memory upper-limit in MB
   stub_mode: "off"  # Options: "off", "fs_handler", "s3_client"
   mountpoint_debug: false
   mountpoint_debug_crt: false
@@ -53,7 +54,7 @@ benchmarks:
     fio_io_engine: "psync"
   
   prefetch:
-    max_memory_target: !!null
+    max_memory_target: !!null # memory upper-limit in MB
   
   crt:
     crt_benchmarks_path: !!null


### PR DESCRIPTION
Add `max_memory_target` configuration and `mem_limiter` Cargo feature flag to Mountpoint benchmarks. This is to enable testing mountpoint using Fio benchmaks with a maximum memory limit that the mem_limiter can then react on.

### Does this change impact existing behavior?

No, benchmarks change only.

### Does this change need a changelog entry? Does it require a version change?

No, benchmarks change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
