### PR TITLE
Unstable flag to open a new FD on each fuse thread.

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -95,6 +95,7 @@ impl ConfigOptions {
             allow_other: self.allow_other,
             allow_root: self.allow_root,
             auto_unmount: self.auto_unmount.unwrap_or(false),
+            clone_fd: false,
         };
         FuseSessionConfig::new(mount_point, fuse_options, self.max_threads.unwrap_or(16))
     }

--- a/mountpoint-s3-fs/src/fuse/config.rs
+++ b/mountpoint-s3-fs/src/fuse/config.rs
@@ -14,6 +14,7 @@ pub struct FuseSessionConfig {
     pub(crate) mount_point: MountPoint,
     pub(crate) options: Vec<MountOption>,
     pub(crate) max_threads: usize,
+    pub(crate) clone_fuse_fd: bool,
 }
 
 /// Mount options to be passed to FUSE.
@@ -27,6 +28,8 @@ pub struct FuseOptions {
     pub allow_root: bool,
     /// Allow other users, including root, to access file system
     pub allow_other: bool,
+    /// UNSTABLE: Use clone_fd optimization?
+    pub clone_fd: bool,
 }
 
 impl FuseSessionConfig {
@@ -74,6 +77,7 @@ impl FuseSessionConfig {
             mount_point,
             options,
             max_threads,
+            clone_fuse_fd: fuse_options.clone_fd,
         })
     }
 

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -254,7 +254,7 @@ where
     };
 
     (
-        FuseSession::from_session(session, test_config.max_worker_threads).unwrap(),
+        FuseSession::from_session(session, test_config.max_worker_threads, false).unwrap(),
         mount,
     )
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -696,6 +696,12 @@ impl CliArgs {
         Ok(s3_path.bucket_description())
     }
 
+    fn clone_fd_from_env(&self) -> bool {
+        std::env::var("UNSTABLE_MOUNTPOINT_CLONE_FUSE_FD")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
     pub fn fuse_session_config(&self) -> anyhow::Result<FuseSessionConfig> {
         let mount_point = MountPoint::new(&self.mount_point).context("Failed to create mount point")?;
         let fuse_options = FuseOptions {
@@ -703,6 +709,7 @@ impl CliArgs {
             auto_unmount: self.auto_unmount,
             allow_root: self.allow_root,
             allow_other: self.allow_other,
+            clone_fd: self.clone_fd_from_env(),
         };
         FuseSessionConfig::new(mount_point, fuse_options, self.max_threads as usize)
     }


### PR DESCRIPTION
This mimics the libfuse behaviour.  This is currently behind a flag because the performance and compatibility concerns are still being considered.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
