### PR TITLE
Skip fuser tests on macOS in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,8 @@ jobs:
     - name: Build tests
       run: cargo test --no-run
     - name: Run tests
-      run: cargo test -- --skip=mnt::test::mount_unmount
+      # Skip `mountpoint-s3-fuser` tests on macOS.
+      run: cargo test --workspace --exclude mountpoint-s3-fuser
 
   check:
     name: Check all targets


### PR DESCRIPTION
Avoid running unit tests in CI for the `mountpoint-s3-fuser` crate on macOS. Since `fuser` also removed their macOS CI, we don't want to trigger spurious failures on a platform we do not support.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
