### PR TITLE
Add Docker build (no publish) in CI, fix image sources, minor style changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -318,3 +318,19 @@ jobs:
         run: uvx ruff format --diff .
       - name: Lint check
         run: uvx ruff check --output-format=github .
+
+  docker:
+    name: "Container build checks"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Build Dockerfile using official release binaries
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          file: docker/Dockerfile
+      - name: Build Dockerfile using Mountpoint source code
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          file: docker/Dockerfile.source

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Download and verify the RPM in this container
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 
 # We need the full version of GnuPG
 RUN dnf install -y --allowerasing wget gnupg2
@@ -17,7 +17,7 @@ RUN gpg --import KEYS && \
 RUN gpg --verify mount-s3.rpm.asc
 
 # Install the RPM in a fresh container to minimize dependencies
-FROM amazonlinux:2023
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS release
 COPY --from=builder /mount-s3.rpm /mount-s3.rpm
 
 RUN dnf upgrade -y && \

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -1,4 +1,4 @@
-FROM amazonlinux:2023 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS builder
 
 # Install build tools
 RUN dnf upgrade -y && \
@@ -23,7 +23,7 @@ RUN git clone --recurse-submodules https://github.com/awslabs/mountpoint-s3.git 
 
 
 
-FROM amazonlinux:2023 as release
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS release
 COPY --from=builder /mountpoint-s3/target/release/mount-s3 /mount-s3
 
 RUN dnf upgrade -y && \


### PR DESCRIPTION
Building the container images had warnings due to style inconsistencies. Additionally, the base image did not use the ECR images in all cases. On top of addressing these two issues, this PR adds a job to CI to verify that the container images are buildable.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
