### PR TITLE
Fix benchmarks not running on PRs

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write # required by bench.yml and bench_s3express.yml even if we don't actually publish the results to gh-pages for PRs
 
 jobs:
   integration:


### PR DESCRIPTION
Address an issue introduced in #1722 where benchmark workflows would not run on PRs (enabled when setting the "performance" label).

### Does this change impact existing behavior?

No, CI only.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
