### PR TITLE
s3io_benchmark: Add peak memory reporting

### DIFF
--- a/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
@@ -27,6 +27,9 @@ pub struct GlobalConfig {
     pub sse: Option<SseType>,
     pub sse_kms_key_id: Option<String>,
     pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// Memory monitoring polling interval. Default: 100ms.
+    #[serde(default, with = "humantime_serde")]
+    pub memory_monitor_interval: Option<Duration>,
 
     // === Job defaults (optional, overridable per job) ===
     #[serde(flatten)]

--- a/mountpoint-s3-fs/examples/s3io_benchmark/monitoring.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/monitoring.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
+
+/// Memory monitor that tracks peak RSS usage
+/// Adapted from metrics.rs
+#[derive(Default)]
+pub struct MemoryMonitor {
+    peak_memory: Arc<AtomicU64>,
+    monitor_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl MemoryMonitor {
+    pub fn start(&mut self, interval: Option<Duration>) {
+        let peak_memory = Arc::clone(&self.peak_memory);
+        let interval = interval.unwrap_or(Duration::from_millis(100));
+        let handle = tokio::spawn(async move {
+            monitor_memory_loop(peak_memory, interval).await;
+        });
+        self.monitor_handle = Some(handle);
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(handle) = self.monitor_handle.take() {
+            handle.abort();
+        }
+
+        // Poll memory one final time
+        let mut sys = System::new();
+        if let Ok(pid) = get_current_pid() {
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                false,
+                ProcessRefreshKind::nothing().with_memory(),
+            );
+            if let Some(process) = sys.process(pid) {
+                let current_memory = process.memory();
+                self.peak_memory.fetch_max(current_memory, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Get the peak memory usage in MiB
+    pub fn peak_memory_mib(&self) -> f64 {
+        let peak_bytes = self.peak_memory.load(Ordering::Relaxed);
+        peak_bytes as f64 / (1024.0 * 1024.0)
+    }
+}
+
+/// Monitor memory usage and track peak RSS
+async fn monitor_memory_loop(peak_memory: Arc<AtomicU64>, interval: Duration) {
+    let mut sys = System::new();
+    let pid = get_current_pid().expect("Failed to get current PID");
+
+    loop {
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_memory(),
+        );
+
+        if let Some(process) = sys.process(pid) {
+            let current_memory = process.memory();
+            peak_memory.fetch_max(current_memory, Ordering::Relaxed);
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+}

--- a/mountpoint-s3-fs/examples/s3io_benchmark/results.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/results.rs
@@ -43,10 +43,11 @@ pub struct SummaryResult {
     #[serde_as(as = "DurationSecondsWithFrac<f64>")]
     pub total_elapsed_seconds: Duration,
     pub total_errors: usize,
+    pub peak_memory_mib: f64,
 }
 
 impl BenchmarkResults {
-    pub fn aggregate(results: Vec<JobResult>) -> Self {
+    pub fn aggregate(results: Vec<JobResult>, peak_memory_mib: f64) -> Self {
         let total_bytes: u64 = results.iter().map(|r| r.total_bytes).sum();
         let total_elapsed_seconds = results
             .iter()
@@ -61,6 +62,7 @@ impl BenchmarkResults {
                 total_bytes,
                 total_elapsed_seconds,
                 total_errors,
+                peak_memory_mib,
             },
         }
     }


### PR DESCRIPTION
**What changed and why?** Need to track peak memory usage for `s3io_benchmark.rs`

- Created memory tracker (adapted from `metrics.rs`)
- Set default polling interval to 100ms.

### Does this change impact existing behavior?

N/A - benchmark only

### Does this change need a changelog entry? Does it require a version change?

N/A - benchmark only

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
