### PR TITLE
Change ioctl log level from warn to debug

### DIFF
--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -520,7 +520,7 @@ where
         fuse_unsupported!("bmap", reply);
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, cmd=cmd))]
+    #[instrument(level="debug", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, cmd=cmd))]
     fn ioctl(
         &self,
         _req: &Request<'_>,
@@ -532,7 +532,7 @@ where
         _out_size: u32,
         reply: ReplyIoctl,
     ) {
-        fuse_unsupported!("ioctl", reply);
+        fuse_unsupported!("ioctl", reply, libc::ENOSYS, tracing::Level::DEBUG);
     }
 
     #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=length))]


### PR DESCRIPTION
Reduces log noise in production environments by changing ioctl function logging from WARN to DEBUG level. 

## Changes
- Changed `#[instrument(level="warn")]` to `#[instrument(level="debug")]` for ioctl function  
- Updated `fuse_unsupported!` macro call to use `tracing::Level::DEBUG`

## Testing
Verified that with `RUST_LOG=warn`, ioctl calls produce no log messages, reducing production noise while keeping debug info available with `RUST_LOG=debug`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
