### PR TITLE
Make benchmark log output colored.

### DIFF
--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -3,6 +3,8 @@
 
 defaults:
   - _self_
+  - override hydra/job_logging: colorlog
+  - override hydra/hydra_logging: colorlog
 
 # ===== Common parameters for all benchmarks =====
 s3_bucket: ???

--- a/benchmark/pyproject.toml
+++ b/benchmark/pyproject.toml
@@ -5,6 +5,7 @@ description = "Benchmark runner for measuring Mountpoint performance while varyi
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "hydra-colorlog>=1.2.0",
     "hydra-core>=1.3.2",
     "psutil>=7.0.0",
 ]

--- a/benchmark/uv.lock
+++ b/benchmark/uv.lock
@@ -13,6 +13,7 @@ name = "benchmark"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "hydra-colorlog" },
     { name = "hydra-core" },
     { name = "psutil" },
 ]
@@ -21,6 +22,41 @@ dependencies = [
 requires-dist = [
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "psutil", specifier = ">=7.0.0" },
+    { name = "hydra-colorlog", specifier = ">=1.2.0" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/7a/359f4d5df2353f26172b3cc39ea32daa39af8de522205f512f458923e677/colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2", size = 16624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/51/9b208e85196941db2f0654ad0357ca6388ab3ed67efdbfc799f35d1f83aa/colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff", size = 11424 },
+]
+
+[[package]]
+name = "hydra-colorlog"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorlog" },
+    { name = "hydra-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/fc/ab5ca078d5184ae3280d5654734860198c643cd2caaaaaece63283d9f76d/hydra-colorlog-1.2.0.tar.gz", hash = "sha256:d44f85008fabd2448c7e3b496c31b44d7610560f6fff74f3673afaa949870899", size = 3060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/50/a08b0453c18088da369991d015ef3902a9ab532b515a41f1bfbe1394854d/hydra_colorlog-1.2.0-py3-none-any.whl", hash = "sha256:33d05fc11ca9bc7a5d69cfb3c8fb395a1bc52fa1dfe7aca6a6f5ffb57f6e7c4b", size = 3638 },
 ]
 
 [[package]]


### PR DESCRIPTION
This makes benchmark output easier to read.  Using the hydra-colorlog package, which internally uses colorlog and configured Hydra log formatters appropriately.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
