### PR TITLE
Update RPM workflow to handle configurable release

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -309,7 +309,7 @@ jobs:
       image: amazonlinux:2023
 
     outputs:
-      version: ${{ steps.build-srpm.outputs.version }}
+      version-tag: ${{ steps.build-srpm.outputs.version-tag }}
 
     steps:
     - name: Install build tools and dependencies
@@ -396,18 +396,19 @@ jobs:
 
     - name: Test RPM build with Mock in Amazon Linux 2023 chroot
       run: |
-        VERSION="${{ needs.build-srpm.outputs.version }}"
-        sudo mock -r amazonlinux-2023-${{ matrix.arch }} --rebuild /tmp/srpms/mount-s3-${VERSION}-amzn2023.src.rpm
+        VERSION_TAG="${{ needs.build-srpm.outputs.version-tag }}"
+        sudo mock -r amazonlinux-2023-${{ matrix.arch }} --rebuild /tmp/srpms/mount-s3-${VERSION_TAG}.src.rpm
 
     - name: Build log
+      if: always()
       run: |
         echo "Mock build log:"
         cat /var/lib/mock/amazonlinux-2023-${{ matrix.arch }}/result/build.log
 
     - name: Test RPM installation
       run: |
-        VERSION="${{ needs.build-srpm.outputs.version }}"
-        dnf -y install /var/lib/mock/amazonlinux-2023-${{ matrix.arch }}/result/mount-s3-${VERSION}-amzn2023.${{ matrix.arch }}.rpm
+        VERSION_TAG="${{ needs.build-srpm.outputs.version-tag }}"
+        dnf -y install /var/lib/mock/amazonlinux-2023-${{ matrix.arch }}/result/mount-s3-${VERSION_TAG}.${{ matrix.arch }}.rpm
         which mount-s3
         mount-s3 --version
         mount-s3 --help

--- a/package/generate_amzn2023_srpm.sh
+++ b/package/generate_amzn2023_srpm.sh
@@ -26,5 +26,9 @@ rpmbuild -bs ~/rpmbuild/SPECS/amzn2023.spec
 
 # For GitHub Actions (if running in CI)
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    # Required by current workflow - TODO: remove later
     echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+    # TODO: replace "amzn2023" with the release field from the spec file
+    echo "version-tag=${VERSION}-amzn2023" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
Update the RPM workflow to use a "version tag" (`<VERSION>-<RELEASE>`), which will allow to handle a configurable release in a future change.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
