### PR TITLE
Upgrade to Rust 1.95

### DIFF
--- a/mountpoint-s3-client/src/failure_client.rs
+++ b/mountpoint-s3-client/src/failure_client.rs
@@ -249,21 +249,17 @@ impl<Client: ObjectClient> Stream for FailureGetResponse<Client> {
         *this.poll_count += 1;
 
         match this.failure_mode {
-            Some(GetObjectFailureMode::StreamShortCircuit(pos)) => {
-                if this.poll_count >= pos {
-                    return Poll::Ready(None);
-                }
+            Some(GetObjectFailureMode::StreamShortCircuit(pos)) if *this.poll_count >= *pos => {
+                return Poll::Ready(None);
             }
-            Some(GetObjectFailureMode::StreamPositionError(pos, _)) => {
-                if this.poll_count >= pos {
-                    let GetObjectFailureMode::StreamPositionError(_, err) = this.failure_mode.take().unwrap() else {
-                        unreachable!()
-                    };
-                    return Poll::Ready(Some(Err(err)));
-                }
+            Some(GetObjectFailureMode::StreamPositionError(pos, _)) if *this.poll_count >= *pos => {
+                let GetObjectFailureMode::StreamPositionError(_, err) = this.failure_mode.take().unwrap() else {
+                    unreachable!()
+                };
+                return Poll::Ready(Some(Err(err)));
             }
             Some(GetObjectFailureMode::OperationError(_)) => unreachable!(),
-            None => {}
+            _ => {}
         }
 
         this.request.poll_next(cx)

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -1808,7 +1808,7 @@ mod tests {
         let prefixes: HashSet<_> = result1
             .common_prefixes
             .into_iter()
-            .chain(result2.common_prefixes.into_iter())
+            .chain(result2.common_prefixes)
             .collect();
         let objects: HashSet<_> = result1
             .objects
@@ -1873,7 +1873,7 @@ mod tests {
                 .expect("should not fail");
             continuation_token = result.next_continuation_token;
 
-            prefixes.extend(result.common_prefixes.into_iter());
+            prefixes.extend(result.common_prefixes);
             objects.extend(result.objects.into_iter().map(|o| o.key));
 
             if continuation_token.is_none() {
@@ -1940,7 +1940,7 @@ mod tests {
                 .expect("should not fail");
             continuation_token = result.next_continuation_token;
 
-            prefixes.extend(result.common_prefixes.into_iter());
+            prefixes.extend(result.common_prefixes);
             objects.extend(result.objects.into_iter().map(|o| o.key));
 
             if continuation_token.is_none() {

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -394,7 +394,7 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
         let expected_checksums: Vec<_> = contents.chunks(PART_SIZE).map(crc32c::checksum).collect();
 
         assert_eq!(checksums.len(), expected_checksums.len());
-        for (checksum, expected_checksum) in checksums.into_iter().zip(expected_checksums.into_iter()) {
+        for (checksum, expected_checksum) in checksums.into_iter().zip(expected_checksums) {
             let encoded = crc32c_to_base64(&expected_checksum);
             assert_eq!(checksum, encoded);
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93"
+channel = "1.95"
 components = ["rust-src"]


### PR DESCRIPTION
Upgrade Rust toolchain to 1.95 and address new clippy issues in tests and mock client.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
