### PR TITLE
Adding more parameters to the sweeper combinations for FUSE threads and objects.

### DIFF
--- a/benchmark/conf/hydra/sweeper/base.yaml
+++ b/benchmark/conf/hydra/sweeper/base.yaml
@@ -2,7 +2,7 @@
 _target_: hydra._internal.core_plugins.basic_sweeper.BasicSweeper
 max_batch_size: null
 params:
-  'application_workers': 1, 16 # 4, 64
+  'application_workers': 1, 4, 16, 64
   'iteration': "range(${iterations})"
   'network.maximum_throughput_gbps': 400
   # 'crt_eventloop_threads': 128, 256, 1024

--- a/benchmark/conf/hydra/sweeper/fio.yaml
+++ b/benchmark/conf/hydra/sweeper/fio.yaml
@@ -1,4 +1,4 @@
 # @package hydra.sweeper
 params:
   'benchmarks.fio.direct_io': false, true
-  'benchmarks.fio.fuse_threads': 16 #1, 64
+  'benchmarks.fio.fuse_threads': 1, 16, 64


### PR DESCRIPTION
# Adding more parameters to the sweeper combinations for FUSE threads and application workers

## What changed and why?

Expanded the parameter combinations in the benchmark sweeper configuration to include more values for testing:
- `application_workers`: Added values 4 and 64 to the existing 1, 16 combination
- `fuse_threads`: Added values 1 and 64 to the existing 16 value

This change supports an ongoing investigation that requires testing across a broader range of worker and thread configurations.

## Does this change impact existing behavior?

No breaking changes. This only adds additional parameter combinations for benchmarking - existing functionality remains unchanged.

## Does this change need a changelog entry? Does it require a version change?

No changelog entry or version change required. This is an internal benchmarking configuration change that doesn't affect the public API or user-facing functionality.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
