### PR TITLE
Thread request ID from meta-request options into CRT buffer pool reservations

### DIFF
--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -83,7 +83,7 @@ pub mod config {
     #[doc(hidden)]
     pub use mountpoint_s3_crt::s3::s3_library_init;
 
-    pub use mountpoint_s3_crt::s3::client::MetaRequestType;
+    pub use mountpoint_s3_crt::s3::client::{MetaRequest, MetaRequestType};
     pub use mountpoint_s3_crt::s3::pool::{MemoryPool, MemoryPoolFactory, MemoryPoolFactoryOptions};
 }
 

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -240,6 +240,9 @@ pub struct GetObjectParams {
     pub range: Option<Range<u64>>,
     pub if_match: Option<ETag>,
     pub checksum_mode: Option<ChecksumMode>,
+    /// An optional caller-supplied identifier passed through to the memory pool on buffer
+    /// allocations for this request. Not related to the S3 request ID returned by the service.
+    pub custom_id: Option<u64>,
 }
 
 impl GetObjectParams {
@@ -263,6 +266,12 @@ impl GetObjectParams {
     /// Set option to retrieve checksum as part of the GetObject request
     pub fn checksum_mode(mut self, value: Option<ChecksumMode>) -> Self {
         self.checksum_mode = value;
+        self
+    }
+
+    /// Set the custom identifier for memory pool buffer allocations.
+    pub fn custom_id(mut self, value: Option<u64>) -> Self {
+        self.custom_id = value;
         self
     }
 }
@@ -553,6 +562,9 @@ pub struct PutObjectParams {
     pub custom_headers: Vec<(String, String)>,
     /// User-defined object metadata
     pub object_metadata: ObjectMetadata,
+    /// An optional caller-supplied identifier passed through to the memory pool on buffer
+    /// allocations for this request. Not related to the S3 request ID returned by the service.
+    pub custom_id: Option<u64>,
 }
 
 impl PutObjectParams {
@@ -594,6 +606,12 @@ impl PutObjectParams {
     /// Set user defined object metadata.
     pub fn object_metadata(mut self, value: ObjectMetadata) -> Self {
         self.object_metadata = value;
+        self
+    }
+
+    /// Set the custom identifier for memory pool buffer allocations.
+    pub fn custom_id(mut self, value: Option<u64>) -> Self {
+        self.custom_id = value;
         self
     }
 }

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -269,7 +269,8 @@ impl GetObjectParams {
         self
     }
 
-    /// Set the custom identifier for memory pool buffer allocations.
+    /// Set an optional caller-supplied identifier passed through to the memory pool on buffer
+    /// allocations for this request. Not related to the S3 request ID returned by the service.
     pub fn custom_id(mut self, value: Option<u64>) -> Self {
         self.custom_id = value;
         self
@@ -609,7 +610,8 @@ impl PutObjectParams {
         self
     }
 
-    /// Set the custom identifier for memory pool buffer allocations.
+    /// Set an optional caller-supplied identifier passed through to the memory pool on buffer
+    /// allocations for this request. Not related to the S3 request ID returned by the service.
     pub fn custom_id(mut self, value: Option<u64>) -> Self {
         self.custom_id = value;
         self

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -78,6 +78,9 @@ impl S3CrtClient {
 
             let mut options = message.into_options(S3Operation::GetObject);
             options.part_size(self.inner.read_part_size as u64);
+            if let Some(id) = params.custom_id {
+                options.custom_id(id);
+            }
 
             let mut headers_sender = Some(event_sender.clone());
             let part_sender = event_sender.clone();

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -73,6 +73,9 @@ impl S3CrtClient {
             options.send_using_async_writes(true);
             options.on_upload_review(move |review| callback.invoke(review));
             options.part_size(self.inner.write_part_size as u64);
+            if let Some(id) = params.custom_id {
+                options.custom_id(id);
+            }
 
             let on_mpu_created_sender = Arc::new(Mutex::new(Some(mpu_created_sender)));
             let on_failure_sender = on_mpu_created_sender.clone();

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -1,4 +1,4 @@
-use mountpoint_s3_client::config::{MemoryPool, MetaRequestType};
+use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 /// Creates a memory pool to use in tests.
 pub fn new_for_tests() -> impl MemoryPool {
@@ -12,7 +12,7 @@ struct NoReusePool();
 impl MemoryPool for NoReusePool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize, _type: MetaRequestType, _request_id: u64) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, _meta_request: &MetaRequest) -> Self::Buffer {
         vec![0u8; size].into_boxed_slice()
     }
 

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -12,7 +12,7 @@ struct NoReusePool();
 impl MemoryPool for NoReusePool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize, _type: MetaRequestType) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, _type: MetaRequestType, _request_id: u64) -> Self::Buffer {
         vec![0u8; size].into_boxed_slice()
     }
 

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -17,7 +17,7 @@ struct NoReusePool();
 impl MemoryPool for NoReusePool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize, _meta_request: MetaRequest) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, _meta_request: &MetaRequest) -> Self::Buffer {
         vec![0u8; size].into_boxed_slice()
     }
 
@@ -33,12 +33,6 @@ pub struct RecordingMemoryPool {
 }
 
 impl RecordingMemoryPool {
-    pub fn new() -> Self {
-        Self {
-            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
     pub fn observed_custom_ids(&self) -> Vec<Option<u64>> {
         self.observed_custom_ids.lock().unwrap().clone()
     }
@@ -47,7 +41,7 @@ impl RecordingMemoryPool {
 impl MemoryPool for RecordingMemoryPool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
         self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
         vec![0u8; size].into_boxed_slice()
     }

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -1,23 +1,58 @@
+use std::sync::{Arc, Mutex};
+
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 /// Creates a memory pool to use in tests.
+#[cfg(feature = "pool_tests")]
 pub fn new_for_tests() -> impl MemoryPool {
     NoReusePool()
 }
 
 /// Trivial memory pool implementation that always allocates new buffers.
+#[cfg(feature = "pool_tests")]
 #[derive(Debug, Clone)]
 struct NoReusePool();
 
+#[cfg(feature = "pool_tests")]
 impl MemoryPool for NoReusePool {
     type Buffer = Box<[u8]>;
 
-    fn get_buffer(&self, size: usize, _meta_request: &MetaRequest) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, _meta_request: MetaRequest) -> Self::Buffer {
         vec![0u8; size].into_boxed_slice()
     }
 
     fn trim(&self) -> bool {
         // Nothing to do.
+        false
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct RecordingMemoryPool {
+    observed_custom_ids: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+impl RecordingMemoryPool {
+    pub fn new() -> Self {
+        Self {
+            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn observed_custom_ids(&self) -> Vec<Option<u64>> {
+        self.observed_custom_ids.lock().unwrap().clone()
+    }
+}
+
+impl MemoryPool for RecordingMemoryPool {
+    type Buffer = Box<[u8]>;
+
+    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer {
+        self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
+        vec![0u8; size].into_boxed_slice()
+    }
+
+    fn trim(&self) -> bool {
         false
     }
 }

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -25,7 +25,6 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
 
 pub mod creds;
-#[cfg(feature = "pool_tests")]
 pub mod memory_pool;
 pub mod tracing_test;
 

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::option::Option::None;
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::ChecksumAlgorithm;
@@ -14,7 +15,7 @@ use common::creds::get_no_permissions_provider;
 use common::*;
 use futures::pin_mut;
 use futures::stream::StreamExt;
-use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_client::config::{MemoryPool, MetaRequest, S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use mountpoint_s3_client::types::{
@@ -24,6 +25,36 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 use test_case::test_case;
 
 use crate::common::creds::assert_no_permissions_error;
+
+#[derive(Clone)]
+struct RecordingMemoryPool {
+    observed_custom_ids: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+impl RecordingMemoryPool {
+    fn new() -> Self {
+        Self {
+            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn observed_custom_ids(&self) -> Vec<Option<u64>> {
+        self.observed_custom_ids.lock().unwrap().clone()
+    }
+}
+
+impl MemoryPool for RecordingMemoryPool {
+    type Buffer = Box<[u8]>;
+
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
+        self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
+        vec![0u8; size].into_boxed_slice()
+    }
+
+    fn trim(&self) -> bool {
+        false
+    }
+}
 
 #[test_case(1, None; "1-byte object")]
 #[test_case(10, None; "small object")]
@@ -59,6 +90,42 @@ async fn test_get_object(size: usize, range: Option<Range<u64>>) {
         None => &body,
     };
     check_get_result(result, range, expected).await;
+}
+
+#[tokio::test]
+async fn test_get_object_custom_id_propagates_to_memory_pool() {
+    let sdk_client = get_test_sdk_client().await;
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_get_object_custom_id_propagates_to_memory_pool");
+
+    let key = format!("{prefix}/test");
+    let body = vec![0x42; 1024];
+    sdk_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(ByteStream::from(body.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let recording_pool = RecordingMemoryPool::new();
+    let client_config = S3ClientConfig::new()
+        .endpoint_config(get_test_endpoint_config())
+        .memory_pool(recording_pool.clone());
+    let client = get_test_client_with_config(client_config);
+
+    let custom_id = 4242;
+    let result = client
+        .get_object(&bucket, &key, &GetObjectParams::new().custom_id(Some(custom_id)))
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &body).await;
+
+    let observed = recording_pool.observed_custom_ids();
+    assert!(
+        observed.contains(&Some(custom_id)),
+        "expected to observe custom id {custom_id}, observed: {observed:?}"
+    );
 }
 
 #[test_case(1, None; "1-byte object")]

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -78,10 +78,12 @@ async fn test_get_object_custom_id_propagates_to_memory_pool() {
         .await
         .unwrap();
 
-    let recording_pool = RecordingMemoryPool::new();
+    let recording_pool = RecordingMemoryPool::default();
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .memory_pool(recording_pool.clone());
+    // Constructing the client directly instead of using get_test_client_with_config,
+    // which would override our RecordingMemoryPool in some test configurations.
     let client = S3CrtClient::new(client_config).expect("could not create test client");
 
     let custom_id = 4242;

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -6,16 +6,16 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::option::Option::None;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::ChecksumAlgorithm;
 use bytes::Bytes;
 use common::creds::get_no_permissions_provider;
+use common::memory_pool::RecordingMemoryPool;
 use common::*;
 use futures::pin_mut;
 use futures::stream::StreamExt;
-use mountpoint_s3_client::config::{MemoryPool, MetaRequest, S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::error_metadata::{ClientErrorMetadata, ProvideErrorMetadata};
 use mountpoint_s3_client::types::{
@@ -25,36 +25,6 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 use test_case::test_case;
 
 use crate::common::creds::assert_no_permissions_error;
-
-#[derive(Clone)]
-struct RecordingMemoryPool {
-    observed_custom_ids: Arc<Mutex<Vec<Option<u64>>>>,
-}
-
-impl RecordingMemoryPool {
-    fn new() -> Self {
-        Self {
-            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn observed_custom_ids(&self) -> Vec<Option<u64>> {
-        self.observed_custom_ids.lock().unwrap().clone()
-    }
-}
-
-impl MemoryPool for RecordingMemoryPool {
-    type Buffer = Box<[u8]>;
-
-    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
-        self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
-        vec![0u8; size].into_boxed_slice()
-    }
-
-    fn trim(&self) -> bool {
-        false
-    }
-}
 
 #[test_case(1, None; "1-byte object")]
 #[test_case(10, None; "small object")]
@@ -112,7 +82,7 @@ async fn test_get_object_custom_id_propagates_to_memory_pool() {
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .memory_pool(recording_pool.clone());
-    let client = get_test_client_with_config(client_config);
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
 
     let custom_id = 4242;
     let result = client

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -62,10 +62,12 @@ async fn test_put_object_custom_id_propagates_to_memory_pool() {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_object_custom_id_propagates_to_memory_pool");
     let key = format!("{prefix}hello");
 
-    let recording_pool = RecordingMemoryPool::new();
+    let recording_pool = RecordingMemoryPool::default();
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .memory_pool(recording_pool.clone());
+    // Constructing the client directly instead of using get_test_client_with_config,
+    // which would override our RecordingMemoryPool in some test configurations.
     let client = S3CrtClient::new(client_config).expect("could not create test client");
 
     let custom_id = 31337;

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -3,9 +3,9 @@
 pub mod common;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use common::memory_pool::RecordingMemoryPool;
 use common::*;
 
 use futures::{FutureExt, StreamExt, pin_mut};
@@ -13,43 +13,13 @@ use rand::RngExt;
 use test_case::test_case;
 
 use mountpoint_s3_client::checksums::{crc32c, crc32c_to_base64};
-use mountpoint_s3_client::config::{MemoryPool, MetaRequest, S3ClientConfig};
+use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
     ChecksumAlgorithm, GetObjectParams, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
     PutObjectTrailingChecksums,
 };
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3RequestError};
-
-#[derive(Clone)]
-struct RecordingMemoryPool {
-    observed_custom_ids: Arc<Mutex<Vec<Option<u64>>>>,
-}
-
-impl RecordingMemoryPool {
-    fn new() -> Self {
-        Self {
-            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn observed_custom_ids(&self) -> Vec<Option<u64>> {
-        self.observed_custom_ids.lock().unwrap().clone()
-    }
-}
-
-impl MemoryPool for RecordingMemoryPool {
-    type Buffer = Box<[u8]>;
-
-    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
-        self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
-        vec![0u8; size].into_boxed_slice()
-    }
-
-    fn trim(&self) -> bool {
-        false
-    }
-}
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
 
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
 // contents are correct with a GET.
@@ -96,7 +66,7 @@ async fn test_put_object_custom_id_propagates_to_memory_pool() {
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .memory_pool(recording_pool.clone());
-    let client = get_test_client_with_config(client_config);
+    let client = S3CrtClient::new(client_config).expect("could not create test client");
 
     let custom_id = 31337;
     let mut request = client

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -3,6 +3,7 @@
 pub mod common;
 
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::*;
@@ -12,13 +13,43 @@ use rand::RngExt;
 use test_case::test_case;
 
 use mountpoint_s3_client::checksums::{crc32c, crc32c_to_base64};
-use mountpoint_s3_client::config::S3ClientConfig;
+use mountpoint_s3_client::config::{MemoryPool, MetaRequest, S3ClientConfig};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::types::{
     ChecksumAlgorithm, GetObjectParams, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
     PutObjectTrailingChecksums,
 };
 use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3RequestError};
+
+#[derive(Clone)]
+struct RecordingMemoryPool {
+    observed_custom_ids: Arc<Mutex<Vec<Option<u64>>>>,
+}
+
+impl RecordingMemoryPool {
+    fn new() -> Self {
+        Self {
+            observed_custom_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn observed_custom_ids(&self) -> Vec<Option<u64>> {
+        self.observed_custom_ids.lock().unwrap().clone()
+    }
+}
+
+impl MemoryPool for RecordingMemoryPool {
+    type Buffer = Box<[u8]>;
+
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
+        self.observed_custom_ids.lock().unwrap().push(meta_request.custom_id());
+        vec![0u8; size].into_boxed_slice()
+    }
+
+    fn trim(&self) -> bool {
+        false
+    }
+}
 
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
 // contents are correct with a GET.
@@ -55,6 +86,34 @@ async fn test_put_object(
 }
 
 object_client_test!(test_put_object);
+
+#[tokio::test]
+async fn test_put_object_custom_id_propagates_to_memory_pool() {
+    let (bucket, prefix) = get_test_bucket_and_prefix("test_put_object_custom_id_propagates_to_memory_pool");
+    let key = format!("{prefix}hello");
+
+    let recording_pool = RecordingMemoryPool::new();
+    let client_config = S3ClientConfig::new()
+        .endpoint_config(get_test_endpoint_config())
+        .memory_pool(recording_pool.clone());
+    let client = get_test_client_with_config(client_config);
+
+    let custom_id = 31337;
+    let mut request = client
+        .put_object(&bucket, &key, &PutObjectParams::new().custom_id(Some(custom_id)))
+        .await
+        .expect("put_object should succeed");
+
+    let body = vec![0x7f; 1024];
+    request.write(&body).await.expect("write should succeed");
+    let _ = request.complete().await.expect("complete should succeed");
+
+    let observed = recording_pool.observed_custom_ids();
+    assert!(
+        observed.contains(&Some(custom_id)),
+        "expected to observe custom id {custom_id}, observed: {observed:?}"
+    );
+}
 
 // Simple test for PUT object. Puts a single, empty object and checks that the (empty)
 // contents are correct with a GET.

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -286,6 +286,9 @@ struct MetaRequestOptionsInner<'a> {
     /// Finish callback, if provided (and not already called, since it's FnOnce).
     on_finish: Option<FinishCallback>,
 
+    /// Opaque identifier for this meta request, readable from the buffer pool reserve path.
+    request_id: u64,
+
     /// Pin this struct because inner.user_data will be a pointer to this object.
     _pinned: PhantomPinned,
 }
@@ -358,6 +361,7 @@ impl<'a> MetaRequestOptions<'a> {
             on_body_ex: None,
             on_upload_review: None,
             on_finish: None,
+            request_id: 0,
             _pinned: Default::default(),
         });
 
@@ -506,6 +510,30 @@ impl<'a> MetaRequestOptions<'a> {
         options.inner.copy_source_uri = unsafe { options.copy_source_uri.as_mut().unwrap().as_aws_byte_cursor() };
         self
     }
+
+    /// Set an opaque identifier for this meta request. This value can be retrieved
+    /// from the buffer pool reserve path via [`meta_request_id`].
+    pub fn request_id(&mut self, id: u64) -> &mut Self {
+        // SAFETY: we aren't moving out of the struct.
+        let options = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.0)) };
+        options.request_id = id;
+        self
+    }
+}
+
+/// Retrieve the request id stored in a meta request's user_data.
+///
+/// # Safety
+///
+/// `meta_request` must be a valid pointer to an `aws_s3_meta_request` whose
+/// `user_data` was set by [`MetaRequestOptions`].
+pub(crate) unsafe fn meta_request_id(meta_request: *const aws_s3_meta_request) -> u64 {
+    // SAFETY: caller guarantees `meta_request` is a valid pointer.
+    let user_data = unsafe { (*meta_request).user_data };
+    debug_assert!(!user_data.is_null());
+    // SAFETY: `user_data` was set to point to a valid `MetaRequestOptionsInner` in `MetaRequestOptions::new`.
+    let options = unsafe { &*(user_data as *const MetaRequestOptionsInner) };
+    options.request_id
 }
 
 impl Default for MetaRequestOptions<'_> {

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -711,14 +711,16 @@ pub struct MetaRequest {
 }
 
 impl MetaRequest {
-    /// Acquires a reference to an `aws_s3_meta_request` raw pointer, incrementing its ref-count.
+    /// Creates a new instance from an `aws_s3_meta_request` raw pointer, incrementing its ref-count.
     ///
     /// # Safety
     ///
     /// `raw` must be a valid, non-null pointer to an `aws_s3_meta_request` whose `user_data`
     /// was initialised by [`MetaRequestOptions`].
     pub(crate) unsafe fn from_raw_acquire(raw: *mut aws_s3_meta_request) -> Self {
-        // SAFETY: caller guarantees `raw` is valid and non-null.
+        // SAFETY: caller guarantees `raw` is a valid `aws_s3_meta_request`, and
+        // `aws_s3_meta_request_acquire` increments the reference count for it
+        // (and always returns a copy of the input, which is non-null).
         let inner = unsafe { NonNull::new_unchecked(aws_s3_meta_request_acquire(raw)) };
         Self { inner }
     }
@@ -1787,28 +1789,10 @@ impl UploadReviewPart {
 
 #[cfg(test)]
 mod tests {
-    use std::pin::Pin;
-
     use test_case::test_case;
 
     use crate::aws_s3_request_type;
-    use crate::s3::client::{MetaRequestOptions, RequestType};
-
-    #[test]
-    fn meta_request_options_custom_id_round_trip() {
-        let mut options = MetaRequestOptions::new();
-        options.custom_id(42);
-        // SAFETY: directly accessing inner struct for testing, not moving out of it.
-        let inner = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut options.0)) };
-        assert_eq!(inner.custom_id, Some(42));
-    }
-
-    #[test]
-    fn meta_request_options_default_custom_id_is_none() {
-        let options = MetaRequestOptions::new();
-        // `Pin<Box<T>>` implements `Deref<Target=T>` so no unsafe needed for shared access.
-        assert_eq!(options.0.custom_id, None);
-    }
+    use crate::s3::client::RequestType;
 
     #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_UNKNOWN, RequestType::Unknown)]
     #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_HEAD_OBJECT, RequestType::HeadObject)]

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -523,23 +523,6 @@ impl<'a> MetaRequestOptions<'a> {
     }
 }
 
-/// Retrieve the caller-supplied custom identifier stored in a meta request's user_data.
-///
-/// Returns `None` if no custom id was set via [`MetaRequestOptions::custom_id`].
-///
-/// # Safety
-///
-/// `meta_request` must be a valid pointer to an `aws_s3_meta_request` whose
-/// `user_data` was set by [`MetaRequestOptions`].
-pub(crate) unsafe fn meta_request_custom_id(meta_request: *const aws_s3_meta_request) -> Option<u64> {
-    // SAFETY: caller guarantees `meta_request` is a valid pointer.
-    let user_data = unsafe { (*meta_request).user_data };
-    debug_assert!(!user_data.is_null());
-    // SAFETY: `user_data` was set to point to a valid `MetaRequestOptionsInner` in `MetaRequestOptions::new`.
-    let options = unsafe { &*(user_data as *const MetaRequestOptionsInner) };
-    options.custom_id
-}
-
 impl Default for MetaRequestOptions<'_> {
     fn default() -> Self {
         Self::new()
@@ -718,9 +701,8 @@ impl MetaRequest {
     /// `raw` must be a valid, non-null pointer to an `aws_s3_meta_request` whose `user_data`
     /// was initialised by [`MetaRequestOptions`].
     pub(crate) unsafe fn from_raw_acquire(raw: *mut aws_s3_meta_request) -> Self {
-        // SAFETY: caller guarantees `raw` is a valid `aws_s3_meta_request`, and
-        // `aws_s3_meta_request_acquire` increments the reference count for it
-        // (and always returns a copy of the input, which is non-null).
+        // SAFETY: caller guarantees `raw` is valid and non-null.
+        // `aws_s3_meta_request_acquire` always returns its input, which is non-null.
         let inner = unsafe { NonNull::new_unchecked(aws_s3_meta_request_acquire(raw)) };
         Self { inner }
     }
@@ -733,9 +715,13 @@ impl MetaRequest {
 
     /// Returns the caller-supplied custom identifier, or `None` if not set.
     pub fn custom_id(&self) -> Option<u64> {
-        // SAFETY: `self.inner` is a valid `aws_s3_meta_request` whose `user_data` was set by
-        // `MetaRequestOptions`.
-        unsafe { meta_request_custom_id(self.inner.as_ptr()) }
+        // SAFETY: self.inner is a valid aws_s3_meta_request whose user_data was set
+        // to point to a valid MetaRequestOptionsInner in MetaRequestOptions::new.
+        let user_data = unsafe { (*self.inner.as_ptr()).user_data };
+        debug_assert!(!user_data.is_null());
+        // SAFETY: `user_data` points to a valid `MetaRequestOptionsInner` set in `MetaRequestOptions::new`.
+        let options = unsafe { &*(user_data as *const MetaRequestOptionsInner) };
+        options.custom_id
     }
 
     /// Cancel the meta request. Does nothing (but does not fail/panic) if the request has already

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -286,8 +286,9 @@ struct MetaRequestOptionsInner<'a> {
     /// Finish callback, if provided (and not already called, since it's FnOnce).
     on_finish: Option<FinishCallback>,
 
-    /// Opaque identifier for this meta request, readable from the buffer pool reserve path.
-    request_id: u64,
+    /// Opaque caller-supplied identifier for this meta request, readable from the buffer pool
+    /// reserve path. Not related to the S3 request ID returned by the service.
+    custom_id: Option<u64>,
 
     /// Pin this struct because inner.user_data will be a pointer to this object.
     _pinned: PhantomPinned,
@@ -361,7 +362,7 @@ impl<'a> MetaRequestOptions<'a> {
             on_body_ex: None,
             on_upload_review: None,
             on_finish: None,
-            request_id: 0,
+            custom_id: None,
             _pinned: Default::default(),
         });
 
@@ -511,29 +512,32 @@ impl<'a> MetaRequestOptions<'a> {
         self
     }
 
-    /// Set an opaque identifier for this meta request. This value can be retrieved
-    /// from the buffer pool reserve path via [`meta_request_id`].
-    pub fn request_id(&mut self, id: u64) -> &mut Self {
+    /// Set an opaque caller-supplied identifier for this meta request.
+    ///
+    /// Not related to the S3 request ID returned by the service.
+    pub fn custom_id(&mut self, id: u64) -> &mut Self {
         // SAFETY: we aren't moving out of the struct.
         let options = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.0)) };
-        options.request_id = id;
+        options.custom_id = Some(id);
         self
     }
 }
 
-/// Retrieve the request id stored in a meta request's user_data.
+/// Retrieve the caller-supplied custom identifier stored in a meta request's user_data.
+///
+/// Returns `None` if no custom id was set via [`MetaRequestOptions::custom_id`].
 ///
 /// # Safety
 ///
 /// `meta_request` must be a valid pointer to an `aws_s3_meta_request` whose
 /// `user_data` was set by [`MetaRequestOptions`].
-pub(crate) unsafe fn meta_request_id(meta_request: *const aws_s3_meta_request) -> u64 {
+pub(crate) unsafe fn meta_request_custom_id(meta_request: *const aws_s3_meta_request) -> Option<u64> {
     // SAFETY: caller guarantees `meta_request` is a valid pointer.
     let user_data = unsafe { (*meta_request).user_data };
     debug_assert!(!user_data.is_null());
     // SAFETY: `user_data` was set to point to a valid `MetaRequestOptionsInner` in `MetaRequestOptions::new`.
     let options = unsafe { &*(user_data as *const MetaRequestOptionsInner) };
-    options.request_id
+    options.custom_id
 }
 
 impl Default for MetaRequestOptions<'_> {
@@ -544,7 +548,7 @@ impl Default for MetaRequestOptions<'_> {
 
 /// What transformation to apply to a single [MetaRequest] to transform it into a collection of
 /// requests to S3.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetaRequestType {
     /// Send the request as-is (no transformation)
     Default,
@@ -707,6 +711,31 @@ pub struct MetaRequest {
 }
 
 impl MetaRequest {
+    /// Acquires a reference to an `aws_s3_meta_request` raw pointer, incrementing its ref-count.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a valid, non-null pointer to an `aws_s3_meta_request` whose `user_data`
+    /// was initialised by [`MetaRequestOptions`].
+    pub(crate) unsafe fn from_raw_acquire(raw: *mut aws_s3_meta_request) -> Self {
+        // SAFETY: caller guarantees `raw` is valid and non-null.
+        let inner = unsafe { NonNull::new_unchecked(aws_s3_meta_request_acquire(raw)) };
+        Self { inner }
+    }
+
+    /// Returns the type of this meta request.
+    pub fn meta_request_type(&self) -> MetaRequestType {
+        // SAFETY: `self.inner` is a valid `aws_s3_meta_request` since we hold a ref count to it.
+        unsafe { (*self.inner.as_ptr()).type_ }.into()
+    }
+
+    /// Returns the caller-supplied custom identifier, or `None` if not set.
+    pub fn custom_id(&self) -> Option<u64> {
+        // SAFETY: `self.inner` is a valid `aws_s3_meta_request` whose `user_data` was set by
+        // `MetaRequestOptions`.
+        unsafe { meta_request_custom_id(self.inner.as_ptr()) }
+    }
+
     /// Cancel the meta request. Does nothing (but does not fail/panic) if the request has already
     /// completed. If the request has not already completed, parts may still be delivered to the
     /// `body_callback` after this method completes, and the `finish_callback` will still be
@@ -1758,10 +1787,28 @@ impl UploadReviewPart {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+
     use test_case::test_case;
 
     use crate::aws_s3_request_type;
-    use crate::s3::client::RequestType;
+    use crate::s3::client::{MetaRequestOptions, RequestType};
+
+    #[test]
+    fn meta_request_options_custom_id_round_trip() {
+        let mut options = MetaRequestOptions::new();
+        options.custom_id(42);
+        // SAFETY: directly accessing inner struct for testing, not moving out of it.
+        let inner = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut options.0)) };
+        assert_eq!(inner.custom_id, Some(42));
+    }
+
+    #[test]
+    fn meta_request_options_default_custom_id_is_none() {
+        let options = MetaRequestOptions::new();
+        // `Pin<Box<T>>` implements `Deref<Target=T>` so no unsafe needed for shared access.
+        assert_eq!(options.0.custom_id, None);
+    }
 
     #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_UNKNOWN, RequestType::Unknown)]
     #[test_case(aws_s3_request_type::AWS_S3_REQUEST_TYPE_HEAD_OBJECT, RequestType::HeadObject)]

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -29,7 +29,9 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     type Buffer: AsMut<[u8]> + Send;
 
     /// Get a buffer of at least `size` bytes for the given meta request.
-    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer;
+    ///
+    /// The `meta_request` is reference-counted and may be cloned if needed.
+    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer;
 
     /// Get a buffer of at least `size` bytes asynchronously for the given meta request.
     /// Returns a future that resolves to the buffer.
@@ -41,7 +43,7 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     /// The default implementation wraps [`get_buffer`](Self::get_buffer) in a
     /// ready future. Override this when the pool needs to wait for memory to free up.
     fn get_buffer_async(&self, size: usize, meta_request: MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
-        ready(self.get_buffer(size, &meta_request))
+        ready(self.get_buffer(size, meta_request))
     }
 
     /// Trim the pool.
@@ -327,7 +329,7 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
         if can_block {
             // The write path in s3_meta_request.c expects the ticket to be fulfilled
             // synchronously — it treats an unfulfilled future as error.
-            let buffer = self.pool.get_buffer(size, &meta_request);
+            let buffer = self.pool.get_buffer(size, meta_request);
             let ticket = CrtTicket::new(buffer, ticket_vtable);
             future.set(ticket);
         } else {
@@ -361,9 +363,7 @@ unsafe extern "C" fn pool_reserve<Pool: MemoryPool>(
     let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
 
     // SAFETY: `meta.meta_request` is a valid pointer to an `aws_s3_meta_request` whose
-    // `user_data` was initialised by `MetaRequestOptions`. `from_raw_acquire` increments
-    // the ref-count so the `MetaRequest` is safe to use and drop independently of the
-    // lifetime of the callback's `meta` argument.
+    // `user_data` was initialised by `MetaRequestOptions`.
     let meta_request = unsafe { MetaRequest::from_raw_acquire(meta.meta_request) };
     let future = crt_pool.reserve(meta.size, meta_request, meta.can_block);
 

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -29,9 +29,7 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     type Buffer: AsMut<[u8]> + Send;
 
     /// Get a buffer of at least `size` bytes for the given meta request.
-    ///
-    /// The `meta_request` is reference-counted and may be cloned if needed.
-    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer;
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer;
 
     /// Get a buffer of at least `size` bytes asynchronously for the given meta request.
     /// Returns a future that resolves to the buffer.
@@ -42,7 +40,7 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     ///
     /// The default implementation wraps [`get_buffer`](Self::get_buffer) in a
     /// ready future. Override this when the pool needs to wait for memory to free up.
-    fn get_buffer_async(&self, size: usize, meta_request: MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
+    fn get_buffer_async(&self, size: usize, meta_request: &MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
         ready(self.get_buffer(size, meta_request))
     }
 
@@ -329,7 +327,7 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
         if can_block {
             // The write path in s3_meta_request.c expects the ticket to be fulfilled
             // synchronously — it treats an unfulfilled future as error.
-            let buffer = self.pool.get_buffer(size, meta_request);
+            let buffer = self.pool.get_buffer(size, &meta_request);
             let ticket = CrtTicket::new(buffer, ticket_vtable);
             future.set(ticket);
         } else {
@@ -345,7 +343,7 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
             // in-flight ticket futures. If one is added, we could propagate it to
             // `get_buffer_async` to avoid the wasteful buffer allocation.
             let _handle = self.event_loop_group.spawn_future(async move {
-                let buffer = pool.get_buffer_async(size, meta_request).await;
+                let buffer = pool.get_buffer_async(size, &meta_request).await;
                 let ticket = CrtTicket::new(buffer, ticket_vtable);
                 future_clone.set(ticket);
             });

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -19,6 +19,7 @@ use crate::common::allocator::Allocator;
 use crate::io::event_loop::EventLoopGroup;
 use crate::io::futures::FutureSpawner;
 use crate::s3::client::MetaRequestType;
+use crate::s3::client::meta_request_id;
 
 /// A custom memory pool.
 ///
@@ -29,7 +30,8 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     type Buffer: AsMut<[u8]> + Send;
 
     /// Get a buffer of at least the requested size.
-    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType) -> Self::Buffer;
+    /// `request_id` is a lightweight per-request identifier for tracking/correlation.
+    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType, request_id: u64) -> Self::Buffer;
 
     /// Get a buffer of at least the requested size asynchronously.
     /// Returns a future that resolves to the buffer.
@@ -44,8 +46,9 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
         &self,
         size: usize,
         meta_request_type: MetaRequestType,
+        request_id: u64,
     ) -> impl Future<Output = Self::Buffer> + Send {
-        ready(self.get_buffer(size, meta_request_type))
+        ready(self.get_buffer(size, meta_request_type, request_id))
     }
 
     /// Trim the pool.
@@ -324,14 +327,20 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
         self.pool.trim();
     }
 
-    fn reserve(&self, size: usize, meta_request_type: MetaRequestType, can_block: bool) -> CrtTicketFuture {
+    fn reserve(
+        &self,
+        size: usize,
+        meta_request_type: MetaRequestType,
+        request_id: u64,
+        can_block: bool,
+    ) -> CrtTicketFuture {
         let future = CrtTicketFuture::new(&self.allocator);
         let ticket_vtable = self.ticket_vtable;
 
         if can_block {
             // The write path in s3_meta_request.c expects the ticket to be fulfilled
             // synchronously — it treats an unfulfilled future as error.
-            let buffer = self.pool.get_buffer(size, meta_request_type);
+            let buffer = self.pool.get_buffer(size, meta_request_type, request_id);
             let ticket = CrtTicket::new(buffer, ticket_vtable);
             future.set(ticket);
         } else {
@@ -347,7 +356,7 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
             // in-flight ticket futures. If one is added, we could propagate it to
             // `get_buffer_async` to avoid the wasteful buffer allocation.
             let _handle = self.event_loop_group.spawn_future(async move {
-                let buffer = pool.get_buffer_async(size, meta_request_type).await;
+                let buffer = pool.get_buffer_async(size, meta_request_type, request_id).await;
                 let ticket = CrtTicket::new(buffer, ticket_vtable);
                 future_clone.set(ticket);
             });
@@ -366,8 +375,10 @@ unsafe extern "C" fn pool_reserve<Pool: MemoryPool>(
 
     // SAFETY: `meta.meta_request` is a pointer to a valid `aws_s3_meta_request`.
     let request_type = unsafe { (*meta.meta_request).type_ };
-
-    let future = crt_pool.reserve(meta.size, request_type.into(), meta.can_block);
+    // SAFETY: `meta.meta_request` is a pointer to a valid `aws_s3_meta_request` whose
+    // user_data was initialized by `MetaRequestOptions`.
+    let request_id = unsafe { meta_request_id(meta.meta_request) };
+    let future = crt_pool.reserve(meta.size, request_type.into(), request_id, meta.can_block);
 
     // SAFETY: the CRT will take ownership of the future.
     unsafe { future.into_inner_ptr() }

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -18,8 +18,7 @@ use crate::ToAwsByteCursor as _;
 use crate::common::allocator::Allocator;
 use crate::io::event_loop::EventLoopGroup;
 use crate::io::futures::FutureSpawner;
-use crate::s3::client::MetaRequestType;
-use crate::s3::client::meta_request_id;
+use crate::s3::client::MetaRequest;
 
 /// A custom memory pool.
 ///
@@ -29,11 +28,10 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     /// Associated buffer type.
     type Buffer: AsMut<[u8]> + Send;
 
-    /// Get a buffer of at least the requested size.
-    /// `request_id` is a lightweight per-request identifier for tracking/correlation.
-    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType, request_id: u64) -> Self::Buffer;
+    /// Get a buffer of at least `size` bytes for the given meta request.
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer;
 
-    /// Get a buffer of at least the requested size asynchronously.
+    /// Get a buffer of at least `size` bytes asynchronously for the given meta request.
     /// Returns a future that resolves to the buffer.
     ///
     /// Implementations must always eventually resolve. If memory is not immediately
@@ -42,13 +40,8 @@ pub trait MemoryPool: Clone + Send + Sync + 'static {
     ///
     /// The default implementation wraps [`get_buffer`](Self::get_buffer) in a
     /// ready future. Override this when the pool needs to wait for memory to free up.
-    fn get_buffer_async(
-        &self,
-        size: usize,
-        meta_request_type: MetaRequestType,
-        request_id: u64,
-    ) -> impl Future<Output = Self::Buffer> + Send {
-        ready(self.get_buffer(size, meta_request_type, request_id))
+    fn get_buffer_async(&self, size: usize, meta_request: MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
+        ready(self.get_buffer(size, &meta_request))
     }
 
     /// Trim the pool.
@@ -327,20 +320,14 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
         self.pool.trim();
     }
 
-    fn reserve(
-        &self,
-        size: usize,
-        meta_request_type: MetaRequestType,
-        request_id: u64,
-        can_block: bool,
-    ) -> CrtTicketFuture {
+    fn reserve(&self, size: usize, meta_request: MetaRequest, can_block: bool) -> CrtTicketFuture {
         let future = CrtTicketFuture::new(&self.allocator);
         let ticket_vtable = self.ticket_vtable;
 
         if can_block {
             // The write path in s3_meta_request.c expects the ticket to be fulfilled
             // synchronously — it treats an unfulfilled future as error.
-            let buffer = self.pool.get_buffer(size, meta_request_type, request_id);
+            let buffer = self.pool.get_buffer(size, &meta_request);
             let ticket = CrtTicket::new(buffer, ticket_vtable);
             future.set(ticket);
         } else {
@@ -356,7 +343,7 @@ impl<Pool: MemoryPool> CrtBufferPool<Pool> {
             // in-flight ticket futures. If one is added, we could propagate it to
             // `get_buffer_async` to avoid the wasteful buffer allocation.
             let _handle = self.event_loop_group.spawn_future(async move {
-                let buffer = pool.get_buffer_async(size, meta_request_type, request_id).await;
+                let buffer = pool.get_buffer_async(size, meta_request).await;
                 let ticket = CrtTicket::new(buffer, ticket_vtable);
                 future_clone.set(ticket);
             });
@@ -373,12 +360,12 @@ unsafe extern "C" fn pool_reserve<Pool: MemoryPool>(
     // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
     let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
 
-    // SAFETY: `meta.meta_request` is a pointer to a valid `aws_s3_meta_request`.
-    let request_type = unsafe { (*meta.meta_request).type_ };
-    // SAFETY: `meta.meta_request` is a pointer to a valid `aws_s3_meta_request` whose
-    // user_data was initialized by `MetaRequestOptions`.
-    let request_id = unsafe { meta_request_id(meta.meta_request) };
-    let future = crt_pool.reserve(meta.size, request_type.into(), request_id, meta.can_block);
+    // SAFETY: `meta.meta_request` is a valid pointer to an `aws_s3_meta_request` whose
+    // `user_data` was initialised by `MetaRequestOptions`. `from_raw_acquire` increments
+    // the ref-count so the `MetaRequest` is safe to use and drop independently of the
+    // lifetime of the callback's `meta` argument.
+    let meta_request = unsafe { MetaRequest::from_raw_acquire(meta.meta_request) };
+    let future = crt_pool.reserve(meta.size, meta_request, meta.can_block);
 
     // SAFETY: the CRT will take ownership of the future.
     unsafe { future.into_inner_ptr() }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -156,7 +156,7 @@ impl PagedPool {
 impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
-    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer {
         self.get_buffer(size, meta_request.meta_request_type().into())
     }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -156,7 +156,7 @@ impl PagedPool {
 impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
-    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType, _request_id: u64) -> Self::Buffer {
         self.get_buffer(size, meta_request_type.into())
     }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mountpoint_s3_client::config::{MemoryPool, MetaRequestType};
+use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::sync::{Arc, RwLock};
 
@@ -156,8 +156,8 @@ impl PagedPool {
 impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
-    fn get_buffer(&self, size: usize, meta_request_type: MetaRequestType, _request_id: u64) -> Self::Buffer {
-        self.get_buffer(size, meta_request_type.into())
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
+        self.get_buffer(size, meta_request.meta_request_type().into())
     }
 
     fn trim(&self) -> bool {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -156,7 +156,7 @@ impl PagedPool {
 impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
-    fn get_buffer(&self, size: usize, meta_request: MetaRequest) -> Self::Buffer {
+    fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
         self.get_buffer(size, meta_request.meta_request_type().into())
     }
 


### PR DESCRIPTION
We need to be able to identify which meta-request a buffer allocation belongs to at the CRT pool layer.

This PR adds an optional `custom_id` to `MetaRequestOptionsInner` and exposes it through `MetaRequest`, which is now passed directly to `MemoryPool::get_buffer` / `get_buffer_async`. The identifier can be set via `GetObjectParams::custom_id` and `PutObjectParams::custom_id` in the client crate.


### Does this change impact existing behavior?
No.

### Does this change need a changelog entry? Does it require a version change?
The `MemoryPool` trait signature changed, but the trait is marked experimental. No user-visible behavior change otherwise.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
