### PR TITLE
Add `max_background` setting to `S3FilesystemConfig`

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -106,6 +106,7 @@ impl ConfigOptions {
     fn build_filesystem_config(&self) -> Result<S3FilesystemConfig> {
         let mut fs_config = S3FilesystemConfig {
             cache_config: CacheConfig::new(mountpoint_s3_fs::fs::TimeToLive::Indefinite),
+            max_background_fuse_requests: self.max_background_fuse_requests,
             ..Default::default()
         };
 
@@ -124,9 +125,6 @@ impl ConfigOptions {
         }
         if let Some(memory_limit_bytes) = self.memory_limit_bytes {
             fs_config.mem_limit = memory_limit_bytes;
-        }
-        if let Some(max_background_fuse_requests) = self.max_background_fuse_requests {
-            fs_config.max_background_fuse_requests = max_background_fuse_requests;
         }
         // For this binary we expect sequential read pattern. Thus, opt-out from the 1MB-initial request,
         // trading-off latency for throughput and more accurate memory limiting.


### PR DESCRIPTION
Add `max_background` setting to `S3FilesystemConfig`.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Yes, new version of `mountpoint-s3-fs`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
