### PR TITLE
fix: https://github.com/awslabs/mountpoint-s3/issues/717

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -130,6 +130,7 @@ impl ConfigOptions {
             bind: None,
             part_config: PartConfig::with_part_size(self.part_size.unwrap_or(8388608)),
             user_agent: UserAgent::new(Some(user_agent_string)),
+            insecure_no_tls: false,
         })
     }
 

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -51,6 +51,9 @@ pub struct ClientConfig {
 
     /// Value for the user-agent header
     pub user_agent: UserAgent,
+
+    /// Insecure: disable TLS by using HTTP instead of HTTPS. For debugging only.
+    pub insecure_no_tls: bool,
 }
 
 #[derive(Debug)]
@@ -202,7 +205,12 @@ impl ClientConfig {
             endpoint_config = endpoint_config.endpoint(endpoint_uri);
         }
 
-        let client = S3CrtClient::new(client_config.clone().endpoint_config(endpoint_config.clone()))?;
+        let client = S3CrtClient::new(
+            client_config
+                .clone()
+                .endpoint_config(endpoint_config.clone())
+                .insecure_no_tls(self.insecure_no_tls),
+        )?;
 
         if let Some(s3_path) = validate_on_s3_path {
             validate_client_for_bucket(client, s3_path, self.region, endpoint_config, client_config)

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -378,6 +378,13 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
 
     #[clap(
         long,
+        help = "Disable TLS certificate verification by using HTTP instead of HTTPS (INSECURE; for debugging only)",
+        help_heading = ADVANCED_OPTIONS_HEADER,
+    )]
+    pub insecure_no_verify_ssl: bool,
+
+    #[clap(
+        long,
         help = "Server-side encryption algorithm to use when uploading new objects",
         help_heading = BUCKET_OPTIONS_HEADER,
         value_parser = clap::builder::PossibleValuesParser::new(["aws:kms", "aws:kms:dsse", "AES256"]))]
@@ -798,6 +805,7 @@ impl CliArgs {
             bind: self.bind.clone(),
             part_config: self.part_config(),
             user_agent,
+            insecure_no_tls: self.insecure_no_verify_ssl,
         }
     }
 }


### PR DESCRIPTION
fix issue #717 
What I changed
•  New CLI flag:
•  --insecure-no-verify-ssl
•  Help text: “Disable TLS certificate verification by using HTTP instead of HTTPS (INSECURE; for debugging only)”
•  File: mountpoint-s3/src/cli.rs
•  CLI plumbed into fs ClientConfig:
•  Added field insecure_no_tls: bool to mountpoint-s3-fs/src/s3/config.rs::ClientConfig.
•  Passes CLI value into that field in cli.rs when constructing ClientConfig.
•  Client configuration to S3 client:
•  Added builder method insecure_no_tls(bool) to mountpoint-s3-client/src/s3_crt_client.rs::S3ClientConfig.
•  S3CrtClientInner stores the flag.
•  Force HTTP in the S3 client when insecure flag is set:
•  In mountpoint-s3-client/src/s3_crt_client.rs, during request setup (new_request_template), if insecure_no_tls is true, the resolved endpoint URI is rewritten from https://… to http://… before being used for requests.
•  Updated example that constructs fs::s3::ClientConfig literal:
•  mountpoint-s3-fs/examples/mount_from_config.rs now includes insecure_no_tls: false.

### Does this change impact existing behavior?

no

### Does this change need a changelog entry? Does it require a version change?

no

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
