### PR TITLE
🧊Change colour palette for icy flamegraphs ❄️

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -229,7 +229,7 @@ class ResourceMonitoring:
             # Step 3: ./flamegraph.pl --inverted stacks.txt > inverted-flamegraph.svg
             with open("stacks.txt", "r") as stacks_txt, open("inverted-flamegraph.svg", "w") as flamegraph_svg:
                 result = subprocess.run(
-                    [flamegraph_script, "--inverted", "--reverse"],
+                    [flamegraph_script, "--inverted", "--reverse", "--colors", "blue"],
                     stdin=stacks_txt,
                     stdout=flamegraph_svg,
                     stderr=subprocess.PIPE,


### PR DESCRIPTION
Makes icycle flamegraphs more icy, by changing to blue colour palette from the currently used red (aka `hot`) one.

No changelog entry needed, as only affects benchmarking visualisations.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
