### PR TITLE
Use explicit result type in readdir reply callback

### DIFF
--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -645,7 +645,7 @@ impl DirHandle {
 #[cfg(test)]
 mod tests {
     use crate::fs::FUSE_ROOT_INODE;
-    use crate::metablock::{InodeKind, Metablock};
+    use crate::metablock::{AddDirEntryResult, InodeKind, Metablock};
     use crate::s3::{Bucket, S3Path};
     use crate::superblock::Superblock;
     use crate::sync::Arc;
@@ -690,7 +690,13 @@ mod tests {
             .expect("Finish writing failed");
 
         superblock
-            .readdir(FUSE_ROOT_INODE, handle_id, 0, false, Box::new(|_, _, _, _| false))
+            .readdir(
+                FUSE_ROOT_INODE,
+                handle_id,
+                0,
+                false,
+                Box::new(|_, _, _, _| AddDirEntryResult::EntryAdded),
+            )
             .await
             .expect("Readdir failed");
     }


### PR DESCRIPTION
The readdir reply callback in the `metablock` module was misleading and its documentation was wrong: `TryAddDirEntry` would return `false` on success (contrary to the rustdoc and common sense). Note though that all existing invocations were using it correctly.

This change introduces an explicit return type to avoid any confusion, at the cost of some increase in verbosity.

### Does this change impact existing behavior?

No, code tidy only.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
