### PR TITLE
Small fix for stdev of singleton list

### DIFF
--- a/benchmark/analysis-scripts/autogroup.py
+++ b/benchmark/analysis-scripts/autogroup.py
@@ -201,7 +201,10 @@ def main() -> None:
             row.append(value)
         row.append(len(throughputs))
         row.append(f"{statistics.median(throughputs):.2f}")
-        row.append(f"{statistics.stdev(throughputs):.2f}")
+        if len(throughputs) > 1:
+            row.append(f"{statistics.stdev(throughputs):.2f}")
+        else:
+            row.append("N/A")
         row.append(f"{min(throughputs):.2f}")
         row.append(f"{max(throughputs):.2f}")
         aggregated_rows.append(row)


### PR DESCRIPTION
Fixes a small bug where the autogrouping script to analyse benchmark runs in cmd may fail if a group only has 1 benchmark run, as ´statistics.stdev´ fails when the list has less than 2 entries. In these cases, we will now return `N/A` as stddev.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

