### PR TITLE
Remove left-over parameter

### DIFF
--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -81,7 +81,7 @@ class ClientBenchmark(BaseBenchmark):
 
         log.info("Client benchmark command prepared with args: %s", subprocess_args)
 
-        return Command(args=subprocess_args, env=client_env, capture_output=True)
+        return Command(args=subprocess_args, env=client_env)
 
     def post_process(self, result: CommandResult) -> Dict[str, Any]:
         if result.returncode != 0:

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -78,7 +78,7 @@ class PrefetchBenchmark(BaseBenchmark):
 
         log.info("Prefetch benchmark command prepared with args: %s", subprocess_args)
 
-        return Command(args=subprocess_args, env=prefetch_env, capture_output=True)
+        return Command(args=subprocess_args, env=prefetch_env)
 
     def post_process(self, result: CommandResult) -> Dict[str, Any]:
         if result.returncode != 0:


### PR DESCRIPTION
Removes accidentially forgotten parameter, fixing the prefetcher and client benchmarks to be executable again.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
