### PR TITLE
Fix dependencies for analyzing results from benchmarks

### DIFF
--- a/benchmark/pyproject.toml
+++ b/benchmark/pyproject.toml
@@ -12,8 +12,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest",
-]
-analysis = [
     "omegaconf",
     "tabulate",
 ]

--- a/benchmark/pyproject.toml
+++ b/benchmark/pyproject.toml
@@ -13,3 +13,7 @@ dependencies = [
 dev = [
     "pytest",
 ]
+analysis = [
+    "omegaconf",
+    "tabulate",
+]


### PR DESCRIPTION

**What changed and why?**

Added analysis dependency group to pyproject.toml containing omegaconf and tabulate packages required by the autogroup.py script for processing benchmark results.

### Does this change impact existing behavior?

No 

### Does this change need a changelog entry? Does it require a version change?

No 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
