### PR TITLE
Add DEVELOPMENT.md doc

### DIFF
--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -124,9 +124,9 @@ the Mountpoint team works with an internal fork of the repository.
 
 Many team members are using [Visual Studio Code](https://code.visualstudio.com/) to work with the project.
 
-The project contains a `Makefile` which provides quick ways to run common tasks
-while excluding the `fuser` crate which we don't typically aren't modifying.
-For example, `make fmt-check` and `make clippy` runs `rustfmt` and `clippy` against all but the fuser crate.
+The project contains a `Makefile` providing quick ways to run common tasks
+while excluding the `fuser` crate which is not typically being modified.
+For example, `make pre-pr-check` runs a group of commands such as `cargo fmt` while excluding the `fuser` crate.
 
 ### Running Unit Tests
 


### PR DESCRIPTION
This introduces a document describing how to get started as a contributor to Mountpoint. This partially replaces existing internal documentation that we have.

By moving it into the repository, it is:

- In an expected location
- Available to internal and external contributors alike
- Available for both developers but also AI agents should a developer want to make use of AI tooling

### Does this change impact existing behavior?

No, project docs change only.

### Does this change need a changelog entry? Does it require a version change?

No, docs change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
