### PR TITLE
Ignore bincode's unmaintained status temporarily

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,3 +21,6 @@ license-files = [
 
 [advisories]
 yanked = "warn"
+ignore = [
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained (https://rustsec.org/advisories/RUSTSEC-2025-0141). Ignore unmaintained warning until we remove the dependency." },
+]


### PR DESCRIPTION
Until we migrate away from bincode, ignore the [unmaintained status](https://rustsec.org/advisories/RUSTSEC-2025-0141) to unblock the builds

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
