### PR TITLE
Add info logging around FUSE session join

### DIFF
--- a/mountpoint-s3-fs/src/fuse/session.rs
+++ b/mountpoint-s3-fs/src/fuse/session.rs
@@ -156,7 +156,7 @@ impl FuseSession {
             handler();
         }
 
-        trace!("unmounting filesystem");
+        info!("attempting unmount");
         self.unmounter.unmount().context("failed to unmount FUSE session")
     }
 }


### PR DESCRIPTION
This change adds some new `INFO` logging around exits. In the past, we've seen tickets where Mountpoint "spontaneously" unmounts. It's not clear what's going on in those tickets and has not been possible to reproduce given no access to those systems. This change adds a little bit of extra logging to try and give better visibility into what Mountpoint thinks is happening.

### Does this change impact existing behavior?

No change to end-user behavior. Only new logs are added at `INFO` level, which is shown to customers.

### Does this change need a changelog entry? Does it require a version change?

No, just a simple logging addition.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
