### PR TITLE
Fix TypeError in autogroup.py by handling None values before float conversion in sort key

### DIFF
--- a/benchmark/analysis-scripts/autogroup.py
+++ b/benchmark/analysis-scripts/autogroup.py
@@ -244,13 +244,14 @@ def main() -> None:
                 # Use custom ordering for benchmark type
                 key_parts.append(benchmark_type_sort_key(value))
             else:
-                # For other columns, sort alphabetically/numerically
-                try:
-                    # Try to convert to float for numeric sorting
-                    key_parts.append(float(value))
-                except (ValueError, TypeError):
-                    # If not numeric, sort as string
-                    key_parts.append(str(value))
+                # Handle None/null values before trying float conversion
+                if value == "None" or value == "null" or value is None:
+                    key_parts.append(-1)  # Sort nulls first
+                else:
+                    try:
+                        key_parts.append(float(value))
+                    except (ValueError, TypeError):
+                        key_parts.append(str(value))
         return key_parts
 
     aggregated_rows.sort(key=sort_key)


### PR DESCRIPTION
Fix TypeError in autogroup.py by handling None values before float conversion in sort key


**What changed and why?**
The `autogroup.py` script was crashing with `TypeError: '<' not supported between instances of 'float' and 'str'` when sorting benchmark results that contained null values (e.g., `backpressure_window_size` is null for FIO benchmarks but numeric for client_bp benchmarks).

The fix adds a null check before attempting float conversion in the `sort_key` function. Null values are now converted to `-1` to ensure all sort keys are numeric and comparable, preventing the TypeError while maintaining consistent sorting behavior (nulls sort first).


### Does this change impact existing behavior?

No
### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
