### PR TITLE
Propagate file handle ID through the prefetcher as a HandleId type

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -240,7 +240,6 @@ pub struct GetObjectParams {
     pub range: Option<Range<u64>>,
     pub if_match: Option<ETag>,
     pub checksum_mode: Option<ChecksumMode>,
-    pub handle_id: Option<u64>,
 }
 
 impl GetObjectParams {
@@ -264,12 +263,6 @@ impl GetObjectParams {
     /// Set option to retrieve checksum as part of the GetObject request
     pub fn checksum_mode(mut self, value: Option<ChecksumMode>) -> Self {
         self.checksum_mode = value;
-        self
-    }
-
-    /// Set the file handle ID that originated this request
-    pub fn handle_id(mut self, value: Option<u64>) -> Self {
-        self.handle_id = value;
         self
     }
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -240,6 +240,7 @@ pub struct GetObjectParams {
     pub range: Option<Range<u64>>,
     pub if_match: Option<ETag>,
     pub checksum_mode: Option<ChecksumMode>,
+    pub handle_id: Option<u64>,
 }
 
 impl GetObjectParams {
@@ -263,6 +264,12 @@ impl GetObjectParams {
     /// Set option to retrieve checksum as part of the GetObject request
     pub fn checksum_mode(mut self, value: Option<ChecksumMode>) -> Self {
         self.checksum_mode = value;
+        self
+    }
+
+    /// Set the file handle ID that originated this request
+    pub fn handle_id(mut self, value: Option<u64>) -> Self {
+        self.handle_id = value;
         self
     }
 }

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -15,7 +15,7 @@ use mountpoint_s3_fs::Runtime;
 use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
-use mountpoint_s3_fs::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
+use mountpoint_s3_fs::prefetch::{HandleId, PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use serde_json::{json, to_writer};
 use sysinfo::{RefreshKind, System};
 use tracing_subscriber::EnvFilter;
@@ -204,10 +204,11 @@ fn main() -> anyhow::Result<()> {
         thread::scope(|scope| {
             let mut download_tasks = Vec::new();
 
-            for (object_id, size) in &object_metadata {
+            for (idx, (object_id, size)) in object_metadata.iter().enumerate() {
                 let received_bytes = received_bytes.clone();
                 let object_id = object_id.clone();
-                let request = manager.prefetch(bucket.to_string(), object_id.clone(), 0, *size);
+                let handle_id = HandleId::new(idx as u64);
+                let request = manager.prefetch(bucket.to_string(), object_id.clone(), handle_id, *size);
                 let read_size = args.read_size;
 
                 let task = scope.spawn(move || {

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -207,7 +207,7 @@ fn main() -> anyhow::Result<()> {
             for (object_id, size) in &object_metadata {
                 let received_bytes = received_bytes.clone();
                 let object_id = object_id.clone();
-                let request = manager.prefetch(bucket.to_string(), object_id.clone(), *size);
+                let request = manager.prefetch(bucket.to_string(), object_id.clone(), 0, *size);
                 let read_size = args.read_size;
 
                 let task = scope.spawn(move || {

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -38,6 +38,7 @@ pub struct Executor {
     pub client: S3CrtClient,
     pub uploader: Uploader<S3CrtClient>,
     prefetcher: Prefetcher<S3CrtClient>,
+    next_handle_id: std::sync::atomic::AtomicU64,
 }
 
 impl Executor {
@@ -118,6 +119,7 @@ impl Executor {
             client,
             uploader,
             prefetcher,
+            next_handle_id: std::sync::atomic::AtomicU64::new(1),
         })
     }
 
@@ -153,11 +155,7 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = {
-            let mut h = DefaultHasher::new();
-            config.name.hash(&mut h);
-            HandleId::new(h.finish())
-        };
+        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -231,11 +229,7 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = {
-            let mut h = DefaultHasher::new();
-            config.name.hash(&mut h);
-            HandleId::new(h.finish())
-        };
+        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
@@ -38,7 +39,7 @@ pub struct Executor {
     pub client: S3CrtClient,
     pub uploader: Uploader<S3CrtClient>,
     prefetcher: Prefetcher<S3CrtClient>,
-    next_handle_id: std::sync::atomic::AtomicU64,
+    next_handle_id: AtomicU64,
 }
 
 impl Executor {
@@ -119,7 +120,7 @@ impl Executor {
             client,
             uploader,
             prefetcher,
-            next_handle_id: std::sync::atomic::AtomicU64::new(1),
+            next_handle_id: AtomicU64::new(1),
         })
     }
 
@@ -155,7 +156,7 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -229,7 +230,7 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -176,7 +176,7 @@ impl Executor {
                 break;
             }
 
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), 0, size);
             let mut offset = 0;
             while offset < size {
                 if let Some(max_dur) = max_duration
@@ -251,9 +251,7 @@ impl Executor {
             }
 
             let iteration_start = Instant::now();
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
-
-            // Create a unique, deterministic seed by combining randseed with object_id hash
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), 0, size);
             // and iteration. This ensures each object/iteration has a different but reproducible
             // random access pattern.
             let randseed = config.randseed;

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -9,7 +9,7 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::mem_limiter::MemoryLimiter;
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
-use mountpoint_s3_fs::prefetch::{Prefetcher, PrefetcherConfig};
+use mountpoint_s3_fs::prefetch::{HandleId, Prefetcher, PrefetcherConfig};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use rand::{RngExt, SeedableRng};
@@ -153,6 +153,11 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
+        let handle_id = {
+            let mut h = DefaultHasher::new();
+            config.name.hash(&mut h);
+            HandleId::new(h.finish())
+        };
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -176,7 +181,7 @@ impl Executor {
                 break;
             }
 
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), 0, size);
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), handle_id, size);
             let mut offset = 0;
             while offset < size {
                 if let Some(max_dur) = max_duration
@@ -226,6 +231,11 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
+        let handle_id = {
+            let mut h = DefaultHasher::new();
+            config.name.hash(&mut h);
+            HandleId::new(h.finish())
+        };
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -251,7 +261,9 @@ impl Executor {
             }
 
             let iteration_start = Instant::now();
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), 0, size);
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), handle_id, size);
+
+            // Create a unique, deterministic seed by combining randseed with object_id hash
             // and iteration. This ensures each object/iteration has a different but reproducible
             // random access pattern.
             let randseed = config.randseed;

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -351,7 +351,7 @@ where
         let fh = self.next_handle(); // TODO: can we delay obtaining the next handle until we know we are creating a new file handle?
         let write_mode = self.config.write_mode();
         let new_handle = self.metablock.open_handle(ino, fh, &write_mode, flags).await?;
-        let state = FileHandleState::new(&new_handle, flags, self).await?;
+        let state = FileHandleState::new(fh, &new_handle, flags, self).await?;
         let handle = FileHandle {
             ino,
             location: new_handle.lookup.try_into_s3_location()?,

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -58,6 +58,7 @@ where
     Client: ObjectClient + Clone + Send + Sync,
 {
     pub async fn new(
+        fh: u64,
         handle: &NewHandle,
         flags: OpenFlags,
         fs: &S3Filesystem<Client>,
@@ -76,7 +77,7 @@ where
                     Some(etag) => ETag::from_str(etag).expect("E-Tag should be set"),
                 };
                 let object_id = ObjectId::new(full_key.into(), etag);
-                let request = fs.prefetcher.prefetch(bucket.to_string(), object_id, object_size);
+                let request = fs.prefetcher.prefetch(bucket.to_string(), object_id, fh, object_size);
                 let handle = FileHandleState::Read {
                     request,
                     flushed: false,

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error};
 use crate::fs::InodeError;
 use crate::metablock::{Lookup, Metablock, NewHandle, PendingUploadHook, ReadWriteMode, S3Location};
 use crate::object::ObjectId;
-use crate::prefetch::PrefetchGetObject;
+use crate::prefetch::{HandleId, PrefetchGetObject};
 use crate::sync::{Arc, AsyncMutex};
 use crate::upload::{AppendUploadRequest, UploadRequest};
 
@@ -77,7 +77,9 @@ where
                     Some(etag) => ETag::from_str(etag).expect("E-Tag should be set"),
                 };
                 let object_id = ObjectId::new(full_key.into(), etag);
-                let request = fs.prefetcher.prefetch(bucket.to_string(), object_id, fh, object_size);
+                let request = fs
+                    .prefetcher
+                    .prefetch(bucket.to_string(), object_id, HandleId::new(fh), object_size);
                 let handle = FileHandleState::Read {
                     request,
                     flushed: false,

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -71,7 +71,7 @@ impl HandleId {
         Self(id)
     }
 
-    pub fn get(&self) -> u64 {
+    pub fn as_raw(&self) -> u64 {
         self.0
     }
 }

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -62,6 +62,20 @@ use part_stream::{PartStream, RequestRange, RequestTaskConfig};
 use seek_window::SeekWindow;
 use task::RequestTask;
 
+/// Opaque identifier for a file handle, used to attribute prefetch requests to their origin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HandleId(u64);
+
+impl HandleId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
 // This is a weird looking number! We really want our first request size to be 1MiB,
 // which is a common IO size. But Linux's readahead will try to read an extra 128k on on
 // top of a 1MiB read, which we'd have to wait for a second request to service. Because
@@ -218,7 +232,13 @@ where
     }
 
     /// Start a new prefetch request to the specified object.
-    pub fn prefetch(&self, bucket: String, object_id: ObjectId, handle_id: u64, size: u64) -> PrefetchGetObject<Client>
+    pub fn prefetch(
+        &self,
+        bucket: String,
+        object_id: ObjectId,
+        handle_id: HandleId,
+        size: u64,
+    ) -> PrefetchGetObject<Client>
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
@@ -257,7 +277,7 @@ where
     size: u64,
     mem_limiter: Arc<MemoryLimiter>,
     /// File handle ID that owns this prefetch request, for per-handle memory accounting.
-    handle_id: u64,
+    handle_id: HandleId,
 }
 
 impl<Client> PrefetchGetObject<Client>
@@ -270,7 +290,7 @@ where
         config: PrefetcherConfig,
         bucket: String,
         object_id: ObjectId,
-        handle_id: u64,
+        handle_id: HandleId,
         size: u64,
         mem_limiter: Arc<MemoryLimiter>,
     ) -> Self {
@@ -435,7 +455,7 @@ where
         let config = RequestTaskConfig {
             bucket: self.bucket.clone(),
             object_id: self.object_id.clone(),
-            handle_id: Some(self.handle_id),
+            handle_id: self.handle_id,
             range,
             read_part_size,
             preferred_part_size: self.preferred_part_size,
@@ -655,7 +675,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = 1;
+        let fh = HandleId::new(1);
         let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
 
         let mut next_offset = 0;
@@ -737,7 +757,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = 1;
+        let fh = HandleId::new(1);
         let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size as u64);
         let result = block_on(request.read(0, read_size));
         assert!(matches!(result, Err(PrefetchReadError::BackpressurePreconditionFailed)));
@@ -823,7 +843,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = 1;
+        let fh = HandleId::new(1);
         let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
 
         let mut next_offset = 0;
@@ -954,7 +974,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = 1;
+        let fh = HandleId::new(1);
         let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
         for (offset, length) in reads {
@@ -1118,7 +1138,7 @@ mod tests {
         let prefetcher = build_prefetcher(client, PrefetcherType::Default, Default::default());
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
 
             // The first read should trigger the prefetcher to try and get the whole object (in 2 parts).
@@ -1182,7 +1202,7 @@ mod tests {
 
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
 
             // First read will terminate early
@@ -1238,7 +1258,7 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in first_read_size + 1..OBJECT_SIZE {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
@@ -1274,7 +1294,7 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in 0..first_read_size {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
@@ -1324,7 +1344,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), PrefetcherType::Default, prefetcher_config);
         let object_id = ObjectId::new("test-object".to_owned(), etag);
-        let fh = 1;
+        let fh = HandleId::new(1);
         let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
         // Perform sequential reads to test the download functionality
@@ -1394,7 +1414,7 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
             let mut next_offset = 0;
@@ -1457,7 +1477,7 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let fh = 1;
+            let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
             let num_reads = rng.gen_range(10usize..50);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -218,7 +218,7 @@ where
     }
 
     /// Start a new prefetch request to the specified object.
-    pub fn prefetch(&self, bucket: String, object_id: ObjectId, size: u64) -> PrefetchGetObject<Client>
+    pub fn prefetch(&self, bucket: String, object_id: ObjectId, handle_id: u64, size: u64) -> PrefetchGetObject<Client>
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
@@ -227,6 +227,7 @@ where
             self.config,
             bucket,
             object_id,
+            handle_id,
             size,
             self.mem_limiter.clone(),
         )
@@ -255,6 +256,8 @@ where
     next_request_offset: u64,
     size: u64,
     mem_limiter: Arc<MemoryLimiter>,
+    /// File handle ID that owns this prefetch request, for per-handle memory accounting.
+    handle_id: u64,
 }
 
 impl<Client> PrefetchGetObject<Client>
@@ -267,6 +270,7 @@ where
         config: PrefetcherConfig,
         bucket: String,
         object_id: ObjectId,
+        handle_id: u64,
         size: u64,
         mem_limiter: Arc<MemoryLimiter>,
     ) -> Self {
@@ -289,6 +293,7 @@ where
             object_id,
             size,
             mem_limiter,
+            handle_id,
         }
     }
 
@@ -430,6 +435,7 @@ where
         let config = RequestTaskConfig {
             bucket: self.bucket.clone(),
             object_id: self.object_id.clone(),
+            handle_id: Some(self.handle_id),
             range,
             read_part_size,
             preferred_part_size: self.preferred_part_size,
@@ -649,7 +655,8 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, size);
+        let fh = 1;
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
 
         let mut next_offset = 0;
         loop {
@@ -730,7 +737,8 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size as u64);
+        let fh = 1;
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size as u64);
         let result = block_on(request.read(0, read_size));
         assert!(matches!(result, Err(PrefetchReadError::BackpressurePreconditionFailed)));
     }
@@ -815,7 +823,8 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, size);
+        let fh = 1;
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
 
         let mut next_offset = 0;
         loop {
@@ -945,7 +954,8 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
+        let fh = 1;
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
         for (offset, length) in reads {
             assert!(offset < object_size);
@@ -1108,7 +1118,8 @@ mod tests {
         let prefetcher = build_prefetcher(client, PrefetcherType::Default, Default::default());
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
 
             // The first read should trigger the prefetcher to try and get the whole object (in 2 parts).
             _ = request.read(0, 1).await.expect("first read should succeed");
@@ -1171,7 +1182,8 @@ mod tests {
 
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
 
             // First read will terminate early
             assert!(matches!(
@@ -1226,7 +1238,8 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in first_read_size + 1..OBJECT_SIZE {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
             }
@@ -1261,7 +1274,8 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in 0..first_read_size {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
             }
@@ -1310,7 +1324,8 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), PrefetcherType::Default, prefetcher_config);
         let object_id = ObjectId::new("test-object".to_owned(), etag);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
+        let fh = 1;
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
         // Perform sequential reads to test the download functionality
         let mut next_offset = 0;
@@ -1379,7 +1394,8 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
             let mut next_offset = 0;
             loop {
@@ -1441,7 +1457,8 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
+            let fh = 1;
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
 
             let num_reads = rng.gen_range(10usize..50);
             for _ in 0..num_reads {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -420,6 +420,7 @@ mod tests {
         mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter},
         memory::PagedPool,
         object::ObjectId,
+        prefetch::HandleId,
     };
 
     use super::*;
@@ -445,6 +446,7 @@ mod tests {
         let seed = 0xaa;
         let object = MockObject::ramp(seed, object_size, ETag::for_tests());
         let id = ObjectId::new(key.to_owned(), object.etag());
+        let handle_id = HandleId::new(1);
 
         // backpressure config
         let initial_request_size = 1 * MB;
@@ -478,7 +480,7 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
-                handle_id: None,
+                handle_id,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -505,7 +507,7 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
-                handle_id: None,
+                handle_id,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -559,7 +561,7 @@ mod tests {
                 let config = RequestTaskConfig {
                     bucket: bucket.to_owned(),
                     object_id: id.clone(),
-                    handle_id: None,
+                    handle_id: HandleId::new(1),
                     range: RequestRange::new(object_size, offset as u64, preferred_size),
                     read_part_size: client_part_size,
                     preferred_part_size: 256 * KB,

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -220,6 +220,7 @@ where
             cache_key.clone(),
             initial_request_end_offset,
             block_aligned_byte_range,
+            self.config.handle_id,
         );
 
         let mut part_composer = CachingPartComposer {
@@ -477,6 +478,7 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
+                handle_id: None,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -503,6 +505,7 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
+                handle_id: None,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -556,6 +559,7 @@ mod tests {
                 let config = RequestTaskConfig {
                     bucket: bucket.to_owned(),
                     object_id: id.clone(),
+                    handle_id: None,
                     range: RequestRange::new(object_size, offset as u64, preferred_size),
                     read_part_size: client_part_size,
                     preferred_part_size: 256 * KB,

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -36,6 +36,7 @@ pub trait ObjectPartStream<Client: ObjectClient + Clone + Send + Sync + 'static>
 pub struct RequestTaskConfig {
     pub bucket: String,
     pub object_id: ObjectId,
+    pub handle_id: Option<u64>,
     pub range: RequestRange,
     pub read_part_size: usize,
     pub preferred_part_size: usize,
@@ -265,6 +266,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
                         config.object_id.clone(),
                         initial_request_end_offset,
                         config.range,
+                        config.handle_id,
                     );
 
                     let part_composer = ClientPartComposer {
@@ -345,6 +347,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     object_id: ObjectId,
     initial_request_end_offset: u64,
     range: RequestRange,
+    handle_id: Option<u64>,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
@@ -357,6 +360,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 first_req_range.into(),
+                handle_id,
             );
             pin_mut!(first_request_stream);
             while let Some(next) = first_request_stream.next().await {
@@ -409,6 +413,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 range.into(),
+                handle_id,
             );
             pin_mut!(request_stream);
             while let Some(next) = request_stream.next().await {
@@ -427,10 +432,11 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     bucket: String,
     id: ObjectId,
     request_range: Range<u64>,
+    handle_id: Option<u64>,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).handle_id(handle_id))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -14,6 +14,7 @@ use crate::mem_limiter::MemoryLimiter;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
+use super::HandleId;
 use super::PrefetchReadError;
 use super::backpressure_controller::{BackpressureConfig, BackpressureLimiter, new_backpressure_controller};
 use super::part::{Part, PartSource};
@@ -36,7 +37,7 @@ pub trait ObjectPartStream<Client: ObjectClient + Clone + Send + Sync + 'static>
 pub struct RequestTaskConfig {
     pub bucket: String,
     pub object_id: ObjectId,
-    pub handle_id: Option<u64>,
+    pub handle_id: HandleId,
     pub range: RequestRange,
     pub read_part_size: usize,
     pub preferred_part_size: usize,
@@ -347,7 +348,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     object_id: ObjectId,
     initial_request_end_offset: u64,
     range: RequestRange,
-    handle_id: Option<u64>,
+    handle_id: HandleId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
@@ -432,11 +433,13 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     bucket: String,
     id: ObjectId,
     request_range: Range<u64>,
-    handle_id: Option<u64>,
+    handle_id: HandleId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
+    // TODO: Pass handle_id to GetObjectParams once the client crate exposes the field
+    let _ = handle_id;
     try_stream! {
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).handle_id(handle_id))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;


### PR DESCRIPTION
We need to attribute CRT meta-request buffer allocations back to the file handle that originated them. This is a prerequisite for per-handle memory accounting in the `MemoryLimiter`.

This PR threads the FUSE file handle ID (`fh`) from the point where a file is opened (`FileHandleState::new`) all the way down to `GetObjectParams`, where it is available in scope when the CRT meta-request is created. The changes are purely additive data threading — no existing logic is altered.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No, this is an internal refactor with no user-visible behavior change and no public API impact.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
