### PR TITLE
Add metric configuration for OTLP export

### DIFF
--- a/mountpoint-s3-fs/src/metrics/data.rs
+++ b/mountpoint-s3-fs/src/metrics/data.rs
@@ -2,12 +2,17 @@ use crate::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use crate::sync::{Arc, Mutex};
 
 #[cfg(feature = "otlp_integration")]
+use crate::metrics::defs::MetricConfig;
+#[cfg(feature = "otlp_integration")]
+use crate::metrics_otel::OtlpMetricsExporter;
+#[cfg(feature = "otlp_integration")]
 use opentelemetry::KeyValue;
 
 #[cfg(feature = "otlp_integration")]
-fn labels_to_attributes(labels: &metrics::Key) -> Vec<KeyValue> {
+fn filter_attributes(labels: &metrics::Key, allowed: &[&str]) -> Vec<KeyValue> {
     labels
         .labels()
+        .filter(|label| allowed.contains(&label.key()))
         .map(|label| KeyValue::new(label.key().to_string(), label.value().to_string()))
         .collect()
 }
@@ -15,6 +20,9 @@ fn labels_to_attributes(labels: &metrics::Key) -> Vec<KeyValue> {
 #[cfg(feature = "otlp_integration")]
 #[derive(Debug)]
 pub(crate) struct OtlpData<T> {
+    // TODO: Currently, each unique key+labels creates separate OTel
+    // instrument. We could optimise this further to use a single instrument
+    // for all attributes/labels
     pub instrument: T,
     pub attributes: Vec<KeyValue>,
 }
@@ -41,14 +49,10 @@ impl Metric {
     }
 
     #[cfg(feature = "otlp_integration")]
-    pub fn counter_otlp(
-        exporter: &crate::metrics_otel::OtlpMetricsExporter,
-        name: String,
-        labels: &metrics::Key,
-    ) -> Self {
-        let attributes = labels_to_attributes(labels);
-        let instrument = exporter.create_counter_instrument(name);
-        Self::Counter(Arc::new(ValueAndCount::with_otlp(instrument, attributes)))
+    pub fn counter_otlp(exporter: &OtlpMetricsExporter, key: &metrics::Key, config: &MetricConfig) -> Self {
+        let filtered_attributes = filter_attributes(key, config.otlp_attributes);
+        let instrument = exporter.create_counter_instrument(key.name(), config.unit, config.stability);
+        Self::Counter(Arc::new(ValueAndCount::with_otlp(instrument, filtered_attributes)))
     }
 
     pub fn as_counter(&self) -> metrics::Counter {
@@ -63,14 +67,10 @@ impl Metric {
     }
 
     #[cfg(feature = "otlp_integration")]
-    pub fn gauge_otlp(
-        exporter: &crate::metrics_otel::OtlpMetricsExporter,
-        name: String,
-        labels: &metrics::Key,
-    ) -> Self {
-        let attributes = labels_to_attributes(labels);
-        let instrument = exporter.create_gauge_instrument(name);
-        Self::Gauge(Arc::new(AtomicGauge::with_otlp(instrument, attributes)))
+    pub fn gauge_otlp(exporter: &OtlpMetricsExporter, key: &metrics::Key, config: &MetricConfig) -> Self {
+        let filtered_attributes = filter_attributes(key, config.otlp_attributes);
+        let instrument = exporter.create_gauge_instrument(key.name(), config.unit, config.stability);
+        Self::Gauge(Arc::new(AtomicGauge::with_otlp(instrument, filtered_attributes)))
     }
 
     pub fn as_gauge(&self) -> metrics::Gauge {
@@ -85,14 +85,10 @@ impl Metric {
     }
 
     #[cfg(feature = "otlp_integration")]
-    pub fn histogram_otlp(
-        exporter: &crate::metrics_otel::OtlpMetricsExporter,
-        name: String,
-        labels: &metrics::Key,
-    ) -> Self {
-        let attributes = labels_to_attributes(labels);
-        let instrument = exporter.create_histogram_instrument(name);
-        Self::Histogram(Arc::new(Histogram::with_otlp(instrument, attributes)))
+    pub fn histogram_otlp(exporter: &OtlpMetricsExporter, key: &metrics::Key, config: &MetricConfig) -> Self {
+        let filtered_attributes = filter_attributes(key, config.otlp_attributes);
+        let instrument = exporter.create_histogram_instrument(key.name(), config.unit, config.stability);
+        Self::Histogram(Arc::new(Histogram::with_otlp(instrument, filtered_attributes)))
     }
 
     pub fn as_histogram(&self) -> metrics::Histogram {
@@ -335,7 +331,7 @@ mod tests {
             vec![Label::new("op", "read"), Label::new("status", "success")],
         );
 
-        let attributes = labels_to_attributes(&key);
+        let attributes = filter_attributes(&key, &["op", "status"]);
 
         assert_eq!(attributes.len(), 2);
         assert_eq!(attributes[0].key.as_str(), "op");
@@ -358,7 +354,7 @@ mod tests {
         let provider = SdkMeterProvider::builder().with_reader(reader).build();
         let meter = provider.meter("test-meter");
 
-        let otlp_counter = meter.u64_counter("test-counter").build();
+        let otlp_counter = meter.u64_counter("test-counter").with_unit("some-unit").build();
         let attributes = vec![opentelemetry::KeyValue::new("some-label", "some-value")];
 
         let counter = ValueAndCount::with_otlp(otlp_counter, attributes);
@@ -388,6 +384,7 @@ mod tests {
         let metric = found_counter.unwrap();
 
         assert_eq!(metric.name(), "test-counter");
+        assert_eq!(metric.unit(), "some-unit");
 
         let data = metric.data();
         match data {
@@ -424,7 +421,7 @@ mod tests {
         let provider = SdkMeterProvider::builder().with_reader(reader).build();
         let meter = provider.meter("test-meter");
 
-        let otlp_gauge = meter.f64_gauge("test_gauge").build();
+        let otlp_gauge = meter.f64_gauge("test_gauge").with_unit("some-unit").build();
         let attributes = vec![opentelemetry::KeyValue::new("some-label", "some-value")];
 
         let gauge = AtomicGauge::with_otlp(otlp_gauge, attributes);
@@ -454,6 +451,7 @@ mod tests {
         let metric = found_gauge.unwrap();
 
         assert_eq!(metric.name(), "test_gauge");
+        assert_eq!(metric.unit(), "some-unit");
 
         let data = metric.data();
 
@@ -491,7 +489,7 @@ mod tests {
         let provider = SdkMeterProvider::builder().with_reader(reader).build();
         let meter = provider.meter("test-meter");
 
-        let otlp_histogram = meter.f64_histogram("test_histogram").build();
+        let otlp_histogram = meter.f64_histogram("test_histogram").with_unit("some-unit").build();
         let attributes = vec![opentelemetry::KeyValue::new("some-label", "some-value")];
 
         let histogram = Histogram::with_otlp(otlp_histogram, attributes);
@@ -525,6 +523,7 @@ mod tests {
         let metric = found_histogram.unwrap();
 
         assert_eq!(metric.name(), "test_histogram");
+        assert_eq!(metric.unit(), "some-unit");
 
         let data = metric.data();
 

--- a/mountpoint-s3-fs/src/metrics/defs.rs
+++ b/mountpoint-s3-fs/src/metrics/defs.rs
@@ -1,0 +1,86 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricStability {
+    Stable,
+    Experimental,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MetricConfig {
+    pub unit: &'static str,
+    pub stability: MetricStability,
+    pub otlp_attributes: &'static [&'static str],
+}
+
+// Metric name constants
+pub const FUSE_REQUEST_LATENCY: &str = "fuse.request_latency";
+pub const FUSE_IO_SIZE: &str = "fuse.io_size";
+pub const FUSE_REQUEST_FAILURE: &str = "fuse.request_failure";
+pub const FUSE_IDLE_THREADS: &str = "fuse.idle_threads";
+
+pub const S3_REQUEST_COUNT: &str = "s3.request_count";
+pub const S3_REQUEST_FAILURE: &str = "s3.request_failure";
+pub const S3_REQUEST_TOTAL_LATENCY: &str = "s3.request_total_latency";
+pub const S3_REQUEST_FIRST_BYTE_LATENCY: &str = "s3.request_first_byte_latency";
+
+pub const PROCESS_MEMORY_USAGE: &str = "process.memory_usage";
+
+// Attribute constants
+pub const FUSE_REQUEST: &str = "fuse.request";
+pub const S3_REQUEST: &str = "s3.request";
+pub const S3_ERROR: &str = "s3.error";
+
+pub fn lookup_config(name: &str) -> MetricConfig {
+    match name {
+        FUSE_REQUEST_LATENCY => MetricConfig {
+            unit: "us",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[FUSE_REQUEST],
+        },
+        FUSE_IO_SIZE => MetricConfig {
+            unit: "By",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[FUSE_REQUEST],
+        },
+        FUSE_REQUEST_FAILURE => MetricConfig {
+            unit: "",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[FUSE_REQUEST],
+        },
+        FUSE_IDLE_THREADS => MetricConfig {
+            unit: "",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[],
+        },
+        S3_REQUEST_COUNT => MetricConfig {
+            unit: "",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[S3_REQUEST],
+        },
+        S3_REQUEST_FAILURE => MetricConfig {
+            unit: "",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[S3_REQUEST, S3_ERROR],
+        },
+        S3_REQUEST_TOTAL_LATENCY => MetricConfig {
+            unit: "us",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[S3_REQUEST],
+        },
+        S3_REQUEST_FIRST_BYTE_LATENCY => MetricConfig {
+            unit: "us",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[S3_REQUEST],
+        },
+        PROCESS_MEMORY_USAGE => MetricConfig {
+            unit: "By",
+            stability: MetricStability::Stable,
+            otlp_attributes: &[],
+        },
+        _ => MetricConfig {
+            unit: "",
+            stability: MetricStability::Internal,
+            otlp_attributes: &[],
+        },
+    }
+}


### PR DESCRIPTION
This PR defines metric configuration for OTLP export and adds support for passing units and filtering stable metrics for otlp export. 

The log based metrics will also log units for the subset of metrics allowlisted for OTLP export.

### Does this change impact existing behavior?

Changes log format for some metrics to include units

### Does this change need a changelog entry? Does it require a version change?

Requires a changelog entry but not a version change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
