### PR TITLE
benchmark: Refactor resource monitoring tools into separate classes

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,15 +1,12 @@
-from contextlib import contextmanager
 import json
 import logging
 import os
-import signal
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
 import hydra
-import psutil
 from hydra.core.hydra_config import HydraConfig
 from hydra.types import RunMode
 from omegaconf import DictConfig, OmegaConf
@@ -20,6 +17,9 @@ from benchmarks.command import CommandResult
 from benchmarks.crt_benchmark import CrtBenchmark
 from benchmarks.fio_benchmark import FioBenchmark
 from benchmarks.prefetch_benchmark import PrefetchBenchmark
+
+from monitoring import ResourceMonitoring
+from monitoring.tools import MonitoringTool, MpstatTool, BwmNgTool, PerfStatTool, FlamegraphTool
 
 logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
 
@@ -98,250 +98,6 @@ def upload_results_to_s3(bucket_name: str, region: str) -> None:
         log.info("Skipping benchmark upload for non-multirun")
 
 
-class ResourceMonitoring:
-    def __init__(
-        self,
-        target_pid,
-        with_bwm: bool,
-        with_perf_stat: bool,
-        with_flamegraph: bool,
-        flamegraph_scripts_path: Optional[str] = None,
-    ):
-        """Resource monitoring setup.
-
-        target_pid: Process pid to monitor where applicable
-        with_bwm: Whether to start bandwidth monitor tool `bwm-ng`.  Optional because it's not available
-        in the default AL2023 distro so you have to install it first.
-        with_perf_stat: Whether to gather performance counter statistics.
-        flamegraph_scripts_path: Path to directory containing flamegraph.pl scripts (optional)"""
-
-        self.target_pid = target_pid
-        self.mpstat_process = None
-        self.bwm_ng_process = None
-        self.perf_stat_process = None
-        self.flamegraph_process = None
-        self.with_bwm = with_bwm
-        self.with_perf_stat = with_perf_stat
-        self.with_flamegraph = with_flamegraph
-        self.flamegraph_scripts_path = flamegraph_scripts_path
-        self.output_files = []
-
-    def _start(self) -> None:
-        log.debug("Starting resource monitors...")
-        self.mpstat_process = self._start_mpstat()
-        if self.with_bwm:
-            self.bwm_ng_process = self._start_bwm_ng()
-        if self.with_perf_stat:
-            self.perf_stat_process = self._start_perf_stat()
-        if self.with_flamegraph:
-            self.flamegraph_process = self._start_flamegraph()
-
-    def _close(self) -> None:
-        log.debug("Shutting down resource monitors...")
-        for process in [self.mpstat_process, self.bwm_ng_process, self.perf_stat_process]:
-            self._stop_resource_monitor(process)
-        if self.flamegraph_process is not None:
-            self._stop_flamegraph(self.flamegraph_process)
-
-        for output_file in self.output_files:
-            try:
-                output_file.close()
-            except Exception:
-                log.error("Error closing {output_file}:", exc_info=True)
-
-    def _stop_resource_monitor(self, process):
-        try:
-            if process:
-                process.send_signal(signal.SIGINT)
-                process.wait()
-        except Exception:
-            log.error("Error shutting down monitoring:", exc_info=True)
-
-    def _stop_flamegraph(self, process):
-        try:
-            if process:
-                # Find all perf processes that are children of the flamegraph process
-                try:
-                    parent = psutil.Process(process.pid)
-                    children = parent.children(recursive=True)
-                    # Kill perf process first (child)
-                    for child in children:
-                        if 'perf' in child.name():
-                            child.send_signal(signal.SIGINT)
-                            child.wait()
-                    # Then kill the flamegraph process (parent)
-                    process.send_signal(signal.SIGINT)
-                    process.wait()
-
-                except psutil.NoSuchProcess:
-                    log.warning(f"Process {process.pid} no longer exists")
-
-                # Generate inverted flamegraph if scripts path is provided and perf.data exists
-                if self.flamegraph_scripts_path and os.path.exists("perf.data"):
-                    self._generate_inverted_flamegraph()
-
-                # Clean up perf.data file if it exists
-                try:
-                    if os.path.exists("perf.data"):
-                        os.remove("perf.data")
-                        log.debug("Cleaned up perf.data file")
-                except Exception:
-                    log.warning("Failed to clean up perf.data file", exc_info=True)
-
-        except Exception:
-            log.error("Error shutting down monitoring:", exc_info=True)
-
-    def _generate_inverted_flamegraph(self):
-        """Generate inverted flamegraph using flamegraph.pl scripts.
-
-        Possible enhancement/TODO: We could optimise runtime here by not using cargo flamegraph to get perf data and compute both graphs from one invocation of stackcollapse, etc.
-        """
-        try:
-            assert self.flamegraph_scripts_path
-            stackcollapse_script = os.path.join(self.flamegraph_scripts_path, "stackcollapse-perf.pl")
-            flamegraph_script = os.path.join(self.flamegraph_scripts_path, "flamegraph.pl")
-
-            # Check if scripts exist
-            if not os.path.exists(stackcollapse_script) or not os.path.exists(flamegraph_script):
-                log.warning(f"Flamegraph scripts not found in {self.flamegraph_scripts_path}")
-                return
-
-            log.info("Generating inverted flamegraph...")
-
-            # Step 1: perf script -i perf.data > perf.txt
-            with open("perf.txt", "w") as perf_txt:
-                result = subprocess.run(
-                    ["perf", "script", "-i", "perf.data"], stdout=perf_txt, stderr=subprocess.PIPE, text=True
-                )
-                if result.returncode != 0:
-                    log.warning(f"perf script failed: {result.stderr}")
-                    return
-
-            # Step 2: ./stackcollapse-perf.pl perf.txt > stacks.txt
-            with open("perf.txt", "r") as perf_txt, open("stacks.txt", "w") as stacks_txt:
-                result = subprocess.run(
-                    [stackcollapse_script], stdin=perf_txt, stdout=stacks_txt, stderr=subprocess.PIPE, text=True
-                )
-                if result.returncode != 0:
-                    log.warning(f"stackcollapse-perf.pl failed: {result.stderr}")
-                    return
-
-            # Step 3: ./flamegraph.pl --inverted stacks.txt > inverted-flamegraph.svg
-            with open("stacks.txt", "r") as stacks_txt, open("inverted-flamegraph.svg", "w") as flamegraph_svg:
-                result = subprocess.run(
-                    [flamegraph_script, "--inverted", "--reverse", "--colors", "blue"],
-                    stdin=stacks_txt,
-                    stdout=flamegraph_svg,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                )
-                if result.returncode != 0:
-                    log.warning(f"flamegraph.pl failed: {result.stderr}")
-                    return
-
-            log.info("Successfully generated inverted flamegraph: inverted-flamegraph.svg")
-
-            # Clean up intermediate files
-            for temp_file in ["perf.txt", "stacks.txt"]:
-                try:
-                    if os.path.exists(temp_file):
-                        os.remove(temp_file)
-                except Exception as e:
-                    log.debug(f"Failed to remove temporary file {temp_file}: {e}")
-
-        except Exception:
-            log.error("Error generating inverted flamegraph:", exc_info=True)
-
-    def _start_monitor_with_builtin_repeat(self, process_args: List[str], output_file) -> subprocess.Popen:
-        """Start process_args with output to output_file.
-
-        Used for starting processes in the background to do monitoring; good for tools that repeat the
-        measurement themselves so only need to be started once, and that can write their output to stdout.
-        """
-        f = open(output_file, 'w')
-        self.output_files.append(f)
-        log.debug(f"Starting monitoring tool {' '.join(process_args)}")
-        return subprocess.Popen(process_args, stdout=f)
-
-    def _start_mpstat(self) -> subprocess.Popen:
-        # fmt: off
-        return self._start_monitor_with_builtin_repeat([
-                "/usr/bin/mpstat",
-                "-P", "ALL", # cores
-                "-o", "JSON",
-                "1", # interval
-            ], 'mpstat.json')
-        # fmt: on
-
-    def _start_bwm_ng(self) -> subprocess.Popen:
-        """Starts bwm-ng, which probably needs to be installed.
-
-        https://www.gropp.org/?id=projects&sub=bwm-ng"""
-        return self._start_monitor_with_builtin_repeat(['/usr/local/bin/bwm-ng', '-o', 'csv'], 'bwm-ng.csv')
-
-    def _start_perf_stat(self) -> subprocess.Popen:
-        """Gather perf count statistics"""
-        perf_events = ["cycles", "instructions", "cache-references", "cache-misses", "bus-cycles"]
-
-        # fmt: off
-        perf_args = [
-            "perf", "stat",
-            "-I", "500",              # 500ms interval
-            "-e", ",".join(perf_events),
-            "-j",                     # JSON output format
-            "-p", str(self.target_pid),
-            "-o", "perfstat.json"
-        ]
-        # fmt: on
-
-        log.info("Starting perf stat with args: %s", " ".join(perf_args))
-        return subprocess.Popen(perf_args)
-
-    def _start_flamegraph(self) -> subprocess.Popen:
-        """Produces a flamegraph"""
-
-        try:
-            with open('/proc/sys/kernel/kptr_restrict', 'r') as f:
-                kptr_restrict_value = f.read().strip()
-            if kptr_restrict_value != '0':
-                log.warning(
-                    f"kernel.kptr_restrict is set to {kptr_restrict_value}, not 0. "
-                    f"For comprehensive flamegraphs, consider running: sudo sysctl kernel.kptr_restrict=0"
-                )
-            else:
-                log.info("verified that kernel.kptr_restrict=0 (for flamegraphing)")
-        except (OSError, IOError) as e:
-            log.warning(f"Could not check kernel.kptr_restrict: {e}")
-
-        # Check perf_event_paranoid for kernel tracing permissions
-        try:
-            with open('/proc/sys/kernel/perf_event_paranoid', 'r') as f:
-                paranoid_value = f.read().strip()
-            if paranoid_value not in ['-1', '0']:
-                log.warning(
-                    f"kernel.perf_event_paranoid is set to {paranoid_value}. "
-                    f"For comprehensive kernel tracing, consider running: sudo sysctl kernel.perf_event_paranoid=-1"
-                )
-            else:
-                log.info(f"verified that kernel.perf_event_paranoid={paranoid_value} for flamegraphing")
-        except (OSError, IOError) as e:
-            log.warning(f"Could not check kernel.perf_event_paranoid: {e}")
-
-        flamegraph_args = ["flamegraph", "--pid", str(self.target_pid), "-o", "flamegraph.svg"]
-
-        log.info("Starting flamegraph with args %s", " ".join(flamegraph_args))
-        return subprocess.Popen(flamegraph_args)
-
-    @contextmanager
-    def managed(target_pid, with_bwm=False, with_perf_stat=False, with_flamegraph=False, flamegraph_scripts_path=None):
-        resource = ResourceMonitoring(target_pid, with_bwm, with_perf_stat, with_flamegraph, flamegraph_scripts_path)
-        try:
-            resource._start()
-            yield resource
-        finally:
-            resource._close()
-
-
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def run_experiment(cfg: DictConfig) -> None:
     """
@@ -389,13 +145,16 @@ def run_experiment(cfg: DictConfig) -> None:
         target_pid = metadata.get("target_pid", process.pid)
         metadata["target_pid"] = target_pid
 
-        with ResourceMonitoring.managed(
-            target_pid,
-            cfg.monitoring.with_bwm,
-            cfg.monitoring.with_perf_stat,
-            cfg.monitoring.with_flamegraph,
-            cfg.monitoring.flamegraph_scripts_path,
-        ):
+        # Construct monitoring tools
+        tools: List[MonitoringTool] = [MpstatTool()]
+        if cfg.monitoring.with_bwm:
+            tools.append(BwmNgTool())
+        if cfg.monitoring.with_perf_stat:
+            tools.append(PerfStatTool(target_pid))
+        if cfg.monitoring.with_flamegraph:
+            tools.append(FlamegraphTool(target_pid, cfg.monitoring.flamegraph_scripts_path))
+
+        with ResourceMonitoring.managed(tools):
             stdout, stderr = process.communicate()
 
             if stdout is not None and isinstance(stdout, bytes):

--- a/benchmark/monitoring/__init__.py
+++ b/benchmark/monitoring/__init__.py
@@ -1,0 +1,49 @@
+from contextlib import contextmanager
+import logging
+from typing import List
+
+from .base import MonitoringTool
+
+log = logging.getLogger(__name__)
+
+
+class ResourceMonitoring:
+    """Manages lifecycle of multiple monitoring tools during benchmark execution.
+
+    Coordinates starting and stopping of monitoring tools like mpstat, bwm-ng,
+    perf stat, and flamegraph. Provides a context manager interface for automatic
+    cleanup of monitoring resources.
+
+    Example:
+        tools = [MpstatTool(), PerfStatTool(pid)]
+        with ResourceMonitoring.managed(tools):
+            # Run benchmark while monitoring
+            pass
+    """
+
+    def __init__(self, tools: List[MonitoringTool]):
+        """Resource monitoring setup.
+
+        tools: List of MonitoringTool instances to manage
+        """
+        self.tools = tools
+
+    def _start(self) -> None:
+        log.debug("Starting resource monitors...")
+        for tool in self.tools:
+            tool.start()
+
+    def _close(self) -> None:
+        log.debug("Shutting down resource monitors...")
+        for tool in self.tools:
+            tool.stop()
+
+    @staticmethod
+    @contextmanager
+    def managed(tools: List[MonitoringTool]):
+        resource = ResourceMonitoring(tools)
+        try:
+            resource._start()
+            yield resource
+        finally:
+            resource._close()

--- a/benchmark/monitoring/base.py
+++ b/benchmark/monitoring/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class MonitoringTool(ABC):
+    @abstractmethod
+    def start(self) -> None:
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        pass

--- a/benchmark/monitoring/tools.py
+++ b/benchmark/monitoring/tools.py
@@ -1,0 +1,217 @@
+import logging
+import os
+import signal
+import subprocess
+from typing import Optional
+
+import psutil
+
+from .base import MonitoringTool
+
+log = logging.getLogger(__name__)
+
+
+class MpstatTool(MonitoringTool):
+    def __init__(self):
+        self.process = None
+        self.output_file = None
+
+    def start(self) -> None:
+        self.output_file = open('mpstat.json', 'w')
+        log.info("Starting mpstat monitoring")
+        # fmt: off
+        self.process = subprocess.Popen([
+            "/usr/bin/mpstat",
+            "-P", "ALL",
+            "-o", "JSON",
+            "1"
+        ], stdout=self.output_file)
+        # fmt: on
+
+    def stop(self) -> None:
+        if self.process:
+            try:
+                self.process.send_signal(signal.SIGINT)
+                self.process.wait()
+            except Exception:
+                log.error("Error shutting down mpstat:", exc_info=True)
+        if self.output_file:
+            try:
+                self.output_file.close()
+            except Exception:
+                log.error("Error closing mpstat output file:", exc_info=True)
+
+
+class BwmNgTool(MonitoringTool):
+    def __init__(self):
+        self.process = None
+        self.output_file = None
+
+    def start(self) -> None:
+        self.output_file = open('bwm-ng.csv', 'w')
+        log.info("Starting bwm-ng monitoring")
+        # fmt: off
+        self.process = subprocess.Popen([
+            '/usr/local/bin/bwm-ng', '-o', 'csv'
+        ], stdout=self.output_file)
+        # fmt: on
+
+    def stop(self) -> None:
+        if self.process:
+            try:
+                self.process.send_signal(signal.SIGINT)
+                self.process.wait()
+            except Exception:
+                log.error("Error shutting down bwm-ng:", exc_info=True)
+        if self.output_file:
+            try:
+                self.output_file.close()
+            except Exception:
+                log.error("Error closing bwm-ng output file:", exc_info=True)
+
+
+class PerfStatTool(MonitoringTool):
+    def __init__(self, target_pid: int):
+        self.target_pid = target_pid
+        self.process = None
+
+    def start(self) -> None:
+        perf_events = ["cycles", "instructions", "cache-references", "cache-misses", "bus-cycles"]
+        # fmt: off
+        perf_args = [
+            "perf", "stat",
+            "-I", "500",
+            "-e", ",".join(perf_events),
+            "-j",
+            "-p", str(self.target_pid),
+            "-o", "perfstat.json"
+        ]
+        # fmt: on
+        log.info("Starting perf stat with args: %s", " ".join(perf_args))
+        self.process = subprocess.Popen(perf_args)
+
+    def stop(self) -> None:
+        if self.process:
+            try:
+                self.process.send_signal(signal.SIGINT)
+                self.process.wait()
+            except Exception:
+                log.error("Error shutting down perf stat:", exc_info=True)
+
+
+class FlamegraphTool(MonitoringTool):
+    def __init__(self, target_pid: int, flamegraph_scripts_path: Optional[str] = None):
+        self.target_pid = target_pid
+        self.flamegraph_scripts_path = flamegraph_scripts_path
+        self.process = None
+
+    def start(self) -> None:
+        self._check_kernel_settings()
+        flamegraph_args = ["flamegraph", "--pid", str(self.target_pid), "-o", "flamegraph.svg"]
+        log.info("Starting flamegraph with args %s", " ".join(flamegraph_args))
+        self.process = subprocess.Popen(flamegraph_args)
+
+    def stop(self) -> None:
+        if self.process:
+            try:
+                parent = psutil.Process(self.process.pid)
+                children = parent.children(recursive=True)
+                for child in children:
+                    if 'perf' in child.name():
+                        child.send_signal(signal.SIGINT)
+                        child.wait()
+                self.process.send_signal(signal.SIGINT)
+                self.process.wait()
+            except psutil.NoSuchProcess:
+                log.warning(f"Process {self.process.pid} no longer exists")
+            except Exception:
+                log.error("Error shutting down flamegraph:", exc_info=True)
+
+            if self.flamegraph_scripts_path and os.path.exists("perf.data"):
+                self._generate_inverted_flamegraph()
+
+            try:
+                if os.path.exists("perf.data"):
+                    os.remove("perf.data")
+                    log.debug("Cleaned up perf.data file")
+            except Exception:
+                log.warning("Failed to clean up perf.data file", exc_info=True)
+
+    def _check_kernel_settings(self):
+        try:
+            with open('/proc/sys/kernel/kptr_restrict', 'r') as f:
+                kptr_restrict_value = f.read().strip()
+            if kptr_restrict_value != '0':
+                log.warning(
+                    f"kernel.kptr_restrict is set to {kptr_restrict_value}, not 0. "
+                    f"For comprehensive flamegraphs, consider running: sudo sysctl kernel.kptr_restrict=0"
+                )
+            else:
+                log.info("verified that kernel.kptr_restrict=0 (for flamegraphing)")
+        except (OSError, IOError) as e:
+            log.warning(f"Could not check kernel.kptr_restrict: {e}")
+
+        try:
+            with open('/proc/sys/kernel/perf_event_paranoid', 'r') as f:
+                paranoid_value = f.read().strip()
+            if paranoid_value not in ['-1', '0']:
+                log.warning(
+                    f"kernel.perf_event_paranoid is set to {paranoid_value}. "
+                    f"For comprehensive kernel tracing, consider running: sudo sysctl kernel.perf_event_paranoid=-1"
+                )
+            else:
+                log.info(f"verified that kernel.perf_event_paranoid={paranoid_value} for flamegraphing")
+        except (OSError, IOError) as e:
+            log.warning(f"Could not check kernel.perf_event_paranoid: {e}")
+
+    def _generate_inverted_flamegraph(self):
+        try:
+            assert self.flamegraph_scripts_path
+            stackcollapse_script = os.path.join(self.flamegraph_scripts_path, "stackcollapse-perf.pl")
+            flamegraph_script = os.path.join(self.flamegraph_scripts_path, "flamegraph.pl")
+
+            if not os.path.exists(stackcollapse_script) or not os.path.exists(flamegraph_script):
+                log.warning(f"Flamegraph scripts not found in {self.flamegraph_scripts_path}")
+                return
+
+            log.info("Generating inverted flamegraph...")
+
+            with open("perf.txt", "w") as perf_txt:
+                result = subprocess.run(
+                    ["perf", "script", "-i", "perf.data"], stdout=perf_txt, stderr=subprocess.PIPE, text=True
+                )
+                if result.returncode != 0:
+                    log.warning(f"perf script failed: {result.stderr}")
+                    return
+
+            with open("perf.txt", "r") as perf_txt, open("stacks.txt", "w") as stacks_txt:
+                result = subprocess.run(
+                    [stackcollapse_script], stdin=perf_txt, stdout=stacks_txt, stderr=subprocess.PIPE, text=True
+                )
+                if result.returncode != 0:
+                    log.warning(f"stackcollapse-perf.pl failed: {result.stderr}")
+                    return
+
+            with open("stacks.txt", "r") as stacks_txt, open("inverted-flamegraph.svg", "w") as flamegraph_svg:
+                result = subprocess.run(
+                    [flamegraph_script, "--inverted", "--reverse", "--colors", "blue"],
+                    stdin=stacks_txt,
+                    stdout=flamegraph_svg,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    log.warning(f"flamegraph.pl failed: {result.stderr}")
+                    return
+
+            log.info("Successfully generated inverted flamegraph: inverted-flamegraph.svg")
+
+            for temp_file in ["perf.txt", "stacks.txt"]:
+                try:
+                    if os.path.exists(temp_file):
+                        os.remove(temp_file)
+                except Exception as e:
+                    log.debug(f"Failed to remove temporary file {temp_file}: {e}")
+
+        except Exception:
+            log.error("Error generating inverted flamegraph:", exc_info=True)

--- a/benchmark/test_monitoring_tools.py
+++ b/benchmark/test_monitoring_tools.py
@@ -1,0 +1,171 @@
+from unittest.mock import Mock, patch, MagicMock
+
+from monitoring import ResourceMonitoring
+from monitoring.base import MonitoringTool
+from monitoring.tools import MpstatTool, BwmNgTool, PerfStatTool, FlamegraphTool
+
+
+class TestMpstatTool:
+    """Test cases for MpstatTool monitoring functionality."""
+
+    @patch('subprocess.Popen')
+    @patch('builtins.open')
+    def test_mpstat_tool_lifecycle(self, mock_open, mock_popen):
+        """
+        Test that MpstatTool correctly starts and stops CPU monitoring.
+
+        Verifies that the tool opens an output file, starts the mpstat process,
+        and properly cleans up resources when stopped.
+        """
+        # Given: Mock file and process objects
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        tool = MpstatTool()
+
+        # When: Starting the tool
+        tool.start()
+
+        # Then: File is opened and process is started
+        mock_open.assert_called_once_with('mpstat.json', 'w')
+        mock_popen.assert_called_once()
+
+        # When: Stopping the tool
+        tool.stop()
+
+        # Then: Process is terminated and file is closed
+        mock_process.send_signal.assert_called_once()
+        mock_process.wait.assert_called_once()
+        mock_file.close.assert_called_once()
+
+
+class TestBwmNgTool:
+    """Test cases for BwmNgTool bandwidth monitoring functionality."""
+
+    @patch('subprocess.Popen')
+    @patch('builtins.open')
+    def test_bwm_ng_tool_lifecycle(self, mock_open, mock_popen):
+        """
+        Test that BwmNgTool correctly starts and stops bandwidth monitoring.
+
+        Verifies that the tool opens an output file, starts the bwm-ng process,
+        and properly cleans up resources when stopped.
+        """
+        # Given: Mock file and process objects
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        tool = BwmNgTool()
+
+        # When: Starting the tool
+        tool.start()
+
+        # Then: File is opened and process is started
+        mock_open.assert_called_once_with('bwm-ng.csv', 'w')
+        mock_popen.assert_called_once()
+
+        # When: Stopping the tool
+        tool.stop()
+
+        # Then: Process is terminated and file is closed
+        mock_process.send_signal.assert_called_once()
+        mock_process.wait.assert_called_once()
+        mock_file.close.assert_called_once()
+
+
+class TestPerfStatTool:
+    """Test cases for PerfStatTool performance monitoring functionality."""
+
+    @patch('subprocess.Popen')
+    def test_perf_stat_tool_uses_target_pid(self, mock_popen):
+        """
+        Test that PerfStatTool correctly monitors a specific process ID.
+
+        Verifies that the tool starts perf stat with the correct target PID
+        and includes the expected perf command arguments.
+        """
+        # Given: Mock process and a target PID
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        target_pid = 12345
+        tool = PerfStatTool(target_pid)
+
+        # When: Starting the tool
+        tool.start()
+
+        # Then: Process is started with correct PID and perf command
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert str(target_pid) in args
+        assert "perf" in args
+
+
+class TestFlamegraphTool:
+    """Test cases for FlamegraphTool profiling functionality."""
+
+    @patch('subprocess.Popen')
+    def test_flamegraph_tool_uses_target_pid(self, mock_popen):
+        """
+        Test that FlamegraphTool correctly profiles a specific process ID.
+
+        Verifies that the tool starts flamegraph with the correct target PID
+        and includes the expected flamegraph command arguments.
+        """
+        # Given: Mock process and a target PID
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        target_pid = 12345
+        tool = FlamegraphTool(target_pid)
+
+        # When: Starting the tool
+        tool.start()
+
+        # Then: Process is started with correct PID and flamegraph command
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert str(target_pid) in args
+        assert "flamegraph" in args
+
+
+class TestResourceMonitoring:
+    """Test cases for ResourceMonitoring coordination functionality."""
+
+    def test_resource_monitoring_starts_all_tools(self):
+        """
+        Test that ResourceMonitoring starts all provided monitoring tools.
+
+        Verifies that when _start() is called, the start() method is invoked
+        on each tool in the tools list exactly once.
+        """
+        # Given: Mock monitoring tools
+        tool1 = Mock(spec=MonitoringTool)
+        tool2 = Mock(spec=MonitoringTool)
+        resource = ResourceMonitoring([tool1, tool2])
+
+        # When: Starting resource monitoring
+        resource._start()
+
+        # Then: All tools are started
+        tool1.start.assert_called_once()
+        tool2.start.assert_called_once()
+
+    def test_resource_monitoring_stops_all_tools(self):
+        """
+        Test that ResourceMonitoring stops all provided monitoring tools.
+
+        Verifies that when _close() is called, the stop() method is invoked
+        on each tool in the tools list exactly once for proper cleanup.
+        """
+        # Given: Mock monitoring tools
+        tool1 = Mock(spec=MonitoringTool)
+        tool2 = Mock(spec=MonitoringTool)
+        resource = ResourceMonitoring([tool1, tool2])
+
+        # When: Stopping resource monitoring
+        resource._close()
+
+        # Then: All tools are stopped
+        tool1.stop.assert_called_once()
+        tool2.stop.assert_called_once()


### PR DESCRIPTION
Extract individual monitoring tools (mpstat, bwm-ng, perf-stat, flamegraph) from benchmark ResourceMonitoring class into separate tool classes that implement a common MonitoringTool interface. This improves benchmark code maintainability and makes adding new monitoring tools easier.

- Add benchmark/monitoring package with base MonitoringTool ABC
- Extract MpstatTool, BwmNgTool, PerfStatTool, FlamegraphTool classes
- Refactor ResourceMonitoring to manage list of tool instances
- Maintain backward compatibility with existing managed() API
- Add unit tests

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
