### PR TITLE
Pass HandleId as custom_id in S3 request params

### DIFF
--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -435,11 +435,9 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     request_range: Range<u64>,
     handle_id: HandleId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
-    // TODO: Pass handle_id to GetObjectParams once the client crate exposes the field
-    let _ = handle_id;
     try_stream! {
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(handle_id.as_raw())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;


### PR DESCRIPTION
Connects the file handle ID to S3 request params, completing the link between PR #1809 (HandleId through prefetcher) and PR #1812 (custom_id through CRT buffer pool).

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
