### PR TITLE
Add 'workflow complete' GHA targets to codify CI requirements

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Approval Gate
         run: echo "Approved!"
 
-  test:
+  fs-test:
     name: FS Tests (${{ matrix.bucket-type.name }}, ${{ matrix.runner.name }}, FUSE ${{ matrix.fuseVersion }})
     runs-on: ${{ matrix.runner.tags }}
 
@@ -338,7 +338,7 @@ jobs:
       run: |
         chmod +x package/generate_amzn2023_srpm.sh
         ./package/generate_amzn2023_srpm.sh
-        
+
         echo "## Generated Amazon Linux 2023 Spec File" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```spec' >> $GITHUB_STEP_SUMMARY
@@ -359,13 +359,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       test-prefix: "${S3_BUCKET_TEST_PREFIX}test-rpm/${{ matrix.arch }}/"
-    
+
     strategy:
       matrix:
         include:
           - arch: x86_64
             runner: ubuntu-latest
-          - arch: aarch64  
+          - arch: aarch64
             runner: [self-hosted, linux, arm64]
 
     container:
@@ -380,7 +380,7 @@ jobs:
     - name: Preventing container PAM sudo errors
       run: |
         # https://github.com/geerlingguy/docker-rockylinux9-ansible/issues/6
-        chmod 0400 /etc/shadow 
+        chmod 0400 /etc/shadow
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v5
@@ -425,11 +425,24 @@ jobs:
         # Write Test
         echo "Hello from RPM write test" > /mnt/s3-test/write-test.txt
         aws s3 cp "s3://${S3_BUCKET_NAME}/${{ env.test-prefix }}write-test.txt" - | grep -q "Hello from RPM write test"
-  
+
         sudo umount /mnt/s3-test
-        
+
     - name: Cleanup test resources
       if: always()
       run: |
         aws s3 rm "s3://${S3_BUCKET_NAME}/${{ env.test-prefix }}test.txt"
         aws s3 rm "s3://${S3_BUCKET_NAME}/${{ env.test-prefix }}write-test.txt"
+
+  workflow-complete:
+    name: "Integration Tests Complete"
+    runs-on: ubuntu-latest
+    needs:
+      - fs-test
+      - client-test
+      - fstab
+      - asan
+      - metrics
+      - test-rpm
+    steps:
+      - run: echo "Workflow complete"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -337,3 +337,22 @@ jobs:
         with:
           push: false
           file: docker/Dockerfile.source
+
+  workflow-complete:
+    name: "Tests Workflow Complete"
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - macos-test
+      - check
+      - bench
+      - shuttle
+      - rustfmt
+      - clippy
+      - docs
+      - deny
+      - benchmark-script-checks
+      - package-script-checks
+      - docker
+    steps:
+      - run: echo "Workflow complete"


### PR DESCRIPTION
Mountpoint's GitHub repository today blocks PR approvals based on a list of jobs in the branch protection rules. This is not visible to contributors and also not possible to update unless you have additional privileges on the repository. When new workflows are added, it is frequently missed to update the branch protection rules.

This change instead defines targets within the workflow YAML files, such that it is clear what the requirements are. Changes in requirements can go through version control and code review.

I've only covered the tests and integration test workflows, as most other workflows have only one job. These workflows are also where most changes occur.

Following this commit, the GitHub branch protection rules should be updated to require only these new targets for these two workflows.

### Does this change impact existing behavior?

It changes CI only. There will be no actual change in behavior, just a change in how we maintain the rules.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
