### PR TITLE
Add checking step to PUBLISHING_CRATES.md

### DIFF
--- a/doc/PUBLISHING_CRATES.md
+++ b/doc/PUBLISHING_CRATES.md
@@ -118,4 +118,10 @@ For each crate replacing the crate and version number where applicable:
    git push upstream mountpoint-s3-crt-sys-9.9.9
    ```
 
-Once these steps have been completed for all crates that need to be updated, you're done.
+Once these steps have been completed for all crates that need to be updated, you're done. You can check the new versions on crates.io:
+
+* [mountpoint-s3-crt-sys](https://crates.io/crates/mountpoint-s3-client)
+* [mountpoint-s3-crt](https://crates.io/crates/mountpoint-s3-crt)
+* [mountpoint-s3-client](https://crates.io/crates/mountpoint-s3-client)
+* [mountpoint-s3-fuser](https://crates.io/crates/mountpoint-s3-fuser)
+* [mountpoint-s3-fs](https://crates.io/crates/mountpoint-s3-fs)


### PR DESCRIPTION
We currently don't have a step for checking the newly published versions. This change adds links to `crates.io` to facilitate this.

### Does this change impact existing behavior?

No, only change to documentation.

### Does this change need a changelog entry? Does it require a version change?

No, only change to documentation.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
