### PR TITLE
Release crates including mounpoint-s3-fs 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v0.19.3 (October 27, 2025)
+
+* Change FUSE and S3 request metric names in logs. ([#1630](https://github.com/awslabs/mountpoint-s3/pull/1630), [#1653](https://github.com/awslabs/mountpoint-s3/pull/1653))
+
 ## v0.19.2 (October 17, 2025)
 
 * Upgrade toolchain to Rust 1.90. ([#1650](https://github.com/awslabs/mountpoint-s3/pull/1650))

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.19.2"
+version = "0.19.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "High-performance Amazon S3 client for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.13.2" }
+mountpoint-s3-crt = { path = "../mountpoint-s3-crt", version = "0.13.3" }
 
 async-trait = "0.1.89"
 auto_impl = "1.3.0"

--- a/mountpoint-s3-crt-sys/CHANGELOG.md
+++ b/mountpoint-s3-crt-sys/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v0.15.2 (October 27, 2025)
+
+* Propagate -O flags when building aws-lc. ([#1673](https://github.com/awslabs/mountpoint-s3/pull/1673))
+
 ## v0.15.1 (October 17, 2025)
 
 * Upgrade cargo dependencies.

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt-sys"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v0.13.3 (October 27, 2025)
+
+* Update on_telemetry to use operation_name rather than request_type for metrics. ([#1669](https://github.com/awslabs/mountpoint-s3/pull/1669))
+
 ## v0.13.2 (October 17, 2025)
 
 * Upgrade cargo dependencies.

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"
 description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazon S3."
 
 [dependencies]
-mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.15.1" }
+mountpoint-s3-crt-sys = { path = "../mountpoint-s3-crt-sys", version = "0.15.2" }
 
 futures = "0.3.31"
 libc = "0.2.176"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased (v0.8.2)
+## Unreleased
 
-* Change FUSE and S3 request metric names in logs ([#1630](https://github.com/awslabs/mountpoint-s3/pull/1630), [#1653](https://github.com/awslabs/mountpoint-s3/pull/1653))
+## v0.8.2 (October 27, 2025)
+
+* Change FUSE and S3 request metric names in logs. ([#1630](https://github.com/awslabs/mountpoint-s3/pull/1630), [#1653](https://github.com/awslabs/mountpoint-s3/pull/1653))
+* Keep a constant memory reservation for backwards seek for each file handle. ([#1631](https://github.com/awslabs/mountpoint-s3/pull/1631))
 
 ## v0.8.1 (October 17, 2025)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.1", features = ["abi-7-28", "libfuse"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.2" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.3" }
 
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 async-channel = "2.5.0"

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "mount-s3"
 
 [dependencies]
 mountpoint-s3-fs = { path = "../mountpoint-s3-fs", version = "0.8.2" }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.2" }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.19.3" }
 
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 clap = { version = "4.5.48", features = ["derive"] }


### PR DESCRIPTION
Release mounpoint-s3-fs 0.8.2 and dependencies.

Changes since last release: [compare](https://github.com/awslabs/mountpoint-s3/compare/5502a861ee11eaa6dc61aa8e711262b2d4388d8c...main).

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
