### PR TITLE
Remove usage of `capture_output` from crt benchmark

### DIFF
--- a/benchmark/benchmarks/crt_benchmark.py
+++ b/benchmark/benchmarks/crt_benchmark.py
@@ -106,7 +106,7 @@ class CrtBenchmark(BaseBenchmark):
             subprocess_args.extend(["--nic", ",".join(network_interfaces)])
 
         log.info(f"CRT benchmark command prepared with args: {subprocess_args}")
-        return Command(args=subprocess_args, capture_output=True)
+        return Command(args=subprocess_args)
 
     def parse_benchmark_output(self, output):
         """Parse the CRT benchmark output and extract metrics."""


### PR DESCRIPTION
Removes usage of `capture_output` from CRT benchmarks as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
