### PR TITLE
Fix internal failure on atomic upload

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -435,8 +435,10 @@ pub fn countdown_failure_client<Client: ObjectClient>(
                 },
                 result_fn: |state| {
                     state.count += 1;
-                    if state.count >= state.fail_count {
-                        Err(state.error.take().unwrap())
+                    if state.count >= state.fail_count
+                        && let Some(error) = state.error.take()
+                    {
+                        Err(error)
                     } else {
                         Ok(())
                     }


### PR DESCRIPTION
Improve handling of errors on `CreateMultiPartUpload` in the atomic upload code path. Similarly to the change in #1728, the issue only manifests when attempting to further write or complete an upload after an error and it does not affect Mountpoint file system users, since that's already prevented at that level.

### Does this change impact existing behavior?

No, user-visible behavior not impacted.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
