### PR TITLE
fix: Use cgroup-aware memory detection in mem limiter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,6 +384,55 @@ jobs:
           push: false
           file: docker/Dockerfile.source
 
+  cgroup-mem-limit:
+    name: Cgroup memory limit detection
+    runs-on: ubuntu-22.04
+
+    container:
+      image: ubuntu:22.04
+      options: >-
+        --memory=2g
+        --memory-swap=2g
+
+    steps:
+    - name: Install prerequisites for container
+      run: |
+        apt-get update
+        apt-get install -y git curl g++
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        submodules: true
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        fuseVersion: 2
+        run-as-root: true
+    - name: Set up Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+    - name: Cargo cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Verify cgroup limit is visible
+      run: |
+        echo "=== cgroup v2 ==="
+        cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "not found"
+        echo "=== cgroup v1 ==="
+        cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "not found"
+    - name: Run cgroup-aware memory detection test
+      env:
+        TEST_CGROUP_MEM_LIMIT_MB: "2048"
+      run: cargo test -p mountpoint-s3-fs --lib mem_limiter::tests::test_effective_total_memory_respects_cgroup
+
   workflow-complete:
     name: "Tests Workflow Complete"
     runs-on: ubuntu-latest
@@ -402,6 +451,7 @@ jobs:
       - benchmark-script-checks
       - package-script-checks
       - docker
+      - cgroup-mem-limit
     steps:
       - name: Verify jobs succeeded
         run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,6 @@ dependencies = [
  "serde",
  "serde_json",
  "syscalls",
- "sysinfo",
  "tempfile",
  "test-case",
  "tokio",

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Update to latest S3 client. ([#1793](https://github.com/awslabs/mountpoint-s3/pull/1793))
 
 ## v0.9.2 (March 20, 2026)

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -12,12 +12,11 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::Runtime;
-use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
+use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use serde_json::{json, to_writer};
-use sysinfo::{RefreshKind, System};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -127,9 +126,8 @@ impl CliArgs {
         if let Some(target) = self.max_memory_target {
             target * 1024 * 1024
         } else {
-            // Default to 95% of total system memory
-            let sys = System::new_with_specifics(RefreshKind::everything());
-            (sys.total_memory() as f64 * 0.95) as u64
+            // Default to 95% of total system memory (cgroup-aware)
+            (effective_total_memory() as f64 * 0.95) as u64
         }
     }
 

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
+use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{Prefetcher, PrefetcherConfig};
@@ -46,11 +46,9 @@ impl Executor {
         let read_part_size = global.read_part_size.unwrap_or(8 * 1024 * 1024);
         let write_part_size = global.write_part_size.unwrap_or(8 * 1024 * 1024);
 
-        let max_memory_target = global.max_memory_target.unwrap_or_else(|| {
-            use sysinfo::{RefreshKind, System};
-            let sys = System::new_with_specifics(RefreshKind::everything());
-            ((sys.total_memory() as f64 * 0.95) / (1024.0 * 1024.0)) as usize
-        });
+        let max_memory_target = global
+            .max_memory_target
+            .unwrap_or_else(|| ((effective_total_memory() as f64 * 0.95) / (1024.0 * 1024.0)) as usize);
 
         let bind = global.bind.clone().unwrap_or_default();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -5,11 +5,10 @@ use clap::Parser;
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, RustLogAdapter, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::ChecksumAlgorithm;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
+use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
-use sysinfo::{RefreshKind, System};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -111,9 +110,8 @@ fn main() {
         let max_memory_target = if let Some(target) = args.max_memory_target {
             target * 1024 * 1024
         } else {
-            // Default to 95% of total system memory
-            let sys = System::new_with_specifics(RefreshKind::everything());
-            (sys.total_memory() as f64 * 0.95) as u64
+            // Default to 95% of total system memory (cgroup-aware)
+            (effective_total_memory() as f64 * 0.95) as u64
         };
         let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), max_memory_target));
 

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -2,6 +2,7 @@ use std::{sync::atomic::Ordering, time::Instant};
 
 use humansize::make_format;
 use metrics::atomics::AtomicU64;
+use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
@@ -154,5 +155,62 @@ impl MemoryLimiter {
         // * PutObject (multi-part uploads),
         // * Other (currently not used).
         (self.pool.reserved_bytes(BufferKind::PutObject) + self.pool.reserved_bytes(BufferKind::Other)) as u64
+    }
+}
+
+/// Returns the effective total memory available to this process in bytes.
+///
+/// On Linux, this respects cgroup memory limits when set.
+/// On other platforms, returns the total physical memory.
+pub fn effective_total_memory() -> u64 {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    sys.cgroup_limits()
+        .map(|cg| cg.total_memory)
+        .unwrap_or_else(|| sys.total_memory())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When the `TEST_CGROUP_MEM_LIMIT_MB` environment variable is set (e.g. in a
+    /// container started with `--memory=4g`), verify that [effective_total_memory]
+    /// returns a value equal to the cgroup limit rather than the host's total RAM.
+    ///
+    /// This test is run by the `cgroup-mem-limit` CI job (see `.github/workflows/tests.yml`)
+    /// inside a memory-limited container. Outside that job the env var is unset and the
+    /// test is skipped.
+    #[test]
+    fn test_effective_total_memory_respects_cgroup() {
+        let Ok(expected_str) = std::env::var("TEST_CGROUP_MEM_LIMIT_MB") else {
+            // Nothing to check outside the dedicated CI container job.
+            return;
+        };
+        let expected_bytes: u64 = expected_str.parse::<u64>().expect("invalid TEST_CGROUP_MEM_LIMIT_MB") * 1024 * 1024;
+        let mem = effective_total_memory();
+        assert_eq!(
+            mem, expected_bytes,
+            "effective_total_memory() returned {mem} bytes, expected exactly {expected_bytes} bytes (cgroup limit). \
+             The function may not be reading the cgroup memory constraint.",
+        );
+    }
+
+    /// When no cgroup memory limit is active, [effective_total_memory] should
+    /// fall back to the total physical memory reported by the system.
+    #[test]
+    fn test_effective_total_memory_falls_back_to_system_memory() {
+        let mut sys = System::new();
+        sys.refresh_memory();
+        if sys.cgroup_limits().is_some() {
+            // A cgroup limit is active on this machine — the fallback path
+            // won't be exercised, so there's nothing to assert here.
+            return;
+        }
+        assert_eq!(
+            effective_total_memory(),
+            sys.total_memory(),
+            "without a cgroup limit, effective_total_memory() should equal total physical memory",
+        );
     }
 }

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
+
 ## v1.22.3 (April 28, 2026)
 
 * Improve error message when S3 Express session creation fails. ([#1793](https://github.com/awslabs/mountpoint-s3/pull/1793))

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -19,7 +19,6 @@ owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 regex = "1.12.3"
 serde = "1.0.228"
 serde_json = "1.0.149"
-sysinfo = "0.38.3"
 tracing = "0.1.44"
 
 [dev-dependencies]

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -11,11 +11,10 @@ use mountpoint_s3_fs::data_cache::{CacheLimit, DataCacheConfig, DiskDataCacheCon
 use mountpoint_s3_fs::fs::{CacheConfig, ServerSideEncryption, TimeToLive};
 use mountpoint_s3_fs::fuse::config::{FuseOptions, FuseSessionConfig, MountPoint};
 use mountpoint_s3_fs::logging::{LoggingConfig, prepare_log_file_name};
-use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+use mountpoint_s3_fs::mem_limiter::{MINIMUM_MEM_LIMIT, effective_total_memory};
 use mountpoint_s3_fs::s3::config::{ClientConfig, PartConfig, TargetThroughputSetting};
 use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path, S3PathError, S3Personality};
 use mountpoint_s3_fs::{S3FilesystemConfig, autoconfigure, metrics};
-use sysinfo::{RefreshKind, System};
 
 use crate::build_info;
 
@@ -486,8 +485,7 @@ impl CliArgs {
     fn mem_limit(&self) -> u64 {
         let mut mem_limit = MINIMUM_MEM_LIMIT;
 
-        let sys = System::new_with_specifics(RefreshKind::everything());
-        let default_mem_target = (sys.total_memory() as f64 * 0.95) as u64;
+        let default_mem_target = (effective_total_memory() as f64 * 0.95) as u64;
         mem_limit = mem_limit.max(default_mem_target);
 
         #[cfg(feature = "mem_limiter")]


### PR DESCRIPTION
**What changed and why?** 

Replace direct `sysinfo::System::total_memory()` call with a new `effective_total_memory()` helper that respects `cgroup` memory limits. This fixes incorrect memory limit detection when running inside containers with memory constraints.

Changes:
- Add `effective_total_memory()` to `mem_limiter` that checks `sysinfo`'s `cgroup_limits()` before falling back to total physical memory
  - Library automatically handles cgroup v1 vs v2, path resolution, no limit, Linux vs non-Linux, and other edge cases: https://github.com/GuillaumeGomez/sysinfo/blob/main/src/unix/linux/cgroup.rs
- Update `cli.rs` and `benchmark` examples to use the new helper
- Add CI job to run cgroup memory detection test in a memory-limited container

### Does this change impact existing behavior?

No - it prevents potential OOM in containers with memory constraints.

### Does this change need a changelog entry? Does it require a version change?

Done.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
