### PR TITLE
Update CI approvals to use single job with 'needs' relationship

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,11 +29,19 @@ env:
   MAX_VALUES_IN_BENCH_CHART: 30
 
 jobs:
+  approval:
+    name: Approval Gate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Approval Gate
+        run: echo "Approved!"
+
   bench:
     name: Benchmark (Throughput)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     steps:
     - name: Configure AWS credentials
@@ -117,7 +125,7 @@ jobs:
     name: Benchmark (Latency)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     steps:
     - name: Configure AWS credentials
@@ -183,7 +191,7 @@ jobs:
     name: Benchmark (Cache)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     steps:
     - name: Configure AWS credentials

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -29,11 +29,19 @@ env:
   MAX_VALUES_IN_BENCH_CHART: 30
 
 jobs:
+  approval:
+    name: Approval Gate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Approval Gate
+        run: echo "Approved!"
+
   bench:
     name: Benchmark (Throughput)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     steps:
     - name: Configure AWS credentials
@@ -116,7 +124,7 @@ jobs:
     name: Benchmark (Latency)
     runs-on: [self-hosted, linux, x64, nvme-high-performance]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     steps:
     - name: Configure AWS credentials

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,11 +43,19 @@ permissions:
   contents: read
 
 jobs:
+  approval:
+    name: Approval Gate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Approval Gate
+        run: echo "Approved!"
+
   test:
     name: FS Tests (${{ matrix.bucket-type.name }}, ${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
     runs-on: ${{ matrix.runner.tags }}
 
-    environment: ${{ inputs.environment }}
+    needs: approval
     env:
       features: fuse_tests,s3_tests,fips_tests,event_log,second_account_tests,manifest,${{ matrix.bucket-type.feature }}
       packages: --package mountpoint-s3 --package mountpoint-s3-fs
@@ -107,7 +115,7 @@ jobs:
     name: Client Tests (${{ matrix.bucket-type.name }}, ${{ matrix.runner.name }}, ${{ matrix.pool.name }})
     runs-on: ${{ matrix.runner.tags }}
 
-    environment: ${{ inputs.environment }}
+    needs: approval
     env:
       features: s3_tests,fips_tests,${{ matrix.pool.feature }},${{ matrix.bucket-type.feature }}
       packages: --package mountpoint-s3-client --package mountpoint-s3-crt --package mountpoint-s3-crt-sys
@@ -168,7 +176,7 @@ jobs:
     name: fstab tests (${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.tags }}
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     strategy:
       fail-fast: false
@@ -215,7 +223,7 @@ jobs:
     name: Address sanitizer
     runs-on: [self-hosted, linux, arm64]
 
-    environment: ${{ inputs.environment }}
+    needs: approval
 
     env:
       # We're using ASan to test our CRT bindings, so focus only on S3, not on FUSE


### PR DESCRIPTION
This change reduces noise from CI approvals by using one single job with its own approval, which all other jobs "need" before they start.

`needs` definition: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds

Reference: https://github.com/awslabs/s3-connector-for-pytorch/pull/373/

### Does this change impact existing behavior?

CI change only. It now has all jobs requiring approval wait on a single job to succeed, which is itself gated by the GitHub environment.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
