### PR TITLE
Enable resource monitoring for all benchmark types

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -358,7 +358,6 @@ def run_experiment(cfg: DictConfig) -> None:
             process = subprocess.Popen(
                 command.args,
                 env=command.env,
-                cwd=command.cwd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -377,7 +376,6 @@ def run_experiment(cfg: DictConfig) -> None:
             cfg.monitoring.get("flamegraph_scripts_path"),
         ):
             stdout, stderr = process.communicate()
-            execution_time = time.time() - start_time
 
             if stdout is not None and isinstance(stdout, bytes):
                 stdout = stdout.decode('utf-8')
@@ -385,7 +383,7 @@ def run_experiment(cfg: DictConfig) -> None:
                 stderr = stderr.decode('utf-8')
 
             result = CommandResult(
-                returncode=process.returncode, stdout=stdout, stderr=stderr, execution_time=execution_time
+                returncode=process.returncode, stdout=stdout, stderr=stderr
             )
 
         metadata["success"] = True

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -352,16 +352,13 @@ def run_experiment(cfg: DictConfig) -> None:
         benchmark.setup()
         command = benchmark.get_command()
 
-        if command.capture_output:
-            process = subprocess.Popen(
-                command.args,
-                env=command.env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-        else:
-            process = subprocess.Popen(command.args, env=command.env, cwd=command.cwd)
+        process = subprocess.Popen(
+            command.args,
+            env=command.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
 
         target_pid = metadata.get("target_pid", process.pid)
         metadata["target_pid"] = target_pid

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -4,7 +4,6 @@ import logging
 import os
 import signal
 import subprocess
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -353,7 +352,6 @@ def run_experiment(cfg: DictConfig) -> None:
         benchmark.setup()
         command = benchmark.get_command()
 
-        start_time = time.time()
         if command.capture_output:
             process = subprocess.Popen(
                 command.args,
@@ -382,9 +380,7 @@ def run_experiment(cfg: DictConfig) -> None:
             if stderr is not None and isinstance(stderr, bytes):
                 stderr = stderr.decode('utf-8')
 
-            result = CommandResult(
-                returncode=process.returncode, stdout=stdout, stderr=stderr
-            )
+            result = CommandResult(returncode=process.returncode, stdout=stdout, stderr=stderr)
 
         metadata["success"] = True
 

--- a/benchmark/benchmarks/base_benchmark.py
+++ b/benchmark/benchmarks/base_benchmark.py
@@ -1,16 +1,14 @@
 from abc import ABC, abstractmethod
-import logging
 from typing import Dict, Any
 
-
-log = logging.getLogger(__name__)
+from .command import Command, CommandResult
 
 
 class BaseBenchmark(ABC):
     """
     Abstract base class for all benchmarks.
     - setup: Prepare the environment for the benchmark
-    - run_benchmark: Execute the actual benchmark workload
+    - get_command: Return the command to execute for this benchmark
     - post_process: Process results, collect logs, and clean up
     """
 
@@ -25,19 +23,22 @@ class BaseBenchmark(ABC):
         pass
 
     @abstractmethod
-    def run_benchmark(self) -> Dict[str, Any]:
+    def get_command(self) -> Command:
         """
-        Run the actual benchmark workload.
+        Return the command to execute for this benchmark.
 
         Returns:
-            Dict containing benchmark results metadata
+            Command object containing the subprocess arguments and environment.
         """
         pass
 
     @abstractmethod
-    def post_process(self) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> Dict[str, Any]:
         """
-        Process results, collect logs, and clean up resources.
+        Process results and output, collect logs, and clean up resources.
+
+        Args:
+            result: The result of command execution
 
         Returns:
             Dict containing post-processing metadata

--- a/benchmark/benchmarks/cargo_helper.py
+++ b/benchmark/benchmarks/cargo_helper.py
@@ -1,0 +1,95 @@
+import json
+import logging
+import subprocess
+from typing import List, Optional, Dict
+import os
+
+log = logging.getLogger(__name__)
+
+
+def build_example(name: str, features: Optional[List[str]] = None, build_env: Optional[Dict[str, str]] = None) -> str:
+    """
+    Compile a Rust example and return the path to the executable.
+
+    Args:
+        name: Name of the example
+        features: Optional list of features to enable
+
+    Returns:
+        Path to the compiled executable
+    """
+    return _build_and_get_executable(example_name=name, features=features, build_env=build_env)
+
+
+def build_binary(name: str, features: Optional[List[str]] = None, build_env: Optional[Dict[str, str]] = None) -> str:
+    """
+    Compile a Rust binary and return the path to the executable.
+
+    Args:
+        name: Name of the binary
+        features: Optional list of features to enable
+
+    Returns:
+        Path to the compiled executable
+    """
+    return _build_and_get_executable(binary_name=name, features=features, build_env=build_env)
+
+
+def _build_and_get_executable(
+    binary_name: Optional[str] = None,
+    example_name: Optional[str] = None,
+    features: Optional[List[str]] = None,
+    build_env: Optional[Dict[str, str]] = None,
+) -> str:
+    """Build and get executable path."""
+
+    # Build the cargo command
+    cargo_args = ["cargo", "build", "--release", "--message-format=json-render-diagnostics"]
+
+    if binary_name:
+        cargo_args.extend(["--bin", binary_name])
+    elif example_name:
+        cargo_args.extend(["--example", example_name])
+    else:
+        raise ValueError("Must specify either binary_name or example_name")
+
+    if features:
+        cargo_args.extend(["--features", ",".join(features)])
+
+    # Prepare environment for compilation
+    env = os.environ.copy()
+    if build_env:
+        env.update(build_env)
+        log.info(f"Build environment: {build_env}")
+
+    log.info(f"Compiling: {' '.join(cargo_args)}")
+
+    try:
+        result = subprocess.run(cargo_args, capture_output=True, text=True, check=True, env=env)
+        return _extract_executable_path(result.stdout)
+    except subprocess.CalledProcessError as e:
+        log.error(f"Cargo build failed: {e.stderr}")
+        raise RuntimeError(f"Compilation failed: {e.stderr}")
+
+
+def _extract_executable_path(cargo_output: str) -> str:
+    """Extract executable path from cargo JSON output."""
+
+    executables = []
+
+    for line in cargo_output.strip().split('\n'):
+        if not line.strip():
+            continue
+
+        try:
+            data = json.loads(line)
+            if data.get("reason") == "compiler-artifact" and data.get("executable") is not None:
+                executables.append(data["executable"])
+        except json.JSONDecodeError:
+            continue
+
+    if not executables:
+        raise RuntimeError("No executable found in cargo build output")
+
+    # Return the last executable (most recent)
+    return executables[-1]

--- a/benchmark/benchmarks/command.py
+++ b/benchmark/benchmarks/command.py
@@ -18,7 +18,6 @@ class Command:
 
     args: List[str]
     env: Dict[str, str] = field(default_factory=dict)
-    capture_output: bool = False
 
     def __post_init__(self):
         """Merge command environment with current environment."""

--- a/benchmark/benchmarks/command.py
+++ b/benchmark/benchmarks/command.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+import os
+
+
+@dataclass
+class CommandResult:
+    """Result of command execution."""
+
+    returncode: int
+    stdout: Optional[str] = None
+    stderr: Optional[str] = None
+    execution_time: float = 0.0
+
+
+@dataclass
+class Command:
+    """Represents a command to be executed with its environment."""
+
+    args: List[str]
+    env: Dict[str, str] = field(default_factory=dict)
+    cwd: Optional[str] = None
+    capture_output: bool = False
+
+    def __post_init__(self):
+        """Merge command environment with current environment."""
+        full_env = os.environ.copy()
+        full_env.update(self.env)
+        self.env = full_env

--- a/benchmark/benchmarks/command.py
+++ b/benchmark/benchmarks/command.py
@@ -10,7 +10,6 @@ class CommandResult:
     returncode: int
     stdout: Optional[str] = None
     stderr: Optional[str] = None
-    execution_time: float = 0.0
 
 
 @dataclass
@@ -19,7 +18,6 @@ class Command:
 
     args: List[str]
     env: Dict[str, str] = field(default_factory=dict)
-    cwd: Optional[str] = None
     capture_output: bool = False
 
     def __post_init__(self):


### PR DESCRIPTION
Adds the possibility to run resource monitoring for all benchmark types. This is achieved by introducing a `Command` abstraction that is returned by the benchmark. Then when the command has just started executing we start the monitoring with it, unless we already have a PID to monitor (used for FIO). (Thanks, Q )

Additionally changes the way we run most cargo commands by seperating the phase where replacing `cargo run` by instead doing `cargo build` and getting the executable path -- otherwise the compilation was part of the flamegraph. 


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
