### PR TITLE
Udpate docs with cache metrics for OTLP export

### DIFF
--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -94,6 +94,10 @@ Mountpoint emits the following metrics:
 | `s3.request_errors` | Counter | `s3_request` (GetObject, PutObject, etc.)<br>`http_status` (403, 404, etc.) | Number of S3 request errors |
 | `s3.request_first_byte_latency` | Histogram | `s3_request` (GetObject, PutObject, etc.) | Time from initiation of an S3 request until the first byte is received |
 | `s3.request_total_latency` | Histogram | `s3_request` (GetObject, PutObject, etc.) | Time from initiation of an S3 request until the response is received |
+| `experimental.cache.evict_latency` | Histogram | `cache` | Time to evict data from [data cache](CONFIGURATION.md#data-cache) |
+| `experimental.cache.get_latency` | Histogram | `cache` | Time to retrieve from [data cache](CONFIGURATION.md#data-cache) |
+| `experimental.cache.put_latency` | Histogram | `cache` | Time to store in [date cache](CONFIGURATION.md#data-cache) |
+| `experimental.fuse.cache_hit` | Counter | | Number of FUSE requests fully served from [data cache](CONFIGURATION.md#data-cache)<br> (Prefetched data served from memory or partial cache hits are not included in this metric) |
 | `experimental.fuse.idle_threads` | Histogram | | FUSE worker threads waiting for new requests |
 | `experimental.fuse.total_threads` | Gauge | | Total number of FUSE worker threads spawned |
 | `experimental.prefetch.reset_state` | Counter | | Times Mountpoint discarded prefetched data due to access patterns |


### PR DESCRIPTION
Updates documentation with new cache metrics available for OTLP export

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
