### PR TITLE
Add unstable flag to use FUSE_DEV_IOC_CLONE

### DIFF
--- a/benchmark/benchmarks/benchmark_config_parser.py
+++ b/benchmark/benchmarks/benchmark_config_parser.py
@@ -57,6 +57,7 @@ class BenchmarkConfigParser:
             'mountpoint_debug': getattr(mp_cfg, 'mountpoint_debug', False),
             'mountpoint_debug_crt': getattr(mp_cfg, 'mountpoint_debug_crt', False),
             'mountpoint_max_background': getattr(mp_cfg, 'mountpoint_max_background', None),
+            'mountpoint_clone_fuse_fd': getattr(mp_cfg, 'mountpoint_clone_fuse_fd', None),
             'prefix': getattr(mp_cfg, 'prefix', None),
             'stub_mode': getattr(mp_cfg, 'stub_mode', 'off'),
             'upload_checksums': getattr(mp_cfg, 'upload_checksums', None),

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -116,6 +116,9 @@ def mount_mp(cfg: DictConfig, mount_dir: str) -> Dict[str, Any]:
     if mp_config['mountpoint_congestion_threshold'] is not None:
         mp_env["UNSTABLE_MOUNTPOINT_CONGESTION_THRESHOLD"] = str(mp_config["mountpoint_congestion_threshold"])
 
+    if mp_config['mountpoint_clone_fuse_fd'] is not None:
+        mp_env["UNSTABLE_MOUNTPOINT_CLONE_FUSE_FD"] = str(mp_config["mountpoint_clone_fuse_fd"]).lower()
+
     mp_env["UNSTABLE_MOUNTPOINT_PID_FILE"] = f"{mount_dir}.pid"
     if not common_config['download_checksums']:
         mp_env["EXPERIMENTAL_MOUNTPOINT_NO_DOWNLOAD_INTEGRITY_VALIDATION"] = "ON"

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -48,6 +48,7 @@ mountpoint:
   stub_mode: "off"  # Options: "off", "fs_handler", "s3_client"
   mountpoint_debug: false
   mountpoint_debug_crt: false
+  mountpoint_clone_fuse_fd: false
 
 # ===== Benchmark-specific configurations =====
 benchmarks:
@@ -84,6 +85,7 @@ hydra:
       'application_workers': 1, 4, 16, 64, 128
       'iteration': "range(${iterations})"
       'mountpoint.fuse_threads': 1, 16, 64
+      'mountpoint.mountpoint_clone_fuse_fd': false, true
       'benchmarks.fio.direct_io': false, true
       # 'benchmarks.prefetch.max_memory_target': !!null, 1073741824, 2147483648  # null, 1GB, 2GB
       #'benchmarks.client_backpressure.read_window_size': 8388608, 2147483648

--- a/mountpoint-s3-fuser/Cargo.toml
+++ b/mountpoint-s3-fuser/Cargo.toml
@@ -21,7 +21,7 @@ page_size = "0.6.0"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"
 zerocopy = { version = "0.8", features = ["derive"] }
-nix = { version = "0.29.0", features = ["fs", "user"] }
+nix = { version = "0.29.0", features = ["fs", "user", "ioctl"] }
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/mountpoint-s3-fuser/src/session.rs
+++ b/mountpoint-s3-fuser/src/session.rs
@@ -148,8 +148,35 @@ impl<FS: Filesystem> Session<FS> {
     /// calls into the filesystem.
     /// This version also notifies callers of kernel requests before and after they
     /// are dispatched to the filesystem.
-    pub fn run_with_callbacks<FA, FB>(&self, mut before_dispatch: FB, mut after_dispatch: FA) -> io::Result<()> 
-    where 
+    pub fn run_with_callbacks<FA, FB>(&self, before_dispatch: FB, after_dispatch: FA) -> io::Result<()>
+    where
+        FB: FnMut(&Request<'_>),
+        FA: FnMut(&Request<'_>),
+    {
+        // Check if UNSTABLE_MOUNTPOINT_CLONE_FUSE_FD environment variable is set to true
+        // If not set or not "true", don't clone the channel (default behavior)
+        let clone_fd = std::env::var("UNSTABLE_MOUNTPOINT_CLONE_FUSE_FD")
+            .map(|val| val.to_lowercase() == "true")
+            .unwrap_or(false);
+
+        info!("FUSE channel cloning: {}", if clone_fd { "enabled" } else { "disabled" });
+
+        // Create a worker channel for this thread if cloning is enabled
+        // Otherwise use the original channel directly
+        if clone_fd {
+            // Create a worker channel for this thread using FUSE_DEV_IOC_CLONE
+            // This allows multiple threads to read from the FUSE device without contention
+            let worker_channel = self.ch.clone_channel()?;
+            self.process_requests(&worker_channel, before_dispatch, after_dispatch)
+        } else {
+            // Use the original channel without cloning
+            self.process_requests(&self.ch, before_dispatch, after_dispatch)
+        }
+    }
+
+    /// Process requests using the given channel
+    fn process_requests<FA, FB>(&self, channel: &Channel, mut before_dispatch: FB, mut after_dispatch: FA) -> io::Result<()>
+    where
         FB: FnMut(&Request<'_>),
         FA: FnMut(&Request<'_>),
     {
@@ -161,10 +188,9 @@ impl<FS: Filesystem> Session<FS> {
             std::mem::align_of::<abi::fuse_in_header>(),
         );
         loop {
-            // Read the next request from the given channel to kernel driver
-            // The kernel driver makes sure that we get exactly one request per read
-            match self.ch.receive(buf) {
-                Ok(size) => match Request::new(self.ch.sender(), &buf[..size]) {
+            // Read the next request from the channel
+            match channel.receive(buf) {
+                Ok(size) => match Request::new(channel.sender(), &buf[..size]) {
                     // Dispatch request
                     Some(req) => {
                         before_dispatch(&req);


### PR DESCRIPTION
When creating threads to communicate with the FUSE device, instead of sharing a file descriptor, allow the option to create a new file descriptor with a clone of the session using the `FUSE_DEV_IOC_CLONE` ioctl.

To enable this, set the `UNSTABLE_MOUNTPOINT_CLONE_FUSE_FD` environment variable to `true` for the mountpoint process.

This behavior is similar to libfuse which also has this as an option.  The benefit of enabling this is that some of the processing queues in the kernel data structures are no longer shared, which theoretically reduces lock contention.  Several tests on current mountpoint do not show a statistically significant performance benefit with this change so it's not the default, however, it could be that other bottlenecks are currently more important and this will be more relevant once they're addressed.

The change also updates the benchmark.py to offer this option when running benchmarks, so we can evaluate performance with and without the change.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
