### PR TITLE
Tidy up propagation of remote status from the superblock

### DIFF
--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -101,11 +101,6 @@ impl Inode {
         &self.inner.valid_key
     }
 
-    pub fn is_remote(&self) -> Result<bool, InodeError> {
-        let state = self.get_inode_state()?;
-        Ok(state.write_status == WriteStatus::Remote)
-    }
-
     /// return Inode State with read lock after checking whether the directory inode is deleted or not.
     pub fn get_inode_state(&self) -> Result<InodeLockedForReading<'_>, InodeError> {
         let inode_state = self.inner.sync.read().unwrap();
@@ -254,6 +249,10 @@ impl InodeState {
             kind_data: InodeKindData::default_for(kind),
             write_status,
         }
+    }
+
+    pub fn is_remote(&self) -> bool {
+        self.write_status == WriteStatus::Remote
     }
 }
 

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -84,6 +84,7 @@ impl ReaddirHandle {
                             inode,
                             stat,
                             path: inner.s3_path.clone(),
+                            is_remote: false,
                         },
                     })
                 }),


### PR DESCRIPTION
Internal change to correctly propagate remote status information from the internal inode representation in the superblock to the consuming file system. This fixes a gap introduced with the `Metablock` abstraction (#1500), where the remote status was checked separately from the inode's `stat`.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
