### PR TITLE
Buffer Pruning: Add Per-Handle Active Read Tracking

### DIFF
--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -221,6 +221,18 @@ impl MemoryLimiter {
     }
 }
 
+/// Returns the effective total memory available to this process in bytes.
+///
+/// On Linux, this respects cgroup memory limits when set.
+/// On other platforms, returns the total physical memory.
+pub fn effective_total_memory() -> u64 {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    sys.cgroup_limits()
+        .map(|cg| cg.total_memory)
+        .unwrap_or_else(|| sys.total_memory())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,23 +286,6 @@ mod tests {
         drop(guard);
         assert!(!limiter.has_active_read_in_range(handle, 1000, 4096));
     }
-}
-
-/// Returns the effective total memory available to this process in bytes.
-///
-/// On Linux, this respects cgroup memory limits when set.
-/// On other platforms, returns the total physical memory.
-pub fn effective_total_memory() -> u64 {
-    let mut sys = System::new();
-    sys.refresh_memory();
-    sys.cgroup_limits()
-        .map(|cg| cg.total_memory)
-        .unwrap_or_else(|| sys.total_memory())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
 
     /// When the `TEST_CGROUP_MEM_LIMIT_MB` environment variable is set (e.g. in a
     /// container started with `--memory=4g`), verify that [effective_total_memory]

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -1,11 +1,14 @@
 use std::{sync::atomic::Ordering, time::Instant};
 
+use dashmap::DashMap;
 use humansize::make_format;
 use metrics::atomics::AtomicU64;
 use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
+use crate::prefetch::HandleId;
+use crate::sync::Arc;
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
 
@@ -22,6 +25,39 @@ impl BufferArea {
             BufferArea::Upload => "upload",
             BufferArea::Prefetch => "prefetch",
         }
+    }
+}
+
+/// Describes an active FUSE read request for a specific file handle.
+/// Used by the pruning logic to determine which buffers are high priority
+/// (actively being waited on by a user) vs. speculative (prefetched ahead).
+#[derive(Debug, Clone, Copy)]
+pub struct ActiveRead {
+    /// Start offset of the read in the file.
+    pub offset: u64,
+    /// Size of the read in bytes.
+    pub size: usize,
+}
+
+impl ActiveRead {
+    /// Check if this active read overlaps with the given range.
+    pub fn overlaps(&self, offset: u64, size: usize) -> bool {
+        let self_end = self.offset + self.size as u64;
+        let other_end = offset + size as u64;
+        self.offset < other_end && offset < self_end
+    }
+}
+
+/// RAII guard that clears the active read for a handle when dropped.
+/// Ensures the active read is always cleared, even on early returns or panics.
+pub struct ActiveReadGuard {
+    mem_limiter: Arc<MemoryLimiter>,
+    handle_id: HandleId,
+}
+
+impl Drop for ActiveReadGuard {
+    fn drop(&mut self) {
+        self.mem_limiter.clear_active_read(self.handle_id);
     }
 }
 
@@ -68,6 +104,9 @@ pub struct MemoryLimiter {
     /// Since we don't directly control memory usage of multi-part uploads (atomic uploader), we will
     /// rely on the pool's stats for PutObject buffers and adjust the prefetcher read window accordingly.
     pool: PagedPool,
+    /// Per-handle active read tracking. When a FUSE read is in progress for a handle,
+    /// the requested range is stored here. Absence means the handle is speculative.
+    active_reads: DashMap<HandleId, ActiveRead>,
 }
 
 impl MemoryLimiter {
@@ -85,6 +124,7 @@ impl MemoryLimiter {
             mem_limit,
             mem_reserved: AtomicU64::new(0),
             additional_mem_reserved: reserved_mem,
+            active_reads: DashMap::new(),
         }
     }
 
@@ -145,6 +185,29 @@ impl MemoryLimiter {
             .saturating_sub(self.additional_mem_reserved)
     }
 
+    /// Record that a FUSE read is active for the given handle at the specified range.
+    /// Returns a guard that will clear the active read when dropped.
+    pub fn set_active_read(self: &Arc<Self>, handle_id: HandleId, offset: u64, size: usize) -> ActiveReadGuard {
+        self.active_reads.insert(handle_id, ActiveRead { offset, size });
+        ActiveReadGuard {
+            mem_limiter: Arc::clone(self),
+            handle_id,
+        }
+    }
+
+    /// Clear the active read for the given handle (read completed or errored).
+    fn clear_active_read(&self, handle_id: HandleId) {
+        self.active_reads.remove(&handle_id);
+    }
+
+    /// Check if the given handle has an active read overlapping the specified range.
+    pub fn has_active_read_in_range(&self, handle_id: HandleId, offset: u64, size: usize) -> bool {
+        self.active_reads
+            .get(&handle_id)
+            .map(|r| r.overlaps(offset, size))
+            .unwrap_or(false)
+    }
+
     /// Get reserved memory from the memory pool for buffers not tracked by this limiter.
     fn pool_mem_reserved(&self) -> u64 {
         // The limiter already tracks buffers from
@@ -155,6 +218,61 @@ impl MemoryLimiter {
         // * PutObject (multi-part uploads),
         // * Other (currently not used).
         (self.pool.reserved_bytes(BufferKind::PutObject) + self.pool.reserved_bytes(BufferKind::Other)) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::PagedPool;
+
+    fn new_limiter() -> Arc<MemoryLimiter> {
+        let pool = PagedPool::new_with_candidate_sizes([1024]);
+        Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT))
+    }
+
+    #[test]
+    fn test_active_read_overlap_detection() {
+        let limiter = new_limiter();
+        let handle = HandleId::new(1);
+
+        // Active read at [1000, 5096)
+        let _guard = limiter.set_active_read(handle, 1000, 4096);
+
+        // Overlapping ranges → true
+        assert!(limiter.has_active_read_in_range(handle, 1000, 4096)); // exact match
+        assert!(limiter.has_active_read_in_range(handle, 500, 1000)); // overlap from left
+        assert!(limiter.has_active_read_in_range(handle, 5000, 1000)); // overlap from right
+        assert!(limiter.has_active_read_in_range(handle, 2000, 100)); // contained
+
+        // Non-overlapping ranges → false
+        assert!(!limiter.has_active_read_in_range(handle, 0, 500)); // before
+        assert!(!limiter.has_active_read_in_range(handle, 5096, 1000)); // after
+
+        // Different handle → false
+        assert!(!limiter.has_active_read_in_range(HandleId::new(2), 1000, 4096));
+    }
+
+    /// Simulates the allocation queue's perspective: one thread holds an active read
+    /// while another thread queries whether a given range is active.
+    #[test]
+    fn test_query_active_read_from_another_thread() {
+        let limiter = new_limiter();
+        let handle = HandleId::new(1);
+
+        let guard = limiter.set_active_read(handle, 1000, 4096);
+
+        let limiter_clone = Arc::clone(&limiter);
+        let query_thread = std::thread::spawn(move || {
+            // Allocation for the active range → high priority
+            assert!(limiter_clone.has_active_read_in_range(handle, 1000, 4096));
+            // Allocation for a prefetch-ahead range → low priority
+            assert!(!limiter_clone.has_active_read_in_range(handle, 50000, 4096));
+        });
+        query_thread.join().unwrap();
+
+        drop(guard);
+        assert!(!limiter.has_active_read_in_range(handle, 1000, 4096));
     }
 }
 

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -380,7 +380,7 @@ where
         // the skipped bytes the prefetcher must consume to reach the requested offset.
         let active_start = self.next_sequential_read_offset.min(offset);
         let active_size = (offset + length as u64 - active_start) as usize;
-        let mut _active_read_guard = self
+        let _active_read_guard = self
             .mem_limiter
             .set_active_read(self.handle_id, active_start, active_size);
 
@@ -400,13 +400,6 @@ where
                 // This is an approximation, tolerating some seeking caused by concurrent readahead.
                 self.record_contiguous_read_metric();
                 self.reset_prefetch_to_offset(offset);
-
-                // A failed forward seek resets the prefetcher to `offset`, so the widened
-                // active range is no longer valid. Replace with just the requested range.
-                if active_start != offset {
-                    drop(_active_read_guard);
-                    _active_read_guard = self.mem_limiter.set_active_read(self.handle_id, offset, length);
-                }
             }
         }
         assert_eq!(self.next_sequential_read_offset, offset);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -379,7 +379,7 @@ where
         // Set the active read range before any blocking. For forward seeks, widen to include
         // the skipped bytes the prefetcher must consume to reach the requested offset.
         let active_start = self.next_sequential_read_offset.min(offset);
-        let active_size = (offset + length as u64 - active_start) as usize;
+        let active_size = length + offset.saturating_sub(self.next_sequential_read_offset) as usize;
         let _active_read_guard = self
             .mem_limiter
             .set_active_read(self.handle_id, active_start, active_size);

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -332,6 +332,12 @@ where
             "read"
         );
 
+        // Record the active read range so the pruning/allocation logic knows
+        // this handle has a user waiting for data at this specific range.
+        // The guard ensures the active read is cleared when it goes out of scope,
+        // even on early returns or panics.
+        let _active_read_guard = self.mem_limiter.set_active_read(self.handle_id, offset, length);
+
         match self.try_read(offset, length).await {
             Ok((data, cache_hit)) => {
                 // Record cache hit metric for FUSE layer. We only record a cache hit when ALL parts

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -86,6 +86,17 @@ impl HandleId {
 // to avoid the latency hit of the second request.
 pub const INITIAL_REQUEST_SIZE: usize = 1024 * 1024 + 128 * 1024;
 
+/// Classifies the type of seek needed before a read.
+#[derive(Debug, PartialEq)]
+enum SeekKind {
+    /// No seek needed — sequential read.
+    None,
+    /// Forward seek — skip ahead, may need to consume intermediate bytes.
+    Forward,
+    /// Backward seek — served from in-memory seek window, or becomes a reset.
+    Backward,
+}
+
 #[derive(Debug, Error)]
 pub enum PrefetchReadError<E> {
     #[error("get object request failed")]
@@ -332,12 +343,6 @@ where
             "read"
         );
 
-        // Record the active read range so the pruning/allocation logic knows
-        // this handle has a user waiting for data at this specific range.
-        // The guard ensures the active read is cleared when it goes out of scope,
-        // even on early returns or panics.
-        let _active_read_guard = self.mem_limiter.set_active_read(self.handle_id, offset, length);
-
         match self.try_read(offset, length).await {
             Ok((data, cache_hit)) => {
                 // Record cache hit metric for FUSE layer. We only record a cache hit when ALL parts
@@ -382,25 +387,23 @@ where
         }
         let mut to_read = (length as u64).min(remaining);
 
-        // Try to seek if this read is not sequential, and if seeking fails, cancel and reset the
-        // prefetcher.
-        if self.next_sequential_read_offset != offset {
-            if self.try_seek(offset).await? {
-                trace!("seek succeeded");
-            } else {
-                trace!(
-                    expected = self.next_sequential_read_offset,
-                    actual = offset,
-                    "out-of-order read, resetting prefetch"
-                );
-                counter!(PREFETCH_RESET_STATE).increment(1);
+        // Determine the seek kind and active read range (cheap, no awaits).
+        let (seek_kind, active_start) = if self.next_sequential_read_offset == offset {
+            (SeekKind::None, offset)
+        } else if offset > self.next_sequential_read_offset {
+            (SeekKind::Forward, self.next_sequential_read_offset)
+        } else {
+            (SeekKind::Backward, offset)
+        };
+        let active_size = (offset + length as u64 - active_start) as usize;
 
-                // This is an approximation, tolerating some seeking caused by concurrent readahead.
-                self.record_contiguous_read_metric();
+        // Set the active read range BEFORE any blocking so the allocator knows this range is high priority.
+        let _active_read_guard = self
+            .mem_limiter
+            .set_active_read(self.handle_id, active_start, active_size);
 
-                self.reset_prefetch_to_offset(offset);
-            }
-        }
+        // Act on the seek (may block/await).
+        self.perform_seek(seek_kind, offset).await?;
         assert_eq!(self.next_sequential_read_offset, offset);
 
         if self.backpressure_task.is_none() {
@@ -479,6 +482,33 @@ where
         self.sequential_read_start_offset = offset;
         self.next_sequential_read_offset = offset;
         self.next_request_offset = offset;
+    }
+
+    /// Act on the seek decision. This may block waiting for S3 data (forward seek)
+    /// or reset the prefetcher (random seek). The active read must already be set
+    /// before calling this method.
+    async fn perform_seek(
+        &mut self,
+        seek_kind: SeekKind,
+        offset: u64,
+    ) -> Result<(), PrefetchReadError<Client::ClientError>> {
+        if seek_kind != SeekKind::None {
+            if self.try_seek(offset).await? {
+                trace!("seek succeeded");
+            } else {
+                trace!(
+                    expected = self.next_sequential_read_offset,
+                    actual = offset,
+                    "out-of-order read, resetting prefetch"
+                );
+                counter!(PREFETCH_RESET_STATE).increment(1);
+
+                // This is an approximation, tolerating some seeking caused by concurrent readahead.
+                self.record_contiguous_read_metric();
+                self.reset_prefetch_to_offset(offset);
+            }
+        }
+        Ok(())
     }
 
     /// Try to seek within the current inflight requests without restarting them. Returns true if

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -42,7 +42,7 @@ use tracing::trace;
 use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use crate::mem_limiter::{BufferArea, MemoryLimiter};
+use crate::mem_limiter::{ActiveReadGuard, BufferArea, MemoryLimiter};
 use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
 use crate::object::ObjectId;
 use crate::sync::Arc;
@@ -387,23 +387,17 @@ where
         }
         let mut to_read = (length as u64).min(remaining);
 
-        // Determine the seek kind and active read range (cheap, no awaits).
-        let (seek_kind, active_start) = if self.next_sequential_read_offset == offset {
-            (SeekKind::None, offset)
+        // Determine the seek kind (cheap, no awaits).
+        let seek_kind = if self.next_sequential_read_offset == offset {
+            SeekKind::None
         } else if offset > self.next_sequential_read_offset {
-            (SeekKind::Forward, self.next_sequential_read_offset)
+            SeekKind::Forward
         } else {
-            (SeekKind::Backward, offset)
+            SeekKind::Backward
         };
-        let active_size = (offset + length as u64 - active_start) as usize;
-
-        // Set the active read range BEFORE any blocking so the allocator knows this range is high priority.
-        let _active_read_guard = self
-            .mem_limiter
-            .set_active_read(self.handle_id, active_start, active_size);
-
-        // Act on the seek (may block/await).
-        self.perform_seek(seek_kind, offset).await?;
+        // Act on the seek and set the active read range before any blocking wait.
+        // For forward seek failures, this returns a corrected guard for the reset range.
+        let _active_read_guard = self.perform_seek(seek_kind, offset, length).await?;
         assert_eq!(self.next_sequential_read_offset, offset);
 
         if self.backpressure_task.is_none() {
@@ -484,31 +478,55 @@ where
         self.next_request_offset = offset;
     }
 
-    /// Act on the seek decision. This may block waiting for S3 data (forward seek)
-    /// or reset the prefetcher (random seek). The active read must already be set
-    /// before calling this method.
+    /// Act on the seek decision and return the active read guard for the effective read range.
+    ///
+    /// This may block waiting for S3 data (forward seek) or reset the prefetcher (random seek).
+    /// The returned guard keeps the active read set for the remainder of `try_read`.
     async fn perform_seek(
         &mut self,
         seek_kind: SeekKind,
         offset: u64,
-    ) -> Result<(), PrefetchReadError<Client::ClientError>> {
-        if seek_kind != SeekKind::None {
-            if self.try_seek(offset).await? {
-                trace!("seek succeeded");
-            } else {
-                trace!(
-                    expected = self.next_sequential_read_offset,
-                    actual = offset,
-                    "out-of-order read, resetting prefetch"
-                );
-                counter!(PREFETCH_RESET_STATE).increment(1);
-
-                // This is an approximation, tolerating some seeking caused by concurrent readahead.
-                self.record_contiguous_read_metric();
-                self.reset_prefetch_to_offset(offset);
-            }
+        length: usize,
+    ) -> Result<ActiveReadGuard, PrefetchReadError<Client::ClientError>> {
+        let mut active_start = offset;
+        if seek_kind == SeekKind::Forward {
+            active_start = self.next_sequential_read_offset;
         }
-        Ok(())
+        let active_size = (offset + length as u64 - active_start) as usize;
+
+        // Set active read before any await so allocator can prioritize correctly while blocked.
+        let guard = self
+            .mem_limiter
+            .set_active_read(self.handle_id, active_start, active_size);
+
+        if seek_kind == SeekKind::None {
+            return Ok(guard);
+        }
+
+        if self.try_seek(offset).await? {
+            trace!("seek succeeded");
+            return Ok(guard);
+        }
+
+        trace!(
+            expected = self.next_sequential_read_offset,
+            actual = offset,
+            "out-of-order read, resetting prefetch"
+        );
+        counter!(PREFETCH_RESET_STATE).increment(1);
+
+        // This is an approximation, tolerating some seeking caused by concurrent readahead.
+        self.record_contiguous_read_metric();
+        self.reset_prefetch_to_offset(offset);
+
+        // Forward-seek failure changes the effective read to start at `offset` after reset.
+        // Replace the widened guard with the corrected post-reset range.
+        if seek_kind == SeekKind::Forward {
+            drop(guard);
+            return Ok(self.mem_limiter.set_active_read(self.handle_id, offset, length));
+        }
+
+        Ok(guard)
     }
 
     /// Try to seek within the current inflight requests without restarting them. Returns true if

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -42,7 +42,7 @@ use tracing::trace;
 use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use crate::mem_limiter::{ActiveReadGuard, BufferArea, MemoryLimiter};
+use crate::mem_limiter::{BufferArea, MemoryLimiter};
 use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
 use crate::object::ObjectId;
 use crate::sync::Arc;
@@ -85,17 +85,6 @@ impl HandleId {
 // waiting for the readahead hurts random IO. So we add 128k to the first request size
 // to avoid the latency hit of the second request.
 pub const INITIAL_REQUEST_SIZE: usize = 1024 * 1024 + 128 * 1024;
-
-/// Classifies the type of seek needed before a read.
-#[derive(Debug, PartialEq)]
-enum SeekKind {
-    /// No seek needed — sequential read.
-    None,
-    /// Forward seek — skip ahead, may need to consume intermediate bytes.
-    Forward,
-    /// Backward seek — served from in-memory seek window, or becomes a reset.
-    Backward,
-}
 
 #[derive(Debug, Error)]
 pub enum PrefetchReadError<E> {
@@ -387,17 +376,39 @@ where
         }
         let mut to_read = (length as u64).min(remaining);
 
-        // Determine the seek kind (cheap, no awaits).
-        let seek_kind = if self.next_sequential_read_offset == offset {
-            SeekKind::None
-        } else if offset > self.next_sequential_read_offset {
-            SeekKind::Forward
-        } else {
-            SeekKind::Backward
-        };
-        // Act on the seek and set the active read range before any blocking wait.
-        // For forward seek failures, this returns a corrected guard for the reset range.
-        let _active_read_guard = self.perform_seek(seek_kind, offset, length).await?;
+        // Set the active read range before any blocking. For forward seeks, widen to include
+        // the skipped bytes the prefetcher must consume to reach the requested offset.
+        let active_start = self.next_sequential_read_offset.min(offset);
+        let active_size = (offset + length as u64 - active_start) as usize;
+        let mut _active_read_guard = self
+            .mem_limiter
+            .set_active_read(self.handle_id, active_start, active_size);
+
+        // Try to seek if this read is not sequential, and if seeking fails, cancel and reset the
+        // prefetcher.
+        if self.next_sequential_read_offset != offset {
+            if self.try_seek(offset).await? {
+                trace!("seek succeeded");
+            } else {
+                trace!(
+                    expected = self.next_sequential_read_offset,
+                    actual = offset,
+                    "out-of-order read, resetting prefetch"
+                );
+                counter!(PREFETCH_RESET_STATE).increment(1);
+
+                // This is an approximation, tolerating some seeking caused by concurrent readahead.
+                self.record_contiguous_read_metric();
+                self.reset_prefetch_to_offset(offset);
+
+                // A failed forward seek resets the prefetcher to `offset`, so the widened
+                // active range is no longer valid. Replace with just the requested range.
+                if active_start != offset {
+                    drop(_active_read_guard);
+                    _active_read_guard = self.mem_limiter.set_active_read(self.handle_id, offset, length);
+                }
+            }
+        }
         assert_eq!(self.next_sequential_read_offset, offset);
 
         if self.backpressure_task.is_none() {
@@ -476,57 +487,6 @@ where
         self.sequential_read_start_offset = offset;
         self.next_sequential_read_offset = offset;
         self.next_request_offset = offset;
-    }
-
-    /// Act on the seek decision and return the active read guard for the effective read range.
-    ///
-    /// This may block waiting for S3 data (forward seek) or reset the prefetcher (random seek).
-    /// The returned guard keeps the active read set for the remainder of `try_read`.
-    async fn perform_seek(
-        &mut self,
-        seek_kind: SeekKind,
-        offset: u64,
-        length: usize,
-    ) -> Result<ActiveReadGuard, PrefetchReadError<Client::ClientError>> {
-        let mut active_start = offset;
-        if seek_kind == SeekKind::Forward {
-            active_start = self.next_sequential_read_offset;
-        }
-        let active_size = (offset + length as u64 - active_start) as usize;
-
-        // Set active read before any await so allocator can prioritize correctly while blocked.
-        let guard = self
-            .mem_limiter
-            .set_active_read(self.handle_id, active_start, active_size);
-
-        if seek_kind == SeekKind::None {
-            return Ok(guard);
-        }
-
-        if self.try_seek(offset).await? {
-            trace!("seek succeeded");
-            return Ok(guard);
-        }
-
-        trace!(
-            expected = self.next_sequential_read_offset,
-            actual = offset,
-            "out-of-order read, resetting prefetch"
-        );
-        counter!(PREFETCH_RESET_STATE).increment(1);
-
-        // This is an approximation, tolerating some seeking caused by concurrent readahead.
-        self.record_contiguous_read_metric();
-        self.reset_prefetch_to_offset(offset);
-
-        // Forward-seek failure changes the effective read to start at `offset` after reset.
-        // Replace the widened guard with the corrected post-reset range.
-        if seek_kind == SeekKind::Forward {
-            drop(guard);
-            return Ok(self.mem_limiter.set_active_read(self.handle_id, offset, length));
-        }
-
-        Ok(guard)
     }
 
     /// Try to seek within the current inflight requests without restarting them. Returns true if


### PR DESCRIPTION
The pruning system currently has no way to tell which buffers a user is actively waiting on vs. which are just prefetched ahead.

This PR adds per-handle active read tracking to the memory limiter. When a FUSE read comes in, we record the offset and size of what the user is waiting for. The allocation queue can later check if a buffer overlaps with an active read and prioritize accordingly. A concurrent map makes this safe to query from other threads, and an RAII guard ensures cleanup even on panics or early returns.

The active read range is set before any blocking. For forward seeks, the range is widened to include the skipped bytes the prefetcher must consume.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No, these are internal changes to the memory limiter with no user-visible behavior change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
