### PR TITLE
Use OTel's exponential histograms for histogram metrics.

### DIFF
--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -51,7 +51,7 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 opentelemetry = { version = "0.30.0", features = ["metrics"], optional = true }
-opentelemetry_sdk = { version = "0.30.0", features = ["metrics", "rt-tokio"], optional = true }
+opentelemetry_sdk = { version = "0.30.0", features = ["metrics", "rt-tokio", "spec_unstable_metrics_views"], optional = true }
 opentelemetry-otlp = { version = "0.30.0", features = ["metrics", "http-proto"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
With explicit hitograms, OTel uses fixed bucket bounds, which don't work well for all Mountpoint metrics as they don't fall within the default range. So we need to manually configure the bucket bounds for different metrics with different boundaries. However, with exponential histograms, the bucket boundss are automatically scaled and provide more accurate metrics. However, this relies on OTel SDK's unstable feature. 

In case this isn't supported in the future, we need to switch to explicit Buckets with different bounds for different metrics.

### Does this change impact existing behavior?

No, changes are under a feature flag

### Does this change need a changelog entry? Does it require a version change?


No, changes are under a feature flag

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
