### PR TITLE
Update semantics documentation to describe changes as part of the open-after-close fix

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -230,7 +230,7 @@ Changing last access and modification times (`utime`) is supported only on files
 
 Mountpoint allows a file to have multiple concurrent readers _or_ a single writer. The reference to a file reader/writer can be duplicated by the user (e.g. using `dup()`, `fork()`, as seen in tools like `dd` and `touch`, or in shell redirection), resulting in multiple references pointing to the same file handle in Mountpoint.
 
-A `close` request for a writer generally completes the upload of the object and reports an error if not successful. If a new `open` request is made for the file afterwards, it will succeed following semantics mentioned [here](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#file-operations#open)
+A `close` request for a writer generally completes the upload of the object and reports an error if not successful. If a new `open` request is made for the file afterwards, it will succeed following semantics mentioned [here](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#open).
 
 However, if the file is empty, or if `close` is invoked by a different process than the one that originally opened it, 
 `close` returns immediately and the upload is only completed asynchronously _after_ the last reference to the file is closed.
@@ -245,9 +245,9 @@ An `open` for writing request made for a file once _all_ its existing readers ar
 
 However, a `read` to a duplicate reference after the original `close`, but __before__ a new `open`, will succeed, marking the reader as still active. `open` requests for another reader will succeed, but `open` requests for a writer will return an `EPERM` error since the file is already being read.
 
-[!WARNING]
-In releases up to `v1.21.0`, an `open` for writing request made for a file immediately after a `close` could occasionally fail unexpectedly, because Mountpoint would try to process the `open` before completing an asynchronous upload for the writer or recording that the last reference to a reader had been closed.
-See Github issues [#1344](https://github.com/awslabs/mountpoint-s3/issues/1344) and [#1327](https://github.com/awslabs/mountpoint-s3/issues/1327).
+> [!WARNING]
+> In releases up to `v1.21.0`, an `open` for writing request made immediately after a `close` could occasionally fail unexpectedly, because Mountpoint would try to process the `open` before completing an asynchronous upload for the writer or recording that the last reference to a reader had been closed.
+> See GitHub issues [#1344](https://github.com/awslabs/mountpoint-s3/issues/1344) and [#1327](https://github.com/awslabs/mountpoint-s3/issues/1327).
 
 #### Deletes
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-* Address an issue where opening a file for reading/writing immediately after the file had been closed would occasionally fail. Since this release, opening a new file handle after close will succeed and trigger the completion of deferred uploads if required. As a consequence, duplicate references to the closed file handle will become invalid and read or write operations on them will fail. See [this section in the semantics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#close-and-re-open) for details. ([#1704](https://github.com/awslabs/mountpoint-s3/pull/1704))
+* Address an issue where opening a file for reading/writing immediately after the file had been closed would occasionally fail. Since this release, opening a new file handle after close will succeed and trigger the completion of a deferred upload if required. As a consequence, duplicate references to the closed file handle will become invalid and read or write operations on them will fail. See [this section in the semantics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#close-and-re-open) for details. ([#1704](https://github.com/awslabs/mountpoint-s3/pull/1704))
 
 ### Other changes
 


### PR DESCRIPTION
Update semantics documentation to describe changes done as part of the open-after-close fix in [PR #1704](https://github.com/awslabs/mountpoint-s3/pull/1704)

Updates done to `doc/SEMANTICS.md` documentation and some more details added in`mountpoint-s3/CHANGELOG.md`.

### Does this change impact existing behavior?

No, documentation update only.

### Does this change need a changelog entry? Does it require a version change?

No, documentation update only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
