### PR TITLE
Upgrade cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.13.9"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.129.0"
+version = "1.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
+checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -367,23 +367,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -467,13 +467,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -505,7 +505,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5 0.11.0",
+ "md-5",
  "pin-project-lite",
  "sha1 0.11.0",
  "sha2 0.11.0",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -894,9 +894,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1036,6 +1036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1067,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03efed02df0504d71e44bfd51d3329f401b8303a2fd14254acf05c95a0af0153"
 
 [[package]]
 name = "const_format"
@@ -1098,6 +1110,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "corosensei"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c54787b605c7df106ceccf798df23da4f2e09918defad66705d1cedf3bb914f"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1293,19 +1318,20 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+ "link-section",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.7"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "ctrlc"
@@ -1316,6 +1342,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1430,6 +1465,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1463,18 +1499,18 @@ checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "dtor"
-version = "0.1.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.6"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "dunce"
@@ -1778,21 +1814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows-link",
- "windows-result",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2496,9 +2526,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -2542,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2562,6 +2592,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
 
 [[package]]
 name = "linked-hash-map"
@@ -2612,16 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -2720,7 +2746,8 @@ dependencies = [
  "const_format",
  "ctor",
  "futures",
- "md-5 0.10.6",
+ "hex",
+ "md-5",
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
@@ -2834,7 +2861,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serial_test",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "shuttle",
  "signal-hook",
  "supports-color 3.0.2",
@@ -3722,7 +3749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -3752,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -4175,14 +4202,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+checksum = "ba93071c1b720be2505f4c8ce2863502cb9a26a3819e268df1932458a755152c"
 dependencies = [
  "assoc",
  "bitvec",
  "cfg-if",
- "generator",
+ "const-siphasher",
+ "corosensei",
  "hex",
  "owo-colors 3.5.0",
  "rand 0.8.6",
@@ -4595,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -4605,14 +4633,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4623,7 +4651,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -4779,9 +4807,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -4920,11 +4948,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4933,7 +4961,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5278,12 +5306,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -5319,6 +5341,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,12 +1069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03efed02df0504d71e44bfd51d3329f401b8303a2fd14254acf05c95a0af0153"
-
-[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,19 +1104,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "corosensei"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c54787b605c7df106ceccf798df23da4f2e09918defad66705d1cedf3bb914f"
-dependencies = [
- "autocfg",
- "cfg-if",
- "libc",
- "scopeguard",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1811,6 +1792,21 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -4202,15 +4198,14 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle"
-version = "0.9.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba93071c1b720be2505f4c8ce2863502cb9a26a3819e268df1932458a755152c"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
 dependencies = [
  "assoc",
  "bitvec",
  "cfg-if",
- "const-siphasher",
- "corosensei",
+ "generator",
  "hex",
  "owo-colors 3.5.0",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 mountpoint-s3-fs = { version = "0.9.3", path = "./mountpoint-s3-fs" }
 mountpoint-s3-client = { version = "0.20.0", path = "./mountpoint-s3-client" }
-mountpoint-s3-crt = { version = "0.13.9", path = "./mountpoint-s3-crt" }
+mountpoint-s3-crt = { version = "0.14.0", path = "./mountpoint-s3-crt" }
 mountpoint-s3-crt-sys = { version = "0.16.3", path = "./mountpoint-s3-crt-sys" }
 mountpoint-s3-fuser = { version = "0.1.1", path = "./mountpoint-s3-fuser", features = ["abi-7-28", "libfuse"] }
 

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## Unreleased (v0.20.0)
 
 * Add S3 client error covering failures to create S3 Express session. ([#1793](https://github.com/awslabs/mountpoint-s3/pull/1793))
+* Expose the originating `MetaRequest` in `MemoryPool` trait methods. ([#1812](https://github.com/awslabs/mountpoint-s3/pull/1812))
 * Update to latest CRT dependencies.
 
 ## v0.19.8 (March 20, 2026)

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -14,12 +14,12 @@ async-trait = "0.1.89"
 auto_impl = "1.3.0"
 base64ct = { version = "1.8.3", features = ["std"] }
 bytes = "1.11.1"
-const_format = "0.2.35"
+const_format = "0.2.36"
 futures = "0.3.32"
 metrics = "0.24.3"
 percent-encoding = "2.3.2"
 pin-project = "1.1.11"
-platform-info = "2.0.5"
+platform-info = "2.1.0"
 regex = "1.12.3"
 serde_json = "1.0.149"
 static_assertions = "1.1.0"
@@ -27,28 +27,29 @@ supports-color = "3.0.2"
 thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["formatting", "parsing"] }
 tracing = { version = "0.1.44", default-features = false, features = ["std", "log"] }
-uuid = { version = "1.21.0", features = ["v4"]}
+uuid = { version = "1.23.1", features = ["v4"]}
 xmltree = "0.12.0"
 
 # Dependencies for the mock client only
 async-io = { version = "2.6.0", optional = true }
 async-lock = { version = "3.4.2", optional = true }
-md-5 = { version = "0.10.6", optional = true }
+hex = { version = "0.4.3", optional = true }
+md-5 = { version = "0.11.0", optional = true }
 rand = { version = "0.10.1", optional = true }
 
 [dev-dependencies]
-aws-config = "1.8.14"
-aws-credential-types = "1.2.13"
-aws-sdk-s3 = { version = "1.124.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
-aws-smithy-runtime-api = "1.11.6"
-clap = { version = "4.5.60", features = ["derive"] }
-ctor = "0.6.3"
-proptest = "1.10.0"
+aws-config = "1.8.16"
+aws-credential-types = "1.2.14"
+aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
+aws-smithy-runtime-api = "1.12.0"
+clap = { version = "4.6.1", features = ["derive"] }
+ctor = "0.10.1"
+proptest = "1.11.0"
 rusty-fork = "0.3.1"
-tempfile = "3.26.0"
+tempfile = "3.27.0"
 test-case = "3.3.1"
-tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "macros"] }
-tracing-subscriber = { version = "0.3.22", features = ["fmt", "env-filter"] }
+tokio = { version = "1.52.1", features = ["rt", "rt-multi-thread", "macros"] }
+tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 
 # HACK: we want our own tests to use the mock client, but don't want to enable it for consumers by
 # default, so we take a dev-dependency on ourself with that feature enabled.
@@ -62,7 +63,7 @@ mountpoint-s3-fs = { path = "../mountpoint-s3-fs" }
 built = { version = "0.8.0", features = ["git2"] }
 
 [features]
-mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand"]
+mock = ["dep:async-io", "dep:async-lock", "dep:hex", "dep:md-5", "dep:rand"]
 # Features for choosing tests
 s3_tests = []
 fips_tests = []

--- a/mountpoint-s3-client/src/object_client/etag.rs
+++ b/mountpoint-s3-client/src/object_client/etag.rs
@@ -32,9 +32,8 @@ impl ETag {
 
         let mut hasher = md5::Md5::new();
         hasher.update(data);
-
         let hash = hasher.finalize();
-        let result = format!("{hash:x}");
+        let result = hex::encode(hash);
         Self(result)
     }
 }

--- a/mountpoint-s3-crt-sys/Cargo.toml
+++ b/mountpoint-s3-crt-sys/Cargo.toml
@@ -77,13 +77,13 @@ exclude = [
 bindgen = { version = "0.72.1", default-features = false, features = [
     "runtime",
 ] }
-cc = "1.2.56"
-cmake = "0.1.57"
+cc = "1.2.61"
+cmake = "0.1.58"
 rustflags = "0.1.7"
-which = "8.0.0"
+which = "8.0.2"
 
 [dependencies]
-libc = "0.2.182"
+libc = "0.2.186"
 
 [lib]
 # this prevents C docs being interpreted as rustdoc tests after bindgen

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## Unreleased (v0.14.0)
 
+* Expose the originating `MetaRequest` in `MemoryPool` trait methods. ([#1812](https://github.com/awslabs/mountpoint-s3/pull/1812))
 * Update to latest CRT dependencies.
 
 ## v0.13.8 (March 20, 2026)

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -11,7 +11,7 @@ description = "Rust interface to the AWS Common Runtime for Mountpoint for Amazo
 mountpoint-s3-crt-sys = { workspace = true }
 
 futures = "0.3.32"
-libc = "0.2.182"
+libc = "0.2.186"
 log = "0.4.29"
 smallstr = "0.3.1"
 static_assertions = "1.1.0"
@@ -19,14 +19,14 @@ thiserror = "2.0.18"
 
 [dev-dependencies]
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 criterion = "0.8.2"
-ctor = "0.6.3"
+ctor = "0.10.1"
 rand = "0.10.1"
 serde_json = "1.0.149"
 test-case = "3.3.1"
 tracing = { version = "0.1.44", default-features = false, features = ["std", "log"] }
-tracing-subscriber = { version = "0.3.22", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 
 [[bench]]
 name = "event_loop_future"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-crt"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.13.9"
+version = "0.14.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Unreleased (v0.9.3)
 
 * Update to latest S3 client. ([#1793](https://github.com/awslabs/mountpoint-s3/pull/1793))
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -79,7 +79,7 @@ rusty-fork = "0.3.1"
 serde_with = "3.18.0"
 serial_test = "3.4.0"
 sha2 = "0.11.0"
-shuttle = { version = "0.9.1" }
+shuttle = { version = "0.8.1" }
 syscalls = { version = "0.8.1", default-features = false }
 test-case = "3.3.1"
 tokio = { version = "1.52.1", features = ["rt", "macros", "rt-multi-thread"] }

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -18,10 +18,10 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 base64ct = "1.8.3"
 bincode = { version = "2.0.1", features = ["std"] }
-bitflags = "2.11.0"
+bitflags = "2.11.1"
 bytes = { version = "1.11.1", features = ["serde"] }
-clap = { version = "4.5.60", features = ["derive"] }
-const_format = "0.2.35"
+clap = { version = "4.6.1", features = ["derive"] }
+const_format = "0.2.36"
 crc32c = "0.6.8"
 csv = { version = "1.4.0", optional = true }
 ctrlc = { version = "3.5.2", features = ["termination"] }
@@ -30,29 +30,29 @@ futures = "0.3.32"
 hdrhistogram = { version = "7.5.4", default-features = false }
 hex = "0.4.3"
 humansize = "2.1.3"
-libc = "0.2.182"
+libc = "0.2.186"
 linked-hash-map = "0.5.6"
 metrics = "0.24.3"
 nix = { version = "0.31.2", default-features = false, features = ["fs", "process", "signal", "user"] }
 rand = "0.10.1"
 regex = "1.12.3"
-rusqlite = { version = "0.38.0", features = ["bundled", "fallible_uint"], optional = true }
+rusqlite = { version = "0.39.0", features = ["bundled", "fallible_uint"], optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-sha2 = "0.10.9"
-signal-hook = "0.4.3"
+sha2 = "0.11.0"
+signal-hook = "0.4.4"
 supports-color = "3.0.2"
-sysinfo = "0.38.3"
+sysinfo = "0.38.4"
 syslog = "7.0.0"
-tempfile = "3.26.0"
+tempfile = "3.27.0"
 thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["macros", "formatting", "serde-well-known"] }
 tracing = { version = "0.1.44", features = ["log"] }
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "spec_unstable_metrics_views"] }
-opentelemetry-otlp = { version = "0.31.0", features = ["metrics", "http-proto"] }
+opentelemetry-otlp = { version = "0.31.1", features = ["metrics", "http-proto"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18.0", default-features = false }
@@ -60,30 +60,30 @@ procfs = { version = "0.18.0", default-features = false }
 [dev-dependencies]
 mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
 
-assert_cmd = "2.1.2"
+assert_cmd = "2.2.1"
 assert_fs = "1.1.3"
-aws-config = "1.8.14"
-aws-credential-types = "1.2.13"
-aws-sdk-s3 = { version = "1.124.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
+aws-config = "1.8.16"
+aws-credential-types = "1.2.14"
+aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
 criterion = { version = "0.8.2", features = ["async", "async_futures"] }
-ctor = "0.6.3"
+ctor = "0.10.1"
 filetime = "0.2.27"
 futures = { version = "0.3.32", features = ["thread-pool"] }
 humantime-serde = "1.1.1"
 opentelemetry_sdk = { version = "0.31.0", features = ["testing"] }
 predicates = "3.1.4"
-proptest = "1.10.0"
+proptest = "1.11.0"
 proptest-derive = "0.8.0"
-rand_pcg = "0.10.1"
+rand_pcg = "0.10.2"
 rusty-fork = "0.3.1"
-serde_with = "3.17.0"
+serde_with = "3.18.0"
 serial_test = "3.4.0"
-sha2 = "0.10.9"
-shuttle = { version = "0.8.1" }
+sha2 = "0.11.0"
+shuttle = { version = "0.9.1" }
 syscalls = { version = "0.8.1", default-features = false }
 test-case = "3.3.1"
-tokio = { version = "1.49.0", features = ["rt", "macros", "rt-multi-thread"] }
-toml = "0.9.8"
+tokio = { version = "1.52.1", features = ["rt", "macros", "rt-multi-thread"] }
+toml = "1.1.2"
 walkdir = "2.5.0"
 wiremock = "0.6.5"
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -11,35 +11,35 @@ mountpoint-s3-fs = { workspace = true }
 mountpoint-s3-client = { workspace = true }
 
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-clap = { version = "4.5.60", features = ["derive"] }
-const_format = "0.2.35"
+clap = { version = "4.6.1", features = ["derive"] }
+const_format = "0.2.36"
 futures = "0.3.32"
 nix = { version = "0.31.2", default-features = false, features = ["fs", "process", "signal", "user"] }
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 regex = "1.12.3"
 serde = "1.0.228"
 serde_json = "1.0.149"
-sysinfo = "0.38.3"
+sysinfo = "0.38.4"
 tracing = "0.1.44"
 
 [dev-dependencies]
 mountpoint-s3-client = { path = "../mountpoint-s3-client", features = ["mock"] }
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser" }
-assert_cmd = "2.1.2"
+assert_cmd = "2.2.1"
 assert_fs = "1.1.3"
-aws-config = "1.8.14"
-aws-credential-types = "1.2.13"
-aws-sdk-s3 = { version = "1.124.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
+aws-config = "1.8.16"
+aws-credential-types = "1.2.14"
+aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["behavior-version-latest", "sigv4a", "rt-tokio", "default-https-client"] }
 futures = { version = "0.3.32", features = ["thread-pool"] }
 predicates = "3.1.4"
-proptest = "1.10.0"
+proptest = "1.11.0"
 proptest-derive = "0.8.0"
 syscalls = "0.8.1"
 rand = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 test-case = "3.3.1"
-tempfile = "3.26.0"
-tokio = { version = "1.49.0" }
+tempfile = "3.27.0"
+tokio = { version = "1.52.1" }
 tracing = { version = "0.1.44", features = ["log"] }
 
 [build-dependencies]


### PR DESCRIPTION
Upgrade cargo dependencies. Notes: 
- in order to handle a minor breaking change in the `md5` crate, we now also import the `hex` crate (when building `mountpoint-s3-client` with the `mock` feature).
- upgrading to the latest `shuttle` version (`0.9.1`) led to a segfault in shuttle tests. Reverted while we investigate further.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Updated version numbers and changelogs to reflected existing changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
