### PR TITLE
Add an option to configure cache in `mount_from_config` example

### DIFF
--- a/mountpoint-s3-fs/examples/config.json.example
+++ b/mountpoint-s3-fs/examples/config.json.example
@@ -17,6 +17,8 @@
         "type": "IMDSAutoConfigure"
     },
     "memory_limit_bytes": 2147483648,
-    "cache": "./cache_dir",
-    "max_cache_size_mib": 10240
+    "disk_cache": {
+        "path": "./cache_dir",
+        "limit_bytes": 1073741824
+    }
 }


### PR DESCRIPTION
Add an option to configure cache in `mount_from_config` example.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
