### PR TITLE
Update S3 log analyzer to parse memory usage correctly

### DIFF
--- a/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
+++ b/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
@@ -27,7 +27,7 @@ struct CliArgs {
 }
 
 fn main() -> anyhow::Result<()> {
-    const MEM_USAGE_LOG_PATTERN: &str = "process\\.memory_usage:\\s\\d+$";
+    const MEM_USAGE_LOG_PATTERN: &str = r"process\.memory_usage.*:\s\d+$";
 
     let args = CliArgs::parse();
     let paths = fs::read_dir(args.log_dir)?;


### PR DESCRIPTION
We recently updated the log format to include an extra space, which broke parsing of memory usage metric from the logs. With this change, log analyzer should be able to parse units or additional spacing before the metric.

### Does this change impact existing behavior?

No, only updates log-analyzer

### Does this change need a changelog entry? Does it require a version change?

No, only updates log-analyzer

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
