### PR TITLE
Add possibility to stub out latency using distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_distr",
  "regex",
  "rusqlite",
  "serde",
@@ -3119,6 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3741,6 +3743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/benchmark/benchmarks/benchmark_config_parser.py
+++ b/benchmark/benchmarks/benchmark_config_parser.py
@@ -86,3 +86,33 @@ class BenchmarkConfigParser:
         return {
             'read_window_size': getattr(client_cfg, 'read_window_size', 2147483648),  # Reaslitic default value 8M/2G?
         }
+
+    def get_stub_latencies_config(self) -> Dict[str, Any]:
+        stub_cfg = getattr(self.cfg, 'stub_latencies', None)
+        if stub_cfg is None:
+            return {
+                'simulate_latencies': False,
+                'tiers': None,
+            }
+
+        return {
+            'simulate_latencies': getattr(stub_cfg, 'simulate_latencies', False),
+            'tiers': {
+                'default': {
+                    'mean': getattr(stub_cfg.default, 'mean', 180.0),
+                    'stddev': getattr(stub_cfg.default, 'stddev', 40.0),
+                },
+                'p90': {
+                    'mean': getattr(stub_cfg.p90, 'mean', 400.0),
+                    'stddev': getattr(stub_cfg.p90, 'stddev', 60.0),
+                },
+                'p99': {
+                    'mean': getattr(stub_cfg.p99, 'mean', 650.0),
+                    'stddev': getattr(stub_cfg.p99, 'stddev', 100.0),
+                },
+                'p999': {
+                    'mean': getattr(stub_cfg.p999, 'mean', 2000.0),
+                    'stddev': getattr(stub_cfg.p999, 'stddev', 5000.0),
+                },
+            }
+        }

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -29,6 +29,7 @@ network:
 monitoring:
   with_bwm: false
   with_perf_stat: false
+  with_flamegraph: false
 
 # ===== Mountpoint configuration =====
 mountpoint:
@@ -40,9 +41,28 @@ mountpoint:
   mountpoint_binary: !!null
   upload_checksums: !!null
   max_memory_target: !!null # memory upper-limit in MB
-  stub_mode: "off"  # Options: "off", "fs_handler", "s3_client"
-  mountpoint_debug: false
+  stub_mode: "fs_handler"  # Options: "off", "fs_handler", "s3_client"
+  mountpoint_debug: true
   mountpoint_debug_crt: false
+
+# ===== Stub latency configuration =====
+stub_latencies:
+  # Enable/disable latency simulation for stubbed filesystem reads
+  simulate_latencies: true
+  # Latency tiers for stubbed filesystem reads (when stub_mode: "fs_handler")
+  # Format: mean and standard deviation in microseconds
+  default:
+    mean: 180.0
+    stddev: 40.0
+  p90:
+    mean: 400.0
+    stddev: 60.0
+  p99:
+    mean: 650.0
+    stddev: 100.0
+  p999:
+    mean: 2000.0
+    stddev: 5000.0
 
 # ===== Benchmark-specific configurations =====
 benchmarks:
@@ -52,18 +72,18 @@ benchmarks:
       - sequential_read
     fio_benchmark: "${benchmarks.fio.fio_benchmarks[0]}"
     fio_io_engine: "psync"
-  
+
   prefetch:
     max_memory_target: !!null # memory upper-limit in MB
-  
+
   crt:
     crt_benchmarks_path: !!null
 
-  client:  
-    # None 
+  client:
+    # None
 
   client_backpressure:
-    read_window_size: !!null #2147483648 
+    read_window_size: !!null #2147483648
 
 
 hydra:

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -35,6 +35,7 @@ linked-hash-map = "0.5.6"
 metrics = "0.24.2"
 nix = { version = "0.29.0", default-features = false, features = ["fs", "process", "signal", "user"] }
 rand = "0.8.5"
+rand_distr = "0.4"
 regex = "1.11.1"
 rusqlite = { version = "0.36.0", features = ["bundled"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -19,6 +19,7 @@ pub mod metrics_otel;
 pub mod object;
 pub mod prefetch;
 pub mod s3;
+mod stubbed_fs;
 mod superblock;
 mod sync;
 pub mod upload;

--- a/mountpoint-s3-fs/src/stubbed_fs/latency_config.rs
+++ b/mountpoint-s3-fs/src/stubbed_fs/latency_config.rs
@@ -1,0 +1,91 @@
+//! Latency configuration for stub filesystem operations
+//!
+//! This module adds a possibility to simulate latency in the stubbed fs.
+//! For this, the user has to configure the distribution by setting the `EXPERIMENTAL_STUB_LATENCY_TIERS`
+//! environment variable.
+//!
+//! To model a high-tailed distribution, we model different percentiles as independent
+//! normal distributions. Thus, we first use a random number to decide which distribution to
+//! sample from and then sample from the respective normal distribution.
+
+use rand::{Rng, thread_rng};
+use rand_distr::{Distribution, Normal};
+use std::env;
+use tracing::info;
+
+/// A latency tier with its distribution parameters
+#[derive(Debug, Clone)]
+struct LatencyTier {
+    threshold: f64, // cumulative probability threshold
+    distribution: Normal<f64>,
+}
+
+/// Configuration for latency simulation in stub modes
+#[derive(Debug)]
+pub struct LatencyConfig {
+    tiers: [LatencyTier; 4],
+}
+
+impl LatencyConfig {
+    /// Create a new LatencyConfig from environment variables
+    ///
+    /// Reads from EXPERIMENTAL_STUB_DISTRIBUTION_TIERS environment variable with format:
+    /// "default_mean,default_stddev,p90_mean,p90_stddev,p99_mean,p99_stddev,p999_mean,p999_stddev"
+    ///
+    /// Example: "180,40,400,60,650,100,2000,5000"
+    pub fn from_env() -> Option<Self> {
+        let config_str = env::var("EXPERIMENTAL_STUB_DISTRIBUTION_TIERS").unwrap_or_default();
+
+        if config_str.is_empty() {
+            return None;
+        }
+
+        let values: Vec<f64> = config_str.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+
+        if values.len() != 8 {
+            info!(
+                "EXPERIMENTAL_STUB_DISTRIBUTION_TIERS must have exactly 8 values \
+                (default_mean,default_stddev,p90_mean,p90_stddev,p99_mean,p99_stddev,p999_mean,p999_stddev). \
+                "
+            );
+            return None;
+        }
+
+        Some(Self {
+            tiers: [
+                LatencyTier {
+                    threshold: 0.9,
+                    distribution: Normal::new(values[0], values[1]).unwrap(),
+                },
+                LatencyTier {
+                    threshold: 0.99,
+                    distribution: Normal::new(values[2], values[3]).unwrap(),
+                },
+                LatencyTier {
+                    threshold: 0.999,
+                    distribution: Normal::new(values[4], values[5]).unwrap(),
+                },
+                LatencyTier {
+                    threshold: 1.0,
+                    distribution: Normal::new(values[6], values[7]).unwrap(),
+                },
+            ],
+        })
+    }
+
+    /// Sample a latency value from the configured distribution
+    ///
+    /// Returns latency in microseconds, guaranteed to be non-negative
+    pub fn sample_latency(&self) -> f64 {
+        let mut rng = thread_rng();
+        let rand_val = rng.gen_range(0.0..1.0);
+
+        let tier = self
+            .tiers
+            .iter()
+            .find(|t| rand_val < t.threshold)
+            .unwrap_or(&self.tiers[3]);
+
+        tier.distribution.sample(&mut rng).max(0.0)
+    }
+}

--- a/mountpoint-s3-fs/src/stubbed_fs/mod.rs
+++ b/mountpoint-s3-fs/src/stubbed_fs/mod.rs
@@ -1,0 +1,6 @@
+//! Stubbing utilities for filesystem operations
+//!
+//! This module provides utilities for simulating latencies for stubbed operations,
+pub mod latency_config;
+
+pub use latency_config::LatencyConfig;


### PR DESCRIPTION
Enhances the stubbing we can do for investigating performance bottlenecks:

-  Allows to simulate the latency of S3 before returning zero-data. 
- For reads under 1 MB uses a statically allocated Vec to return data from to save the allocation.

To simulate the latency, it uses a simple model of 4 latency bins ([0, 9], (0.9, 0.99], (0.99)) where the latency within each bin is normally distributed. 

With the defualt distribution, we see the following samples:
```
2025-08-13T05:48:38.837735Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=11275: min=0 p10=131 p50=186 avg=210.05 p90=311 p99=555 p99.9=835 max=10239
2025-08-13T05:48:43.846652Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=14599: min=0 p10=131 p50=185 avg=205.26 p90=285 p99=523 p99.9=799 max=7167
2025-08-13T05:48:48.854930Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=14599: min=0 p10=131 p50=185 avg=205.54 p90=277 p99=519 p99.9=811 max=9279
2025-08-13T05:48:53.863191Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=14530: min=0 p10=129 p50=185 avg=205.22 p90=281 p99=519 p99.9=799 max=15167
2025-08-13T05:48:58.871483Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=14470: min=0 p10=131 p50=185 avg=206.73 p90=293 p99=527 p99.9=787 max=11775
2025-08-13T05:49:03.879760Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=14406: min=0 p10=131 p50=185 avg=208.13 p90=297 p99=547 p99.9=803 max=12351
2025-08-13T05:49:04.887619Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fs.stubhandler.simulated_latency_us: n=2830: min=0 p10=130 p50=183 avg=206.68 p90=273 p99=543 p99.9=855 max=6751

```

There is a small (~100 us) overhead in read latency still, however, so these parameters may need some further tuning.
```
2025-08-13T05:48:38.837786Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=11274: min=61 p10=253 p50=309 avg=333.53 p90=435 p99=683 p99.9=955 max=10367
2025-08-13T05:48:43.846680Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=14599: min=59 p10=250 p50=305 avg=324.26 p90=405 p99=643 p99.9=915 max=7295
2025-08-13T05:48:48.854956Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=14599: min=59 p10=250 p50=303 avg=324.29 p90=397 p99=639 p99.9=931 max=9407
2025-08-13T05:48:53.863220Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=14530: min=59 p10=249 p50=307 avg=325.40 p90=401 p99=639 p99.9=919 max=15295
2025-08-13T05:48:58.871512Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=14470: min=59 p10=250 p50=305 avg=326.82 p90=411 p99=647 p99.9=907 max=11839
2025-08-13T05:49:03.879788Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=14406: min=60 p10=251 p50=305 avg=328.42 p90=417 p99=667 p99.9=923 max=12479
2025-08-13T05:49:04.887641Z  INFO ThreadId(03) mountpoint_s3_fs::metrics: fuse.op_latency_us[op=read]: n=2831: min=60 p10=251 p50=303 avg=326.89 p90=393 p99=671 p99.9=975 max=6879

```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
