### PR TITLE
Fix race condition in logging tests

### DIFF
--- a/mountpoint-s3-fs/src/logging/envfilter.rs
+++ b/mountpoint-s3-fs/src/logging/envfilter.rs
@@ -47,8 +47,8 @@ pub fn toggleable<S>(mut filters: ToggleableFilters) -> (ToggleableLayer<S>, Tog
 mod tests {
     use tracing_subscriber::layer::SubscriberExt;
 
+    use super::super::testing::LockedWriter;
     use super::*;
-    use crate::logging::testing::LockedWriter;
 
     #[test]
     fn it_works() {
@@ -84,7 +84,7 @@ mod tests {
         });
 
         assert_eq!(
-            buf.into_string(),
+            buf.get_string(),
             "\
 ERROR test: error log 1
 DEBUG test: debug log 2

--- a/mountpoint-s3-fs/src/logging/syslog.rs
+++ b/mountpoint-s3-fs/src/logging/syslog.rs
@@ -210,8 +210,8 @@ struct FormattedFields(String);
 
 #[cfg(test)]
 mod tests {
+    use super::super::testing::LockedWriter;
     use super::*;
-    use crate::logging::testing::LockedWriter;
 
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -227,7 +227,7 @@ mod tests {
             let _enter2 = span2.enter();
             tracing::info!(field5 = 5, field6 = 6, "this is a real {:?} message", "cool");
         });
-        let output = buf.into_string();
+        let output = buf.get_string();
         // The actual output is syslog-formatted, so includes the current time and PID. Let's just
         // check the parts of the payload we really care about.
         let expected = format!(

--- a/mountpoint-s3-fs/src/logging/testing.rs
+++ b/mountpoint-s3-fs/src/logging/testing.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-use std::sync::Mutex;
+use crate::sync::Arc;
+use crate::sync::Mutex;
 
 #[derive(Debug, Clone, Default)]
 pub struct LockedWriter {
@@ -7,9 +7,9 @@ pub struct LockedWriter {
 }
 
 impl LockedWriter {
-    pub fn into_string(self) -> String {
-        let buf = Arc::try_unwrap(self.inner).unwrap().into_inner().unwrap();
-        String::from_utf8(buf).unwrap()
+    pub fn get_string(&self) -> String {
+        let buf = self.inner.lock().unwrap();
+        str::from_utf8(&buf).unwrap().to_owned()
     }
 }
 


### PR DESCRIPTION
Some of the logging tests occasionally failed because `LockedWriter` panicked when trying to retrieve the underlying buffer. For example in https://github.com/awslabs/mountpoint-s3/actions/runs/18838458022/job/53744837442#step:7:2151:

```
thread 'logging::syslog::tests::test_syslog_layer' panicked at mountpoint-s3-fs/src/logging/testing.rs:11:47:
called `Result::unwrap()` on an `Err` value: Mutex [..]
```

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
