### PR TITLE
Reconcile memory limiter reservations with pool allocations

### DIFF
--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -19,7 +19,7 @@ const OBJECT_SIZE: usize = 10 * BLOCK_SIZE as usize;
 async fn read_cache_block(cache: &DiskDataCache, cache_key: &ObjectId) {
     _ = black_box(
         cache
-            .get_block(cache_key, 0, 0, OBJECT_SIZE)
+            .get_block(cache_key, 0, 0, OBJECT_SIZE, None)
             .await
             .expect("is able to read")
             .expect("data is there"),

--- a/mountpoint-s3-fs/src/data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache.rs
@@ -61,6 +61,7 @@ pub trait DataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
+        custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].

--- a/mountpoint-s3-fs/src/data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache.rs
@@ -23,7 +23,7 @@ pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 
 use crate::object::ObjectId;
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;
@@ -62,7 +62,7 @@ pub trait DataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].

--- a/mountpoint-s3-fs/src/data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache.rs
@@ -23,6 +23,7 @@ pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 
 use crate::object::ObjectId;
+use crate::prefetch::HandleId;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;
@@ -61,7 +62,7 @@ pub trait DataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].

--- a/mountpoint-s3-fs/src/data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache.rs
@@ -23,7 +23,7 @@ pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
 pub use crate::data_cache::multilevel_cache::MultilevelDataCache;
 
 use crate::object::ObjectId;
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 
 /// Indexes blocks within a given object.
 pub type BlockIndex = u64;
@@ -62,7 +62,7 @@ pub trait DataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>>;
 
     /// Put block of data to the cache for the given [ObjectId] and [BlockIndex].

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -266,7 +266,7 @@ impl DiskBlock {
         }
 
         let size = header.block_len as usize;
-        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache);
+        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, None);
         buffer.fill_from_reader(reader)?;
         let data = buffer.into_bytes();
 

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -26,6 +26,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY, CACHE_TOTAL_SIZE,
 };
 use crate::object::ObjectId;
+use crate::prefetch::HandleId;
 use crate::sync::Mutex;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -262,7 +263,7 @@ impl DiskBlock {
         reader: &mut impl Read,
         block_size: u64,
         pool: &PagedPool,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> Result<Self, DiskBlockReadWriteError> {
         let header: DiskBlockHeader = bincode::decode_from_std_read(reader, BINCODE_CONFIG)?;
 
@@ -271,7 +272,7 @@ impl DiskBlock {
         }
 
         let size = header.block_len as usize;
-        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, custom_id);
+        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, handle_id);
         buffer.fill_from_reader(reader)?;
         let data = buffer.into_bytes();
 
@@ -342,7 +343,7 @@ impl DiskDataCache {
         cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         trace!(
             key = ?cache_key.key(),
@@ -366,7 +367,7 @@ impl DiskDataCache {
             return Err(DataCacheError::InvalidBlockContent);
         }
 
-        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, custom_id)
+        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, handle_id)
             .inspect_err(|e| warn!(path = ?path.as_ref(), "block could not be deserialized: {:?}", e))?;
         let bytes = block
             .data(cache_key, block_idx, block_offset)
@@ -470,7 +471,7 @@ impl DataCache for DiskDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.config.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
@@ -478,7 +479,7 @@ impl DataCache for DiskDataCache {
         let start = Instant::now();
         let block_key = DiskBlockKey::new(cache_key, block_idx);
         let path = self.get_path_for_block_key(&block_key);
-        let result = match self.read_block(&path, cache_key, block_idx, block_offset, custom_id) {
+        let result = match self.read_block(&path, cache_key, block_idx, block_offset, handle_id) {
             Ok(None) => {
                 // Cache miss.
                 Ok(None)

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -258,7 +258,12 @@ impl DiskBlock {
     }
 
     /// Deserialize an instance from `reader`.
-    fn read(reader: &mut impl Read, block_size: u64, pool: &PagedPool) -> Result<Self, DiskBlockReadWriteError> {
+    fn read(
+        reader: &mut impl Read,
+        block_size: u64,
+        pool: &PagedPool,
+        custom_id: Option<u64>,
+    ) -> Result<Self, DiskBlockReadWriteError> {
         let header: DiskBlockHeader = bincode::decode_from_std_read(reader, BINCODE_CONFIG)?;
 
         if header.block_len > block_size {
@@ -266,7 +271,7 @@ impl DiskBlock {
         }
 
         let size = header.block_len as usize;
-        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, None);
+        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, custom_id);
         buffer.fill_from_reader(reader)?;
         let data = buffer.into_bytes();
 
@@ -337,6 +342,7 @@ impl DiskDataCache {
         cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
+        custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         trace!(
             key = ?cache_key.key(),
@@ -360,7 +366,7 @@ impl DiskDataCache {
             return Err(DataCacheError::InvalidBlockContent);
         }
 
-        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool)
+        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, custom_id)
             .inspect_err(|e| warn!(path = ?path.as_ref(), "block could not be deserialized: {:?}", e))?;
         let bytes = block
             .data(cache_key, block_idx, block_offset)
@@ -464,6 +470,7 @@ impl DataCache for DiskDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
+        custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.config.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
@@ -471,7 +478,7 @@ impl DataCache for DiskDataCache {
         let start = Instant::now();
         let block_key = DiskBlockKey::new(cache_key, block_idx);
         let path = self.get_path_for_block_key(&block_key);
-        let result = match self.read_block(&path, cache_key, block_idx, block_offset) {
+        let result = match self.read_block(&path, cache_key, block_idx, block_offset, custom_id) {
             Ok(None) => {
                 // Cache miss.
                 Ok(None)
@@ -769,7 +776,7 @@ mod tests {
         );
 
         let block = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible");
         assert!(
@@ -783,7 +790,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -798,7 +805,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_2, 0, 0, object_2_size)
+            .get_block(&cache_key_2, 0, 0, object_2_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -813,7 +820,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_1, 1, block_size, object_1_size)
+            .get_block(&cache_key_1, 1, block_size, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -824,7 +831,7 @@ mod tests {
 
         // Entry 1's first block still intact
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -856,7 +863,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key, 0, 0, slice.len())
+            .get_block(&cache_key, 0, 0, slice.len(), None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -890,7 +897,7 @@ mod tests {
             object_size: usize,
         ) -> bool {
             if let Some(retrieved) = cache
-                .get_block(cache_key, block_idx, block_idx * (BLOCK_SIZE) as u64, object_size)
+                .get_block(cache_key, block_idx, block_idx * (BLOCK_SIZE) as u64, object_size, None)
                 .await
                 .expect("cache should be accessible")
             {
@@ -1106,7 +1113,8 @@ mod tests {
         replace_u64_at(&mut buf, offset, u64::MAX);
 
         let pool = PagedPool::new_with_candidate_sizes([MAX_LENGTH as usize]);
-        let err = DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool).expect_err("deserialization should fail");
+        let err =
+            DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None).expect_err("deserialization should fail");
         match length_to_corrupt {
             "key" | "etag" => assert!(matches!(
                 err,
@@ -1147,7 +1155,7 @@ mod tests {
             let handle = pool
                 .spawn_with_handle(async move {
                     let block = data_cache
-                        .get_block(&cache_key, block_idx, block_offset, object_size)
+                        .get_block(&cache_key, block_idx, block_offset, object_size, None)
                         .await
                         .expect("get_block should not return error");
                     if block.is_none() {

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -26,7 +26,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY, CACHE_TOTAL_SIZE,
 };
 use crate::object::ObjectId;
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 use crate::sync::Mutex;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -263,7 +263,7 @@ impl DiskBlock {
         reader: &mut impl Read,
         block_size: u64,
         pool: &PagedPool,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> Result<Self, DiskBlockReadWriteError> {
         let header: DiskBlockHeader = bincode::decode_from_std_read(reader, BINCODE_CONFIG)?;
 
@@ -272,7 +272,7 @@ impl DiskBlock {
         }
 
         let size = header.block_len as usize;
-        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, handle_id);
+        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, request_id);
         buffer.fill_from_reader(reader)?;
         let data = buffer.into_bytes();
 
@@ -343,7 +343,7 @@ impl DiskDataCache {
         cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         trace!(
             key = ?cache_key.key(),
@@ -367,7 +367,7 @@ impl DiskDataCache {
             return Err(DataCacheError::InvalidBlockContent);
         }
 
-        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, handle_id)
+        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, request_id)
             .inspect_err(|e| warn!(path = ?path.as_ref(), "block could not be deserialized: {:?}", e))?;
         let bytes = block
             .data(cache_key, block_idx, block_offset)
@@ -471,7 +471,7 @@ impl DataCache for DiskDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.config.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
@@ -479,7 +479,7 @@ impl DataCache for DiskDataCache {
         let start = Instant::now();
         let block_key = DiskBlockKey::new(cache_key, block_idx);
         let path = self.get_path_for_block_key(&block_key);
-        let result = match self.read_block(&path, cache_key, block_idx, block_offset, handle_id) {
+        let result = match self.read_block(&path, cache_key, block_idx, block_offset, request_id) {
             Ok(None) => {
                 // Cache miss.
                 Ok(None)

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -26,7 +26,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY, CACHE_TOTAL_SIZE,
 };
 use crate::object::ObjectId;
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 use crate::sync::Mutex;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -263,7 +263,7 @@ impl DiskBlock {
         reader: &mut impl Read,
         block_size: u64,
         pool: &PagedPool,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> Result<Self, DiskBlockReadWriteError> {
         let header: DiskBlockHeader = bincode::decode_from_std_read(reader, BINCODE_CONFIG)?;
 
@@ -272,7 +272,7 @@ impl DiskBlock {
         }
 
         let size = header.block_len as usize;
-        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, request_id);
+        let mut buffer = pool.get_buffer_mut(size, BufferKind::DiskCache, cursor_id);
         buffer.fill_from_reader(reader)?;
         let data = buffer.into_bytes();
 
@@ -343,7 +343,7 @@ impl DiskDataCache {
         cache_key: &ObjectId,
         block_idx: BlockIndex,
         block_offset: u64,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         trace!(
             key = ?cache_key.key(),
@@ -367,7 +367,7 @@ impl DiskDataCache {
             return Err(DataCacheError::InvalidBlockContent);
         }
 
-        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, request_id)
+        let block = DiskBlock::read(&mut file, self.block_size(), &self.pool, cursor_id)
             .inspect_err(|e| warn!(path = ?path.as_ref(), "block could not be deserialized: {:?}", e))?;
         let bytes = block
             .data(cache_key, block_idx, block_offset)
@@ -471,7 +471,7 @@ impl DataCache for DiskDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.config.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
@@ -479,7 +479,7 @@ impl DataCache for DiskDataCache {
         let start = Instant::now();
         let block_key = DiskBlockKey::new(cache_key, block_idx);
         let path = self.get_path_for_block_key(&block_key);
-        let result = match self.read_block(&path, cache_key, block_idx, block_offset, request_id) {
+        let result = match self.read_block(&path, cache_key, block_idx, block_offset, cursor_id) {
             Ok(None) => {
                 // Cache miss.
                 Ok(None)

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -298,6 +298,7 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
+        _custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let start = Instant::now();
         let result = match self.read_block(cache_key, block_idx, block_offset, object_size).await {
@@ -523,7 +524,7 @@ mod tests {
         );
 
         let block = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible");
         assert!(
@@ -537,7 +538,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -553,7 +554,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_2, 0, 0, object_2_size)
+            .get_block(&cache_key_2, 0, 0, object_2_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -569,7 +570,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let entry = cache
-            .get_block(&cache_key_1, 1, block_size, object_1_size)
+            .get_block(&cache_key_1, 1, block_size, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -581,7 +582,7 @@ mod tests {
 
         // Entry 1's first block still intact
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -616,7 +617,7 @@ mod tests {
             .await
             .expect("cache should be accessible");
         let get_result = cache
-            .get_block(&cache_key_1, 0, 0, data_1.len())
+            .get_block(&cache_key_1, 0, 0, data_1.len(), None)
             .await
             .expect("cache should be accessible");
         assert!(get_result.is_none());
@@ -662,7 +663,7 @@ mod tests {
             .await
             .unwrap();
         let (received_data, _) = cache
-            .get_block(&cache_key, 0, 0, data.len())
+            .get_block(&cache_key, 0, 0, data.len(), None)
             .await
             .expect("get should succeed with intact metadata")
             .expect("block should be non-empty")
@@ -677,7 +678,7 @@ mod tests {
             .await
             .unwrap();
         let err = cache
-            .get_block(&cache_key, 0, 0, data.len())
+            .get_block(&cache_key, 0, 0, data.len(), None)
             .await
             .expect_err("cache should return error if checksum isn't present");
         assert!(matches!(err, DataCacheError::InvalidBlockChecksum));
@@ -694,7 +695,7 @@ mod tests {
             .await
             .unwrap();
         let err = cache
-            .get_block(&cache_key, 0, 0, data.len())
+            .get_block(&cache_key, 0, 0, data.len(), None)
             .await
             .expect_err("cache should return error if object metadata isn't present");
         assert!(matches!(err, DataCacheError::InvalidBlockHeader(_)));
@@ -718,7 +719,7 @@ mod tests {
             .await
             .unwrap();
         let err = cache
-            .get_block(&cache_key, 0, 0, data_2.len())
+            .get_block(&cache_key, 0, 0, data_2.len(), None)
             .await
             .expect_err("cache should return error if object metadata doesn't match data");
         assert!(matches!(err, DataCacheError::InvalidBlockHeader(_)));
@@ -737,14 +738,14 @@ mod tests {
             .await
             .unwrap();
         let err = cache
-            .get_block(&cache_key, 0, 0, data.len())
+            .get_block(&cache_key, 0, 0, data.len(), None)
             .await
             .expect_err("cache should return error if source bucket does not match");
         assert!(matches!(err, DataCacheError::InvalidBlockHeader(_)));
 
         // Get data that's not been written yet
         let result = cache
-            .get_block(&cache_key_non_existent, 0, 0, data.len())
+            .get_block(&cache_key_non_existent, 0, 0, data.len(), None)
             .await
             .expect("cache should return None if data is not present");
         assert_eq!(result, None);

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -5,7 +5,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY,
 };
 use crate::object::ObjectId;
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -299,7 +299,7 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        _handle_id: Option<HandleId>,
+        _request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let start = Instant::now();
         let result = match self.read_block(cache_key, block_idx, block_offset, object_size).await {

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -5,7 +5,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY,
 };
 use crate::object::ObjectId;
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -299,7 +299,7 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        _request_id: Option<RequestId>,
+        _cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let start = Instant::now();
         let result = match self.read_block(cache_key, block_idx, block_offset, object_size).await {

--- a/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/express_data_cache.rs
@@ -5,6 +5,7 @@ use crate::metrics::defs::{
     CACHE_PUT_ERRORS, CACHE_PUT_IO_SIZE, CACHE_PUT_LATENCY,
 };
 use crate::object::ObjectId;
+use crate::prefetch::HandleId;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -298,7 +299,7 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        _custom_id: Option<u64>,
+        _handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let start = Instant::now();
         let result = match self.read_block(cache_key, block_idx, block_offset, object_size).await {

--- a/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
@@ -39,6 +39,7 @@ impl DataCache for InMemoryDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
+        _custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);
@@ -95,7 +96,7 @@ mod tests {
         let cache_key_2 = ObjectId::new("b".into(), ETag::for_tests());
 
         let block = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache is accessible");
         assert!(
@@ -109,7 +110,7 @@ mod tests {
             .await
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
@@ -124,7 +125,7 @@ mod tests {
             .await
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_2, 0, 0, object_2_size)
+            .get_block(&cache_key_2, 0, 0, object_2_size, None)
             .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
@@ -139,7 +140,7 @@ mod tests {
             .await
             .expect("cache is accessible");
         let entry = cache
-            .get_block(&cache_key_1, 1, block_size, object_1_size)
+            .get_block(&cache_key_1, 1, block_size, object_1_size, None)
             .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");
@@ -150,7 +151,7 @@ mod tests {
 
         // Entry 1's first block still intact
         let entry = cache
-            .get_block(&cache_key_1, 0, 0, object_1_size)
+            .get_block(&cache_key_1, 0, 0, object_1_size, None)
             .await
             .expect("cache is accessible")
             .expect("cache entry should be returned");

--- a/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 use crate::object::ObjectId;
+use crate::prefetch::HandleId;
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
@@ -39,7 +40,7 @@ impl DataCache for InMemoryDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        _custom_id: Option<u64>,
+        _handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);

--- a/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 use crate::object::ObjectId;
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
@@ -40,7 +40,7 @@ impl DataCache for InMemoryDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        _request_id: Option<RequestId>,
+        _cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);

--- a/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/in_memory_data_cache.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult};
 use crate::object::ObjectId;
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 use crate::sync::RwLock;
 
 /// Simple in-memory (RAM) implementation of [DataCache]. Recommended for use in testing only.
@@ -40,7 +40,7 @@ impl DataCache for InMemoryDataCache {
         block_idx: BlockIndex,
         block_offset: u64,
         _object_size: usize,
-        _handle_id: Option<HandleId>,
+        _request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         if block_offset != block_idx * self.block_size {
             return Err(DataCacheError::InvalidBlockOffset);

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use futures::task::SpawnExt;
 use tracing::{trace, warn};
 
+use crate::prefetch::HandleId;
 use crate::{Runtime, object::ObjectId};
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -45,11 +46,11 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         match self
             .disk_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
             .await
         {
             Ok(Some(data)) => {
@@ -62,7 +63,7 @@ where
 
         if let Some(data) = self
             .express_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
             .await?
         {
             trace!(cache_key=?cache_key, block_idx=block_idx, "block served from the express cache");

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use futures::task::SpawnExt;
 use tracing::{trace, warn};
 
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 use crate::{Runtime, object::ObjectId};
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -46,11 +46,11 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         match self
             .disk_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, cursor_id)
             .await
         {
             Ok(Some(data)) => {
@@ -63,7 +63,7 @@ where
 
         if let Some(data) = self
             .express_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, cursor_id)
             .await?
         {
             trace!(cache_key=?cache_key, block_idx=block_idx, "block served from the express cache");

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use futures::task::SpawnExt;
 use tracing::{trace, warn};
 
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 use crate::{Runtime, object::ObjectId};
 
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
@@ -46,11 +46,11 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         match self
             .disk_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
             .await
         {
             Ok(Some(data)) => {
@@ -63,7 +63,7 @@ where
 
         if let Some(data) = self
             .express_cache
-            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
             .await?
         {
             trace!(cache_key=?cache_key, block_idx=block_idx, "block served from the express cache");

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -45,10 +45,11 @@ where
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
+        custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         match self
             .disk_cache
-            .get_block(cache_key, block_idx, block_offset, object_size)
+            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
             .await
         {
             Ok(Some(data)) => {
@@ -61,7 +62,7 @@ where
 
         if let Some(data) = self
             .express_cache
-            .get_block(cache_key, block_idx, block_offset, object_size)
+            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
             .await?
         {
             trace!(cache_key=?cache_key, block_idx=block_idx, "block served from the express cache");
@@ -186,7 +187,7 @@ mod tests {
 
         // check we can retrieve an entry from one of the caches unless both were cleaned up
         let entry = cache
-            .get_block(&cache_key, 0, 0, object_size)
+            .get_block(&cache_key, 0, 0, object_size, None)
             .await
             .expect("cache should be accessible");
 
@@ -219,7 +220,7 @@ mod tests {
 
         // get from express, put entry in the local cache
         let entry = cache
-            .get_block(&cache_key, 0, 0, object_size)
+            .get_block(&cache_key, 0, 0, object_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -235,7 +236,7 @@ mod tests {
         let mut retries = 10;
         let entry = loop {
             let entry = cache
-                .get_block(&cache_key, 0, 0, object_size)
+                .get_block(&cache_key, 0, 0, object_size, None)
                 .await
                 .expect("cache should be accessible");
             if let Some(entry_data) = entry {
@@ -302,7 +303,7 @@ mod tests {
 
         // get data, which is stored in local only
         let entry = cache
-            .get_block(&cache_key_in_local, 0, 0, local_data_1.len())
+            .get_block(&cache_key_in_local, 0, 0, local_data_1.len(), None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -313,7 +314,7 @@ mod tests {
 
         // get data, which is stored in both caches and check that local has a priority
         let entry = cache
-            .get_block(&cache_key_in_both, 0, 0, local_data_2.len())
+            .get_block(&cache_key_in_both, 0, 0, local_data_2.len(), None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -340,7 +341,7 @@ mod tests {
         let cache = MultilevelDataCache::new(disk_cache, express_cache, runtime);
 
         let entry = cache
-            .get_block(&cache_key, 0, 0, object_size)
+            .get_block(&cache_key, 0, 0, object_size, None)
             .await
             .expect("cache should be accessible")
             .expect("cache entry should be returned");
@@ -373,7 +374,7 @@ mod tests {
         // try to get from the cache, assuming it is missing in local
         cache_dir.close().expect("should clean up local cache");
         let entry = cache
-            .get_block(&cache_key, 0, 0, object_size)
+            .get_block(&cache_key, 0, 0, object_size, None)
             .await
             .expect("cache should be accessible");
         assert!(entry.is_none(), "cache miss is expected for a large object");

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -1,10 +1,12 @@
 use std::{sync::atomic::Ordering, time::Instant};
 
+use dashmap::DashMap;
 use humansize::make_format;
 use metrics::atomics::AtomicU64;
 use tracing::{debug, trace};
 
 use crate::memory::PagedPool;
+use crate::prefetch::HandleId;
 use crate::sync::Arc;
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
@@ -27,10 +29,10 @@ impl BufferArea {
 
 /// `MemoryLimiter` tracks memory used by Mountpoint and makes decisions if a new memory reservation request can be accepted.
 /// Currently, there are two metrics we take into account:
-/// 1) the memory directly reserved on the limiter by prefetcher and (incremental) uploader instances.
-/// 2) the memory reserved on the memory pool by the CRT client for any request (downloads, atomic uploads, etc.)
+/// 1) the memory directly reserved on the limiter by prefetcher instances (read path).
+/// 2) the memory allocated in the memory pool for downloads, uploads, and disk cache.
 ///
-/// Single instance of this struct is shared among all of the prefetchers (file handles) and (incremental) uploaders.
+/// Single instance of this struct is shared among all of the prefetchers (file handles) and uploaders.
 ///
 /// Each file handle makes an initial reservation request with a minimal read window size of `1MiB + 128KiB` on the first
 /// `read()` call. This is accepted unconditionally since we want to allow any file handle to make
@@ -38,30 +40,15 @@ impl BufferArea {
 /// backpressure read window is incremented to fetch more data from underlying part streams. Those reservations may be
 /// rejected if there is no available memory.
 ///
-/// Release of the reserved memory happens on one of the following events:
-/// 1) prefetcher is destroyed (`RequestTask` will be dropped and remaining data in the backpressure read window will be released).
-/// 2) data is moved out of the part queue.
-///
-/// Following is the visualisation of a single prefetcher instance's data stream:
-///
-/// backwards_seek_start        part_queue_start         in_part_queue                 window_end_offset      preferred_window_end_offset
-///  │                              │                           │                               │                            │
-/// ─┼──────────────────────────────┼───────────────────────────┼───────────────────────────────┼────────────────────────────┼───────────-►
-///  │                              │                                                           │
-///  └──────────────────────────────┤                                                           │
-///  mem reserved by the part queue │                                                           │
-///                                 └───────────────────────────────────────────────────────────┤
-///                                     mem reserved by the backpressure controller
-///                                     (on `BackpressureFeedbackEvent`)
-///
-/// Incremental uploder instances may try to reserve multiple buffers to queue append requests. Under memory pressure,
-/// each instance will limit to a single buffer.
+/// Incremental uploader instances check available memory before allocating buffers to queue append
+/// requests. Under memory pressure, each instance will limit to a single buffer.
 #[derive(Debug)]
 pub struct MemoryLimiter {
     mem_limit: u64,
-    /// Reserved memory for allocations we are tracking, such as buffers we allocate for prefetching.
-    /// The memory may not be used yet but has been reserved.
+    /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
+    /// Per-handle reservation tracking. Used for accurate release on handle drop.
+    mem_reserved_per_handle: DashMap<HandleId, AtomicU64>,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -88,19 +75,20 @@ impl MemoryLimiter {
             pool,
             mem_limit,
             mem_reserved,
+            mem_reserved_per_handle: DashMap::new(),
             additional_mem_reserved: reserved_mem,
         }
     }
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    pub fn reserve(&self, area: BufferArea, size: u64) {
-        self.mem_reserved.fetch_add(size, Ordering::SeqCst);
+    pub fn reserve(&self, handle_id: HandleId, area: BufferArea, size: u64) {
+        self.add_reservation(handle_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    pub fn try_reserve(&self, area: BufferArea, size: u64) -> bool {
+    pub fn try_reserve(&self, handle_id: HandleId, area: BufferArea, size: u64) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
@@ -123,6 +111,10 @@ impl MemoryLimiter {
                 Ordering::SeqCst,
             ) {
                 Ok(_) => {
+                    self.mem_reserved_per_handle
+                        .entry(handle_id)
+                        .or_default()
+                        .fetch_add(size, Ordering::SeqCst);
                     metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
                     metrics::histogram!("mem.reserve_latency_us", "area" => area.as_str())
                         .record(start.elapsed().as_micros() as f64);
@@ -134,9 +126,18 @@ impl MemoryLimiter {
     }
 
     /// Release the reserved memory.
-    pub fn release(&self, area: BufferArea, size: u64) {
-        self.mem_reserved.fetch_sub(size, Ordering::SeqCst);
+    pub fn release(&self, handle_id: HandleId, area: BufferArea, size: u64) {
+        self.sub_reservation(handle_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(size as f64);
+    }
+
+    /// Release all remaining reservation for a handle and remove it from tracking.
+    pub fn release_handle(&self, handle_id: HandleId, area: BufferArea) {
+        if let Some((_, reservation)) = self.mem_reserved_per_handle.remove(&handle_id) {
+            let remaining = reservation.load(Ordering::SeqCst);
+            self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
+            metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(remaining as f64);
+        }
     }
 
     /// Query available memory tracked by the memory limiter.
@@ -149,11 +150,25 @@ impl MemoryLimiter {
             .saturating_sub(self.additional_mem_reserved)
     }
 
+    /// Increment both the global total and the per-handle reservation.
+    fn add_reservation(&self, handle_id: HandleId, size: u64) {
+        self.mem_reserved.fetch_add(size, Ordering::SeqCst);
+        self.mem_reserved_per_handle
+            .entry(handle_id)
+            .or_default()
+            .fetch_add(size, Ordering::SeqCst);
+    }
+
+    /// Decrement both the global total and the per-handle reservation.
+    fn sub_reservation(&self, handle_id: HandleId, size: u64) {
+        self.mem_reserved.fetch_sub(size, Ordering::SeqCst);
+        if let Some(reservation) = self.mem_reserved_per_handle.get(&handle_id) {
+            reservation.fetch_sub(size, Ordering::SeqCst);
+        }
+    }
+
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
     fn pool_mem_reserved(&self) -> u64 {
-        // All pool buffer kinds are accounted for here. Note that after task 2 is complete,
-        // mem_reserved will be decremented on pool allocation, so there will be no double-counting
-        // for buffers (which currently go through both mem_reserved and the pool).
         self.pool.total_reserved_bytes() as u64
     }
 }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -91,6 +91,8 @@ pub struct MemoryLimiter {
     /// lifetime) so that late on_reserve callbacks from cancelled CRT meta-requests cannot
     /// incorrectly decrement a re-created entry for the same handle.
     mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>>,
+    /// Counter for generating unique [RequestId]s.
+    next_request_id: AtomicU64,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -154,6 +156,7 @@ impl MemoryLimiter {
             mem_limit,
             mem_reserved,
             mem_reserved_per_request,
+            next_request_id: AtomicU64::new(1),
             additional_mem_reserved,
             active_reads: DashMap::new(),
         }
@@ -211,6 +214,11 @@ impl MemoryLimiter {
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(remaining as f64);
         }
+    }
+
+    /// Generate a new unique [RequestId] for per-request memory tracking.
+    pub fn next_request_id(&self) -> RequestId {
+        RequestId::new_from_raw(self.next_request_id.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Query available memory tracked by the memory limiter.

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -4,7 +4,8 @@ use humansize::make_format;
 use metrics::atomics::AtomicU64;
 use tracing::{debug, trace};
 
-use crate::memory::{BufferKind, PagedPool};
+use crate::memory::PagedPool;
+use crate::sync::Arc;
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
 
@@ -60,7 +61,7 @@ pub struct MemoryLimiter {
     mem_limit: u64,
     /// Reserved memory for allocations we are tracking, such as buffers we allocate for prefetching.
     /// The memory may not be used yet but has been reserved.
-    mem_reserved: AtomicU64,
+    mem_reserved: Arc<AtomicU64>,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -78,10 +79,15 @@ impl MemoryLimiter {
             formatter(mem_limit),
             formatter(reserved_mem)
         );
+        let mem_reserved = Arc::new(AtomicU64::new(0));
+        let mem_reserved_cb = mem_reserved.clone();
+        pool.set_on_reserve(Arc::new(move |bytes| {
+            mem_reserved_cb.fetch_sub(bytes as u64, Ordering::SeqCst);
+        }));
         Self {
             pool,
             mem_limit,
-            mem_reserved: AtomicU64::new(0),
+            mem_reserved,
             additional_mem_reserved: reserved_mem,
         }
     }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -54,7 +54,7 @@ pub struct MemoryLimiter {
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
     /// Per-handle reservation tracking. Used for accurate release on handle drop.
-    mem_reserved_per_handle: Arc<DashMap<HandleId, AtomicU64>>,
+    mem_reserved_per_handle: Arc<DashMap<HandleId, Arc<AtomicU64>>>,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -65,17 +65,17 @@ pub struct MemoryLimiter {
 impl MemoryLimiter {
     pub fn new(pool: PagedPool, mem_limit: u64) -> Self {
         let min_reserved = 128 * 1024 * 1024;
-        let reserved_mem = (mem_limit / 8).max(min_reserved);
+        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
         debug!(
             "target memory usage is {} with {} reserved memory",
             formatter(mem_limit),
-            formatter(reserved_mem)
+            formatter(additional_mem_reserved)
         );
         let mem_reserved = Arc::new(AtomicU64::new(0));
-        let mem_reserved_cb = mem_reserved.clone();
-        let mem_reserved_per_handle: Arc<DashMap<HandleId, AtomicU64>> = Arc::new(DashMap::new());
-        let per_handle_cb = mem_reserved_per_handle.clone();
+        let mem_reserved_cb: Arc<AtomicU64> = mem_reserved.clone();
+        let mem_reserved_per_handle: Arc<DashMap<HandleId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
+        let mem_reserved_per_handle_cb = mem_reserved_per_handle.clone();
         pool.set_on_reserve(Arc::new(move |bytes, custom_id| {
             // Called by the pool on every buffer allocation. For download buffers with a
             // known handle, this converts reservation from "intent" (mem_reserved) to
@@ -88,20 +88,31 @@ impl MemoryLimiter {
             // - The handle has been removed (cancelled request): release_handle already
             //   subtracted the full balance, so we skip to avoid double-decrementing.
             //
+            // We clone the Arc to release the DashMap shard lock before doing atomic
+            // operations, minimizing lock hold time.
+            //
             // Saturating subtraction on the per-handle counter prevents wrapping if a late
             // callback from a cancelled request hits a re-created entry for the same handle.
-            if let Some(handle_id) = custom_id
-                && let Some(reservation) = per_handle_cb.get(&HandleId::new(handle_id))
-            {
-                let mut current = reservation.load(Ordering::SeqCst);
-                let decremented = loop {
-                    let new_val = current.saturating_sub(bytes as u64);
-                    match reservation.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
-                        Ok(_) => break current - new_val,
-                        Err(actual) => current = actual,
-                    }
-                };
-                mem_reserved_cb.fetch_sub(decremented, Ordering::SeqCst);
+            if let Some(handle_id) = custom_id {
+                let handle_reservation = mem_reserved_per_handle_cb
+                    .get(&HandleId::new(handle_id))
+                    .map(|r| r.value().clone());
+                if let Some(handle_reservation) = handle_reservation {
+                    let mut current = handle_reservation.load(Ordering::SeqCst);
+                    let decremented = loop {
+                        let new_val = current.saturating_sub(bytes as u64);
+                        match handle_reservation.compare_exchange_weak(
+                            current,
+                            new_val,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        ) {
+                            Ok(_) => break current - new_val,
+                            Err(actual) => current = actual,
+                        }
+                    };
+                    mem_reserved_cb.fetch_sub(decremented, Ordering::SeqCst);
+                }
             }
         }));
         Self {
@@ -109,7 +120,7 @@ impl MemoryLimiter {
             mem_limit,
             mem_reserved,
             mem_reserved_per_handle,
-            additional_mem_reserved: reserved_mem,
+            additional_mem_reserved,
         }
     }
 

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -6,7 +6,7 @@ use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
-use crate::prefetch::HandleId;
+use crate::prefetch::{HandleId, RequestId};
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicU64, Ordering};
 
@@ -77,8 +77,8 @@ impl Drop for ActiveReadGuard {
 /// Release of the reserved memory happens on one of the following events:
 /// 1) the memory pool allocates a buffer: the `on_reserve` callback decrements `mem_reserved` by the
 ///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
-/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_handle` will
-///    release any remaining unallocated reservation for that handle).
+/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_request` will
+///    release any remaining unallocated reservation for that request).
 ///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
 /// requests. Under memory pressure, each instance will limit to a single buffer.
@@ -87,8 +87,10 @@ pub struct MemoryLimiter {
     mem_limit: u64,
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
-    /// Per-handle reservation tracking. Used for accurate release on handle drop.
-    mem_reserved_per_handle: Arc<DashMap<HandleId, Arc<AtomicU64>>>,
+    /// Per-request reservation tracking. Keyed by RequestId (unique per BackpressureController
+    /// lifetime) so that late on_reserve callbacks from cancelled CRT meta-requests cannot
+    /// incorrectly decrement a re-created entry for the same handle.
+    mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>>,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -111,32 +113,29 @@ impl MemoryLimiter {
         );
         let mem_reserved = Arc::new(AtomicU64::new(0));
         let mem_reserved_cb: Arc<AtomicU64> = mem_reserved.clone();
-        let mem_reserved_per_handle: Arc<DashMap<HandleId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
-        let mem_reserved_per_handle_cb = mem_reserved_per_handle.clone();
-        pool.set_on_reserve(Arc::new(move |bytes, handle_id| {
+        let mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
+        let mem_reserved_per_request_cb = mem_reserved_per_request.clone();
+        pool.set_on_reserve(Arc::new(move |bytes, request_id| {
             // Called by the pool on every buffer allocation. For download buffers with a
-            // known handle, this converts reservation from "intent" (mem_reserved) to
+            // known request, this converts reservation from "intent" (mem_reserved) to
             // "actual allocation" (pool_total) by decrementing both the global and
-            // per-handle counters.
+            // per-request counters.
             //
             // This is a no-op when:
-            // - handle_id is None (e.g. uploads): these allocations have no
+            // - request_id is None (e.g. uploads): these allocations have no
             //   corresponding mem_reserved entry and are tracked only via pool_total.
-            // - The handle has been removed (cancelled request): release_handle already
+            // - The request has been removed (cancelled request): release_request already
             //   subtracted the full balance, so we skip to avoid double-decrementing.
             //
             // We clone the Arc to release the DashMap shard lock before doing atomic
             // operations, minimizing lock hold time.
-            //
-            // Saturating subtraction on the per-handle counter prevents wrapping if a late
-            // callback from a cancelled request hits a re-created entry for the same handle.
-            if let Some(handle_id) = handle_id {
-                let handle_reservation = mem_reserved_per_handle_cb.get(&handle_id).map(|r| r.value().clone());
-                if let Some(handle_reservation) = handle_reservation {
-                    let mut current = handle_reservation.load(Ordering::SeqCst);
+            if let Some(request_id) = request_id {
+                let request_reservation = mem_reserved_per_request_cb.get(&request_id).map(|r| r.value().clone());
+                if let Some(request_reservation) = request_reservation {
+                    let mut current = request_reservation.load(Ordering::SeqCst);
                     let decremented = loop {
                         let new_val = current.saturating_sub(bytes as u64);
-                        match handle_reservation.compare_exchange_weak(
+                        match request_reservation.compare_exchange_weak(
                             current,
                             new_val,
                             Ordering::SeqCst,
@@ -154,7 +153,7 @@ impl MemoryLimiter {
             pool,
             mem_limit,
             mem_reserved,
-            mem_reserved_per_handle,
+            mem_reserved_per_request,
             additional_mem_reserved,
             active_reads: DashMap::new(),
         }
@@ -162,13 +161,13 @@ impl MemoryLimiter {
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    pub fn reserve(&self, handle_id: HandleId, area: BufferArea, size: u64) {
-        self.add_reservation(handle_id, size);
+    pub fn reserve(&self, request_id: RequestId, area: BufferArea, size: u64) {
+        self.add_reservation(request_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    pub fn try_reserve(&self, handle_id: HandleId, area: BufferArea, size: u64) -> bool {
+    pub fn try_reserve(&self, request_id: RequestId, area: BufferArea, size: u64) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
@@ -191,8 +190,8 @@ impl MemoryLimiter {
                 Ordering::SeqCst,
             ) {
                 Ok(_) => {
-                    self.mem_reserved_per_handle
-                        .entry(handle_id)
+                    self.mem_reserved_per_request
+                        .entry(request_id)
                         .or_default()
                         .fetch_add(size, Ordering::SeqCst);
                     metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
@@ -205,9 +204,9 @@ impl MemoryLimiter {
         }
     }
 
-    /// Release all remaining reservation for a handle and remove it from tracking.
-    pub fn release_handle(&self, handle_id: HandleId, area: BufferArea) {
-        if let Some((_, reservation)) = self.mem_reserved_per_handle.remove(&handle_id) {
+    /// Release all remaining reservation for a request and remove it from tracking.
+    pub fn release_request(&self, request_id: RequestId, area: BufferArea) {
+        if let Some((_, reservation)) = self.mem_reserved_per_request.remove(&request_id) {
             let remaining = reservation.load(Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(remaining as f64);
@@ -247,11 +246,11 @@ impl MemoryLimiter {
             .unwrap_or(false)
     }
 
-    /// Increment both the global total and the per-handle reservation.
-    fn add_reservation(&self, handle_id: HandleId, size: u64) {
+    /// Increment both the global total and the per-request reservation.
+    fn add_reservation(&self, request_id: RequestId, size: u64) {
         self.mem_reserved.fetch_add(size, Ordering::SeqCst);
-        self.mem_reserved_per_handle
-            .entry(handle_id)
+        self.mem_reserved_per_request
+            .entry(request_id)
             .or_default()
             .fetch_add(size, Ordering::SeqCst);
     }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -69,7 +69,16 @@ impl MemoryLimiter {
         let mem_reserved = Arc::new(AtomicU64::new(0));
         let mem_reserved_cb = mem_reserved.clone();
         pool.set_on_reserve(Arc::new(move |bytes| {
-            mem_reserved_cb.fetch_sub(bytes as u64, Ordering::SeqCst);
+            // Use a CAS loop for saturating subtraction to prevent underflow if the callback
+            // fires after release_handle has already zeroed this handle's reservation.
+            let mut current = mem_reserved_cb.load(Ordering::SeqCst);
+            loop {
+                let new_val = current.saturating_sub(bytes as u64);
+                match mem_reserved_cb.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
+                    Ok(_) => break,
+                    Err(actual) => current = actual,
+                }
+            }
         }));
         Self {
             pool,

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -172,3 +172,114 @@ impl MemoryLimiter {
         self.pool.total_reserved_bytes() as u64
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{BufferKind, PagedPool};
+
+    fn new_limiter(buffer_size: usize, mem_limit: u64) -> (MemoryLimiter, PagedPool) {
+        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
+        let limiter = MemoryLimiter::new(pool.clone(), mem_limit);
+        (limiter, pool)
+    }
+
+    #[test]
+    fn test_reserve_and_release_handle() {
+        let (limiter, _pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        limiter.reserve(handle, BufferArea::Prefetch, 100);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 100);
+
+        limiter.release_handle(handle, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(limiter.mem_reserved_per_handle.is_empty());
+    }
+
+    #[test]
+    fn test_pool_allocation_decrements_mem_reserved() {
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        // Reserve 1024 bytes of intent
+        limiter.reserve(handle, BufferArea::Prefetch, 1024);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+
+        // Pool allocation triggers on_reserve callback, decrementing mem_reserved
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_reserve_pool_allocate_release_handle() {
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        // Reserve 2048 bytes of intent
+        limiter.reserve(handle, BufferArea::Prefetch, 2048);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
+
+        // Pool allocates 1024 — callback decrements global by 1024
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+
+        // release_handle releases the remaining 2048 from per-handle (not aware of pool decrement)
+        // Global goes to 1024 - 2048 which would underflow — this is the known limitation
+        // that per-handle tracking doesn't account for pool callback decrements.
+        // For now, release_handle releases the per-handle balance.
+        limiter.release_handle(handle, BufferArea::Prefetch);
+
+        // Per-handle entry is removed
+        assert!(limiter.mem_reserved_per_handle.is_empty());
+    }
+
+    #[test]
+    fn test_try_reserve_respects_limit() {
+        let (limiter, _pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        // Fill up to the limit (minus additional_mem_reserved)
+        let available = limiter.available_mem();
+        limiter.reserve(handle, BufferArea::Prefetch, available);
+
+        // Should fail — no room left
+        assert!(!limiter.try_reserve(handle, BufferArea::Prefetch, 1));
+    }
+
+    #[test]
+    fn test_multiple_handles_independent() {
+        let (limiter, _pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle1 = HandleId::new(1);
+        let handle2 = HandleId::new(2);
+
+        limiter.reserve(handle1, BufferArea::Prefetch, 100);
+        limiter.reserve(handle2, BufferArea::Prefetch, 200);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 300);
+
+        // Release handle1 — only its 100 bytes
+        limiter.release_handle(handle1, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 200);
+        assert!(!limiter.mem_reserved_per_handle.contains_key(&handle1));
+
+        // Handle2 still tracked
+        assert!(limiter.mem_reserved_per_handle.contains_key(&handle2));
+
+        limiter.release_handle(handle2, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(limiter.mem_reserved_per_handle.is_empty());
+    }
+
+    #[test]
+    fn test_release_handle_idempotent() {
+        let (limiter, _pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        limiter.reserve(handle, BufferArea::Prefetch, 100);
+        limiter.release_handle(handle, BufferArea::Prefetch);
+
+        // Second call is a no-op
+        limiter.release_handle(handle, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+}

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -6,7 +6,7 @@ use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
-use crate::prefetch::{HandleId, RequestId};
+use crate::prefetch::{CursorId, HandleId};
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicU64, Ordering};
 
@@ -77,8 +77,8 @@ impl Drop for ActiveReadGuard {
 /// Release of the reserved memory happens on one of the following events:
 /// 1) the memory pool allocates a buffer: the `on_reserve` callback decrements `mem_reserved` by the
 ///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
-/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_request` will
-///    release any remaining unallocated reservation for that request).
+/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_cursor` will
+///    release any remaining unallocated reservation for that cursor).
 ///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
 /// requests. Under memory pressure, each instance will limit to a single buffer.
@@ -87,12 +87,12 @@ pub struct MemoryLimiter {
     mem_limit: u64,
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
-    /// Per-request reservation tracking. Keyed by RequestId (unique per BackpressureController
+    /// Per-cursor reservation tracking. Keyed by CursorId (unique per BackpressureController
     /// lifetime) so that late on_reserve callbacks from cancelled CRT meta-requests cannot
     /// incorrectly decrement a re-created entry for the same handle.
-    mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>>,
-    /// Counter for generating unique [RequestId]s.
-    next_request_id: AtomicU64,
+    mem_reserved_per_cursor: Arc<DashMap<CursorId, Arc<AtomicU64>>>,
+    /// Counter for generating unique [CursorId]s.
+    next_cursor_id: AtomicU64,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -115,17 +115,17 @@ impl MemoryLimiter {
         );
         let mem_reserved = Arc::new(AtomicU64::new(0));
         let mem_reserved_cb: Arc<AtomicU64> = mem_reserved.clone();
-        let mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
-        let mem_reserved_per_request_cb = mem_reserved_per_request.clone();
-        pool.set_on_reserve(Arc::new(move |bytes, request_id| {
-            Self::on_pool_reserve(bytes, request_id, &mem_reserved_cb, &mem_reserved_per_request_cb);
+        let mem_reserved_per_cursor: Arc<DashMap<CursorId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
+        let mem_reserved_per_cursor_cb = mem_reserved_per_cursor.clone();
+        pool.set_on_reserve(Arc::new(move |bytes, cursor_id| {
+            Self::on_pool_reserve(bytes, cursor_id, &mem_reserved_cb, &mem_reserved_per_cursor_cb);
         }));
         Self {
             pool,
             mem_limit,
             mem_reserved,
-            mem_reserved_per_request,
-            next_request_id: AtomicU64::new(1),
+            mem_reserved_per_cursor,
+            next_cursor_id: AtomicU64::new(1),
             additional_mem_reserved,
             active_reads: DashMap::new(),
         }
@@ -133,13 +133,13 @@ impl MemoryLimiter {
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    pub fn reserve(&self, request_id: RequestId, area: BufferArea, size: u64) {
-        self.add_reservation(request_id, size);
+    pub fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
+        self.add_reservation(cursor_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    pub fn try_reserve(&self, request_id: RequestId, area: BufferArea, size: u64) -> bool {
+    pub fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
@@ -162,8 +162,8 @@ impl MemoryLimiter {
                 Ordering::SeqCst,
             ) {
                 Ok(_) => {
-                    self.mem_reserved_per_request
-                        .entry(request_id)
+                    self.mem_reserved_per_cursor
+                        .entry(cursor_id)
                         .or_default()
                         .fetch_add(size, Ordering::SeqCst);
                     metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
@@ -176,18 +176,18 @@ impl MemoryLimiter {
         }
     }
 
-    /// Release all remaining reservation for a request and remove it from tracking.
-    pub fn release_request(&self, request_id: RequestId, area: BufferArea) {
-        if let Some((_, reservation)) = self.mem_reserved_per_request.remove(&request_id) {
+    /// Release all remaining reservation for a cursor and remove it from tracking.
+    pub fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
+        if let Some((_, reservation)) = self.mem_reserved_per_cursor.remove(&cursor_id) {
             let remaining = reservation.swap(0, Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(remaining as f64);
         }
     }
 
-    /// Generate a new unique [RequestId] for per-request memory tracking.
-    pub fn next_request_id(&self) -> RequestId {
-        RequestId::new_from_raw(self.next_request_id.fetch_add(1, Ordering::Relaxed))
+    /// Generate a new unique [CursorId] for per-cursor memory tracking.
+    pub fn next_cursor_id(&self) -> CursorId {
+        CursorId::new_from_raw(self.next_cursor_id.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Query available memory tracked by the memory limiter.
@@ -223,38 +223,38 @@ impl MemoryLimiter {
             .unwrap_or(false)
     }
 
-    /// Increment both the global total and the per-request reservation.
-    fn add_reservation(&self, request_id: RequestId, size: u64) {
+    /// Increment both the global total and the per-cursor reservation.
+    fn add_reservation(&self, cursor_id: CursorId, size: u64) {
         self.mem_reserved.fetch_add(size, Ordering::SeqCst);
-        self.mem_reserved_per_request
-            .entry(request_id)
+        self.mem_reserved_per_cursor
+            .entry(cursor_id)
             .or_default()
             .fetch_add(size, Ordering::SeqCst);
     }
 
-    /// Called by the pool on every buffer allocation. For download buffers with a known request,
+    /// Called by the pool on every buffer allocation. For download buffers with a known cursor,
     /// this converts reservation from "intent" (`mem_reserved`) to "actual allocation" (pool stats)
-    /// by decrementing both the global and per-request counters.
+    /// by decrementing both the global and per-cursor counters.
     ///
-    /// No-op when `request_id` is `None` (e.g. uploads) or the request has already been removed
-    /// by `release_request`.
+    /// No-op when `cursor_id` is `None` (e.g. uploads) or the cursor has already been removed
+    /// by `release_cursor`.
     fn on_pool_reserve(
         bytes: usize,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
         mem_reserved: &AtomicU64,
-        per_request: &DashMap<RequestId, Arc<AtomicU64>>,
+        per_cursor: &DashMap<CursorId, Arc<AtomicU64>>,
     ) {
-        let Some(request_id) = request_id else {
+        let Some(cursor_id) = cursor_id else {
             return;
         };
         // Clone the Arc to release the DashMap shard lock before doing atomic operations.
-        let Some(request_reservation) = per_request.get(&request_id).map(|r| r.value().clone()) else {
+        let Some(cursor_reservation) = per_cursor.get(&cursor_id).map(|r| r.value().clone()) else {
             return;
         };
-        let mut current = request_reservation.load(Ordering::SeqCst);
+        let mut current = cursor_reservation.load(Ordering::SeqCst);
         let decremented = loop {
             let new_val = current.saturating_sub(bytes as u64);
-            match request_reservation.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
+            match cursor_reservation.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
                 Ok(_) => break current - new_val,
                 Err(actual) => current = actual,
             }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -27,15 +27,15 @@ impl BufferArea {
 /// `MemoryLimiter` tracks memory used by Mountpoint and makes decisions if a new memory reservation request can be accepted.
 /// Currently, there are two metrics we take into account:
 /// 1) the memory directly reserved on the limiter by prefetcher and (incremental) uploader instances.
-/// 2) the memory reserved on the memory pool by the CRT client for any other request (currently, for multi-part uploads,
-///    triggered by atomic uploader instances).
+/// 2) the memory reserved on the memory pool by the CRT client for any request (downloads, atomic uploads, etc.)
 ///
 /// Single instance of this struct is shared among all of the prefetchers (file handles) and (incremental) uploaders.
 ///
-/// Each file handle upon creation makes an initial reservation request with a minimal read window size of `1MiB + 128KiB`. This
-/// is accepted unconditionally since we want to allow any file handle to make progress even if that means going over the memory
-/// limit. Additional reservations for a file handle arise when the backpressure read window is incremented to fetch more data
-/// from underlying part streams. Those reservations may be rejected if there is no available memory.
+/// Each file handle makes an initial reservation request with a minimal read window size of `1MiB + 128KiB` on the first
+/// `read()` call. This is accepted unconditionally since we want to allow any file handle to make
+/// progress even if that means going over the memory limit. Additional reservations for a file handle arise when the
+/// backpressure read window is incremented to fetch more data from underlying part streams. Those reservations may be
+/// rejected if there is no available memory.
 ///
 /// Release of the reserved memory happens on one of the following events:
 /// 1) prefetcher is destroyed (`RequestTask` will be dropped and remaining data in the backpressure read window will be released).
@@ -63,9 +63,8 @@ pub struct MemoryLimiter {
     mem_reserved: AtomicU64,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
-    /// Memory pool used by the S3 client.
-    /// Since we don't directly control memory usage of multi-part uploads (atomic uploader), we will
-    /// rely on the pool's stats for PutObject buffers and adjust the prefetcher read window accordingly.
+    /// Memory pool used by the S3 client and disk cache.
+    /// We rely on the pool's stats to account for all buffer allocations (e.g. GetObject, DiskCache, PutObject buffers).
     pool: PagedPool,
 }
 
@@ -144,15 +143,11 @@ impl MemoryLimiter {
             .saturating_sub(self.additional_mem_reserved)
     }
 
-    /// Get reserved memory from the memory pool for buffers not tracked by this limiter.
+    /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
     fn pool_mem_reserved(&self) -> u64 {
-        // The limiter already tracks buffers from
-        // * the prefetcher (GetObject and DiskCache),
-        // * the incremental uploader (Append).
-        //
-        // Here we fetch the pool's stats for the remaining kinds:
-        // * PutObject (multi-part uploads),
-        // * Other (currently not used).
-        (self.pool.reserved_bytes(BufferKind::PutObject) + self.pool.reserved_bytes(BufferKind::Other)) as u64
+        // All pool buffer kinds are accounted for here. Note that after task 2 is complete,
+        // mem_reserved will be decremented on pool allocation, so there will be no double-counting
+        // for buffers (which currently go through both mem_reserved and the pool).
+        self.pool.total_reserved_bytes() as u64
     }
 }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -118,38 +118,7 @@ impl MemoryLimiter {
         let mem_reserved_per_request: Arc<DashMap<RequestId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
         let mem_reserved_per_request_cb = mem_reserved_per_request.clone();
         pool.set_on_reserve(Arc::new(move |bytes, request_id| {
-            // Called by the pool on every buffer allocation. For download buffers with a
-            // known request, this converts reservation from "intent" (mem_reserved) to
-            // "actual allocation" (pool_total) by decrementing both the global and
-            // per-request counters.
-            //
-            // This is a no-op when:
-            // - request_id is None (e.g. uploads): these allocations have no
-            //   corresponding mem_reserved entry and are tracked only via pool_total.
-            // - The request has been removed (cancelled request): release_request already
-            //   subtracted the full balance, so we skip to avoid double-decrementing.
-            //
-            // We clone the Arc to release the DashMap shard lock before doing atomic
-            // operations, minimizing lock hold time.
-            if let Some(request_id) = request_id {
-                let request_reservation = mem_reserved_per_request_cb.get(&request_id).map(|r| r.value().clone());
-                if let Some(request_reservation) = request_reservation {
-                    let mut current = request_reservation.load(Ordering::SeqCst);
-                    let decremented = loop {
-                        let new_val = current.saturating_sub(bytes as u64);
-                        match request_reservation.compare_exchange_weak(
-                            current,
-                            new_val,
-                            Ordering::SeqCst,
-                            Ordering::SeqCst,
-                        ) {
-                            Ok(_) => break current - new_val,
-                            Err(actual) => current = actual,
-                        }
-                    };
-                    mem_reserved_cb.fetch_sub(decremented, Ordering::SeqCst);
-                }
-            }
+            Self::on_pool_reserve(bytes, request_id, &mem_reserved_cb, &mem_reserved_per_request_cb);
         }));
         Self {
             pool,
@@ -210,7 +179,7 @@ impl MemoryLimiter {
     /// Release all remaining reservation for a request and remove it from tracking.
     pub fn release_request(&self, request_id: RequestId, area: BufferArea) {
         if let Some((_, reservation)) = self.mem_reserved_per_request.remove(&request_id) {
-            let remaining = reservation.load(Ordering::SeqCst);
+            let remaining = reservation.swap(0, Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(remaining as f64);
         }
@@ -261,6 +230,36 @@ impl MemoryLimiter {
             .entry(request_id)
             .or_default()
             .fetch_add(size, Ordering::SeqCst);
+    }
+
+    /// Called by the pool on every buffer allocation. For download buffers with a known request,
+    /// this converts reservation from "intent" (`mem_reserved`) to "actual allocation" (pool stats)
+    /// by decrementing both the global and per-request counters.
+    ///
+    /// No-op when `request_id` is `None` (e.g. uploads) or the request has already been removed
+    /// by `release_request`.
+    fn on_pool_reserve(
+        bytes: usize,
+        request_id: Option<RequestId>,
+        mem_reserved: &AtomicU64,
+        per_request: &DashMap<RequestId, Arc<AtomicU64>>,
+    ) {
+        let Some(request_id) = request_id else {
+            return;
+        };
+        // Clone the Arc to release the DashMap shard lock before doing atomic operations.
+        let Some(request_reservation) = per_request.get(&request_id).map(|r| r.value().clone()) else {
+            return;
+        };
+        let mut current = request_reservation.load(Ordering::SeqCst);
+        let decremented = loop {
+            let new_val = current.saturating_sub(bytes as u64);
+            match request_reservation.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => break current - new_val,
+                Err(actual) => current = actual,
+            }
+        };
+        mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -1,13 +1,13 @@
-use std::{sync::atomic::Ordering, time::Instant};
+use std::time::Instant;
 
 use dashmap::DashMap;
 use humansize::make_format;
-use metrics::atomics::AtomicU64;
 use tracing::{debug, trace};
 
 use crate::memory::PagedPool;
 use crate::prefetch::HandleId;
 use crate::sync::Arc;
+use crate::sync::atomic::{AtomicU64, Ordering};
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
 
@@ -87,6 +87,9 @@ impl MemoryLimiter {
             //   corresponding mem_reserved entry and are tracked only via pool_total.
             // - The handle has been removed (cancelled request): release_handle already
             //   subtracted the full balance, so we skip to avoid double-decrementing.
+            //
+            // Saturating subtraction on the per-handle counter prevents wrapping if a late
+            // callback from a cancelled request hits a re-created entry for the same handle.
             if let Some(handle_id) = custom_id
                 && let Some(reservation) = per_handle_cb.get(&HandleId::new(handle_id))
             {
@@ -293,5 +296,83 @@ mod tests {
         // Second call is a no-op
         limiter.release_handle(handle, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_callback_noop_after_release_handle() {
+        // Simulates the cancellation race: on_reserve fires after release_handle
+        // removed the entry. The callback should be a no-op.
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        limiter.reserve(handle, BufferArea::Prefetch, 1024);
+        limiter.release_handle(handle, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // Late allocation for the cancelled request — handle is gone
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+
+        // mem_reserved should stay at 0, not go negative or wrap
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_callback_saturates_on_recreated_handle() {
+        // Simulates the re-creation race: handle is released and re-created (same ID),
+        // then a late callback from the old request hits the new entry.
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        // First lifecycle: reserve and release
+        limiter.reserve(handle, BufferArea::Prefetch, 1024);
+        limiter.release_handle(handle, BufferArea::Prefetch);
+
+        // Second lifecycle: re-create with a smaller reservation
+        limiter.reserve(handle, BufferArea::Prefetch, 512);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 512);
+
+        // Late callback from old request tries to decrement 1024 from the new entry (which only has 512).
+        // Saturating subtraction should clamp to 0, only decrementing 512 from global.
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // release_handle should subtract 0 (the per-handle counter is already 0)
+        limiter.release_handle(handle, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_available_mem_includes_pool_total() {
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+        let handle = HandleId::new(1);
+
+        let initial_available = limiter.available_mem();
+
+        // Reserve intent — available decreases
+        limiter.reserve(handle, BufferArea::Prefetch, 1024);
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
+
+        // Pool allocates — intent converts to pool_total, available stays the same
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
+
+        // Drop the buffer — pool_total decreases, available goes back up
+        drop(_buffer);
+        assert_eq!(limiter.available_mem(), initial_available);
+    }
+
+    #[test]
+    fn test_upload_allocation_does_not_affect_mem_reserved() {
+        let (limiter, pool) = new_limiter(1024, MINIMUM_MEM_LIMIT);
+
+        let initial_available = limiter.available_mem();
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // Upload allocates without custom_id — should not touch mem_reserved
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::Append, None);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // But available_mem should decrease (pool_total increased)
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
     }
 }

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -77,21 +77,28 @@ impl MemoryLimiter {
         let mem_reserved_per_handle: Arc<DashMap<HandleId, AtomicU64>> = Arc::new(DashMap::new());
         let per_handle_cb = mem_reserved_per_handle.clone();
         pool.set_on_reserve(Arc::new(move |bytes, custom_id| {
-            // Saturating subtraction prevents underflow if this callback races with
-            // release_handle during meta-request cancellation. In that case the global
-            // clamps to 0 — a harmless under-count corrected when the pool buffer is dropped.
-            let mut current = mem_reserved_cb.load(Ordering::SeqCst);
-            loop {
-                let new_val = current.saturating_sub(bytes as u64);
-                match mem_reserved_cb.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
-                    Ok(_) => break,
-                    Err(actual) => current = actual,
-                }
-            }
+            // Called by the pool on every buffer allocation. For download buffers with a
+            // known handle, this converts reservation from "intent" (mem_reserved) to
+            // "actual allocation" (pool_total) by decrementing both the global and
+            // per-handle counters.
+            //
+            // This is a no-op when:
+            // - custom_id is None (e.g. disk cache, uploads): these allocations have no
+            //   corresponding mem_reserved entry and are tracked only via pool_total.
+            // - The handle has been removed (cancelled request): release_handle already
+            //   subtracted the full balance, so we skip to avoid double-decrementing.
             if let Some(handle_id) = custom_id
                 && let Some(reservation) = per_handle_cb.get(&HandleId::new(handle_id))
             {
-                reservation.fetch_sub(bytes as u64, Ordering::SeqCst);
+                let mut current = reservation.load(Ordering::SeqCst);
+                let decremented = loop {
+                    let new_val = current.saturating_sub(bytes as u64);
+                    match reservation.compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst) {
+                        Ok(_) => break current - new_val,
+                        Err(actual) => current = actual,
+                    }
+                };
+                mem_reserved_cb.fetch_sub(decremented, Ordering::SeqCst);
             }
         }));
         Self {
@@ -216,7 +223,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
         // Pool allocation triggers on_reserve callback, decrementing mem_reserved
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, None);
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -76,14 +76,14 @@ impl MemoryLimiter {
         let mem_reserved_cb: Arc<AtomicU64> = mem_reserved.clone();
         let mem_reserved_per_handle: Arc<DashMap<HandleId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
         let mem_reserved_per_handle_cb = mem_reserved_per_handle.clone();
-        pool.set_on_reserve(Arc::new(move |bytes, custom_id| {
+        pool.set_on_reserve(Arc::new(move |bytes, handle_id| {
             // Called by the pool on every buffer allocation. For download buffers with a
             // known handle, this converts reservation from "intent" (mem_reserved) to
             // "actual allocation" (pool_total) by decrementing both the global and
             // per-handle counters.
             //
             // This is a no-op when:
-            // - custom_id is None (e.g. uploads): these allocations have no
+            // - handle_id is None (e.g. uploads): these allocations have no
             //   corresponding mem_reserved entry and are tracked only via pool_total.
             // - The handle has been removed (cancelled request): release_handle already
             //   subtracted the full balance, so we skip to avoid double-decrementing.
@@ -93,10 +93,8 @@ impl MemoryLimiter {
             //
             // Saturating subtraction on the per-handle counter prevents wrapping if a late
             // callback from a cancelled request hits a re-created entry for the same handle.
-            if let Some(handle_id) = custom_id {
-                let handle_reservation = mem_reserved_per_handle_cb
-                    .get(&HandleId::new(handle_id))
-                    .map(|r| r.value().clone());
+            if let Some(handle_id) = handle_id {
+                let handle_reservation = mem_reserved_per_handle_cb.get(&handle_id).map(|r| r.value().clone());
                 if let Some(handle_reservation) = handle_reservation {
                     let mut current = handle_reservation.load(Ordering::SeqCst);
                     let decremented = loop {
@@ -237,7 +235,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
         // Pool allocation triggers on_reserve callback, decrementing mem_reserved
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
@@ -251,7 +249,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
 
         // Pool allocates 1024 — callback decrements both global and per-handle
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
         // release_handle releases the remaining per-handle balance (2048 - 1024 = 1024)
@@ -321,7 +319,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // Late allocation for the cancelled request — handle is gone
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle));
 
         // mem_reserved should stay at 0, not go negative or wrap
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
@@ -344,7 +342,7 @@ mod tests {
 
         // Late callback from old request tries to decrement 1024 from the new entry (which only has 512).
         // Saturating subtraction should clamp to 0, only decrementing 512 from global.
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // release_handle should subtract 0 (the per-handle counter is already 0)
@@ -364,7 +362,7 @@ mod tests {
         assert_eq!(limiter.available_mem(), initial_available - 1024);
 
         // Pool allocates — intent converts to pool_total, available stays the same
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle));
         assert_eq!(limiter.available_mem(), initial_available - 1024);
 
         // Drop the buffer — pool_total decreases, available goes back up

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -40,6 +40,12 @@ impl BufferArea {
 /// backpressure read window is incremented to fetch more data from underlying part streams. Those reservations may be
 /// rejected if there is no available memory.
 ///
+/// Release of the reserved memory happens on one of the following events:
+/// 1) the memory pool allocates a buffer: the `on_reserve` callback decrements `mem_reserved` by the
+///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
+/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_handle` will
+///    release any remaining unallocated reservation for that handle).
+///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
 /// requests. Under memory pressure, each instance will limit to a single buffer.
 #[derive(Debug)]
@@ -142,12 +148,6 @@ impl MemoryLimiter {
         }
     }
 
-    /// Release the reserved memory.
-    pub fn release(&self, handle_id: HandleId, area: BufferArea, size: u64) {
-        self.sub_reservation(handle_id, size);
-        metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).decrement(size as f64);
-    }
-
     /// Release all remaining reservation for a handle and remove it from tracking.
     pub fn release_handle(&self, handle_id: HandleId, area: BufferArea) {
         if let Some((_, reservation)) = self.mem_reserved_per_handle.remove(&handle_id) {
@@ -174,14 +174,6 @@ impl MemoryLimiter {
             .entry(handle_id)
             .or_default()
             .fetch_add(size, Ordering::SeqCst);
-    }
-
-    /// Decrement both the global total and the per-handle reservation.
-    fn sub_reservation(&self, handle_id: HandleId, size: u64) {
-        self.mem_reserved.fetch_sub(size, Ordering::SeqCst);
-        if let Some(reservation) = self.mem_reserved_per_handle.get(&handle_id) {
-            reservation.fetch_sub(size, Ordering::SeqCst);
-        }
     }
 
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -5,7 +5,7 @@ use humansize::make_format;
 use sysinfo::System;
 use tracing::{debug, trace};
 
-use crate::memory::{BufferKind, PagedPool};
+use crate::memory::PagedPool;
 use crate::prefetch::{CursorId, HandleId};
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicU64, Ordering};
@@ -264,14 +264,8 @@ impl MemoryLimiter {
 
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
     fn pool_mem_reserved(&self) -> u64 {
-        // The limiter already tracks buffers from
-        // * the prefetcher (GetObject and DiskCache),
-        // * the incremental uploader (Append).
-        //
-        // Here we fetch the pool's stats for the remaining kinds:
-        // * PutObject (multi-part uploads),
-        // * Other (currently not used).
-        (self.pool.reserved_bytes(BufferKind::PutObject) + self.pool.reserved_bytes(BufferKind::Other)) as u64
+        // All pool buffer kinds are accounted for here.
+        self.pool.total_reserved_bytes() as u64
     }
 }
 
@@ -290,11 +284,192 @@ pub fn effective_total_memory() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::PagedPool;
+    use crate::memory::{BufferKind, PagedPool};
 
     fn new_limiter() -> Arc<MemoryLimiter> {
         let pool = PagedPool::new_with_candidate_sizes([1024]);
         Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT))
+    }
+
+    fn new_limiter_with_pool(buffer_size: usize, mem_limit: u64) -> (Arc<MemoryLimiter>, PagedPool) {
+        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
+        let limiter = Arc::new(MemoryLimiter::new(pool.clone(), mem_limit));
+        (limiter, pool)
+    }
+
+    #[test]
+    fn test_reserve_and_release_cursor() {
+        let limiter = new_limiter();
+        let cursor = limiter.next_cursor_id();
+
+        limiter.reserve(cursor, BufferArea::Prefetch, 100);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 100);
+
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
+    }
+
+    #[test]
+    fn test_pool_allocation_decrements_mem_reserved() {
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let cursor = limiter.next_cursor_id();
+
+        // Reserve 1024 bytes of intent
+        limiter.reserve(cursor, BufferArea::Prefetch, 1024);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+
+        // Pool allocation triggers on_reserve callback, decrementing mem_reserved
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_reserve_pool_allocate_release_cursor() {
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let cursor = limiter.next_cursor_id();
+
+        // Reserve 2048 bytes of intent
+        limiter.reserve(cursor, BufferArea::Prefetch, 2048);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
+
+        // Pool allocates 1024 — callback decrements both global and per-cursor
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+
+        // release_cursor releases the remaining per-cursor balance (2048 - 1024 = 1024)
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
+    }
+
+    #[test]
+    fn test_try_reserve_respects_limit() {
+        let limiter = new_limiter();
+        let cursor = limiter.next_cursor_id();
+
+        // Fill up to the limit (minus additional_mem_reserved)
+        let available = limiter.available_mem();
+        limiter.reserve(cursor, BufferArea::Prefetch, available);
+
+        // Should fail — no room left
+        assert!(!limiter.try_reserve(cursor, BufferArea::Prefetch, 1));
+    }
+
+    #[test]
+    fn test_multiple_cursors_independent() {
+        let limiter = new_limiter();
+        let cursor1 = limiter.next_cursor_id();
+        let cursor2 = limiter.next_cursor_id();
+
+        limiter.reserve(cursor1, BufferArea::Prefetch, 100);
+        limiter.reserve(cursor2, BufferArea::Prefetch, 200);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 300);
+
+        // Release cursor1 — only its 100 bytes
+        limiter.release_cursor(cursor1, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 200);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor1));
+
+        // Cursor2 still tracked
+        assert!(limiter.mem_reserved_per_cursor.contains_key(&cursor2));
+
+        limiter.release_cursor(cursor2, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(limiter.mem_reserved_per_cursor.is_empty());
+    }
+
+    #[test]
+    fn test_release_cursor_idempotent() {
+        let limiter = new_limiter();
+        let cursor = limiter.next_cursor_id();
+
+        limiter.reserve(cursor, BufferArea::Prefetch, 100);
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+
+        // Second call is a no-op
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_callback_noop_after_release_cursor() {
+        // Simulates the cancellation race: on_reserve fires after release_cursor
+        // removed the entry. The callback should be a no-op.
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let cursor = limiter.next_cursor_id();
+
+        limiter.reserve(cursor, BufferArea::Prefetch, 1024);
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // Late allocation for the cancelled request — cursor is gone
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
+
+        // mem_reserved should stay at 0, not go negative or wrap
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_callback_saturates_on_over_decrement() {
+        // Simulates a late callback trying to decrement more than what remains
+        // in the per-cursor counter (e.g. due to a race with a new cursor reusing
+        // the same entry after release).
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let cursor = limiter.next_cursor_id();
+
+        // Reserve only 512 bytes
+        limiter.reserve(cursor, BufferArea::Prefetch, 512);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 512);
+
+        // Pool allocates 1024 — callback should saturate at 512 (not underflow)
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // release_cursor should subtract 0 (the per-cursor counter is already 0)
+        limiter.release_cursor(cursor, BufferArea::Prefetch);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_available_mem_accounts_for_pool_allocations() {
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let cursor = limiter.next_cursor_id();
+
+        let initial_available = limiter.available_mem();
+
+        // Reserve intent — available decreases
+        limiter.reserve(cursor, BufferArea::Prefetch, 1024);
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
+
+        // Pool allocates (on_reserve converts intent to pool stats) — available stays the same
+        // because mem_reserved decreases by 1024 while pool stats increase by 1024.
+        let buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
+
+        // Drop the buffer — pool stats decrease, available goes back up
+        drop(buffer);
+        assert_eq!(limiter.available_mem(), initial_available);
+    }
+
+    #[test]
+    fn test_upload_allocation_does_not_affect_mem_reserved() {
+        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+
+        let initial_available = limiter.available_mem();
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // Upload allocates without cursor_id — should not touch mem_reserved
+        let buffer = pool.get_buffer_mut(1024, BufferKind::Append, None);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        // But available_mem should decrease (pool stats increased)
+        assert_eq!(limiter.available_mem(), initial_available - 1024);
+
+        // Drop the buffer — available goes back up
+        drop(buffer);
+        assert_eq!(limiter.available_mem(), initial_available);
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -83,7 +83,7 @@ impl MemoryLimiter {
             // per-handle counters.
             //
             // This is a no-op when:
-            // - custom_id is None (e.g. disk cache, uploads): these allocations have no
+            // - custom_id is None (e.g. uploads): these allocations have no
             //   corresponding mem_reserved entry and are tracked only via pool_total.
             // - The handle has been removed (cancelled request): release_handle already
             //   subtracted the full balance, so we skip to avoid double-decrementing.

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -48,7 +48,7 @@ pub struct MemoryLimiter {
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
     /// Per-handle reservation tracking. Used for accurate release on handle drop.
-    mem_reserved_per_handle: DashMap<HandleId, AtomicU64>,
+    mem_reserved_per_handle: Arc<DashMap<HandleId, AtomicU64>>,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
     /// Memory pool used by the S3 client and disk cache.
@@ -68,9 +68,12 @@ impl MemoryLimiter {
         );
         let mem_reserved = Arc::new(AtomicU64::new(0));
         let mem_reserved_cb = mem_reserved.clone();
-        pool.set_on_reserve(Arc::new(move |bytes| {
-            // Use a CAS loop for saturating subtraction to prevent underflow if the callback
-            // fires after release_handle has already zeroed this handle's reservation.
+        let mem_reserved_per_handle: Arc<DashMap<HandleId, AtomicU64>> = Arc::new(DashMap::new());
+        let per_handle_cb = mem_reserved_per_handle.clone();
+        pool.set_on_reserve(Arc::new(move |bytes, custom_id| {
+            // Saturating subtraction prevents underflow if this callback races with
+            // release_handle during meta-request cancellation. In that case the global
+            // clamps to 0 — a harmless under-count corrected when the pool buffer is dropped.
             let mut current = mem_reserved_cb.load(Ordering::SeqCst);
             loop {
                 let new_val = current.saturating_sub(bytes as u64);
@@ -79,12 +82,17 @@ impl MemoryLimiter {
                     Err(actual) => current = actual,
                 }
             }
+            if let Some(handle_id) = custom_id
+                && let Some(reservation) = per_handle_cb.get(&HandleId::new(handle_id))
+            {
+                reservation.fetch_sub(bytes as u64, Ordering::SeqCst);
+            }
         }));
         Self {
             pool,
             mem_limit,
             mem_reserved,
-            mem_reserved_per_handle: DashMap::new(),
+            mem_reserved_per_handle,
             additional_mem_reserved: reserved_mem,
         }
     }
@@ -216,7 +224,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
         // Pool allocation triggers on_reserve callback, decrementing mem_reserved
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject);
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, None);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
@@ -229,17 +237,13 @@ mod tests {
         limiter.reserve(handle, BufferArea::Prefetch, 2048);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
 
-        // Pool allocates 1024 — callback decrements global by 1024
-        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject);
+        // Pool allocates 1024 — callback decrements both global and per-handle
+        let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(handle.as_raw()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
-        // release_handle releases the remaining 2048 from per-handle (not aware of pool decrement)
-        // Global goes to 1024 - 2048 which would underflow — this is the known limitation
-        // that per-handle tracking doesn't account for pool callback decrements.
-        // For now, release_handle releases the per-handle balance.
+        // release_handle releases the remaining per-handle balance (2048 - 1024 = 1024)
         limiter.release_handle(handle, BufferArea::Prefetch);
-
-        // Per-handle entry is removed
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
         assert!(limiter.mem_reserved_per_handle.is_empty());
     }
 

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -7,7 +7,7 @@ use crate::sync::Arc;
 
 use super::pages::PagedBufferPtr;
 use super::stats::{BufferKind, PoolStats};
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 
 /// A buffer backed by the pool.
 ///
@@ -34,11 +34,11 @@ impl PoolBuffer {
     pub(super) fn new_secondary(
         size: usize,
         kind: BufferKind,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
         stats: Arc<PoolStats>,
     ) -> Self {
         Self(PoolBufferInner::Secondary(FreeBuffer::new(
-            size, kind, request_id, stats,
+            size, kind, cursor_id, stats,
         )))
     }
 
@@ -182,9 +182,9 @@ struct FreeBuffer {
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, request_id: Option<RequestId>, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, cursor_id: Option<CursorId>, stats: Arc<PoolStats>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
-        stats.reserve_bytes(data.len(), kind, request_id);
+        stats.reserve_bytes(data.len(), kind, cursor_id);
         Self { data, kind, stats }
     }
 }

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -30,8 +30,10 @@ impl PoolBuffer {
         Self(PoolBufferInner::Primary { buffer_ptr, size })
     }
 
-    pub(super) fn new_secondary(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
-        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats)))
+    pub(super) fn new_secondary(size: usize, kind: BufferKind, custom_id: Option<u64>, stats: Arc<PoolStats>) -> Self {
+        Self(PoolBufferInner::Secondary(FreeBuffer::new(
+            size, kind, custom_id, stats,
+        )))
     }
 
     pub fn capacity(&self) -> usize {
@@ -174,9 +176,9 @@ struct FreeBuffer {
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, custom_id: Option<u64>, stats: Arc<PoolStats>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
-        stats.reserve_bytes(data.len(), kind);
+        stats.reserve_bytes(data.len(), kind, custom_id);
         Self { data, kind, stats }
     }
 }
@@ -198,14 +200,14 @@ mod tests {
     fn primary(buffer_size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(buffer_size);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_reserve(BufferKind::Other, None)
             .expect("should be able to reserve a buffer from a new page");
 
         PoolBuffer::new_primary(buffer_ptr, buffer_size)
     }
 
     fn secondary(buffer_size: usize) -> PoolBuffer {
-        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, Arc::new(PoolStats::default()))
+        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, None, Arc::new(PoolStats::default()))
     }
 
     #[test_case(primary)]

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -7,7 +7,7 @@ use crate::sync::Arc;
 
 use super::pages::PagedBufferPtr;
 use super::stats::{BufferKind, PoolStats};
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 
 /// A buffer backed by the pool.
 ///
@@ -34,11 +34,11 @@ impl PoolBuffer {
     pub(super) fn new_secondary(
         size: usize,
         kind: BufferKind,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
         stats: Arc<PoolStats>,
     ) -> Self {
         Self(PoolBufferInner::Secondary(FreeBuffer::new(
-            size, kind, handle_id, stats,
+            size, kind, request_id, stats,
         )))
     }
 
@@ -182,9 +182,9 @@ struct FreeBuffer {
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, handle_id: Option<HandleId>, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, request_id: Option<RequestId>, stats: Arc<PoolStats>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
-        stats.reserve_bytes(data.len(), kind, handle_id);
+        stats.reserve_bytes(data.len(), kind, request_id);
         Self { data, kind, stats }
     }
 }

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -7,6 +7,7 @@ use crate::sync::Arc;
 
 use super::pages::PagedBufferPtr;
 use super::stats::{BufferKind, PoolStats};
+use crate::prefetch::HandleId;
 
 /// A buffer backed by the pool.
 ///
@@ -30,9 +31,14 @@ impl PoolBuffer {
         Self(PoolBufferInner::Primary { buffer_ptr, size })
     }
 
-    pub(super) fn new_secondary(size: usize, kind: BufferKind, custom_id: Option<u64>, stats: Arc<PoolStats>) -> Self {
+    pub(super) fn new_secondary(
+        size: usize,
+        kind: BufferKind,
+        handle_id: Option<HandleId>,
+        stats: Arc<PoolStats>,
+    ) -> Self {
         Self(PoolBufferInner::Secondary(FreeBuffer::new(
-            size, kind, custom_id, stats,
+            size, kind, handle_id, stats,
         )))
     }
 
@@ -176,9 +182,9 @@ struct FreeBuffer {
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, custom_id: Option<u64>, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, handle_id: Option<HandleId>, stats: Arc<PoolStats>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
-        stats.reserve_bytes(data.len(), kind, custom_id);
+        stats.reserve_bytes(data.len(), kind, handle_id);
         Self { data, kind, stats }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -78,14 +78,14 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind, custom_id: Option<u64>) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind);
+        self.inner.stats.add_reserved_buffer(kind, custom_id);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };
@@ -214,24 +214,24 @@ mod tests {
         let mut buffers = Vec::new();
         for _ in 0..Page::BUFFERS_PER_PAGE {
             let buffer_ptr = page
-                .try_reserve(BufferKind::Other)
+                .try_reserve(BufferKind::Other, None)
                 .expect("reserving up to 16 buffers from a new page should succeed");
             buffers.push(buffer_ptr);
         }
 
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, None).is_none(),
             "reserving the 17th buffer from a page should return None"
         );
 
         _ = buffers.pop().expect("drop one of the reserved buffers");
 
         buffers.push(
-            page.try_reserve(BufferKind::Other)
+            page.try_reserve(BufferKind::Other, None)
                 .expect("reserving after dropping 1 buffer should succeed"),
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, None).is_none(),
             "reserving when all 16 buffers are in use should return None"
         );
 
@@ -247,7 +247,7 @@ mod tests {
             "invalidation of a new, empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, None).is_none(),
             "reserving from an invalidated page should return None"
         );
     }
@@ -256,7 +256,7 @@ mod tests {
     fn test_invalidate_in_use() {
         let page = Page::new_for_tests(1024);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_reserve(BufferKind::Other, None)
             .expect("reserving from a new page should succeed");
         assert!(!page.invalidate_if_empty(), "invalidation of a page in use should fail");
         drop(buffer_ptr);
@@ -265,7 +265,7 @@ mod tests {
             "invalidation of an empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, None).is_none(),
             "reserving from an invalidated page should return None"
         );
     }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -3,7 +3,7 @@ use std::alloc::{self, Layout};
 use crate::sync::{Arc, Mutex};
 
 use super::stats::{BufferKind, SizePoolStats};
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 
 /// Page in a size pool.
 ///
@@ -79,14 +79,14 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind, handle_id: Option<HandleId>) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind, request_id: Option<RequestId>) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind, handle_id);
+        self.inner.stats.add_reserved_buffer(kind, request_id);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -3,7 +3,7 @@ use std::alloc::{self, Layout};
 use crate::sync::{Arc, Mutex};
 
 use super::stats::{BufferKind, SizePoolStats};
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 
 /// Page in a size pool.
 ///
@@ -79,14 +79,14 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind, request_id: Option<RequestId>) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind, cursor_id: Option<CursorId>) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind, request_id);
+        self.inner.stats.add_reserved_buffer(kind, cursor_id);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -3,6 +3,7 @@ use std::alloc::{self, Layout};
 use crate::sync::{Arc, Mutex};
 
 use super::stats::{BufferKind, SizePoolStats};
+use crate::prefetch::HandleId;
 
 /// Page in a size pool.
 ///
@@ -78,14 +79,14 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind, custom_id: Option<u64>) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind, handle_id: Option<HandleId>) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind, custom_id);
+        self.inner.stats.add_reserved_buffer(kind, handle_id);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -122,8 +122,8 @@ impl PagedPool {
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `custom_id` is provided, it will be passed to the on_reserve callback
-    /// for per-handle memory tracking.
+    /// If `custom_id` is provided, it will be passed to the `on_reserve` callback
+    /// for per-request memory tracking.
     pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, custom_id: Option<u64>) -> PoolBufferMut {
         let buffer = self.get_buffer(capacity, kind, custom_id);
         PoolBufferMut::new(buffer)

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -7,6 +7,7 @@ use crate::sync::{Arc, RwLock};
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::pages::{Page, PagedBufferPtr};
 use super::stats::{BufferKind, PoolStats, SizePoolStats};
+use crate::prefetch::HandleId;
 
 /// A pool of reusable fixed-size buffers allocated in large pages.
 ///
@@ -117,22 +118,22 @@ impl PagedPool {
 
     /// Register a callback to be invoked whenever bytes are reserved in the pool.
     /// Must be called before any pool allocations occur to ensure accurate accounting.
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<u64>) + Send + Sync>) {
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<HandleId>) + Send + Sync>) {
         self.inner.stats.set_on_reserve(callback);
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `custom_id` is provided, it will be passed to the `on_reserve` callback
+    /// If `handle_id` is provided, it will be passed to the `on_reserve` callback
     /// for per-request memory tracking.
-    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, custom_id: Option<u64>) -> PoolBufferMut {
-        let buffer = self.get_buffer(capacity, kind, custom_id);
+    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, handle_id: Option<HandleId>) -> PoolBufferMut {
+        let buffer = self.get_buffer(capacity, kind, handle_id);
         PoolBufferMut::new(buffer)
     }
 
-    fn get_buffer(&self, size: usize, kind: BufferKind, custom_id: Option<u64>) -> PoolBuffer {
+    fn get_buffer(&self, size: usize, kind: BufferKind, handle_id: Option<HandleId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind, custom_id);
+                let buffer_ptr = pool.reserve(kind, handle_id);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
@@ -142,7 +143,7 @@ impl PagedPool {
             None => {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                PoolBuffer::new_secondary(size, kind, custom_id, self.inner.stats.clone())
+                PoolBuffer::new_secondary(size, kind, handle_id, self.inner.stats.clone())
             }
         }
     }
@@ -170,7 +171,11 @@ impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
     fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
-        self.get_buffer(size, meta_request.meta_request_type().into(), meta_request.custom_id())
+        self.get_buffer(
+            size,
+            meta_request.meta_request_type().into(),
+            meta_request.custom_id().map(HandleId::new),
+        )
     }
 
     fn trim(&self) -> bool {
@@ -234,11 +239,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind, custom_id: Option<u64>) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind, handle_id: Option<HandleId>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, custom_id) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, handle_id) {
                 return buffer_ptr;
             }
         }
@@ -248,13 +253,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, custom_id) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, handle_id) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind, custom_id).unwrap();
+        let buffer_ptr = page.try_reserve(kind, handle_id).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -263,9 +268,9 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind, custom_id))
+        pages.find_map(|page| page.try_reserve(kind, handle_id))
     }
 
     fn buffer_size(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -7,7 +7,7 @@ use crate::sync::{Arc, RwLock};
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::pages::{Page, PagedBufferPtr};
 use super::stats::{BufferKind, PoolStats, SizePoolStats};
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 
 /// A pool of reusable fixed-size buffers allocated in large pages.
 ///
@@ -118,22 +118,22 @@ impl PagedPool {
 
     /// Register a callback to be invoked whenever bytes are reserved in the pool.
     /// Must be called before any pool allocations occur to ensure accurate accounting.
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<RequestId>) + Send + Sync>) {
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<CursorId>) + Send + Sync>) {
         self.inner.stats.set_on_reserve(callback);
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `request_id` is provided, it will be passed to the `on_reserve` callback
-    /// for per-request memory tracking.
-    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, request_id: Option<RequestId>) -> PoolBufferMut {
-        let buffer = self.get_buffer(capacity, kind, request_id);
+    /// If `cursor_id` is provided, it will be passed to the `on_reserve` callback
+    /// for per-cursor memory tracking.
+    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBufferMut {
+        let buffer = self.get_buffer(capacity, kind, cursor_id);
         PoolBufferMut::new(buffer)
     }
 
-    fn get_buffer(&self, size: usize, kind: BufferKind, request_id: Option<RequestId>) -> PoolBuffer {
+    fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind, request_id);
+                let buffer_ptr = pool.reserve(kind, cursor_id);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
@@ -143,7 +143,7 @@ impl PagedPool {
             None => {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                PoolBuffer::new_secondary(size, kind, request_id, self.inner.stats.clone())
+                PoolBuffer::new_secondary(size, kind, cursor_id, self.inner.stats.clone())
             }
         }
     }
@@ -174,7 +174,7 @@ impl MemoryPool for PagedPool {
         self.get_buffer(
             size,
             meta_request.meta_request_type().into(),
-            meta_request.custom_id().map(RequestId::new_from_raw),
+            meta_request.custom_id().map(CursorId::new_from_raw),
         )
     }
 
@@ -239,11 +239,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind, request_id: Option<RequestId>) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind, cursor_id: Option<CursorId>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, request_id) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, cursor_id) {
                 return buffer_ptr;
             }
         }
@@ -253,13 +253,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, request_id) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, cursor_id) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind, request_id).unwrap();
+        let buffer_ptr = page.try_reserve(kind, cursor_id).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -268,9 +268,9 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind, request_id))
+        pages.find_map(|page| page.try_reserve(kind, cursor_id))
     }
 
     fn buffer_size(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -7,7 +7,7 @@ use crate::sync::{Arc, RwLock};
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::pages::{Page, PagedBufferPtr};
 use super::stats::{BufferKind, PoolStats, SizePoolStats};
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 
 /// A pool of reusable fixed-size buffers allocated in large pages.
 ///
@@ -118,22 +118,22 @@ impl PagedPool {
 
     /// Register a callback to be invoked whenever bytes are reserved in the pool.
     /// Must be called before any pool allocations occur to ensure accurate accounting.
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<HandleId>) + Send + Sync>) {
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<RequestId>) + Send + Sync>) {
         self.inner.stats.set_on_reserve(callback);
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `handle_id` is provided, it will be passed to the `on_reserve` callback
+    /// If `request_id` is provided, it will be passed to the `on_reserve` callback
     /// for per-request memory tracking.
-    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, handle_id: Option<HandleId>) -> PoolBufferMut {
-        let buffer = self.get_buffer(capacity, kind, handle_id);
+    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, request_id: Option<RequestId>) -> PoolBufferMut {
+        let buffer = self.get_buffer(capacity, kind, request_id);
         PoolBufferMut::new(buffer)
     }
 
-    fn get_buffer(&self, size: usize, kind: BufferKind, handle_id: Option<HandleId>) -> PoolBuffer {
+    fn get_buffer(&self, size: usize, kind: BufferKind, request_id: Option<RequestId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind, handle_id);
+                let buffer_ptr = pool.reserve(kind, request_id);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
@@ -143,7 +143,7 @@ impl PagedPool {
             None => {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                PoolBuffer::new_secondary(size, kind, handle_id, self.inner.stats.clone())
+                PoolBuffer::new_secondary(size, kind, request_id, self.inner.stats.clone())
             }
         }
     }
@@ -174,7 +174,7 @@ impl MemoryPool for PagedPool {
         self.get_buffer(
             size,
             meta_request.meta_request_type().into(),
-            meta_request.custom_id().map(HandleId::new),
+            meta_request.custom_id().map(RequestId::new_from_raw),
         )
     }
 
@@ -239,11 +239,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind, handle_id: Option<HandleId>) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind, request_id: Option<RequestId>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, handle_id) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, request_id) {
                 return buffer_ptr;
             }
         }
@@ -253,13 +253,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, handle_id) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, request_id) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind, handle_id).unwrap();
+        let buffer_ptr = page.try_reserve(kind, request_id).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -268,9 +268,9 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind, handle_id))
+        pages.find_map(|page| page.try_reserve(kind, request_id))
     }
 
     fn buffer_size(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -110,6 +110,11 @@ impl PagedPool {
         self.inner.stats.reserved_bytes(kind)
     }
 
+    /// Return the total reserved memory in bytes across all buffer kinds.
+    pub fn total_reserved_bytes(&self) -> usize {
+        self.inner.stats.total_reserved_bytes()
+    }
+
     /// Get a new empty mutable buffer from the pool with the requested capacity.
     pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind) -> PoolBufferMut {
         let buffer = self.get_buffer(capacity, kind);

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -115,6 +115,12 @@ impl PagedPool {
         self.inner.stats.total_reserved_bytes()
     }
 
+    /// Register a callback to be invoked whenever bytes are reserved in the pool.
+    /// Must be called before any pool allocations occur to ensure accurate accounting.
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize) + Send + Sync>) {
+        self.inner.stats.set_on_reserve(callback);
+    }
+
     /// Get a new empty mutable buffer from the pool with the requested capacity.
     pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind) -> PoolBufferMut {
         let buffer = self.get_buffer(capacity, kind);

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -117,20 +117,22 @@ impl PagedPool {
 
     /// Register a callback to be invoked whenever bytes are reserved in the pool.
     /// Must be called before any pool allocations occur to ensure accurate accounting.
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize) + Send + Sync>) {
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<u64>) + Send + Sync>) {
         self.inner.stats.set_on_reserve(callback);
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind) -> PoolBufferMut {
-        let buffer = self.get_buffer(capacity, kind);
+    /// If `custom_id` is provided, it will be passed to the on_reserve callback
+    /// for per-handle memory tracking.
+    pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, custom_id: Option<u64>) -> PoolBufferMut {
+        let buffer = self.get_buffer(capacity, kind, custom_id);
         PoolBufferMut::new(buffer)
     }
 
-    fn get_buffer(&self, size: usize, kind: BufferKind) -> PoolBuffer {
+    fn get_buffer(&self, size: usize, kind: BufferKind, custom_id: Option<u64>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind);
+                let buffer_ptr = pool.reserve(kind, custom_id);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
@@ -140,7 +142,7 @@ impl PagedPool {
             None => {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone())
+                PoolBuffer::new_secondary(size, kind, custom_id, self.inner.stats.clone())
             }
         }
     }
@@ -168,7 +170,7 @@ impl MemoryPool for PagedPool {
     type Buffer = PoolBuffer;
 
     fn get_buffer(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
-        self.get_buffer(size, meta_request.meta_request_type().into())
+        self.get_buffer(size, meta_request.meta_request_type().into(), meta_request.custom_id())
     }
 
     fn trim(&self) -> bool {
@@ -232,11 +234,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind, custom_id: Option<u64>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, custom_id) {
                 return buffer_ptr;
             }
         }
@@ -246,13 +248,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, custom_id) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind).unwrap();
+        let buffer_ptr = page.try_reserve(kind, custom_id).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -261,8 +263,9 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
+        custom_id: Option<u64>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind))
+        pages.find_map(|page| page.try_reserve(kind, custom_id))
     }
 
     fn buffer_size(&self) -> usize {
@@ -284,7 +287,7 @@ mod tests {
     use test_case::{test_case, test_matrix};
 
     fn copy_from_slice(pool: &PagedPool, original: &[u8]) -> Bytes {
-        let mut buffer = pool.get_buffer(original.len(), BufferKind::Other);
+        let mut buffer = pool.get_buffer(original.len(), BufferKind::Other, None);
         buffer.as_mut().clone_from_slice(original);
         buffer.into_bytes()
     }
@@ -373,7 +376,7 @@ mod tests {
         let mut buffers = Vec::new();
         for (&kind, &count) in &reservations {
             for _ in 0..count {
-                buffers.push(pool.get_buffer(buffer_size, kind).into_bytes());
+                buffers.push(pool.get_buffer(buffer_size, kind, None).into_bytes());
             }
         }
 

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
-use crate::prefetch::HandleId;
+use crate::prefetch::RequestId;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-type OnReserveCallback = Arc<dyn Fn(usize, Option<HandleId>) + Send + Sync>;
+type OnReserveCallback = Arc<dyn Fn(usize, Option<RequestId>) + Send + Sync>;
 
 /// Usage stats for a pool.
 #[derive(Default)]
@@ -39,10 +39,10 @@ impl PoolStats {
         let _ = self.on_reserve.set(callback);
     }
 
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, handle_id: Option<HandleId>) {
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, request_id: Option<RequestId>) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
         if let Some(cb) = self.on_reserve.get() {
-            cb(bytes, handle_id);
+            cb(bytes, request_id);
         }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
@@ -91,9 +91,9 @@ impl SizePoolStats {
         self.reserved_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, handle_id: Option<HandleId>) {
+    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, request_id: Option<RequestId>) {
         self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind, handle_id);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind, request_id);
     }
 
     pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -6,12 +6,14 @@ use mountpoint_s3_client::config::MetaRequestType;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
+type OnReserveCallback = Arc<dyn Fn(usize, Option<u64>) + Send + Sync>;
+
 /// Usage stats for a pool.
 #[derive(Default)]
 pub struct PoolStats {
     reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
     /// Optional callback invoked whenever bytes are reserved in the pool.
-    on_reserve: OnceLock<Arc<dyn Fn(usize) + Send + Sync>>,
+    on_reserve: OnceLock<OnReserveCallback>,
 }
 
 impl std::fmt::Debug for PoolStats {
@@ -32,14 +34,14 @@ impl PoolStats {
         self.reserved_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
     }
 
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize) + Send + Sync>) {
+    pub fn set_on_reserve(&self, callback: OnReserveCallback) {
         let _ = self.on_reserve.set(callback);
     }
 
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, custom_id: Option<u64>) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
         if let Some(cb) = self.on_reserve.get() {
-            cb(bytes);
+            cb(bytes, custom_id);
         }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
@@ -88,9 +90,9 @@ impl SizePoolStats {
         self.reserved_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind) {
+    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, custom_id: Option<u64>) {
         self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind, custom_id);
     }
 
     pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,4 +1,5 @@
 use std::ops::Index;
+use std::sync::OnceLock;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
@@ -6,9 +7,20 @@ use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
 /// Usage stats for a pool.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct PoolStats {
     reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+    /// Optional callback invoked whenever bytes are reserved in the pool.
+    on_reserve: OnceLock<Arc<dyn Fn(usize) + Send + Sync>>,
+}
+
+impl std::fmt::Debug for PoolStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PoolStats")
+            .field("reserved_bytes", &self.reserved_bytes)
+            .field("on_reserve", &self.on_reserve.get().map(|_| "<callback>"))
+            .finish()
+    }
 }
 
 impl PoolStats {
@@ -20,8 +32,15 @@ impl PoolStats {
         self.reserved_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
     }
 
+    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize) + Send + Sync>) {
+        let _ = self.on_reserve.set(callback);
+    }
+
     pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
+        if let Some(cb) = self.on_reserve.get() {
+            cb(bytes);
+        }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
 

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -3,10 +3,11 @@ use std::sync::OnceLock;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
+use crate::prefetch::HandleId;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-type OnReserveCallback = Arc<dyn Fn(usize, Option<u64>) + Send + Sync>;
+type OnReserveCallback = Arc<dyn Fn(usize, Option<HandleId>) + Send + Sync>;
 
 /// Usage stats for a pool.
 #[derive(Default)]
@@ -38,10 +39,10 @@ impl PoolStats {
         let _ = self.on_reserve.set(callback);
     }
 
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, custom_id: Option<u64>) {
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, handle_id: Option<HandleId>) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
         if let Some(cb) = self.on_reserve.get() {
-            cb(bytes, custom_id);
+            cb(bytes, handle_id);
         }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
@@ -90,9 +91,9 @@ impl SizePoolStats {
         self.reserved_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, custom_id: Option<u64>) {
+    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, handle_id: Option<HandleId>) {
         self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind, custom_id);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind, handle_id);
     }
 
     pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -3,11 +3,11 @@ use std::sync::OnceLock;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
-use crate::prefetch::RequestId;
+use crate::prefetch::CursorId;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-type OnReserveCallback = Arc<dyn Fn(usize, Option<RequestId>) + Send + Sync>;
+type OnReserveCallback = Arc<dyn Fn(usize, Option<CursorId>) + Send + Sync>;
 
 /// Usage stats for a pool.
 #[derive(Default)]
@@ -39,10 +39,10 @@ impl PoolStats {
         let _ = self.on_reserve.set(callback);
     }
 
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, request_id: Option<RequestId>) {
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, cursor_id: Option<CursorId>) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
         if let Some(cb) = self.on_reserve.get() {
-            cb(bytes, request_id);
+            cb(bytes, cursor_id);
         }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
@@ -91,9 +91,9 @@ impl SizePoolStats {
         self.reserved_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, request_id: Option<RequestId>) {
+    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, cursor_id: Option<CursorId>) {
         self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind, request_id);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind, cursor_id);
     }
 
     pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -16,6 +16,10 @@ impl PoolStats {
         self.reserved_bytes[kind].load(Ordering::SeqCst)
     }
 
+    pub fn total_reserved_bytes(&self) -> usize {
+        self.reserved_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
+    }
+
     pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -42,8 +42,10 @@ use tracing::trace;
 use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
+use crate::mem_limiter::MemoryLimiter;
 use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
 use crate::object::ObjectId;
+use crate::sync::Arc;
 
 mod backpressure_controller;
 mod builder;
@@ -199,6 +201,7 @@ fn determine_max_read_size() -> usize {
 #[derive(Debug)]
 pub struct Prefetcher<Client> {
     part_stream: PartStream<Client>,
+    mem_limiter: Arc<MemoryLimiter>,
     config: PrefetcherConfig,
 }
 
@@ -220,8 +223,8 @@ where
     }
 
     /// Create a new [Prefetcher] from the given [ObjectPartStream] instance.
-    pub fn new(part_stream: PartStream<Client>, config: PrefetcherConfig) -> Self {
-        Self { part_stream, config }
+    pub fn new(part_stream: PartStream<Client>, mem_limiter: Arc<MemoryLimiter>, config: PrefetcherConfig) -> Self {
+        Self { part_stream, mem_limiter, config }
     }
 
     /// Start a new prefetch request to the specified object.
@@ -238,6 +241,7 @@ where
         PrefetchGetObject::new(
             self.part_stream.clone(),
             self.config,
+            self.mem_limiter.clone(),
             bucket,
             object_id,
             handle_id,
@@ -254,6 +258,7 @@ where
 {
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
+    mem_limiter: Arc<MemoryLimiter>,
     backpressure_task: Option<RequestTask<Client>>,
     // Invariant: the offset of the last byte in this window is always
     // self.next_sequential_read_offset - 1.
@@ -279,6 +284,7 @@ where
     fn new(
         part_stream: PartStream<Client>,
         config: PrefetcherConfig,
+        mem_limiter: Arc<MemoryLimiter>,
         bucket: String,
         object_id: ObjectId,
         handle_id: HandleId,
@@ -288,6 +294,7 @@ where
         PrefetchGetObject {
             part_stream,
             config,
+            mem_limiter,
             backpressure_task: None,
             backward_seek_window: SeekWindow::new(max_backward_seek_distance),
             preferred_part_size: 128 * 1024,

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -299,7 +299,7 @@ where
         // note that this reservation is done in addition to the one in [PartQueue::push_front]
         let seek_window_reservation =
             Self::seek_window_reservation(part_stream.client().read_part_size(), max_backward_seek_distance);
-        mem_limiter.reserve(BufferArea::Prefetch, seek_window_reservation);
+        mem_limiter.reserve(handle_id, BufferArea::Prefetch, seek_window_reservation);
         PrefetchGetObject {
             part_stream,
             config,
@@ -575,7 +575,8 @@ where
             self.part_stream.client().read_part_size(),
             self.backward_seek_window.max_size(),
         );
-        self.mem_limiter.release(BufferArea::Prefetch, seek_window_reservation);
+        self.mem_limiter
+            .release(self.handle_id, BufferArea::Prefetch, seek_window_reservation);
         self.record_contiguous_read_metric();
     }
 }

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -280,10 +280,10 @@ where
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
     mem_limiter: Arc<MemoryLimiter>,
-    backpressure_task: Option<RequestTask<Client>>,
+    backpressure_task: Option<RequestTask<Client>>, //
     // Invariant: the offset of the last byte in this window is always
     // self.next_sequential_read_offset - 1.
-    backward_seek_window: SeekWindow,
+    backward_seek_window: SeekWindow, //
     bucket: String,
     object_id: ObjectId,
     // preferred part size in the prefetcher's part queue, not the object part

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -76,6 +76,36 @@ impl HandleId {
     }
 }
 
+/// Opaque identifier for a single prefetch request (i.e., one `BackpressureController` lifetime).
+/// Generated fresh on each `RequestTask` creation so that late `on_reserve` callbacks from a
+/// cancelled CRT meta-request cannot incorrectly decrement a re-created entry for the same handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RequestId(u64);
+
+impl Default for RequestId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RequestId {
+    /// Generate a new unique request ID.
+    pub fn new() -> Self {
+        use crate::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Reconstruct a `RequestId` from a raw `u64` (e.g., from CRT `custom_id`).
+    pub fn new_from_raw(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn as_raw(&self) -> u64 {
+        self.0
+    }
+}
+
 // This is a weird looking number! We really want our first request size to be 1MiB,
 // which is a common IO size. But Linux's readahead will try to read an extra 128k on on
 // top of a 1MiB read, which we'd have to wait for a second request to service. Because
@@ -224,7 +254,11 @@ where
 
     /// Create a new [Prefetcher] from the given [ObjectPartStream] instance.
     pub fn new(part_stream: PartStream<Client>, mem_limiter: Arc<MemoryLimiter>, config: PrefetcherConfig) -> Self {
-        Self { part_stream, mem_limiter, config }
+        Self {
+            part_stream,
+            mem_limiter,
+            config,
+        }
     }
 
     /// Start a new prefetch request to the specified object.
@@ -453,7 +487,6 @@ where
         let config = RequestTaskConfig {
             bucket: self.bucket.clone(),
             object_id: self.object_id.clone(),
-            handle_id: self.handle_id,
             range,
             read_part_size,
             preferred_part_size: self.preferred_part_size,

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -42,10 +42,8 @@ use tracing::trace;
 use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
 use crate::object::ObjectId;
-use crate::sync::Arc;
 
 mod backpressure_controller;
 mod builder;
@@ -202,7 +200,6 @@ fn determine_max_read_size() -> usize {
 pub struct Prefetcher<Client> {
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
-    mem_limiter: Arc<MemoryLimiter>,
 }
 
 impl<Client> Prefetcher<Client>
@@ -223,12 +220,8 @@ where
     }
 
     /// Create a new [Prefetcher] from the given [ObjectPartStream] instance.
-    pub fn new(part_stream: PartStream<Client>, config: PrefetcherConfig, mem_limiter: Arc<MemoryLimiter>) -> Self {
-        Self {
-            part_stream,
-            config,
-            mem_limiter,
-        }
+    pub fn new(part_stream: PartStream<Client>, config: PrefetcherConfig) -> Self {
+        Self { part_stream, config }
     }
 
     /// Start a new prefetch request to the specified object.
@@ -249,7 +242,6 @@ where
             object_id,
             handle_id,
             size,
-            self.mem_limiter.clone(),
         )
     }
 }
@@ -275,7 +267,6 @@ where
     next_sequential_read_offset: u64,
     next_request_offset: u64,
     size: u64,
-    mem_limiter: Arc<MemoryLimiter>,
     /// File handle ID that owns this prefetch request, for per-handle memory accounting.
     handle_id: HandleId,
 }
@@ -292,14 +283,8 @@ where
         object_id: ObjectId,
         handle_id: HandleId,
         size: u64,
-        mem_limiter: Arc<MemoryLimiter>,
     ) -> Self {
         let max_backward_seek_distance = config.max_backward_seek_distance as usize;
-        // a conservative memory reservation to avoid violating the memory limit with the large number of file handles
-        // note that this reservation is done in addition to the one in [PartQueue::push_front]
-        let seek_window_reservation =
-            Self::seek_window_reservation(part_stream.client().read_part_size(), max_backward_seek_distance);
-        mem_limiter.reserve(handle_id, BufferArea::Prefetch, seek_window_reservation);
         PrefetchGetObject {
             part_stream,
             config,
@@ -312,7 +297,6 @@ where
             bucket,
             object_id,
             size,
-            mem_limiter,
             handle_id,
         }
     }
@@ -541,10 +525,9 @@ where
             trace!("seek failed: not enough data in backwards seek window");
             return Ok(false);
         };
-        // This also increase `prefetcher_mem_reserved` value in memory limiter.
-        // At least one subsequent `RequestTask::read` is required for memory tracking to work correctly
-        // because `BackpressureController::drop` needs to know the start offset of the part queue to
-        // release the right amount of memory.
+        // Re-inject the parts from the seek window back into the part queue.
+        // The pool already tracks the memory for these buffers, so no additional
+        // reservation on the memory limiter is needed.
         task.push_front(parts).await?;
         self.next_sequential_read_offset = offset;
         Ok(true)
@@ -557,13 +540,6 @@ where
         histogram!("prefetch.contiguous_read_len")
             .record((self.next_sequential_read_offset - self.sequential_read_start_offset) as f64);
     }
-
-    /// The amount of memory reserved for a backwards seek window.
-    ///
-    /// The seek window size is rounded up to the nearest multiple of part_size.
-    fn seek_window_reservation(part_size: usize, seek_window_size: usize) -> u64 {
-        (seek_window_size.div_ceil(part_size) * part_size) as u64
-    }
 }
 
 impl<Client> Drop for PrefetchGetObject<Client>
@@ -571,12 +547,6 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        let seek_window_reservation = Self::seek_window_reservation(
-            self.part_stream.client().read_part_size(),
-            self.backward_seek_window.max_size(),
-        );
-        self.mem_limiter
-            .release(self.handle_id, BufferArea::Prefetch, seek_window_reservation);
         self.record_contiguous_read_metric();
     }
 }
@@ -1305,14 +1275,6 @@ mod tests {
             let expected = ramp_bytes(0xaa + offset, 1);
             assert_eq!(byte.into_bytes().unwrap()[..], expected[..]);
         }
-    }
-
-    #[test_case(8 * 1024 * 1024, 1 * 1024 * 1024, 8 * 1024 * 1024; "8MiB part_size, 1MiB window")]
-    #[test_case(1 * 1024 * 1024, 1 * 1024 * 1024, 1 * 1024 * 1024; "equal part_size and window")]
-    #[test_case(250 * 1024, 1 * 1024 * 1024, 1250 * 1024; "window larger than part_size")]
-    fn test_seek_window_reservation(part_size: usize, seek_window_size: usize, expected: u64) {
-        let reservation = PrefetchGetObject::<MockClient>::seek_window_reservation(part_size, seek_window_size);
-        assert_eq!(reservation, expected);
     }
 
     #[test_case(8 * MB, 8 * MB, 1 * MB + 128 * KB; "default")]

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -82,20 +82,7 @@ impl HandleId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RequestId(u64);
 
-impl Default for RequestId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RequestId {
-    /// Generate a new unique request ID.
-    pub fn new() -> Self {
-        use crate::sync::atomic::{AtomicU64, Ordering};
-        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
-    }
-
     /// Reconstruct a `RequestId` from a raw `u64` (e.g., from CRT `custom_id`).
     pub fn new_from_raw(id: u64) -> Self {
         Self(id)

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -79,11 +79,12 @@ impl HandleId {
 /// Opaque identifier for a single prefetch request (i.e., one `BackpressureController` lifetime).
 /// Generated fresh on each `RequestTask` creation so that late `on_reserve` callbacks from a
 /// cancelled CRT meta-request cannot incorrectly decrement a re-created entry for the same handle.
+/// A cursor consists of a RequestTask and a SeekWindow
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct RequestId(u64);
+pub struct CursorId(u64);
 
-impl RequestId {
-    /// Reconstruct a `RequestId` from a raw `u64` (e.g., from CRT `custom_id`).
+impl CursorId {
+    /// Reconstruct a `CursorId` from a raw `u64` (e.g., from CRT `custom_id`).
     pub fn new_from_raw(id: u64) -> Self {
         Self(id)
     }
@@ -280,10 +281,10 @@ where
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
     mem_limiter: Arc<MemoryLimiter>,
-    backpressure_task: Option<RequestTask<Client>>, //
+    backpressure_task: Option<RequestTask<Client>>,
     // Invariant: the offset of the last byte in this window is always
     // self.next_sequential_read_offset - 1.
-    backward_seek_window: SeekWindow, //
+    backward_seek_window: SeekWindow,
     bucket: String,
     object_id: ObjectId,
     // preferred part size in the prefetcher's part queue, not the object part

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -7,8 +7,8 @@ use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
 
+use super::CursorId;
 use super::PrefetchReadError;
-use super::RequestId;
 
 #[derive(Debug)]
 pub enum BackpressureFeedbackEvent {
@@ -93,8 +93,8 @@ pub struct BackpressureController {
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
     mem_limiter: Arc<MemoryLimiter>,
-    /// Unique request ID for per-request memory reservation tracking.
-    request_id: RequestId,
+    /// Unique cursor ID for per-cursor memory reservation tracking.
+    cursor_id: CursorId,
     /// Enable alignment of read window end to part boundary
     read_window_alignment_config: ReadWindowAlignmentConfig,
 }
@@ -113,9 +113,9 @@ pub struct BackpressureLimiter {
     /// End offset for the request we want to apply backpressure. The request can return
     /// data up to this offset *exclusively*.
     request_end_offset: u64,
-    /// The unique request ID for this backpressure pair. Used as `custom_id` on CRT
-    /// meta-requests and for per-request memory tracking in the pool's `on_reserve` callback.
-    request_id: RequestId,
+    /// The unique cursor ID for this backpressure pair. Used as `custom_id` on CRT
+    /// meta-requests and for per-cursor memory tracking in the pool's `on_reserve` callback.
+    cursor_id: CursorId,
 }
 
 /// Creates a [BackpressureController] and its related [BackpressureLimiter].
@@ -128,9 +128,9 @@ pub fn new_backpressure_controller(
 ) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
-    let request_id = mem_limiter.next_request_id();
+    let cursor_id = mem_limiter.next_cursor_id();
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    mem_limiter.reserve(request_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
+    mem_limiter.reserve(cursor_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
 
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
@@ -144,7 +144,7 @@ pub fn new_backpressure_controller(
         read_window_end_offset,
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
-        request_id,
+        cursor_id,
         mem_limiter,
         read_window_alignment_config: config.read_window_alignment_config,
     };
@@ -155,7 +155,7 @@ pub fn new_backpressure_controller(
         read_window_increment_queue,
         read_window_end_offset,
         request_end_offset: config.request_range.end,
-        request_id,
+        cursor_id,
     };
 
     (controller, limiter)
@@ -203,7 +203,7 @@ impl BackpressureController {
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.mem_limiter
-                            .reserve(self.request_id, BufferArea::Prefetch, to_increase as u64);
+                            .reserve(self.cursor_id, BufferArea::Prefetch, to_increase as u64);
                         self.increment_read_window(to_increase).await;
                         break;
                     }
@@ -212,7 +212,7 @@ impl BackpressureController {
                     // scale down the read window if it fails.
                     if self
                         .mem_limiter
-                        .try_reserve(self.request_id, BufferArea::Prefetch, to_increase as u64)
+                        .try_reserve(self.cursor_id, BufferArea::Prefetch, to_increase as u64)
                     {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.increment_read_window(to_increase).await;
@@ -294,10 +294,10 @@ impl BackpressureController {
 
 impl Drop for BackpressureController {
     fn drop(&mut self) {
-        // Release whatever remains of this request's reservation. The per-request counter
+        // Release whatever remains of this cursor's reservation. The per-cursor counter
         // tracks only the unallocated portion — pool allocations already decremented it
         // via the on_reserve callback.
-        self.mem_limiter.release_request(self.request_id, BufferArea::Prefetch);
+        self.mem_limiter.release_cursor(self.cursor_id, BufferArea::Prefetch);
     }
 }
 
@@ -306,9 +306,9 @@ impl BackpressureLimiter {
         self.read_window_end_offset
     }
 
-    /// The unique request ID for this backpressure pair, used as `custom_id` on CRT requests.
-    pub fn request_id(&self) -> RequestId {
-        self.request_id
+    /// The unique cursor ID for this backpressure pair, used as `custom_id` on CRT requests.
+    pub fn cursor_id(&self) -> CursorId {
+        self.cursor_id
     }
 
     /// Wait until the backpressure window moves ahead of the given offset.

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -164,7 +164,6 @@ impl BackpressureController {
             // Note, that this may come from a backwards seek, so offsets observed by this method are not necessarily ascending
             BackpressureFeedbackEvent::DataRead { offset, length } => {
                 self.next_read_offset = offset + length as u64;
-                self.mem_limiter.release(BufferArea::Prefetch, length as u64);
                 let remaining_window = self.read_window_end_offset.saturating_sub(self.next_read_offset) as usize;
 
                 // Increment the read window only if the remaining window reaches some threshold i.e. half of it left.
@@ -286,7 +285,10 @@ impl Drop for BackpressureController {
             self.next_read_offset <= self.request_end_offset,
             "invariant: the next read offset should never be larger than the request end offset",
         );
-        // Free up memory we have reserved for the read window.
+        // TODO: This release is inaccurate. It releases the full remaining window, but some of
+        // those bytes may have already been decremented from mem_reserved by the pool's on_reserve
+        // callback (when the CRT allocated buffers). We need per-handle reservation tracking in the
+        // MemoryLimiter to know the exact unallocated portion of the window to release here.
         let remaining_window = self.read_window_end_offset.saturating_sub(self.next_read_offset);
         self.mem_limiter.release(BufferArea::Prefetch, remaining_window);
     }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -128,7 +128,7 @@ pub fn new_backpressure_controller(
 ) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
-    let request_id = RequestId::new();
+    let request_id = mem_limiter.next_request_id();
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
     mem_limiter.reserve(request_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
 

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -113,6 +113,9 @@ pub struct BackpressureLimiter {
     /// End offset for the request we want to apply backpressure. The request can return
     /// data up to this offset *exclusively*.
     request_end_offset: u64,
+    /// The unique request ID for this backpressure pair. Used as `custom_id` on CRT
+    /// meta-requests and for per-request memory tracking in the pool's `on_reserve` callback.
+    request_id: RequestId,
 }
 
 /// Creates a [BackpressureController] and its related [BackpressureLimiter].
@@ -122,7 +125,7 @@ pub struct BackpressureLimiter {
 pub fn new_backpressure_controller(
     config: BackpressureConfig,
     mem_limiter: Arc<MemoryLimiter>,
-) -> (BackpressureController, BackpressureLimiter, RequestId) {
+) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
     let request_id = RequestId::new();
@@ -152,9 +155,10 @@ pub fn new_backpressure_controller(
         read_window_increment_queue,
         read_window_end_offset,
         request_end_offset: config.request_range.end,
+        request_id,
     };
 
-    (controller, limiter, request_id)
+    (controller, limiter)
 }
 
 impl BackpressureController {
@@ -300,6 +304,11 @@ impl Drop for BackpressureController {
 impl BackpressureLimiter {
     pub fn read_window_end_offset(&self) -> u64 {
         self.read_window_end_offset
+    }
+
+    /// The unique request ID for this backpressure pair, used as `custom_id` on CRT requests.
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
     }
 
     /// Wait until the backpressure window moves ahead of the given offset.
@@ -509,7 +518,6 @@ mod tests {
             pool,
             backpressure_config.max_read_window_size as u64,
         ));
-        let (controller, limiter, _request_id) = new_backpressure_controller(backpressure_config, mem_limiter.clone());
-        (controller, limiter)
+        new_backpressure_controller(backpressure_config, mem_limiter.clone())
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -7,6 +7,7 @@ use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
 
+use super::HandleId;
 use super::PrefetchReadError;
 
 #[derive(Debug)]
@@ -92,6 +93,8 @@ pub struct BackpressureController {
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
     mem_limiter: Arc<MemoryLimiter>,
+    /// File handle ID for per-handle memory accounting.
+    handle_id: HandleId,
     /// Enable alignment of read window end to part boundary
     read_window_alignment_config: ReadWindowAlignmentConfig,
 }
@@ -118,12 +121,13 @@ pub struct BackpressureLimiter {
 /// informing a producer (a holder of the [BackpressureLimiter]) when it should provide data more aggressively.
 pub fn new_backpressure_controller(
     config: BackpressureConfig,
+    handle_id: HandleId,
     mem_limiter: Arc<MemoryLimiter>,
 ) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    mem_limiter.reserve(BufferArea::Prefetch, config.initial_read_window_size as u64);
+    mem_limiter.reserve(handle_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
 
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
@@ -137,6 +141,7 @@ pub fn new_backpressure_controller(
         read_window_end_offset,
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
+        handle_id,
         mem_limiter,
         read_window_alignment_config: config.read_window_alignment_config,
     };
@@ -193,14 +198,18 @@ impl BackpressureController {
                     // read window size.
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         trace!(new_read_window_end_offset, "sending a read window increment");
-                        self.mem_limiter.reserve(BufferArea::Prefetch, to_increase as u64);
+                        self.mem_limiter
+                            .reserve(self.handle_id, BufferArea::Prefetch, to_increase as u64);
                         self.increment_read_window(to_increase).await;
                         break;
                     }
 
                     // Try to reserve the memory for the length we want to increase before sending the request,
                     // scale down the read window if it fails.
-                    if self.mem_limiter.try_reserve(BufferArea::Prefetch, to_increase as u64) {
+                    if self
+                        .mem_limiter
+                        .try_reserve(self.handle_id, BufferArea::Prefetch, to_increase as u64)
+                    {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.increment_read_window(to_increase).await;
                         break;
@@ -281,16 +290,10 @@ impl BackpressureController {
 
 impl Drop for BackpressureController {
     fn drop(&mut self) {
-        debug_assert!(
-            self.next_read_offset <= self.request_end_offset,
-            "invariant: the next read offset should never be larger than the request end offset",
-        );
-        // TODO: This release is inaccurate. It releases the full remaining window, but some of
-        // those bytes may have already been decremented from mem_reserved by the pool's on_reserve
-        // callback (when the CRT allocated buffers). We need per-handle reservation tracking in the
-        // MemoryLimiter to know the exact unallocated portion of the window to release here.
-        let remaining_window = self.read_window_end_offset.saturating_sub(self.next_read_offset);
-        self.mem_limiter.release(BufferArea::Prefetch, remaining_window);
+        // Release whatever remains of this handle's reservation. The per-handle counter
+        // tracks only the unallocated portion — pool allocations already decremented it
+        // via the on_reserve callback.
+        self.mem_limiter.release_handle(self.handle_id, BufferArea::Prefetch);
     }
 }
 
@@ -506,6 +509,6 @@ mod tests {
             pool,
             backpressure_config.max_read_window_size as u64,
         ));
-        new_backpressure_controller(backpressure_config, mem_limiter.clone())
+        new_backpressure_controller(backpressure_config, HandleId::new(1), mem_limiter.clone())
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -7,8 +7,8 @@ use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
 
-use super::HandleId;
 use super::PrefetchReadError;
+use super::RequestId;
 
 #[derive(Debug)]
 pub enum BackpressureFeedbackEvent {
@@ -93,8 +93,8 @@ pub struct BackpressureController {
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
     mem_limiter: Arc<MemoryLimiter>,
-    /// File handle ID for per-handle memory accounting.
-    handle_id: HandleId,
+    /// Unique request ID for per-request memory reservation tracking.
+    request_id: RequestId,
     /// Enable alignment of read window end to part boundary
     read_window_alignment_config: ReadWindowAlignmentConfig,
 }
@@ -121,13 +121,13 @@ pub struct BackpressureLimiter {
 /// informing a producer (a holder of the [BackpressureLimiter]) when it should provide data more aggressively.
 pub fn new_backpressure_controller(
     config: BackpressureConfig,
-    handle_id: HandleId,
     mem_limiter: Arc<MemoryLimiter>,
-) -> (BackpressureController, BackpressureLimiter) {
+) -> (BackpressureController, BackpressureLimiter, RequestId) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
+    let request_id = RequestId::new();
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    mem_limiter.reserve(handle_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
+    mem_limiter.reserve(request_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
 
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
@@ -141,7 +141,7 @@ pub fn new_backpressure_controller(
         read_window_end_offset,
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
-        handle_id,
+        request_id,
         mem_limiter,
         read_window_alignment_config: config.read_window_alignment_config,
     };
@@ -154,7 +154,7 @@ pub fn new_backpressure_controller(
         request_end_offset: config.request_range.end,
     };
 
-    (controller, limiter)
+    (controller, limiter, request_id)
 }
 
 impl BackpressureController {
@@ -199,7 +199,7 @@ impl BackpressureController {
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.mem_limiter
-                            .reserve(self.handle_id, BufferArea::Prefetch, to_increase as u64);
+                            .reserve(self.request_id, BufferArea::Prefetch, to_increase as u64);
                         self.increment_read_window(to_increase).await;
                         break;
                     }
@@ -208,7 +208,7 @@ impl BackpressureController {
                     // scale down the read window if it fails.
                     if self
                         .mem_limiter
-                        .try_reserve(self.handle_id, BufferArea::Prefetch, to_increase as u64)
+                        .try_reserve(self.request_id, BufferArea::Prefetch, to_increase as u64)
                     {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.increment_read_window(to_increase).await;
@@ -290,10 +290,10 @@ impl BackpressureController {
 
 impl Drop for BackpressureController {
     fn drop(&mut self) {
-        // Release whatever remains of this handle's reservation. The per-handle counter
+        // Release whatever remains of this request's reservation. The per-request counter
         // tracks only the unallocated portion — pool allocations already decremented it
         // via the on_reserve callback.
-        self.mem_limiter.release_handle(self.handle_id, BufferArea::Prefetch);
+        self.mem_limiter.release_request(self.request_id, BufferArea::Prefetch);
     }
 }
 
@@ -509,6 +509,7 @@ mod tests {
             pool,
             backpressure_config.max_read_window_size as u64,
         ));
-        new_backpressure_controller(backpressure_config, HandleId::new(1), mem_limiter.clone())
+        let (controller, limiter, _request_id) = new_backpressure_controller(backpressure_config, mem_limiter.clone());
+        (controller, limiter)
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/builder.rs
+++ b/mountpoint-s3-fs/src/prefetch/builder.rs
@@ -78,7 +78,7 @@ where
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = ClientPartStream::new(runtime, self.client, mem_limiter.clone());
-        Prefetcher::new(PartStream::new(part_stream), prefetcher_config, mem_limiter)
+        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
     }
 }
 
@@ -99,6 +99,6 @@ where
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = CachingPartStream::new(runtime, self.client, mem_limiter.clone(), self.cache);
-        Prefetcher::new(PartStream::new(part_stream), prefetcher_config, mem_limiter)
+        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/builder.rs
+++ b/mountpoint-s3-fs/src/prefetch/builder.rs
@@ -78,7 +78,7 @@ where
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = ClientPartStream::new(runtime, self.client, mem_limiter.clone());
-        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
+        Prefetcher::new(PartStream::new(part_stream), mem_limiter, prefetcher_config)
     }
 }
 
@@ -99,6 +99,6 @@ where
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
         let part_stream = CachingPartStream::new(runtime, self.client, mem_limiter.clone(), self.cache);
-        Prefetcher::new(PartStream::new(part_stream), prefetcher_config)
+        Prefetcher::new(PartStream::new(part_stream), mem_limiter, prefetcher_config)
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -15,7 +15,6 @@ use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
 use super::PrefetchReadError;
-use super::RequestId;
 use super::backpressure_controller::{BackpressureConfig, BackpressureLimiter, new_backpressure_controller};
 use super::part::{Part, PartSource};
 use super::part_queue::{PartQueueProducer, unbounded_part_queue};
@@ -61,7 +60,7 @@ where
             request_range: range.into(),
             read_window_alignment_config: ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
         };
-        let (backpressure_controller, backpressure_limiter, request_id) =
+        let (backpressure_controller, backpressure_limiter) =
             new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
@@ -73,7 +72,6 @@ where
                 self.runtime.clone(),
                 backpressure_limiter,
                 config,
-                request_id,
             );
             let span = debug_span!("prefetch", ?range);
             request.get_from_cache(range, part_queue_producer).instrument(span)
@@ -96,7 +94,6 @@ struct CachingRequest<Client: ObjectClient, Cache> {
     runtime: Runtime,
     backpressure_limiter: BackpressureLimiter,
     config: RequestTaskConfig,
-    request_id: RequestId,
 }
 
 impl<Client, Cache> CachingRequest<Client, Cache>
@@ -110,7 +107,6 @@ where
         runtime: Runtime,
         backpressure_limiter: BackpressureLimiter,
         config: RequestTaskConfig,
-        request_id: RequestId,
     ) -> Self {
         Self {
             client,
@@ -118,7 +114,6 @@ where
             runtime,
             backpressure_limiter,
             config,
-            request_id,
         }
     }
 
@@ -157,7 +152,7 @@ where
                     block_index,
                     block_offset,
                     range.object_size(),
-                    Some(self.request_id),
+                    Some(self.backpressure_limiter.request_id()),
                 )
                 .await
             {
@@ -224,6 +219,7 @@ where
             "fetching data from client"
         );
 
+        let request_id = self.backpressure_limiter.request_id();
         let request_stream = read_from_client_stream(
             &mut self.backpressure_limiter,
             &self.client,
@@ -231,7 +227,7 @@ where
             cache_key.clone(),
             initial_request_end_offset,
             block_aligned_byte_range,
-            self.request_id,
+            request_id,
         );
 
         let mut part_composer = CachingPartComposer {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -15,6 +15,7 @@ use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
 use super::PrefetchReadError;
+use super::RequestId;
 use super::backpressure_controller::{BackpressureConfig, BackpressureLimiter, new_backpressure_controller};
 use super::part::{Part, PartSource};
 use super::part_queue::{PartQueueProducer, unbounded_part_queue};
@@ -60,8 +61,8 @@ where
             request_range: range.into(),
             read_window_alignment_config: ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
         };
-        let (backpressure_controller, backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
+        let (backpressure_controller, backpressure_limiter, request_id) =
+            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 
@@ -72,6 +73,7 @@ where
                 self.runtime.clone(),
                 backpressure_limiter,
                 config,
+                request_id,
             );
             let span = debug_span!("prefetch", ?range);
             request.get_from_cache(range, part_queue_producer).instrument(span)
@@ -94,6 +96,7 @@ struct CachingRequest<Client: ObjectClient, Cache> {
     runtime: Runtime,
     backpressure_limiter: BackpressureLimiter,
     config: RequestTaskConfig,
+    request_id: RequestId,
 }
 
 impl<Client, Cache> CachingRequest<Client, Cache>
@@ -107,6 +110,7 @@ where
         runtime: Runtime,
         backpressure_limiter: BackpressureLimiter,
         config: RequestTaskConfig,
+        request_id: RequestId,
     ) -> Self {
         Self {
             client,
@@ -114,6 +118,7 @@ where
             runtime,
             backpressure_limiter,
             config,
+            request_id,
         }
     }
 
@@ -152,7 +157,7 @@ where
                     block_index,
                     block_offset,
                     range.object_size(),
-                    Some(self.config.handle_id),
+                    Some(self.request_id),
                 )
                 .await
             {
@@ -226,7 +231,7 @@ where
             cache_key.clone(),
             initial_request_end_offset,
             block_aligned_byte_range,
-            self.config.handle_id,
+            self.request_id,
         );
 
         let mut part_composer = CachingPartComposer {
@@ -426,7 +431,6 @@ mod tests {
         mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter},
         memory::PagedPool,
         object::ObjectId,
-        prefetch::HandleId,
     };
 
     use super::*;
@@ -452,7 +456,6 @@ mod tests {
         let seed = 0xaa;
         let object = MockObject::ramp(seed, object_size, ETag::for_tests());
         let id = ObjectId::new(key.to_owned(), object.etag());
-        let handle_id = HandleId::new(1);
 
         // backpressure config
         let initial_request_size = 1 * MB;
@@ -486,7 +489,6 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
-                handle_id,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -513,7 +515,6 @@ mod tests {
             let config = RequestTaskConfig {
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
-                handle_id,
                 range,
                 read_part_size: client_part_size,
                 preferred_part_size: 256 * KB,
@@ -567,7 +568,6 @@ mod tests {
                 let config = RequestTaskConfig {
                     bucket: bucket.to_owned(),
                     object_id: id.clone(),
-                    handle_id: HandleId::new(1),
                     range: RequestRange::new(object_size, offset as u64, preferred_size),
                     read_part_size: client_part_size,
                     preferred_part_size: 256 * KB,

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -152,7 +152,7 @@ where
                     block_index,
                     block_offset,
                     range.object_size(),
-                    Some(self.config.handle_id.as_raw()),
+                    Some(self.config.handle_id),
                 )
                 .await
             {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -61,8 +61,8 @@ where
             read_window_alignment_config: ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
         };
         let (backpressure_controller, backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
-        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone());
+            new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
+        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone(), config.handle_id);
         trace!(?range, "spawning request");
 
         let request_task = {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -152,7 +152,7 @@ where
                     block_index,
                     block_offset,
                     range.object_size(),
-                    Some(self.backpressure_limiter.request_id()),
+                    Some(self.backpressure_limiter.cursor_id()),
                 )
                 .await
             {
@@ -219,7 +219,7 @@ where
             "fetching data from client"
         );
 
-        let request_id = self.backpressure_limiter.request_id();
+        let cursor_id = self.backpressure_limiter.cursor_id();
         let request_stream = read_from_client_stream(
             &mut self.backpressure_limiter,
             &self.client,
@@ -227,7 +227,7 @@ where
             cache_key.clone(),
             initial_request_end_offset,
             block_aligned_byte_range,
-            request_id,
+            cursor_id,
         );
 
         let mut part_composer = CachingPartComposer {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -62,7 +62,7 @@ where
         };
         let (backpressure_controller, backpressure_limiter) =
             new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
-        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone(), config.handle_id);
+        let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 
         let request_task = {

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -147,7 +147,13 @@ where
         for block_index in block_range.clone() {
             match self
                 .cache
-                .get_block(cache_key, block_index, block_offset, range.object_size())
+                .get_block(
+                    cache_key,
+                    block_index,
+                    block_offset,
+                    range.object_size(),
+                    Some(self.config.handle_id.as_raw()),
+                )
                 .await
             {
                 Ok(Some(block)) => {

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -5,6 +5,8 @@ use tracing::trace;
 
 use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::sync::Arc;
+
+use super::HandleId;
 use crate::sync::async_channel::{Receiver, RecvError, Sender, unbounded};
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
@@ -24,6 +26,7 @@ pub struct PartQueue<Client: ObjectClient> {
     /// The total number of bytes sent to the underlying queue of `self.receiver`
     bytes_received: Arc<AtomicUsize>,
     mem_limiter: Arc<MemoryLimiter>,
+    handle_id: HandleId,
 }
 
 /// Producer side of the queue of [Part]s.
@@ -37,6 +40,7 @@ pub struct PartQueueProducer<E: std::error::Error> {
 /// Creates an unbounded [PartQueue] and its related [PartQueueProducer].
 pub fn unbounded_part_queue<Client: ObjectClient>(
     mem_limiter: Arc<MemoryLimiter>,
+    handle_id: HandleId,
 ) -> (PartQueue<Client>, PartQueueProducer<Client::ClientError>) {
     let (sender, receiver) = unbounded();
     let bytes_counter = Arc::new(AtomicUsize::new(0));
@@ -46,6 +50,7 @@ pub fn unbounded_part_queue<Client: ObjectClient>(
         failed: false,
         bytes_received: Arc::clone(&bytes_counter),
         mem_limiter,
+        handle_id,
     };
     let part_queue_producer = PartQueueProducer {
         sender,
@@ -105,7 +110,8 @@ impl<Client: ObjectClient> PartQueue<Client> {
         metrics::gauge!("prefetch.bytes_in_queue").increment(part.len() as f64);
         // The backpressure controller is not aware of the parts from backwards seek,
         // so we have to reserve memory for them here.
-        self.mem_limiter.reserve(BufferArea::Prefetch, part.len() as u64);
+        self.mem_limiter
+            .reserve(self.handle_id, BufferArea::Prefetch, part.len() as u64);
         self.front_queue.push(part);
         Ok(())
     }
@@ -177,7 +183,8 @@ mod tests {
         let pool = PagedPool::new_with_candidate_sizes([1024]);
         let mem_limiter = MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT);
         let part_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>(mem_limiter.into());
+        let handle_id = HandleId::new(1);
+        let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>(mem_limiter.into(), handle_id);
         let mut current_offset = 0;
         let mut current_length = 0;
         for op in ops {

--- a/mountpoint-s3-fs/src/prefetch/part_queue.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_queue.rs
@@ -3,10 +3,7 @@ use std::time::Instant;
 use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
-use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::sync::Arc;
-
-use super::HandleId;
 use crate::sync::async_channel::{Receiver, RecvError, Sender, unbounded};
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
@@ -25,8 +22,6 @@ pub struct PartQueue<Client: ObjectClient> {
     failed: bool,
     /// The total number of bytes sent to the underlying queue of `self.receiver`
     bytes_received: Arc<AtomicUsize>,
-    mem_limiter: Arc<MemoryLimiter>,
-    handle_id: HandleId,
 }
 
 /// Producer side of the queue of [Part]s.
@@ -38,10 +33,7 @@ pub struct PartQueueProducer<E: std::error::Error> {
 }
 
 /// Creates an unbounded [PartQueue] and its related [PartQueueProducer].
-pub fn unbounded_part_queue<Client: ObjectClient>(
-    mem_limiter: Arc<MemoryLimiter>,
-    handle_id: HandleId,
-) -> (PartQueue<Client>, PartQueueProducer<Client::ClientError>) {
+pub fn unbounded_part_queue<Client: ObjectClient>() -> (PartQueue<Client>, PartQueueProducer<Client::ClientError>) {
     let (sender, receiver) = unbounded();
     let bytes_counter = Arc::new(AtomicUsize::new(0));
     let part_queue = PartQueue {
@@ -49,8 +41,6 @@ pub fn unbounded_part_queue<Client: ObjectClient>(
         receiver,
         failed: false,
         bytes_received: Arc::clone(&bytes_counter),
-        mem_limiter,
-        handle_id,
     };
     let part_queue_producer = PartQueueProducer {
         sender,
@@ -108,10 +98,6 @@ impl<Client: ObjectClient> PartQueue<Client> {
         assert!(!self.failed, "cannot use a PartQueue after failure");
 
         metrics::gauge!("prefetch.bytes_in_queue").increment(part.len() as f64);
-        // The backpressure controller is not aware of the parts from backwards seek,
-        // so we have to reserve memory for them here.
-        self.mem_limiter
-            .reserve(self.handle_id, BufferArea::Prefetch, part.len() as u64);
         self.front_queue.push(part);
         Ok(())
     }
@@ -158,8 +144,6 @@ impl<Client: ObjectClient> Drop for PartQueue<Client> {
 #[cfg(test)]
 mod tests {
     use crate::checksums::ChecksummedBytes;
-    use crate::mem_limiter::MINIMUM_MEM_LIMIT;
-    use crate::memory::PagedPool;
     use crate::object::ObjectId;
 
     use super::*;
@@ -180,11 +164,8 @@ mod tests {
     }
 
     async fn run_test(ops: Vec<Op>) {
-        let pool = PagedPool::new_with_candidate_sizes([1024]);
-        let mem_limiter = MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT);
         let part_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let handle_id = HandleId::new(1);
-        let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>(mem_limiter.into(), handle_id);
+        let (mut part_queue, part_queue_producer) = unbounded_part_queue::<MockClient>();
         let mut current_offset = 0;
         let mut current_length = 0;
         for op in ops {

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -250,7 +250,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
         };
         let (backpressure_controller, mut backpressure_limiter) =
             new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
-        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone(), config.handle_id);
+        let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 
         let span = debug_span!("prefetch", ?range);

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -249,8 +249,8 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
             },
         };
         let (backpressure_controller, mut backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
-        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone());
+            new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
+        let (part_queue, part_queue_producer) = unbounded_part_queue(self.mem_limiter.clone(), config.handle_id);
         trace!(?range, "spawning request");
 
         let span = debug_span!("prefetch", ?range);

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -247,7 +247,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
                 part_size: config.read_part_size as u64,
             },
         };
-        let (backpressure_controller, mut backpressure_limiter, request_id) =
+        let (backpressure_controller, mut backpressure_limiter) =
             new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
@@ -258,6 +258,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
             .runtime
             .spawn_with_handle(
                 async move {
+                    let request_id = backpressure_limiter.request_id();
                     let initial_request_end_offset = config.range.start() + config.initial_request_size as u64;
                     let request_stream = read_from_client_stream(
                         &mut backpressure_limiter,

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -14,8 +14,8 @@ use crate::mem_limiter::MemoryLimiter;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
-use super::HandleId;
 use super::PrefetchReadError;
+use super::RequestId;
 use super::backpressure_controller::{BackpressureConfig, BackpressureLimiter, new_backpressure_controller};
 use super::part::{Part, PartSource};
 use super::part_queue::{PartQueueProducer, unbounded_part_queue};
@@ -37,7 +37,6 @@ pub trait ObjectPartStream<Client: ObjectClient + Clone + Send + Sync + 'static>
 pub struct RequestTaskConfig {
     pub bucket: String,
     pub object_id: ObjectId,
-    pub handle_id: HandleId,
     pub range: RequestRange,
     pub read_part_size: usize,
     pub preferred_part_size: usize,
@@ -248,8 +247,8 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
                 part_size: config.read_part_size as u64,
             },
         };
-        let (backpressure_controller, mut backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, config.handle_id, self.mem_limiter.clone());
+        let (backpressure_controller, mut backpressure_limiter, request_id) =
+            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 
@@ -267,7 +266,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
                         config.object_id.clone(),
                         initial_request_end_offset,
                         config.range,
-                        config.handle_id,
+                        request_id,
                     );
 
                     let part_composer = ClientPartComposer {
@@ -348,7 +347,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     object_id: ObjectId,
     initial_request_end_offset: u64,
     range: RequestRange,
-    handle_id: HandleId,
+    request_id: RequestId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
@@ -361,7 +360,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 first_req_range.into(),
-                handle_id,
+                request_id,
             );
             pin_mut!(first_request_stream);
             while let Some(next) = first_request_stream.next().await {
@@ -414,7 +413,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 range.into(),
-                handle_id,
+                request_id,
             );
             pin_mut!(request_stream);
             while let Some(next) = request_stream.next().await {
@@ -433,11 +432,11 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     bucket: String,
     id: ObjectId,
     request_range: Range<u64>,
-    handle_id: HandleId,
+    request_id: RequestId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(handle_id.as_raw())))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(request_id.as_raw())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -14,8 +14,8 @@ use crate::mem_limiter::MemoryLimiter;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
+use super::CursorId;
 use super::PrefetchReadError;
-use super::RequestId;
 use super::backpressure_controller::{BackpressureConfig, BackpressureLimiter, new_backpressure_controller};
 use super::part::{Part, PartSource};
 use super::part_queue::{PartQueueProducer, unbounded_part_queue};
@@ -258,7 +258,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
             .runtime
             .spawn_with_handle(
                 async move {
-                    let request_id = backpressure_limiter.request_id();
+                    let cursor_id = backpressure_limiter.cursor_id();
                     let initial_request_end_offset = config.range.start() + config.initial_request_size as u64;
                     let request_stream = read_from_client_stream(
                         &mut backpressure_limiter,
@@ -267,7 +267,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
                         config.object_id.clone(),
                         initial_request_end_offset,
                         config.range,
-                        request_id,
+                        cursor_id,
                     );
 
                     let part_composer = ClientPartComposer {
@@ -348,7 +348,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
     object_id: ObjectId,
     initial_request_end_offset: u64,
     range: RequestRange,
-    request_id: RequestId,
+    cursor_id: CursorId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         // Let's start by issuing the first request with a range trimmed to initial read window offset
@@ -361,7 +361,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 first_req_range.into(),
-                request_id,
+                cursor_id,
             );
             pin_mut!(first_request_stream);
             while let Some(next) = first_request_stream.next().await {
@@ -414,7 +414,7 @@ pub fn read_from_client_stream<'a, Client: ObjectClient + Clone + 'a>(
                 bucket.clone(),
                 object_id.clone(),
                 range.into(),
-                request_id,
+                cursor_id,
             );
             pin_mut!(request_stream);
             while let Some(next) = request_stream.next().await {
@@ -433,11 +433,11 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     bucket: String,
     id: ObjectId,
     request_range: Range<u64>,
-    request_id: RequestId,
+    cursor_id: CursorId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(request_id.as_raw())))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(cursor_id.as_raw())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;

--- a/mountpoint-s3-fs/src/prefetch/seek_window.rs
+++ b/mountpoint-s3-fs/src/prefetch/seek_window.rs
@@ -75,9 +75,4 @@ impl SeekWindow {
         self.parts.drain(..);
         self.current_size = 0;
     }
-
-    /// Return the maximum size of this window
-    pub fn max_size(&self) -> usize {
-        self.max_size
-    }
 }

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -15,7 +15,7 @@ use tracing::{Instrument, debug_span, trace};
 
 use crate::ServerSideEncryption;
 use crate::async_util::Runtime;
-use crate::mem_limiter::{BufferArea, MemoryLimiter};
+use crate::mem_limiter::MemoryLimiter;
 use crate::memory::{BufferKind, PagedPool, PoolBufferMut};
 use crate::sync::Arc;
 
@@ -266,7 +266,7 @@ where
             }
         };
         while self.requests_in_queue > 0 {
-            match UploadBuffer::try_new(capacity, &checksum_algorithm, &self.pool, self.mem_limiter.clone())? {
+            match UploadBuffer::try_new(capacity, &checksum_algorithm, &self.pool, &self.mem_limiter)? {
                 Some(buffer) => return Ok(buffer),
                 None => {
                     // wait for requests in the queue to complete before trying to reserve memory again
@@ -278,12 +278,7 @@ where
             }
         }
         // no more requests in the queue, so we force creating a new buffer
-        Ok(UploadBuffer::new(
-            capacity,
-            &checksum_algorithm,
-            &self.pool,
-            self.mem_limiter.clone(),
-        )?)
+        Ok(UploadBuffer::new(capacity, &checksum_algorithm, &self.pool)?)
     }
 
     /// Wait on the response channel, updating the state of the [AppendUploadQueue] when the next response arrives.
@@ -417,7 +412,7 @@ async fn append<Client: ObjectClient>(
 
 #[derive(Debug)]
 struct UploadBuffer {
-    data: ReservedBuffer,
+    data: PoolBufferMut,
     // Running checksum for the data.
     hasher: ChecksumHasher,
 }
@@ -428,30 +423,22 @@ impl UploadBuffer {
         capacity: usize,
         checksum_algorithm: &Option<ChecksumAlgorithm>,
         pool: &PagedPool,
-        mem_limiter: Arc<MemoryLimiter>,
     ) -> Result<Self, ChecksumHasherError> {
         let hasher = ChecksumHasher::new(checksum_algorithm)?;
-        mem_limiter.reserve(BufferArea::Upload, capacity as u64);
-        let data = ReservedBuffer {
-            buffer: pool.get_buffer_mut(capacity, BufferKind::Append),
-            mem_limiter,
-        };
+        let data = pool.get_buffer_mut(capacity, BufferKind::Append);
         Ok(Self { data, hasher })
     }
 
-    /// Try creating a new buffer, return `None` if unable to reserve memory for a buffer with the given capacity
+    /// Try creating a new buffer, return `None` if not enough available memory
     fn try_new(
         capacity: usize,
         checksum_algorithm: &Option<ChecksumAlgorithm>,
         pool: &PagedPool,
-        mem_limiter: Arc<MemoryLimiter>,
+        mem_limiter: &MemoryLimiter,
     ) -> Result<Option<Self>, ChecksumHasherError> {
-        if mem_limiter.try_reserve(BufferArea::Upload, capacity as u64) {
+        if mem_limiter.available_mem() >= capacity as u64 {
             let hasher = ChecksumHasher::new(checksum_algorithm)?;
-            let data = ReservedBuffer {
-                buffer: pool.get_buffer_mut(capacity, BufferKind::Append),
-                mem_limiter,
-            };
+            let data = pool.get_buffer_mut(capacity, BufferKind::Append);
             Ok(Some(Self { data, hasher }))
         } else {
             Ok(None)
@@ -461,42 +448,23 @@ impl UploadBuffer {
     /// Write a slice to the buffer. The slice will be trimmed to fit into the buffer,
     /// remaining slice is returned back to the caller.
     fn write<'a>(&mut self, mut slice: &'a [u8]) -> Result<&'a [u8], ChecksumHasherError> {
-        let remaining = self.data.buffer.append_from_slice(&mut slice);
+        let remaining = self.data.append_from_slice(&mut slice);
         self.hasher.update(slice)?;
         Ok(remaining)
     }
 
     fn is_full(&self) -> bool {
-        self.data.buffer.is_full()
+        self.data.is_full()
     }
 
     fn len(&self) -> usize {
-        self.data.buffer.len()
+        self.data.len()
     }
 
     fn freeze(self) -> Result<(Bytes, Option<UploadChecksum>), ChecksumHasherError> {
         let checksum = self.hasher.finalize()?;
         let bytes = Bytes::from_owner(self.data);
         Ok((bytes, checksum))
-    }
-}
-
-#[derive(Debug)]
-struct ReservedBuffer {
-    buffer: PoolBufferMut,
-    mem_limiter: Arc<MemoryLimiter>,
-}
-
-impl Drop for ReservedBuffer {
-    fn drop(&mut self) {
-        self.mem_limiter
-            .release(BufferArea::Upload, self.buffer.capacity() as u64);
-    }
-}
-
-impl AsRef<[u8]> for ReservedBuffer {
-    fn as_ref(&self) -> &[u8] {
-        &self.buffer
     }
 }
 
@@ -584,8 +552,8 @@ mod tests {
 
         // The buffer should be updated
         let buffer = upload_request.buffer.as_ref().unwrap();
-        assert_eq!(buffer_size, buffer.data.buffer.capacity());
-        assert_eq!(&append_data, &buffer.data.as_ref()[..buffer.len()]);
+        assert_eq!(buffer_size, buffer.data.capacity());
+        assert_eq!(&append_data, &buffer.data[..buffer.len()]);
 
         // Write more data to make the buffer full
         let append_data = [0xab; 128];

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -425,7 +425,7 @@ impl UploadBuffer {
         pool: &PagedPool,
     ) -> Result<Self, ChecksumHasherError> {
         let hasher = ChecksumHasher::new(checksum_algorithm)?;
-        let data = pool.get_buffer_mut(capacity, BufferKind::Append);
+        let data = pool.get_buffer_mut(capacity, BufferKind::Append, None);
         Ok(Self { data, hasher })
     }
 
@@ -438,7 +438,7 @@ impl UploadBuffer {
     ) -> Result<Option<Self>, ChecksumHasherError> {
         if mem_limiter.available_mem() >= capacity as u64 {
             let hasher = ChecksumHasher::new(checksum_algorithm)?;
-            let data = pool.get_buffer_mut(capacity, BufferKind::Append);
+            let data = pool.get_buffer_mut(capacity, BufferKind::Append, None);
             Ok(Some(Self { data, hasher }))
         } else {
             Ok(None)

--- a/mountpoint-s3-fs/tests/common/cache.rs
+++ b/mountpoint-s3-fs/tests/common/cache.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use mountpoint_s3_fs::{
     data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult},
     object::ObjectId,
+    prefetch::HandleId,
 };
 
 /// A wrapper around any type implementing [DataCache], which counts operations
@@ -92,12 +93,12 @@ impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Ca
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        custom_id: Option<u64>,
+        handle_id: Option<HandleId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let result = self
             .inner
             .cache
-            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
             .await;
 
         match result.as_ref() {

--- a/mountpoint-s3-fs/tests/common/cache.rs
+++ b/mountpoint-s3-fs/tests/common/cache.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use mountpoint_s3_fs::{
     data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult},
     object::ObjectId,
-    prefetch::RequestId,
+    prefetch::CursorId,
 };
 
 /// A wrapper around any type implementing [DataCache], which counts operations
@@ -93,12 +93,12 @@ impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Ca
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        request_id: Option<RequestId>,
+        cursor_id: Option<CursorId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let result = self
             .inner
             .cache
-            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, cursor_id)
             .await;
 
         match result.as_ref() {

--- a/mountpoint-s3-fs/tests/common/cache.rs
+++ b/mountpoint-s3-fs/tests/common/cache.rs
@@ -92,11 +92,12 @@ impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Ca
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
+        custom_id: Option<u64>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let result = self
             .inner
             .cache
-            .get_block(cache_key, block_idx, block_offset, object_size)
+            .get_block(cache_key, block_idx, block_offset, object_size, custom_id)
             .await;
 
         match result.as_ref() {

--- a/mountpoint-s3-fs/tests/common/cache.rs
+++ b/mountpoint-s3-fs/tests/common/cache.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use mountpoint_s3_fs::{
     data_cache::{BlockIndex, ChecksummedBytes, DataCache, DataCacheError, DataCacheResult},
     object::ObjectId,
-    prefetch::HandleId,
+    prefetch::RequestId,
 };
 
 /// A wrapper around any type implementing [DataCache], which counts operations
@@ -93,12 +93,12 @@ impl<Cache: DataCache + Send + Sync + 'static> DataCache for CacheTestWrapper<Ca
         block_idx: BlockIndex,
         block_offset: u64,
         object_size: usize,
-        handle_id: Option<HandleId>,
+        request_id: Option<RequestId>,
     ) -> DataCacheResult<Option<ChecksummedBytes>> {
         let result = self
             .inner
             .cache
-            .get_block(cache_key, block_idx, block_offset, object_size, handle_id)
+            .get_block(cache_key, block_idx, block_offset, object_size, request_id)
             .await;
 
         match result.as_ref() {

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -336,7 +336,7 @@ where
 
     // Try reading a block that hasn't had anything written to it
     let block = cache
-        .get_block(&get_object_id(&prefix, "does-not-exist", "etag"), 0, 0, 1000)
+        .get_block(&get_object_id(&prefix, "does-not-exist", "etag"), 0, 0, 1000, None)
         .await
         .expect("should not return an error");
     assert!(block.is_none());


### PR DESCRIPTION
The `MemoryLimiter` and `PagedPool` tracked memory independently — the limiter tracked intent (read window reservations) while the pool tracked actual buffer allocations. Download buffers were invisible to the limiter's budget check, the two systems could diverge, and reservations were only tracked as a global total with no way to attribute memory to individual cursors.

This PR makes the limiter aware of all pool allocations. The budget check now includes all buffer kinds (downloads, uploads, disk cache) via `pool.total_reserved_bytes()`. The pool notifies the limiter on each allocation via a callback that decrements both `mem_reserved` and `mem_reserved_per_cursor`, so `mem_reserved` represents only the unallocated portion of the read window. Per-cursor reservation tracking enables accurate cleanup on cursor drop.

The seek window reservation (at file open) and the backward seek re-injection reserve (in `PartQueue::push_front`) were removed — both double-counted memory already tracked by the pool.

The upload path is simplified to rely on pool stats directly instead of calling `reserve`/`release`.

### Does this change impact existing behavior?
No breaking changes to the public API.

### Does this change need a changelog entry? Does it require a version change?
No, these are internal accounting changes to the memory limiter with no user-visible behavior change or API change. The memory limiter is behind a feature flag (`mem_limiter`) and not yet stabilized.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
