### PR TITLE
Fix instructions for updating CRT dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "aws-lc"]
 	path = mountpoint-s3-crt-sys/crt/aws-lc
-	url = https://github.com/awslabs/aws-lc.git
+	url = https://github.com/aws/aws-lc.git
 [submodule "s2n-tls"]
 	path = mountpoint-s3-crt-sys/crt/s2n-tls
 	url = https://github.com/aws/s2n-tls.git

--- a/mountpoint-s3-crt-sys/UPDATING_CRT.md
+++ b/mountpoint-s3-crt-sys/UPDATING_CRT.md
@@ -9,7 +9,7 @@ The CRT submodules can be updated by following these steps:
 1. Update every submodule to the latest tagged release. E.g. by running:
 
    ```sh
-   git submodule foreach 'git fetch -q --tags && git checkout --recurse-submodules `git tag -l --sort=-v:refname | head -1`'
+   git submodule foreach 'git fetch -q -f --tags && git checkout --recurse-submodules `git tag -l --sort=-v:refname | head -1`'
    ```
 
 2. Review the commit history, in particular for `aws-c-s3`, looking for changes that may affect `mountpoint-s3` (bug fixes, API changes, etc.). E.g.:


### PR DESCRIPTION
The command to fetch tags could fail in case of conflict and bail out before upgrading the remaining submodules.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
