### PR TITLE
Fix workflow permissions to publish benchmark results

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write # required to push to gh-pages
         
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write # required to push to gh-pages
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
The changes in #1695 resulted in benchmark actions on push to main to fail when trying to publish results. This change will allow benchmark workflows to write to github pages by fixing their permissions. 

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
