### PR TITLE
Adding Unicode 3 to Accepted Licenses

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -35,8 +35,8 @@ RUN yum install -y \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-RUN wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.6.1/cargo-about-0.6.1-$(uname -p)-unknown-linux-musl.tar.gz" && \
-    wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.6.1/cargo-about-0.6.1-$(uname -p)-unknown-linux-musl.tar.gz.sha256" && \
+RUN wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.8.2/cargo-about-0.8.2-$(uname -p)-unknown-linux-musl.tar.gz" && \
+    wget -q "https://github.com/EmbarkStudios/cargo-about/releases/download/0.8.2/cargo-about-0.8.2-$(uname -p)-unknown-linux-musl.tar.gz.sha256" && \
     echo -n "$(sha256sum cargo-about-*.tar.gz | cut -d' ' -f1)" > checksum.sha256 && \
     diff cargo-about-*.tar.gz.sha256 checksum.sha256 && \
     tar xzf cargo-about-*.tar.gz && \

--- a/package/attribution.toml
+++ b/package/attribution.toml
@@ -5,6 +5,7 @@ accepted = [
     "ISC",
     "MIT",
     "OpenSSL",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",
 ]


### PR DESCRIPTION

**What changed and why?**
Added "Unicode-3.0" to the licensing whitelist.
It is already included in the /mountpoint-s3/deny.toml https://github.com/awslabs/mountpoint-s3/blob/main/deny.toml allowlist, but  it wasn't added here aswell. This fixes that.

The license's absense from the attribution.toml also means the command to generate our third party dependancies fails.

```rust
cargo about generate --config package/attribution.toml --output-file THIRD_PARTY_LICENSES package/attribution.hbs
error: failed to satisfy license requirements
   ┌─ /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unicode-ident-1.0.18/Cargo.toml:36:36
   │
36 │ license = "(MIT OR Apache-2.0) AND Unicode-3.0"
   │                                    -----------

2025-09-25 12:20:14.780429812 +00:00:00 [ERROR] encountered 1 errors resolving licenses, unable to generate output

```
So this fix addresses a need for us to be able to generate these licenses at will, outside of the release process.

### Does this change impact existing behaviour?
No

### Does this change need a changelog entry? Does it require a version change?

No, very minor bug fix

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
