### PR TITLE
Benchmark sweeper fix

### DIFF
--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -58,7 +58,6 @@ benchmarks:
       - sequential_read
     fio_benchmark: "${benchmarks.fio.fio_benchmarks[0]}"
     fio_io_engine: "psync"
-    fuse_threads: !!null
 
   prefetch:
     max_memory_target: !!null # memory upper-limit in MB

--- a/benchmark/conf/hydra/sweeper/fio.yaml
+++ b/benchmark/conf/hydra/sweeper/fio.yaml
@@ -1,4 +1,4 @@
 # @package hydra.sweeper
 params:
   'benchmarks.fio.direct_io': false, true
-  'benchmarks.fio.fuse_threads': 16 #1, 64
+  'mountpoint.fuse_threads': 16 #1, 64

--- a/benchmark/conf/hydra/sweeper/multi.yaml
+++ b/benchmark/conf/hydra/sweeper/multi.yaml
@@ -1,10 +1,5 @@
 # @package hydra.sweeper
 defaults:
   - base
-  - fio
-  - prefetch
-  - client_bp
-  - client
-  - crt
 
 _target_: hydra_plugins.smart_sweeper.smart_benchmark_sweeper.SmartBenchmarkSweeper


### PR DESCRIPTION
Update benchmarks to load sweeper parameters only from benchmark specific configuration files

Until this change, we load configuration parameters from all benchmark configuration files
and pick only the relevant benchmark parameters using regex matching. While this works
for most cases, it doesn't work for mountpoint parameters that don't have benchmark-type
substring and those parameters are picked up by all benchmarks. This change will restrict
sweeping through config parameters defined in the benchmark specific file.

This also includes a change to replace the unused fuse threads configuration with the correct parameter that gets used in benchmarks.

### Does this change impact existing behavior?

No, benchmarks only

### Does this change need a changelog entry? Does it require a version change?

No, it only updates benchmarks. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
