### PR TITLE
Do not append an empty buffer to S3 during file handle RELEASE or FLUSH

### DIFF
--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -77,6 +77,7 @@ where
                 request,
                 initial_etag,
                 written_bytes: 0,
+                previously_flushed: false,
             })
         } else {
             let request = fs
@@ -119,6 +120,7 @@ pub enum UploadState<Client: ObjectClient + Send + Sync> {
         request: AppendUploadRequest<Client>,
         initial_etag: Option<ETag>,
         written_bytes: usize,
+        previously_flushed: bool,
     },
     MPUInProgress {
         request: UploadRequest<Client>,
@@ -196,6 +198,7 @@ where
                 request,
                 initial_etag,
                 written_bytes,
+                ..
             } => {
                 let current_offset = request.current_offset();
                 match Self::commit_append(request, &handle.location).await {
@@ -212,6 +215,7 @@ where
                             request,
                             initial_etag,
                             written_bytes,
+                            previously_flushed: true, // Mark that the "append" has seen a Flush at least once
                         };
                         Ok(())
                     }
@@ -240,8 +244,12 @@ where
         open_pid: u32,
     ) -> Result<(), Error> {
         match self {
-            UploadState::AppendInProgress { written_bytes, .. } => {
-                if *written_bytes == 0 || !are_from_same_process(open_pid, pid) {
+            UploadState::AppendInProgress {
+                written_bytes,
+                previously_flushed,
+                ..
+            } => {
+                if (*written_bytes == 0 && !*previously_flushed) || !are_from_same_process(open_pid, pid) {
                     // Commit current changes, but do not close the write handle.
                     return self.commit(fs, handle).await;
                 }
@@ -296,10 +304,13 @@ where
     ) -> Result<bool, Error> {
         match self {
             UploadState::AppendInProgress {
-                request, initial_etag, written_bytes
+                request,
+                initial_etag,
+                written_bytes,
+                previously_flushed,
             } => {
-                // No data upload should be pending completion as part of the release, because we commit on flush
-                if written_bytes == 0 && request.current_offset() == 0 {
+                // No data upload should be pending completion as part of the release - if we have not written anything locally AND we already committed on a preceding Flush
+                if written_bytes == 0 && previously_flushed {
                     Self::finish(fs, ino, initial_etag).await;
                     return Ok(false);
                 }


### PR DESCRIPTION
With this change, Mountpoint will not commit an in-progress Append during RELEASE or FLUSH fs call, _if the buffer is empty AND there has been a previous Flush on the file handle_. This is because RELEASE call usually only happens after the last FLUSH operation on a file handle, and in that case an empty buffer append (to create the object in S3) must already have been committed as part of that preceding Flush. Hence, the Release (or a FLUSH on a duplicate FD) does not need to do another empty commit to S3, and just marks the inode as "Remote" (from "LocalOpen"). However, in cases when a FLUSH is not called because of some unexpected reason (say, application terminates), the kernel will still cause RELEASE if that application had the last reference of the file descriptor; and hence RELEASE will have to take care of the final commits and cleanup.

This is done to minimise the risk of an async RELEASE from the kernel competing with a new OPEN for the file, and causing the file handle to be in a "LocalOpen" state for longer than required thus failing any OPENs being called immediately after a CLOSE (Flush); however it does not solve the problem completely. It also avoids doing a no-op S3 PuObjectSingle call during RELEASE (and any Flushes on duplicate open FDs) if nothing has been written to the handle.

### Does this change impact existing behavior?

Yes, it changes the behaviour of the RELEASE and FLUSH fs calls in a a specific situation and state of the file handle, only during Append path. Since RELEASE is async, the change only impact customer workloads where duplicate FDs were being open and closed without writing anything (causing multiple empty PuObjectSingle calls to S3 during flushes) for which we will skip doing any append calls if we have previously flushed the empty write.

### Does this change need a changelog entry? Does it require a version change?

No, since it's not a functional change in behaviour/data seen by customer and only a logic optimisation, it does not need a changelog entry or version change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
