### PR TITLE
Remove last usages of forbidden CI bucket

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,8 +23,6 @@ env:
   S3_EXPRESS_ONE_ZONE_ENDPOINT_URL: ${{ vars.S3_EXPRESS_ONE_ZONE_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_REGION }}
   S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_TEST_PREFIX || 'github-actions-tmp/' }}run-${{ github.run_id }}/attempt-${{ github.run_attempt }}/
-  # A bucket our IAM role has no access to, but is in the right region, for permissions tests
-  S3_FORBIDDEN_BUCKET_NAME: ${{ vars.S3_FORBIDDEN_BUCKET_NAME }}
   # An IAM role that tests can assume when they want to create session policies
   S3_SUBSESSION_IAM_ROLE: ${{ vars.S3_SUBSESSION_IAM_ROLE }}
   # Different Access Points Aliases and ARNs

--- a/mountpoint-s3-fs/tests/common/s3.rs
+++ b/mountpoint-s3-fs/tests/common/s3.rs
@@ -51,10 +51,6 @@ pub fn get_standard_bucket() -> String {
     std::env::var("S3_BUCKET_NAME").expect("Set S3_BUCKET_NAME to run integration tests")
 }
 
-pub fn get_test_bucket_forbidden() -> String {
-    std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
-}
-
 /// An S3 Express bucket with SSE-KMS set as a default encryption with a key matching the `KMS_TEST_KEY_ID`
 #[cfg(feature = "s3express_tests")]
 pub fn get_express_sse_kms_bucket() -> String {

--- a/mountpoint-s3/tests/common/creds.rs
+++ b/mountpoint-s3/tests/common/creds.rs
@@ -1,10 +1,7 @@
 use aws_credential_types::Credentials;
 
-#[cfg(not(feature = "s3express_tests"))]
 use crate::common::s3::get_test_region;
-#[cfg(not(feature = "s3express_tests"))]
 use aws_config::{Region, sts::AssumeRoleProvider};
-#[cfg(not(feature = "s3express_tests"))]
 use aws_credential_types::provider::ProvideCredentials;
 
 /// Detect if running on GitHub Actions (GHA) and if so,
@@ -50,7 +47,6 @@ pub fn get_subsession_iam_role() -> String {
 /// See the [session policies section of the AWS IAM User Guide][session_policies] for more detail.
 ///
 /// [session_policies]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session
-#[cfg(not(feature = "s3express_tests"))]
 pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> Credentials {
     let provider = AssumeRoleProvider::builder(get_subsession_iam_role())
         .region(Region::new(get_test_region()))
@@ -64,4 +60,23 @@ pub async fn get_scoped_down_credentials<Policy: AsRef<str>>(policy: Policy) -> 
         .expect("default chain credentials should be available");
     mask_aws_creds_if_on_gha(&credentials);
     credentials
+}
+
+/// Assume a set of Rust SDK [Credentials] that has no S3 permissions.
+///
+/// Uses a deny-all IAM policy to ensure all S3 actions (including `s3express:CreateSession`) are denied.
+pub async fn get_credentials_no_permissions() -> Credentials {
+    let policy = r#"{"Statement": [
+        { "Effect": "Deny", "Action": ["*"], "Resource": "*" }
+    ]}"#;
+    get_scoped_down_credentials(policy).await
+}
+
+/// Setup environment variables on the command to use the specified AWS credentials
+pub fn apply_creds_to_command(cmd: &mut std::process::Command, creds: &Credentials) {
+    cmd.env("AWS_ACCESS_KEY_ID", creds.access_key_id());
+    cmd.env("AWS_SECRET_ACCESS_KEY", creds.secret_access_key());
+    if let Some(token) = creds.session_token() {
+        cmd.env("AWS_SESSION_TOKEN", token);
+    }
 }

--- a/mountpoint-s3/tests/common/s3.rs
+++ b/mountpoint-s3/tests/common/s3.rs
@@ -19,10 +19,6 @@ pub fn get_express_bucket() -> String {
         .expect("Set S3_EXPRESS_ONE_ZONE_BUCKET_NAME to run integration tests")
 }
 
-pub fn get_test_bucket_forbidden() -> String {
-    std::env::var("S3_FORBIDDEN_BUCKET_NAME").expect("Set S3_FORBIDDEN_BUCKET_NAME to run integration tests")
-}
-
 #[cfg(not(feature = "s3express_tests"))]
 pub fn get_test_kms_key_id() -> String {
     std::env::var("KMS_TEST_KEY_ID").expect("Set KMS_TEST_KEY_ID to run integration tests")

--- a/mountpoint-s3/tests/fork_test.rs
+++ b/mountpoint-s3/tests/fork_test.rs
@@ -21,15 +21,18 @@ use test_case::test_case;
 
 mod common;
 
-use common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
+#[cfg(not(feature = "s3express_tests"))]
+use common::creds::get_scoped_down_credentials;
+use common::creds::{
+    apply_creds_to_command, get_credentials_no_permissions, get_sdk_default_chain_creds, get_subsession_iam_role,
+};
 use common::fuse::{mount_for_passing_fuse_fd, read_dir_to_entry_names};
 use common::s3::{
-    create_objects, get_test_bucket_and_prefix, get_test_bucket_forbidden, get_test_endpoint_url, get_test_region,
-    get_test_sdk_client,
+    create_objects, get_test_bucket_and_prefix, get_test_endpoint_url, get_test_region, get_test_sdk_client,
 };
-use common::tokio_block_on;
 #[cfg(not(feature = "s3express_tests"))]
-use common::{creds::get_scoped_down_credentials, s3::get_non_test_region, s3::get_test_kms_key_id};
+use common::s3::{get_non_test_region, get_test_kms_key_id};
+use common::tokio_block_on;
 
 const MOUNT_OPTION_READ_ONLY: &str = "--read-only";
 const MOUNT_OPTION_AUTO_UNMOUNT: &str = "--auto-unmount";
@@ -263,10 +266,12 @@ fn run_in_foreground_with_passed_fuse_fd() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 fn run_in_background_with_passed_fuse_fd_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
-    // the mount would fail from error 403 on HeadBucket
-    let bucket = get_test_bucket_forbidden();
+    let (bucket, prefix) = get_test_bucket_and_prefix("run_in_background_with_passed_fuse_fd_fail_on_mount");
     let mount_point = assert_fs::TempDir::new()?;
     let region = get_test_region();
+
+    // Get credentials with no S3 permissions to trigger 403 on initial ListObjectsV2
+    let credentials = tokio_block_on(get_credentials_no_permissions());
 
     let (fd, mount) = mount_for_passing_fuse_fd(
         mount_point.path(),
@@ -274,10 +279,11 @@ fn run_in_background_with_passed_fuse_fd_fail_on_mount() -> Result<(), Box<dyn s
     );
 
     let mut cmd = Command::new(cargo::cargo_bin!("mount-s3"));
-    let cmd = cmd
-        .arg(&bucket)
+    cmd.arg(&bucket)
         .arg(format!("/dev/fd/{}", fd.as_raw_fd()))
+        .arg(format!("--prefix={prefix}"))
         .arg(format!("--region={region}"));
+    apply_creds_to_command(&mut cmd, &credentials);
     if let Some(endpoint_url) = get_test_endpoint_url() {
         cmd.arg(format!("--endpoint-url={endpoint_url}"));
     }
@@ -298,16 +304,22 @@ fn run_in_background_with_passed_fuse_fd_fail_on_mount() -> Result<(), Box<dyn s
 
 #[test]
 fn run_in_background_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
-    // the mount would fail from error 403 on HeadBucket
-    let bucket = get_test_bucket_forbidden();
+    let (bucket, prefix) = get_test_bucket_and_prefix("run_in_background_fail_on_mount");
     let mount_point = assert_fs::TempDir::new()?;
     let region = get_test_region();
 
+    // Get credentials with no S3 permissions to trigger 403 on initial ListObjectsV2
+    let credentials = tokio_block_on(get_credentials_no_permissions());
+
     let mut cmd = Command::new(cargo::cargo_bin!("mount-s3"));
-    cmd.arg(&bucket).arg(mount_point.path()).arg("--auto-unmount");
+    cmd.arg(&bucket)
+        .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
+        .arg("--auto-unmount")
+        .arg(format!("--region={region}"));
+    apply_creds_to_command(&mut cmd, &credentials);
     if let Some(endpoint_url) = get_test_endpoint_url() {
         cmd.arg(format!("--endpoint-url={endpoint_url}"));
-        cmd.arg(format!("--region={region}"));
     }
 
     let child = cmd.spawn().expect("unable to spawn child");
@@ -322,17 +334,21 @@ fn run_in_background_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn run_in_foreground_fail_on_mount() -> Result<(), Box<dyn std::error::Error>> {
-    // the mount would fail from error 403 on HeadBucket
-    let bucket = get_test_bucket_forbidden();
+    let (bucket, prefix) = get_test_bucket_and_prefix("run_in_foreground_fail_on_mount");
     let mount_point = assert_fs::TempDir::new()?;
     let region = get_test_region();
+
+    // Get credentials with no S3 permissions to trigger 403 on ListObjectsV2
+    let credentials = tokio_block_on(get_credentials_no_permissions());
 
     let mut cmd = Command::new(cargo::cargo_bin!("mount-s3"));
     cmd.arg(&bucket)
         .arg(mount_point.path())
+        .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
         .arg("--foreground")
         .arg(format!("--region={region}"));
+    apply_creds_to_command(&mut cmd, &credentials);
     if let Some(endpoint_url) = get_test_endpoint_url() {
         cmd.arg(format!("--endpoint-url={endpoint_url}"));
     }
@@ -662,12 +678,8 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
         .arg(mount_point.path())
         .arg(format!("--prefix={prefix}"))
         .arg("--auto-unmount")
-        .arg(format!("--region={region}"))
-        .env("AWS_ACCESS_KEY_ID", credentials.access_key_id())
-        .env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
-    if let Some(token) = credentials.session_token() {
-        cmd.env("AWS_SESSION_TOKEN", token);
-    }
+        .arg(format!("--region={region}"));
+    apply_creds_to_command(&mut cmd, &credentials);
     if let Some(endpoint_url) = get_test_endpoint_url() {
         cmd.arg(format!("--endpoint-url={endpoint_url}"));
     }
@@ -685,12 +697,8 @@ fn mount_scoped_credentials() -> Result<(), Box<dyn std::error::Error>> {
         .arg(mount_point.path())
         .arg(format!("--prefix={subprefix}"))
         .arg("--auto-unmount")
-        .arg(format!("--region={region}"))
-        .env("AWS_ACCESS_KEY_ID", credentials.access_key_id())
-        .env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
-    if let Some(token) = credentials.session_token() {
-        cmd.env("AWS_SESSION_TOKEN", token);
-    }
+        .arg(format!("--region={region}"));
+    apply_creds_to_command(&mut cmd, &credentials);
     let child = cmd.spawn().expect("unable to spawn child");
 
     let exit_status = wait_for_exit(child);
@@ -726,11 +734,7 @@ fn mount_with_sse(
         .arg("--auto-unmount")
         .arg("--foreground");
     if let Some(credentials) = credentials {
-        cmd.env("AWS_ACCESS_KEY_ID", credentials.access_key_id())
-            .env("AWS_SECRET_ACCESS_KEY", credentials.secret_access_key());
-        if let Some(token) = credentials.session_token() {
-            cmd.env("AWS_SESSION_TOKEN", token);
-        }
+        apply_creds_to_command(&mut cmd, &credentials);
     }
     if let Some(endpoint_url) = get_test_endpoint_url() {
         cmd.arg(format!("--endpoint-url={endpoint_url}"));


### PR DESCRIPTION
This change removes the last of the 'forbidden bucket' test dependencies. The tests were previously dependent on a bucket with a policy banning almost all S3 operations. Instead, we now use session policies to restrict access on a per-test basis.

### Does this change impact existing behavior?

Test change only. Removes the need to supply a forbidden bucket for tests.

### Does this change need a changelog entry? Does it require a version change?

No, test change only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
