### PR TITLE
Bench client paged pool

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -117,11 +117,11 @@ fn run_benchmark(
         let received_size = received_size.load(Ordering::SeqCst);
         total_bytes += received_size;
         println!(
-            "{}: received {} bytes in {:.2}s: {:.2} Gib/s",
+            "{}: received {} bytes in {:.2}s: {:.2} Gb/s",
             iteration,
             received_size,
             elapsed.as_secs_f64(),
-            (received_size as f64) / elapsed.as_secs_f64() / (1024 * 1024 * 1024 / 8) as f64
+            (received_size as f64) / elapsed.as_secs_f64() / (1000 * 1000 * 1000 / 8) as f64
         );
 
         iter_results.push(json!({
@@ -135,11 +135,11 @@ fn run_benchmark(
 
     let total_elapsed = total_start.elapsed();
     println!(
-        "Total: received {} bytes in {:.2}s across {} iterations: {:.2} Gib/s",
+        "Total: received {} bytes in {:.2}s across {} iterations: {:.2} Gb/s",
         total_bytes,
         total_elapsed.as_secs_f64(),
         iter_results.len(),
-        (total_bytes as f64) / total_elapsed.as_secs_f64() / (1024 * 1024 * 1024 / 8) as f64
+        (total_bytes as f64) / total_elapsed.as_secs_f64() / (1000 * 1000 * 1000 / 8) as f64
     );
 
     if let Some(output_path) = output_path {
@@ -199,7 +199,7 @@ struct CliArgs {
     #[arg(
         long,
         help = "Desired throughput in Gbps",
-        default_value_t = 10.0,
+        default_value_t = 100.0,
         visible_alias = "maximum-throughput-gbps"
     )]
     throughput_target_gbps: f64,


### PR DESCRIPTION
Configure the MP client benchmark to use the new paged memory-pool instead of the default CRT memory pool. This is to make the client benchmark perform more comparably to prefetcher and other upper layers.

A second commit also fixes the throughput display units and max_target_throughput default value.

### Does this change impact existing behavior?

No, benchmark change only.

### Does this change need a changelog entry? Does it require a version change?

No, benchmark change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
