### PR TITLE
Change default logging level from WARN to INFO.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v0.7.2)
+
+* Downgrade setattr logging level from INFO to DEBUG to reduce log noise. ([#1605](https://github.com/awslabs/mountpoint-s3/pull/1605))
 
 ## v0.7.1 (September 15, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-fs"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -324,7 +324,7 @@ where
         size: Option<u64>,
         _flags: Option<u32>,
     ) -> Result<Attr, Error> {
-        tracing::info!(
+        tracing::debug!(
             "fs:setattr with ino {:?} flags {:?} atime {:?} mtime {:?} size {:?}",
             ino,
             _flags,

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v1.21.0)
+
+* Change default logging level from WARN to INFO to improve visibility of important operational messages. ([#1605](https://github.com/awslabs/mountpoint-s3/pull/1605))
 
 ## v1.20.0 (Sep 12, 2025)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mountpoint-s3"
-version = "1.20.0"
+version = "1.21.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false
 default-run = "mount-s3"
 
 [dependencies]
-mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.7.1" }
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.7.2" }
 mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.1" }
 
 anyhow = { version = "1.0.98", features = ["backtrace"] }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -673,7 +673,9 @@ impl CliArgs {
             };
             let crt_verbosity = if self.debug_crt { "debug" } else { "off" };
             filter.push_str(&format!(",{AWSCRT_LOG_TARGET}={crt_verbosity}"));
-            if !self.log_metrics {
+            // Only turn off metrics if neither --log-metrics nor --debug is set.
+            // In debug mode, we want to see all available information including metrics.
+            if !self.log_metrics && !self.debug {
                 filter.push_str(&format!(",{}=off", metrics::TARGET_NAME));
             }
             filter

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -669,12 +669,12 @@ impl CliArgs {
             let mut filter = if self.debug {
                 String::from("debug")
             } else {
-                String::from("warn")
+                String::from("info")
             };
             let crt_verbosity = if self.debug_crt { "debug" } else { "off" };
             filter.push_str(&format!(",{AWSCRT_LOG_TARGET}={crt_verbosity}"));
-            if self.log_metrics {
-                filter.push_str(&format!(",{}=info", metrics::TARGET_NAME));
+            if !self.log_metrics {
+                filter.push_str(&format!(",{}=off", metrics::TARGET_NAME));
             }
             filter
         };


### PR DESCRIPTION
Fixes #1244
- Purpose: Improve visibility of important operational messages (mount success, location) without requiring --debug flag
- Users can now see essential mount information by default
### What changed and why?
1. Default Logging Level:
- Changed default logging level from WARN to INFO in cli.rs
- Added test_info_level_logging to verify the change
- Default INFO logs now show important operational messages:
INFO ThreadId(01) mountpoint_s3::cli: target network throughput 10 Gbps
INFO ThreadId(01) fuser::session: Mounting /tmp/test-mount-new
INFO ThreadId(01) mountpoint_s3::run: successfully mounted bucket 

2. Metrics Logging:
- Metrics now show when either --log-metrics is set OR debug level is enabled
- Explicitly turn off metrics when neither condition is met

3. Log Level Optimization:
- Changed setattr logging from INFO to DEBUG level as it's implementation detail is more appropriate for debugging rather than regular operation

### Does this change impact existing behavior?
- All existing log levels (--debug, --no-log) continue to work as before
- Only changes the default level to show more information
- Setattr logging moved to DEBUG level to reduce noise

### Does this change need a changelog entry? Does it require a version change?
- Changelog entries added:
  * mountpoint-s3: Change default logging level from WARN to INFO to improve visibility of important operational messages
  * mountpoint-s3-fs: Downgrade setattr logging level from INFO to DEBUG to reduce log noise
- Version changes:
  * mountpoint-s3: v1.20.0 -> v1.21.0 (for default logging level change)
  * mountpoint-s3-fs: v0.7.1 -> v0.7.2 (for setattr logging change)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
