### PR TITLE
Change ioctl log level from warn to debug

### DIFF
--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased (v0.7.1)
 
 * Fix race condition that could cause Mountpoint to panic on unlink. ([#1596](https://github.com/awslabs/mountpoint-s3/pull/1596))
+* Downgrade ioctl operation logging level from WARN to DEBUG to reduce log noise. ([#1598](https://github.com/awslabs/mountpoint-s3/pull/1598))
 
 ## v0.7.0 (July 28, 2025)
 

--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -532,7 +532,7 @@ where
         _out_size: u32,
         reply: ReplyIoctl,
     ) {
-        fuse_unsupported!("ioctl", reply);
+        fuse_unsupported!("ioctl", reply, libc::ENOSYS, tracing::Level::DEBUG);
     }
 
     #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=length))]

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Log messages now include the thread ID that logged the message, like "ThreadId(01)", after the level. ([#1460](https://github.com/awslabs/mountpoint-s3/pull/1460))
 * Fix issue preventing incremental upload to handle very large write part sizes. ([#1538](https://github.com/awslabs/mountpoint-s3/pull/1538))
 * Fix race condition that could cause Mountpoint to panic on unlink. ([#1596](https://github.com/awslabs/mountpoint-s3/pull/1596))
+* Downgrade ioctl operation logging level from WARN to DEBUG to reduce log noise. ([#1598](https://github.com/awslabs/mountpoint-s3/pull/1598))
 
 ### Other changes
 


### PR DESCRIPTION
Reduces log noise in production environments by changing ioctl function logging from WARN to DEBUG level. This change improves the signal-to-noise ratio in logs without affecting functionality.

Does this change impact existing behavior? 
No functional impact - only reduces log noise by moving expected ioctl failures from WARN to DEBUG level.

Does this change need a changelog entry? Does it require a version change?
Added entry to CHANGELOG.md. No version change required.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
