### PR TITLE
Fix workflow-complete jobs for GitHub workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -449,6 +449,7 @@ jobs:
   workflow-complete:
     name: "Integration Tests Complete"
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - fs-test
       - client-test
@@ -457,4 +458,5 @@ jobs:
       - metrics
       - test-rpm
     steps:
-      - run: echo "Workflow complete"
+      - name: Verify jobs succeeded
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,6 +384,7 @@ jobs:
   workflow-complete:
     name: "Tests Workflow Complete"
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - test
       - doc-tests
@@ -399,4 +400,5 @@ jobs:
       - package-script-checks
       - docker
     steps:
-      - run: echo "Workflow complete"
+      - name: Verify jobs succeeded
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
Updates jobs to always run and then fail, rather than be skipped when needed jobs fail.
This will allow GitHub to correctly block when tests fail.

`needs` JSON context: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#needs-context

Equivalent CSI driver PR: https://github.com/awslabs/mountpoint-s3-csi-driver/pull/661

### Does this change impact existing behavior?

CI change only.

### Does this change need a changelog entry? Does it require a version change?

No, CI change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
