### PR TITLE
Clean up the cache sub-directory in a background thread

### DIFF
--- a/mountpoint-s3-fs/src/data_cache/cache_directory.rs
+++ b/mountpoint-s3-fs/src/data_cache/cache_directory.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use thiserror::Error;
 
@@ -65,7 +66,7 @@ impl ManagedCacheDir {
         };
 
         if should_cleanup {
-            managed_cache_dir.remove()?;
+            managed_cache_dir.remove_in_background()?;
         }
         Self::create_dir(&managed_cache_dir.mountpoint_cache_path)?;
         if cache_key.is_some() {
@@ -84,6 +85,52 @@ impl ManagedCacheDir {
             }
         }
         tracing::trace!(cache_subdirectory = ?self.mountpoint_cache_path, "cache sub-directory removal complete");
+        Ok(())
+    }
+
+    /// Remove the cache sub-directory in a background thread.
+    /// This method first renames `<parent_path>/mountpoint-cache` into `<parent_path>/old-mountpoint-cache.<EPOCH_NS>` in the current thread,
+    /// and then spawns a detached background thread to clean up the old cache folder.
+    fn remove_in_background(&self) -> Result<(), ManagedCacheDirError> {
+        let exists = self
+            .mountpoint_cache_path
+            .try_exists()
+            .map_err(ManagedCacheDirError::CleanupFailure)?;
+        if !exists {
+            // Nothing to do
+            return Ok(());
+        }
+
+        let epoch_ns = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default();
+        let renamed_cache_path = self
+            .mountpoint_cache_path
+            .with_file_name(format!("old-mountpoint-cache.{epoch_ns}"));
+
+        tracing::debug!(
+            cache_subdirectory = ?self.mountpoint_cache_path,
+            renamed_cache_subdirectory = ?renamed_cache_path,
+            "renaming the cache sub-directory to clean up in a background thread");
+        fs::rename(&self.mountpoint_cache_path, &renamed_cache_path).map_err(ManagedCacheDirError::CleanupFailure)?;
+
+        std::thread::spawn(move || {
+            if let Err(remove_dir_err) = fs::remove_dir_all(&renamed_cache_path) {
+                match remove_dir_err.kind() {
+                    io::ErrorKind::NotFound => (),
+                    _ => {
+                        tracing::error!(
+                            renamed_cache_subdirectory = ?renamed_cache_path,
+                            error = ?remove_dir_err,
+                            "failed to remove cache sub-directory in background");
+                        return;
+                    }
+                }
+            }
+            tracing::debug!(renamed_cache_subdirectory = ?renamed_cache_path, "cache sub-directory removal complete");
+        });
+
         Ok(())
     }
 
@@ -140,6 +187,7 @@ mod tests {
     use std::fs;
     use std::os::unix::ffi::OsStrExt as _;
     use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    use std::time::{Duration, Instant};
 
     const EXPECTED_DIR_MODE: u32 = 0o700;
 
@@ -295,6 +343,103 @@ mod tests {
 
         drop(managed_dir);
         assert_cache_dir_existence_after_cleanup!(!should_cleanup, &expected_path);
+
+        temp_dir.close().unwrap();
+    }
+
+    // This test is disabled by default as it takes 10m+ to run.
+    // #[test_matrix([50_000, 100_000, 250_000, 500_000])]
+    #[allow(unused)]
+    fn test_big_folder_cleaned_in_background(num_entries: usize) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let expected_path = temp_dir.path().join("mountpoint-cache");
+
+        // Here we're trying to create a folder structure similar to how Mountpoint stores local-cache.
+        // Cache folder layout of a Mountpoint instance would look like:
+        //
+        // $ tree -L 3 --filelimit=256 /tmp/mp-cache/mountpoint-cache
+        // /tmp/mp-cache/mountpoint-cache
+        // └── V2
+        //     ├── 00 [418 entries exceeds filelimit, not opening dir]
+        //     ├── 01 [425 entries exceeds filelimit, not opening dir]
+        //     ├── 02 [410 entries exceeds filelimit, not opening dir]
+        //     ├── 03 [454 entries exceeds filelimit, not opening dir]
+        //     ├── 04 [415 entries exceeds filelimit, not opening dir]
+        //     ├── 05 [423 entries exceeds filelimit, not opening dir]
+        //     ├── 06 [404 entries exceeds filelimit, not opening dir]
+        //     ├── 07 [424 entries exceeds filelimit, not opening dir]
+        //     ├── 08 [423 entries exceeds filelimit, not opening dir]
+        //     ├── 09 [396 entries exceeds filelimit, not opening dir]
+        //     ├── 0a [456 entries exceeds filelimit, not opening dir]
+        //           ...
+        //           256 folders in total
+        let start = std::time::Instant::now();
+        const NUM_PARTITIONS: usize = 256;
+        for n in 0..num_entries {
+            let dir = expected_path.join("V2").join(format!("{}", n % NUM_PARTITIONS));
+            fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o775) // something that isn't the expected `0o700`
+                .create(&dir)
+                .unwrap();
+            fs::File::create(dir.join(format!("{n}.txt"))).unwrap();
+        }
+        println!(
+            "created cache directory with {} entries in {:?}",
+            num_entries,
+            start.elapsed()
+        );
+
+        let start = Instant::now();
+        let managed_dir = ManagedCacheDir::new_from_parent_with_cache_key(temp_dir.path(), None, SHOULD_CLEANUP)
+            .expect("creating managed dir should succeed");
+        println!("managed dir constructed in {:?}", start.elapsed());
+
+        // `<parent_path>/mountpoint-cache` should exists with correct permissions and without any entries
+        assert_dir_exists_with_permissions!(&expected_path);
+        assert_eq!(
+            0,
+            fs::read_dir(&expected_path).unwrap().count(),
+            "directory should be empty"
+        );
+
+        // Ensure old cache directory exists...
+        let old_cache_dir = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|res| match res {
+                Ok(entry) => {
+                    let path = entry.path();
+                    let file_name = path.file_name().unwrap().to_str().unwrap();
+                    if file_name.starts_with("old-mountpoint-cache.") {
+                        Some(entry)
+                    } else {
+                        None
+                    }
+                }
+                Err(_) => None,
+            })
+            .next()
+            .expect("missing old cache directory");
+        assert!(old_cache_dir.path().exists(), "old cache directory must exists");
+        // ... but it should be cleaned in the background, and eventually should disappear in 5 mins
+        for _ in 0..300 {
+            std::thread::sleep(Duration::from_secs(1));
+            if !old_cache_dir.path().exists() {
+                break;
+            }
+        }
+        assert!(
+            !old_cache_dir.path().exists(),
+            "old cache directory must disappear after 5 mins"
+        );
+        println!(
+            "old cache directory {:?} cleaned up in {:?}",
+            old_cache_dir.path(),
+            start.elapsed()
+        );
+
+        drop(managed_dir);
+        assert_dir_does_not_exist!(&expected_path, "cache folder should be cleaned on drop");
 
         temp_dir.close().unwrap();
     }


### PR DESCRIPTION
Mountpoint tries to clean up the cache sub-directory during startup and exit in a blocking manner. This causes a cold start on Mountpoint if the cache sub-directory is not cleaned up in exit (e.g., if it's forcefully terminated) and if the cache sub-directory contains lots of files.

This change updates the clean up logic to do a rename first in the current thread to ensure Mountpoint starts with a fresh cache folder, and then spawns a detached background thread to remove the old cache directory. The cache sub-directory is still cleaned up in a blocking manner in the current thread during exit.

### Does this change impact existing behavior?

The cache will now be cleaned up in a background thread, this change may:

- Increase disk space usage temporarily during cleanup, as the new cache begins populating while the old cache still exists for a period of time
- Prevent cache cleanup errors from being propagated, since Mountpoint startup is no longer blocked by the cache cleanup process. Errors will now be just logged instead of propagated
   - In the worst-case scenario, this could cause Mountpoint to leave orphaned cache folders

### Does this change need a changelog entry? Does it require a version change?

Probably requires a changelog entry.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
