### PR TITLE
Fix lifetime ellision warnings and other lints

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -483,7 +483,7 @@ impl S3CrtClientInner {
     /// Pre-populates common headers used across all requests. Sets the "accept" header assuming the
     /// response should be XML; this header should be overwritten for requests like GET that return
     /// object data.
-    fn new_request_template(&self, method: &str, bucket: &str) -> Result<S3Message, ConstructionError> {
+    fn new_request_template(&self, method: &str, bucket: &str) -> Result<S3Message<'_>, ConstructionError> {
         let endpoint = self.endpoint_config.resolve_for_bucket(bucket)?;
         let uri = endpoint.uri()?;
         trace!(?uri, "resolved endpoint");

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -81,6 +81,7 @@ impl S3CrtClient {
                 span,
                 move |metrics| {
                     if metrics.request_type() == RequestType::CreateMultipartUpload && !metrics.error().is_err() {
+                        // Send signal on a successful CreateMultipartUpload request
                         if let Some(sender) = on_mpu_created_sender.lock().unwrap().take() {
                             _ = sender.send(Ok(()));
                         }

--- a/mountpoint-s3-fs/src/metablock/path.rs
+++ b/mountpoint-s3-fs/src/metablock/path.rs
@@ -87,7 +87,7 @@ impl ValidKey {
     /// The name for this key, i.e. the last path component.
     ///
     /// This returns a [ValidName] or [None] if name is empty.
-    pub fn valid_name(&self) -> Option<ValidName> {
+    pub fn valid_name(&self) -> Option<ValidName<'_>> {
         let name = self.name();
         if name.is_empty() { None } else { Some(ValidName(name)) }
     }
@@ -103,7 +103,7 @@ impl ValidKey {
     /// Path components for this key.
     ///
     /// For directories, this does not include empty component after the terminal '/'.
-    pub fn components(&self) -> Vec<ValidName> {
+    pub fn components(&self) -> Vec<ValidName<'_>> {
         if self.key.is_empty() {
             Default::default()
         } else {

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -107,7 +107,7 @@ impl Inode {
     }
 
     /// return Inode State with read lock after checking whether the directory inode is deleted or not.
-    pub fn get_inode_state(&self) -> Result<InodeLockedForReading, InodeError> {
+    pub fn get_inode_state(&self) -> Result<InodeLockedForReading<'_>, InodeError> {
         let inode_state = self.inner.sync.read().unwrap();
         match &inode_state.kind_data {
             InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::InodeDoesNotExist(self.ino())),
@@ -119,7 +119,7 @@ impl Inode {
     }
 
     /// return Inode State with write lock after checking whether the directory inode is deleted or not.
-    pub fn get_mut_inode_state(&self) -> Result<InodeLockedForWriting, InodeError> {
+    pub fn get_mut_inode_state(&self) -> Result<InodeLockedForWriting<'_>, InodeError> {
         let inode_state = self.inner.sync.write().unwrap();
         match &inode_state.kind_data {
             InodeKindData::Directory { deleted, .. } if *deleted => Err(InodeError::InodeDoesNotExist(self.ino())),
@@ -131,7 +131,7 @@ impl Inode {
     }
 
     /// return Inode State with write lock without checking whether the directory inode is deleted or not.
-    pub fn get_mut_inode_state_no_check(&self) -> RwLockWriteGuard<InodeState> {
+    pub fn get_mut_inode_state_no_check(&self) -> RwLockWriteGuard<'_, InodeState> {
         self.inner.sync.write().unwrap()
     }
 


### PR DESCRIPTION
To be ready for newer Rust versions, fix some lints which will start failing builds if we upgrade.

### Does this change impact existing behavior?

No, this only addresses lints by removing ambiguous code or updating to use new methods that make code clearer.

### Does this change need a changelog entry? Does it require a version change?

No, no behavior changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
