### PR TITLE
Disable flamegraphs by default

### DIFF
--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -31,7 +31,7 @@ network:
 monitoring:
   with_bwm: false
   with_perf_stat: false
-  with_flamegraph: true
+  with_flamegraph: false
   flamegraph_scripts_path: !!null        # Path to directory containing stackcollapse-perf.pl and flamegraph.pl from https://github.com/brendangregg/FlameGraph
 
 # ===== Mountpoint configuration =====


### PR DESCRIPTION
Flamegraphs were accidentially enabled by default.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
