### PR TITLE
Capability to set EventLoopGroup thread count as a configurable CRT client config at runtime

### DIFF
--- a/benchmark/benchmarks/benchmark_config_parser.py
+++ b/benchmark/benchmarks/benchmark_config_parser.py
@@ -44,6 +44,7 @@ class BenchmarkConfigParser:
             'with_perf_stat': getattr(self.cfg.monitoring, 'with_perf_stat', False),
             'with_flamegraph': getattr(self.cfg.monitoring, 'with_flamegraph', False),
             'download_checksums': getattr(self.cfg, 'download_checksums', True),
+            'crt_eventloop_threads': getattr(self.cfg, 'crt_eventloop_threads', None),
         }
 
     def get_mountpoint_config(self) -> Dict[str, Any]:

--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -78,6 +78,8 @@ class ClientBenchmark(BaseBenchmark):
         client_env = {}
         if not self.common_config['download_checksums']:
             client_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
+        if (crt_eventloop_threads := self.common_config['crt_eventloop_threads']) is not None:
+            client_env["UNSTABLE_CRT_EVENTLOOP_THREADS"] = str(crt_eventloop_threads)
 
         log.info("Client benchmark command prepared with args: %s", subprocess_args)
 

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -120,6 +120,9 @@ def mount_mp(cfg: DictConfig, mount_dir: str) -> Dict[str, Any]:
     if not common_config['download_checksums']:
         mp_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
 
+    if (crt_eventloop_threads := common_config['crt_eventloop_threads']) is not None:
+        mp_env["UNSTABLE_CRT_EVENTLOOP_THREADS"] = str(crt_eventloop_threads)
+
     if stub_mode != "off" and mp_config["mountpoint_binary"] is not None:
         raise ValueError("Cannot use `stub_mode` with `mountpoint_binary`, `stub_mode` requires recompilation")
 

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -1,5 +1,4 @@
 import logging
-
 import subprocess
 from typing import Dict, Any
 
@@ -75,6 +74,9 @@ class PrefetchBenchmark(BaseBenchmark):
         prefetch_env = {}
         if not self.common_config['download_checksums']:
             prefetch_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"
+
+        if (crt_eventloop_threads := self.common_config['crt_eventloop_threads']) is not None:
+            prefetch_env["UNSTABLE_CRT_EVENTLOOP_THREADS"] = str(crt_eventloop_threads)
 
         log.info("Prefetch benchmark command prepared with args: %s", subprocess_args)
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -21,6 +21,7 @@ object_size_in_gib: 100  # Size of the object to benchmark
 benchmark_type: "fio" # fio, prefetch, client, client-bp, crt
 s3_keys: !!null
 download_checksums: true
+crt_eventloop_threads: !!null # Number of ELG thread count
 
 # Network configuration
 network:
@@ -86,3 +87,4 @@ hydra:
       'benchmarks.fio.direct_io': false, true
       # 'benchmarks.prefetch.max_memory_target': !!null, 1073741824, 2147483648  # null, 1GB, 2GB
       #'benchmarks.client_backpressure.read_window_size': 8388608, 2147483648
+      'crt_eventloop_threads': !!null # 128 (default for Trn1), 256, 1024

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -249,6 +249,14 @@ fn create_s3_client_config(region: &str, args: &CliArgs, nics: Vec<String>) -> S
         );
     }
 
+    const ENV_VAR_KEY_CRT_ELG_THREADS: &str = "UNSTABLE_CRT_EVENTLOOP_THREADS";
+    if let Some(crt_elg_threads) = std::env::var_os(ENV_VAR_KEY_CRT_ELG_THREADS) {
+        let crt_elg_threads = crt_elg_threads.to_string_lossy().parse::<u16>().unwrap_or_else(|_| {
+            panic!("Invalid value for environment variable {ENV_VAR_KEY_CRT_ELG_THREADS}. Must be positive integer.")
+        });
+        config = config.event_loop_threads(crt_elg_threads);
+    }
+
     config
 }
 

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -155,6 +155,16 @@ impl CliArgs {
         if let Some(nics) = &self.bind {
             client_config = client_config.network_interface_names(nics.to_vec());
         }
+        const ENV_VAR_KEY_CRT_ELG_THREADS: &str = "UNSTABLE_CRT_EVENTLOOP_THREADS";
+        if let Some(crt_elg_threads) = std::env::var_os(ENV_VAR_KEY_CRT_ELG_THREADS) {
+            let crt_elg_threads = crt_elg_threads.to_string_lossy().parse::<u16>().unwrap_or_else(|_| {
+                panic!(
+                    "Invalid value for environment variable {ENV_VAR_KEY_CRT_ELG_THREADS}. Must be positive integer."
+                )
+            });
+            client_config = client_config.event_loop_threads(crt_elg_threads);
+        }
+
         client_config
     }
 }

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -175,6 +175,16 @@ impl ClientConfig {
         // jitter, and 20s max backoff time, 10 attempts will take an average of 55 seconds.
         client_config = client_config.max_attempts(NonZeroUsize::new(10).unwrap());
 
+        const ENV_VAR_KEY_CRT_ELG_THREADS: &str = "UNSTABLE_CRT_EVENTLOOP_THREADS";
+        if let Some(crt_elg_threads) = std::env::var_os(ENV_VAR_KEY_CRT_ELG_THREADS) {
+            let crt_elg_threads = crt_elg_threads.to_string_lossy().parse::<u16>().unwrap_or_else(|_| {
+                panic!(
+                    "Invalid value for environment variable {ENV_VAR_KEY_CRT_ELG_THREADS}. Must be positive integer."
+                )
+            });
+            client_config = client_config.event_loop_threads(crt_elg_threads);
+        }
+
         let mut endpoint_config = EndpointConfig::new(self.region.as_str())
             .addressing_style(self.addressing_style)
             .use_accelerate(self.transfer_acceleration)


### PR DESCRIPTION
Add capability to set EventLoopGroup thread count as a configurable CRT client config at runtime so we can override the current default with different values (for e.g., during performance benchmarking) by setting an environment variable `UNSTABLE_CRT_EVENTLOOP_THREADS`. 

### Does this change impact existing behavior?

No, it only introduces an unstable environment variable based capability to _optionally_ configure the thread count for CRT's event loop group. It also introduces a change in the MP/client/prefetcher benchmarks to set that value using benchmark.py. The current default behaviours for Mountpoint and benchmarks stay the same.

### Does this change need a changelog entry? Does it require a version change?
No, as it's not a behavioural change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
