### PR TITLE
Use delta temporality as default for exporting OTLP metrics

### DIFF
--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -126,6 +126,11 @@ def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> 
         if cfg.mountpoint.otlp_export_interval is not None:
             subprocess_args.append(f"--otlp-export-interval={cfg.mountpoint.otlp_export_interval}")
 
+        if cfg.mountpoint.otlp_temporality_preference:
+            mp_env["EXPERIMENTAL_MOUNTPOINT_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = str(
+                cfg.mountpoint.otlp_temporality_preference
+            )
+
     if stub_mode != "off" and cfg.mountpoint.mountpoint_binary is not None:
         raise ValueError("Cannot use `stub_mode` with `mountpoint_binary`, `stub_mode` requires recompilation")
 

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -52,6 +52,7 @@ mountpoint:
   otlp_metrics: false
   otlp_endpoint: !!null # Metrics collector/agent endpoint like "http://localhost:4318"
   otlp_export_interval: !!null  # Export interval in seconds (default: 60)
+  otlp_temporality_preference: !!null  # Options: "cumulative", "delta"
 
 # ===== Benchmark-specific configurations =====
 benchmarks:

--- a/mountpoint-s3-fs/src/metrics_otel.rs
+++ b/mountpoint-s3-fs/src/metrics_otel.rs
@@ -1,6 +1,8 @@
-use opentelemetry::global;
-use opentelemetry_otlp::{Protocol, WithExportConfig};
-use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry::{global, metrics};
+use opentelemetry_otlp::{MetricExporter, Protocol, WithExportConfig};
+use opentelemetry_sdk::metrics::{
+    Aggregation, Instrument, InstrumentKind, PeriodicReader, SdkMeterProvider, Stream, Temporality,
+};
 use std::time::Duration;
 
 /// Get temporality preference from environment variable
@@ -44,7 +46,7 @@ impl OtlpConfig {
 
 #[derive(Debug)]
 pub struct OtlpMetricsExporter {
-    meter: opentelemetry::metrics::Meter,
+    meter: metrics::Meter,
 }
 
 impl OtlpMetricsExporter {
@@ -63,7 +65,7 @@ impl OtlpMetricsExporter {
         };
 
         // Limit to HTTP binary protocol for now
-        let exporter = opentelemetry_otlp::MetricExporter::builder()
+        let exporter = MetricExporter::builder()
             .with_http()
             .with_protocol(Protocol::HttpBinary)
             .with_endpoint(&endpoint_url)
@@ -74,19 +76,19 @@ impl OtlpMetricsExporter {
         let resource = opentelemetry_sdk::resource::Resource::builder_empty().build();
 
         // Create a meter provider with the OTLP Metric Exporter that will collect and export metrics at regular intervals
-        let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        let meter_provider = SdkMeterProvider::builder()
             // The default interval is 60 seconds so we use a PeriodicReader to allow us to specify a custom interval duration
             .with_reader(
-                opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+                PeriodicReader::builder(exporter)
                     .with_interval(Duration::from_secs(config.interval_secs))
                     .build(),
             )
             .with_resource(resource)
-            .with_view(|instrument: &opentelemetry_sdk::metrics::Instrument| {
-                if matches!(instrument.kind(), opentelemetry_sdk::metrics::InstrumentKind::Histogram) {
+            .with_view(|instrument: &Instrument| {
+                if matches!(instrument.kind(), InstrumentKind::Histogram) {
                     Some(
-                        opentelemetry_sdk::metrics::Stream::builder()
-                            .with_aggregation(opentelemetry_sdk::metrics::Aggregation::Base2ExponentialHistogram {
+                        Stream::builder()
+                            .with_aggregation(Aggregation::Base2ExponentialHistogram {
                                 max_size: 160,
                                 max_scale: 20,
                                 record_min_max: true,
@@ -186,7 +188,7 @@ mod tests {
         let config = OtlpConfig::new(&endpoint).with_interval_secs(1);
 
         // Initialize the OpenTelemetry SDK directly
-        let exporter = opentelemetry_otlp::MetricExporter::builder()
+        let exporter = MetricExporter::builder()
             .with_http()
             .with_protocol(Protocol::HttpBinary)
             .with_endpoint(&config.endpoint)
@@ -196,15 +198,13 @@ mod tests {
 
         info!("Created exporter");
 
-        let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
+        let reader = PeriodicReader::builder(exporter)
             .with_interval(Duration::from_secs(1))
             .build();
 
         info!("Created reader");
 
-        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-            .with_reader(reader)
-            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
 
         info!("Created provider");
 


### PR DESCRIPTION
By default, we will use Delta temporality instead of Cumulative temporality to minimise the network payload size while exporting metrics. However, cutomers can switch to Cumulative temporality if their backends don't support Delta temporality

### Does this change impact existing behavior?

No, the changes are under a feature flag

### Does this change need a changelog entry? Does it require a version change?

No, the changes are under a feature flag

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
