### PR TITLE
bench: Add incremental-upload throughput benchmark to S3 Express CI

### DIFF
--- a/.github/actions/scripts/render-mem-summary.sh
+++ b/.github/actions/scripts/render-mem-summary.sh
@@ -16,13 +16,13 @@ fi
 
 out="## Memory Breach Detection
 
-| Test | Peak RSS (MiB) | Memory Limit (MiB) | Status | Peak Prefetch Reserved (MiB) | Peak Upload Reserved (MiB) | Peak Pool GetObject (MiB) | Peak Pool PutObject (MiB) |
-|---|---|---|---|---|---|---|---|
+| Test | Peak RSS (MiB) | Memory Limit (MiB) | Status | Peak Prefetch Reserved (MiB) | Peak Upload Reserved (MiB) | Peak Pool GetObject (MiB) | Peak Pool PutObject (MiB) | Peak Pool Append (MiB) |
+|---|---|---|---|---|---|---|---|---|
 "
 for f in "${files[@]}"; do
   row=$(jq -r '
     (if .breached then "❌ BREACHED" else "✅ OK" end) as $status
-    | "| \(.test) | \(.peak_rss_mib) | \(.mem_limit_mib) | \($status) | \(.peak_prefetch_reserved_mib // "N/A") | \(.peak_upload_reserved_mib // "N/A") | \(.peak_pool_get_object_mib // "N/A") | \(.peak_pool_put_object_mib // "N/A") |"
+    | "| \(.test) | \(.peak_rss_mib) | \(.mem_limit_mib) | \($status) | \(.peak_prefetch_reserved_mib // "N/A") | \(.peak_upload_reserved_mib // "N/A") | \(.peak_pool_get_object_mib // "N/A") | \(.peak_pool_put_object_mib // "N/A") | \(.peak_pool_append_mib // "N/A") |"
   ' "$f")
   out+="${row}
 "

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -268,7 +268,6 @@ jobs:
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
-        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   S3_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
-  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
@@ -182,6 +181,8 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
+      env:
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}latency-bench/
       run: mountpoint-s3/scripts/fs_latency_bench.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix
@@ -268,6 +269,7 @@ jobs:
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,6 +94,7 @@ jobs:
     - name: Run Benchmark
       env:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'
@@ -267,6 +268,7 @@ jobs:
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -54,15 +54,35 @@ jobs:
           - variant: default
             features: ""
             max_memory_target_mib: ""
+            incremental_upload: ""
+            bench_categories: ""
             name_suffix: ""
             data_path_suffix: ""
             results_subdir_suffix: ""
           - variant: mem-limited
             features: "--features mem_limiter"
             max_memory_target_mib: "512"
+            incremental_upload: ""
+            bench_categories: ""
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
             results_subdir_suffix: "-mem-limited"
+          - variant: incremental-upload
+            features: ""
+            max_memory_target_mib: ""
+            incremental_upload: "yes"
+            bench_categories: "write mix"
+            name_suffix: ", Incremental Upload"
+            data_path_suffix: "/incremental_upload"
+            results_subdir_suffix: "-incremental-upload"
+          - variant: incremental-upload-mem-limited
+            features: "--features mem_limiter"
+            max_memory_target_mib: "512"
+            incremental_upload: "yes"
+            bench_categories: "write mix"
+            name_suffix: ", Incremental Upload, Memory-Limited"
+            data_path_suffix: "/incremental_upload/mem_limited"
+            results_subdir_suffix: "-incremental-upload-mem-limited"
 
     steps:
     - name: Configure AWS credentials
@@ -94,9 +114,11 @@ jobs:
     - name: Run Benchmark
       env:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_INCREMENTAL_UPLOAD: ${{ matrix.incremental_upload }}
+        S3_BENCH_CATEGORIES: ${{ matrix.bench_categories }}
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
-      if: matrix.variant == 'mem-limited'
+      if: matrix.max_memory_target_mib != ''
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -116,6 +116,7 @@ jobs:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
         S3_INCREMENTAL_UPLOAD: ${{ matrix.incremental_upload }}
         S3_BENCH_CATEGORIES: ${{ matrix.bench_categories }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
       if: matrix.max_memory_target_mib != ''

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -24,7 +24,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   S3_BUCKET_NAME: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_BUCKET_NAME }}
-  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
@@ -54,7 +53,7 @@ jobs:
           - variant: default
             features: ""
             max_memory_target_mib: ""
-            incremental_upload: ""
+            extra_args: ""
             bench_categories: ""
             name_suffix: ""
             data_path_suffix: ""
@@ -62,7 +61,7 @@ jobs:
           - variant: mem-limited
             features: "--features mem_limiter"
             max_memory_target_mib: "512"
-            incremental_upload: ""
+            extra_args: ""
             bench_categories: ""
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
@@ -70,7 +69,7 @@ jobs:
           - variant: incremental-upload
             features: ""
             max_memory_target_mib: ""
-            incremental_upload: "yes"
+            extra_args: "--incremental-upload"
             bench_categories: "write mix"
             name_suffix: ", Incremental Upload"
             data_path_suffix: "/incremental_upload"
@@ -78,7 +77,7 @@ jobs:
           - variant: incremental-upload-mem-limited
             features: "--features mem_limiter"
             max_memory_target_mib: "512"
-            incremental_upload: "yes"
+            extra_args: "--incremental-upload"
             bench_categories: "write mix"
             name_suffix: ", Incremental Upload, Memory-Limited"
             data_path_suffix: "/incremental_upload/mem_limited"
@@ -114,7 +113,7 @@ jobs:
     - name: Run Benchmark
       env:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
-        S3_INCREMENTAL_UPLOAD: ${{ matrix.incremental_upload }}
+        S3_MOUNTPOINT_EXTRA_ARGS: ${{ matrix.extra_args }}
         S3_BENCH_CATEGORIES: ${{ matrix.bench_categories }}
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
@@ -203,6 +202,8 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
+      env:
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}latency-bench/
       run: mountpoint-s3/scripts/fs_latency_bench.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -29,6 +29,8 @@ We keep the records of benchmarking results in `gh-pages` branch and the perform
 - [throughput chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/bench/mem_limited/)
 - [throughput (with cache) chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/cache_bench/mem_limited/)
 - [throughput (s3-express) chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/mem_limited/)
+- [throughput (s3-express, incremental upload) chart](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/incremental_upload/)
+- [throughput (s3-express, incremental upload, memory-limited) chart](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/incremental_upload/mem_limited/)
 
 ### Running the benchmark
 While our benchmark script is written for CI testing only, it is possible to run manually.

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -41,6 +41,10 @@ if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
   optional_args+=" --max-memory-target=${S3_MAX_MEMORY_TARGET_MIB}"
 fi
 
+if [[ -n "${S3_INCREMENTAL_UPLOAD}" ]]; then
+  optional_args+=" --incremental-upload"
+fi
+
 base_dir=$(dirname "$0")
 project_dir="${base_dir}/../.."
 cd ${project_dir}
@@ -207,9 +211,9 @@ run_benchmarks() {
   done
 }
 
-run_benchmarks read
-run_benchmarks write
-run_benchmarks mix
+for category in ${S3_BENCH_CATEGORIES:-read write mix}; do
+  run_benchmarks "$category"
+done
 
 # combine all bench results into one json file
 echo "Throughput:"

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -41,8 +41,8 @@ if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
   optional_args+=" --max-memory-target=${S3_MAX_MEMORY_TARGET_MIB}"
 fi
 
-if [[ -n "${S3_INCREMENTAL_UPLOAD}" ]]; then
-  optional_args+=" --incremental-upload"
+if [[ -n "${S3_MOUNTPOINT_EXTRA_ARGS}" ]]; then
+  optional_args+=" ${S3_MOUNTPOINT_EXTRA_ARGS}"
 fi
 
 base_dir=$(dirname "$0")

--- a/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
+++ b/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
@@ -54,7 +54,7 @@ struct CliArgs {
 /// JSON field name for the peak (in MiB) and the regex matching lines ending in that
 /// metric's value (bytes). Absent entries are omitted from `_extra_metrics.json` and
 /// rendered as "N/A" in the GH step summary table.
-fn mem_metric_patterns() -> [(&'static str, Regex); 4] {
+fn mem_metric_patterns() -> [(&'static str, Regex); 5] {
     [
         (
             "peak_prefetch_reserved_mib",
@@ -72,6 +72,10 @@ fn mem_metric_patterns() -> [(&'static str, Regex); 4] {
             "peak_pool_put_object_mib",
             Regex::new(r"pool\.reserved_bytes\[kind=put_object\]:\s(\d+)$").unwrap(),
         ),
+        (
+            "peak_pool_append_mib",
+            Regex::new(r"pool\.reserved_bytes\[kind=append\]:\s(\d+)$").unwrap(),
+        ),
     ]
 }
 
@@ -85,7 +89,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut metric_values: Vec<u64> = Vec::new();
     // Peak value (bytes) per mem-metric field; None until first observation.
-    let mut mem_metric_peaks: [Option<u64>; 4] = [None; 4];
+    let mut mem_metric_peaks: [Option<u64>; 5] = [None; 5];
 
     // collect metrics from all log files in the given directory
     for path in paths {

--- a/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
+++ b/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
@@ -54,8 +54,8 @@ struct CliArgs {
 /// JSON field name for the peak (in MiB) and the regex matching lines ending in that
 /// metric's value (bytes). Absent entries are omitted from `_extra_metrics.json` and
 /// rendered as "N/A" in the GH step summary table.
-fn mem_metric_patterns() -> [(&'static str, Regex); 5] {
-    [
+fn mem_metric_patterns() -> Vec<(&'static str, Regex)> {
+    vec![
         (
             "peak_prefetch_reserved_mib",
             Regex::new(r"mem\.bytes_reserved\[area=prefetch\]:\s(\d+)$").unwrap(),
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut metric_values: Vec<u64> = Vec::new();
     // Peak value (bytes) per mem-metric field; None until first observation.
-    let mut mem_metric_peaks: [Option<u64>; 5] = [None; 5];
+    let mut mem_metric_peaks: Vec<Option<u64>> = vec![None; mem_metrics.len()];
 
     // collect metrics from all log files in the given directory
     for path in paths {


### PR DESCRIPTION
## Summary

Extend the existing S3 Express throughput benchmark CI with two new `--incremental-upload` variants, folded into the existing `bench` matrix introduced by #1808 rather than as a separate job:

- `incremental-upload` — default memory budget.
- `incremental-upload-mem-limited` — `--features mem_limiter` + `--max-memory-target=512`.

Both new variants only run the `write` and `mix` fio categories (read is skipped since incremental upload is an upload-path feature).

This PR also isolates `S3_BUCKET_TEST_PREFIX` per matrix leg on the throughput `bench` jobs (S3 Standard and S3 Express). The single workflow-level prefix previously caused all matrix legs to race for the same fio scratch keys in the benchmark bucket. This was latent (silent overlapping MPUs) for non-incremental legs but fatal for incremental upload: the append pipeline conditions each `PutObject` on the object's current ETag, and a sibling leg's `unlink=1` between iterations aborts the upload with `NoSuchKey`.

gh-pages paths follow the `data_path_suffix` convention from #1808:

| Variant | Throughput chart path |
|---|---|
| Incremental Upload | `dev/s3-express/bench/incremental_upload` |
| Incremental Upload, Memory-Limited | `dev/s3-express/bench/incremental_upload/mem_limited` |

### Does this change impact existing behavior?

No - only benchmark prefix changes generating/using new objects.

### Does this change need a changelog entry? Does it require a version change?

No — CI-only change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
