### PR TITLE
Fix client-bp benchmarks

### DIFF
--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -35,7 +35,7 @@ class ClientBenchmark(BaseBenchmark):
 
         if self.backpressure:
             subprocess_args.append("--enable-backpressure")
-            if (initial_window_size := self.cfg.benchmarks.client.read_window_size) is not None:
+            if (initial_window_size := self.cfg.benchmarks.client_bp.read_window_size) is not None:
                 subprocess_args.extend(["--initial-window-size", str(initial_window_size)])
 
         if (run_time := self.cfg.run_time) is not None:


### PR DESCRIPTION
Fixed a problem that occurred in client backpressure benchmarks.

When the benchmark was of client backpressure type, the code was checking the `client` config for the `read_window_size` metric and not the `client_bp` config. Thus it was erroring out as client does not have a read window size.


### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No, Bug fix.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
