### PR TITLE
Add requester process' PID to file system logs

### DIFF
--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add `S3FilesystemConfig::content_type_detection` option to configure automatic content type inference for new uploads. When set to `ContentTypeDetection::Auto`, Mountpoint will infer the `Content-Type` of new objects based on their file extension. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
-* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. Some FUSE operations have a new log printed where it didn't already have one. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
+* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. Some FUSE operations have a new log printed where they didn't already have one. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
 
 ## v0.9.3 (April 28, 2026)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add `S3FilesystemConfig::content_type_detection` option to configure automatic content type inference for new uploads. When set to `ContentTypeDetection::Auto`, Mountpoint will infer the `Content-Type` of new objects based on their file extension. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
+* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. Some FUSE operations have a new log printed where it didn't already have one. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
 
 ## v0.9.3 (April 28, 2026)
 

--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 use time::OffsetDateTime;
-use tracing::{Instrument, field, instrument, debug};
+use tracing::{Instrument, debug, field, instrument};
 
 use crate::fs::{
     DirectoryEntry, DirectoryReplier, InodeNo, S3Filesystem, ToErrno, error_metadata::MOUNTPOINT_EVENT_READY,

--- a/mountpoint-s3-fuser/src/ll/request.rs
+++ b/mountpoint-s3-fuser/src/ll/request.rs
@@ -2133,19 +2133,19 @@ impl<'a> AnyRequest<'a> {
     }
 }
 
-impl Display for AnyRequest<'_> {
+impl fmt::Display for AnyRequest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(op) = self.operation() {
             write!(
                 f,
-                "FUSE({:3}) ino {:#018x} {} pid={}",
-                self.header.unique, self.header.nodeid, op, self.header.pid
+                "FUSE({:3}) ino {:#018x} {}",
+                self.header.unique, self.header.nodeid, op
             )
         } else {
             write!(
                 f,
-                "FUSE({:3}) ino {:#018x} pid={}",
-                self.header.unique, self.header.nodeid, self.header.pid
+                "FUSE({:3}) ino {:#018x}",
+                self.header.unique, self.header.nodeid
             )
         }
     }

--- a/mountpoint-s3-fuser/src/ll/request.rs
+++ b/mountpoint-s3-fuser/src/ll/request.rs
@@ -2133,19 +2133,19 @@ impl<'a> AnyRequest<'a> {
     }
 }
 
-impl fmt::Display for AnyRequest<'_> {
+impl Display for AnyRequest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(op) = self.operation() {
             write!(
                 f,
-                "FUSE({:3}) ino {:#018x} {}",
-                self.header.unique, self.header.nodeid, op
+                "FUSE({:3}) ino {:#018x} {} pid={}",
+                self.header.unique, self.header.nodeid, op, self.header.pid
             )
         } else {
             write!(
                 f,
-                "FUSE({:3}) ino {:#018x}",
-                self.header.unique, self.header.nodeid
+                "FUSE({:3}) ino {:#018x} pid={}",
+                self.header.unique, self.header.nodeid, self.header.pid
             )
         }
     }

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add support for automatic content type detection on file uploads. When the `--infer-content-type` flag is specified, Mountpoint will infer the `Content-Type` of new objects based on their file extension instead of using the default `binary/octet-stream`. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
+* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
 
 ## v1.22.3 (April 28, 2026)
 


### PR DESCRIPTION
Add requester's PID to Filesystem logs.
It also adds an entry point "New request" log to all the (supported) filesystem methods as a proxy for tracking incoming requests at FUSER.

This makes it easier to trace requests dispatched to Mountpoint, especially during workflows using multiple customer processes to make requests concurrently for the same inode(s). 

Additionally, the commit adds/re-orders some other fields in the logs (for a few FS methods) to reattain a consistent order of logging request parameters.

Sample log:
```
2025-12-04T14:56:23.330127Z DEBUG ThreadId(11) lookup{req=3 ino=1 name="._." pid=1860}:head_object{id=3 bucket="multinictesting-iad-benchmarksetupbucket07d0221d-jc1kskgzz2gx" key="._."}: mountpoint_s3_client::s3_crt_client::head_object: new request
```

The commit also does some minor refactoring to name unused method parameters more consistent and adhering to Rust guidelines.

### Does this change impact existing behavior?
No, only (warn-level and higher) logging change.
No breaking changes.

### Does this change need a changelog entry? Does it require a version change?
No, and no.
Logging change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
