### PR TITLE
Add otlp metrics user-agent tag

### DIFF
--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -746,6 +746,10 @@ impl CliArgs {
         if let Some(interfaces) = &self.bind {
             user_agent.key_value("mp-nw-interfaces", &interfaces.len().to_string());
         }
+        #[cfg(feature = "otlp_integration")]
+        if self.otlp_endpoint.is_some() {
+            user_agent.value("mp-otlp");
+        }
         user_agent
     }
 


### PR DESCRIPTION
This adds a user-agent tag when otlp endpoint is configured to get insights into usage of otlp metrics.

### Does this change impact existing behavior?

No, under a feature flag

### Does this change need a changelog entry? Does it require a version change?

No. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
