### PR TITLE
Extract Cursor and track active reads per cursor

### DIFF
--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -15,7 +15,7 @@ use mountpoint_s3_fs::Runtime;
 use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
-use mountpoint_s3_fs::prefetch::{HandleId, PrefetchGetObject, Prefetcher, PrefetcherConfig};
+use mountpoint_s3_fs::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use serde_json::{json, to_writer};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
@@ -202,11 +202,10 @@ fn main() -> anyhow::Result<()> {
         thread::scope(|scope| {
             let mut download_tasks = Vec::new();
 
-            for (idx, (object_id, size)) in object_metadata.iter().enumerate() {
+            for (object_id, size) in &object_metadata {
                 let received_bytes = received_bytes.clone();
                 let object_id = object_id.clone();
-                let handle_id = HandleId::new(idx as u64);
-                let request = manager.prefetch(bucket.to_string(), object_id.clone(), handle_id, *size);
+                let request = manager.prefetch(bucket.to_string(), object_id.clone(), *size);
                 let read_size = args.read_size;
 
                 let task = scope.spawn(move || {

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -1,7 +1,6 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
@@ -10,7 +9,7 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::object::ObjectId;
-use mountpoint_s3_fs::prefetch::{HandleId, Prefetcher, PrefetcherConfig};
+use mountpoint_s3_fs::prefetch::{Prefetcher, PrefetcherConfig};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use rand::{RngExt, SeedableRng};
@@ -39,7 +38,6 @@ pub struct Executor {
     pub client: S3CrtClient,
     pub uploader: Uploader<S3CrtClient>,
     prefetcher: Prefetcher<S3CrtClient>,
-    next_handle_id: AtomicU64,
 }
 
 impl Executor {
@@ -118,7 +116,6 @@ impl Executor {
             client,
             uploader,
             prefetcher,
-            next_handle_id: AtomicU64::new(1),
         })
     }
 
@@ -154,7 +151,6 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -178,7 +174,7 @@ impl Executor {
                 break;
             }
 
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), handle_id, size);
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
             let mut offset = 0;
             while offset < size {
                 if let Some(max_dur) = max_duration
@@ -228,7 +224,6 @@ impl Executor {
         let prefetcher = &self.prefetcher;
         let bucket = &config.bucket;
         let object_key = &config.object_key;
-        let handle_id = HandleId::new(self.next_handle_id.fetch_add(1, Ordering::Relaxed));
 
         let head_result = client
             .head_object(bucket, object_key, &HeadObjectParams::new())
@@ -254,7 +249,7 @@ impl Executor {
             }
 
             let iteration_start = Instant::now();
-            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), handle_id, size);
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
 
             // Create a unique, deterministic seed by combining randseed with object_id hash
             // and iteration. This ensures each object/iteration has a different but reproducible

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -352,7 +352,7 @@ where
         let fh = self.next_handle(); // TODO: can we delay obtaining the next handle until we know we are creating a new file handle?
         let write_mode = self.config.write_mode();
         let new_handle = self.metablock.open_handle(ino, fh, &write_mode, flags).await?;
-        let state = FileHandleState::new(fh, &new_handle, flags, self).await?;
+        let state = FileHandleState::new(&new_handle, flags, self).await?;
         let handle = FileHandle {
             ino,
             location: new_handle.lookup.try_into_s3_location()?,

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error};
 use crate::fs::InodeError;
 use crate::metablock::{Lookup, Metablock, NewHandle, PendingUploadHook, ReadWriteMode, S3Location};
 use crate::object::ObjectId;
-use crate::prefetch::{HandleId, PrefetchGetObject};
+use crate::prefetch::PrefetchGetObject;
 use crate::sync::{Arc, AsyncMutex};
 use crate::upload::{AppendUploadRequest, UploadRequest};
 
@@ -58,7 +58,6 @@ where
     Client: ObjectClient + Clone + Send + Sync,
 {
     pub async fn new(
-        fh: u64,
         handle: &NewHandle,
         flags: OpenFlags,
         fs: &S3Filesystem<Client>,
@@ -77,9 +76,7 @@ where
                     Some(etag) => ETag::from_str(etag).expect("E-Tag should be set"),
                 };
                 let object_id = ObjectId::new(full_key.into(), etag);
-                let request = fs
-                    .prefetcher
-                    .prefetch(bucket.to_string(), object_id, HandleId::new(fh), object_size);
+                let request = fs.prefetcher.prefetch(bucket.to_string(), object_id, object_size);
                 let handle = FileHandleState::Read {
                     request,
                     flushed: false,

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -28,7 +28,7 @@ impl BufferArea {
     }
 }
 
-/// Describes an active FUSE read request for a specific file handle.
+/// Describes an active FUSE read request for a specific cursor.
 /// Used by the pruning logic to determine which buffers are high priority
 /// (actively being waited on by a user) vs. speculative (prefetched ahead).
 #[derive(Debug, Clone, Copy)]
@@ -48,7 +48,7 @@ impl ActiveRead {
     }
 }
 
-/// RAII guard that clears the active read for a handle when dropped.
+/// RAII guard that clears the active read for a cursor when dropped.
 /// Ensures the active read is always cleared, even on early returns or panics.
 pub struct ActiveReadGuard {
     mem_limiter: Arc<MemoryLimiter>,
@@ -68,16 +68,16 @@ impl Drop for ActiveReadGuard {
 ///
 /// Single instance of this struct is shared among all of the prefetchers (file handles) and uploaders.
 ///
-/// Each file handle makes an initial reservation request with a minimal read window size of `1MiB + 128KiB` on the first
-/// `read()` call. This is accepted unconditionally since we want to allow any file handle to make
-/// progress even if that means going over the memory limit. Additional reservations for a file handle arise when the
+/// Each cursor makes an initial reservation request with a minimal read window size of `1MiB + 128KiB` when
+/// it is created. This is accepted unconditionally since we want to allow any cursor to make
+/// progress even if that means going over the memory limit. Additional reservations for a cursor arise when the
 /// backpressure read window is incremented to fetch more data from underlying part streams. Those reservations may be
 /// rejected if there is no available memory.
 ///
 /// Release of the reserved memory happens on one of the following events:
 /// 1) the memory pool allocates a buffer: the `on_reserve` callback decrements `mem_reserved` by the
 ///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
-/// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_cursor` will
+/// 2) the cursor is destroyed (`BackpressureController` will be dropped and `release_cursor` will
 ///    release any remaining unallocated reservation for that cursor).
 ///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
@@ -98,8 +98,8 @@ pub struct MemoryLimiter {
     /// Memory pool used by the S3 client and disk cache.
     /// We rely on the pool's stats to account for all buffer allocations (e.g. GetObject, DiskCache, PutObject buffers).
     pool: PagedPool,
-    /// Per-handle active read tracking. When a FUSE read is in progress for a handle,
-    /// the requested range is stored here. Absence means the handle is speculative.
+    /// Per-cursor active read tracking. When a FUSE read is in progress for a cursor,
+    /// the requested range is stored here. Absence means the cursor is speculative.
     active_reads: DashMap<CursorId, ActiveRead>,
 }
 

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -6,7 +6,7 @@ use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::memory::PagedPool;
-use crate::prefetch::{CursorId, HandleId};
+use crate::prefetch::CursorId;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicU64, Ordering};
 
@@ -52,12 +52,12 @@ impl ActiveRead {
 /// Ensures the active read is always cleared, even on early returns or panics.
 pub struct ActiveReadGuard {
     mem_limiter: Arc<MemoryLimiter>,
-    handle_id: HandleId,
+    cursor_id: CursorId,
 }
 
 impl Drop for ActiveReadGuard {
     fn drop(&mut self) {
-        self.mem_limiter.clear_active_read(self.handle_id);
+        self.mem_limiter.clear_active_read(self.cursor_id);
     }
 }
 
@@ -100,7 +100,7 @@ pub struct MemoryLimiter {
     pool: PagedPool,
     /// Per-handle active read tracking. When a FUSE read is in progress for a handle,
     /// the requested range is stored here. Absence means the handle is speculative.
-    active_reads: DashMap<HandleId, ActiveRead>,
+    active_reads: DashMap<CursorId, ActiveRead>,
 }
 
 impl MemoryLimiter {
@@ -202,23 +202,23 @@ impl MemoryLimiter {
 
     /// Record that a FUSE read is active for the given handle at the specified range.
     /// Returns a guard that will clear the active read when dropped.
-    pub fn set_active_read(self: &Arc<Self>, handle_id: HandleId, offset: u64, size: usize) -> ActiveReadGuard {
-        self.active_reads.insert(handle_id, ActiveRead { offset, size });
+    pub fn set_active_read(self: &Arc<Self>, cursor_id: CursorId, offset: u64, size: usize) -> ActiveReadGuard {
+        self.active_reads.insert(cursor_id, ActiveRead { offset, size });
         ActiveReadGuard {
             mem_limiter: Arc::clone(self),
-            handle_id,
+            cursor_id,
         }
     }
 
     /// Clear the active read for the given handle (read completed or errored).
-    fn clear_active_read(&self, handle_id: HandleId) {
-        self.active_reads.remove(&handle_id);
+    fn clear_active_read(&self, cursor_id: CursorId) {
+        self.active_reads.remove(&cursor_id);
     }
 
     /// Check if the given handle has an active read overlapping the specified range.
-    pub fn has_active_read_in_range(&self, handle_id: HandleId, offset: u64, size: usize) -> bool {
+    pub fn has_active_read_in_range(&self, cursor_id: CursorId, offset: u64, size: usize) -> bool {
         self.active_reads
-            .get(&handle_id)
+            .get(&cursor_id)
             .map(|r| r.overlaps(offset, size))
             .unwrap_or(false)
     }
@@ -475,23 +475,23 @@ mod tests {
     #[test]
     fn test_active_read_overlap_detection() {
         let limiter = new_limiter();
-        let handle = HandleId::new(1);
+        let cursor_id = CursorId::new_from_raw(1);
 
         // Active read at [1000, 5096)
-        let _guard = limiter.set_active_read(handle, 1000, 4096);
+        let _guard = limiter.set_active_read(cursor_id, 1000, 4096);
 
         // Overlapping ranges → true
-        assert!(limiter.has_active_read_in_range(handle, 1000, 4096)); // exact match
-        assert!(limiter.has_active_read_in_range(handle, 500, 1000)); // overlap from left
-        assert!(limiter.has_active_read_in_range(handle, 5000, 1000)); // overlap from right
-        assert!(limiter.has_active_read_in_range(handle, 2000, 100)); // contained
+        assert!(limiter.has_active_read_in_range(cursor_id, 1000, 4096)); // exact match
+        assert!(limiter.has_active_read_in_range(cursor_id, 500, 1000)); // overlap from left
+        assert!(limiter.has_active_read_in_range(cursor_id, 5000, 1000)); // overlap from right
+        assert!(limiter.has_active_read_in_range(cursor_id, 2000, 100)); // contained
 
         // Non-overlapping ranges → false
-        assert!(!limiter.has_active_read_in_range(handle, 0, 500)); // before
-        assert!(!limiter.has_active_read_in_range(handle, 5096, 1000)); // after
+        assert!(!limiter.has_active_read_in_range(cursor_id, 0, 500)); // before
+        assert!(!limiter.has_active_read_in_range(cursor_id, 5096, 1000)); // after
 
-        // Different handle → false
-        assert!(!limiter.has_active_read_in_range(HandleId::new(2), 1000, 4096));
+        // Different cursor_id → false
+        assert!(!limiter.has_active_read_in_range(CursorId::new_from_raw(2), 1000, 4096));
     }
 
     /// Simulates the allocation queue's perspective: one thread holds an active read
@@ -499,21 +499,21 @@ mod tests {
     #[test]
     fn test_query_active_read_from_another_thread() {
         let limiter = new_limiter();
-        let handle = HandleId::new(1);
+        let cursor_id = CursorId::new_from_raw(1);
 
-        let guard = limiter.set_active_read(handle, 1000, 4096);
+        let guard = limiter.set_active_read(cursor_id, 1000, 4096);
 
         let limiter_clone = Arc::clone(&limiter);
         let query_thread = std::thread::spawn(move || {
             // Allocation for the active range → high priority
-            assert!(limiter_clone.has_active_read_in_range(handle, 1000, 4096));
+            assert!(limiter_clone.has_active_read_in_range(cursor_id, 1000, 4096));
             // Allocation for a prefetch-ahead range → low priority
-            assert!(!limiter_clone.has_active_read_in_range(handle, 50000, 4096));
+            assert!(!limiter_clone.has_active_read_in_range(cursor_id, 50000, 4096));
         });
         query_thread.join().unwrap();
 
         drop(guard);
-        assert!(!limiter.has_active_read_in_range(handle, 1000, 4096));
+        assert!(!limiter.has_active_read_in_range(cursor_id, 1000, 4096));
     }
 
     /// When the `TEST_CGROUP_MEM_LIMIT_MB` environment variable is set (e.g. in a

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -9,8 +9,9 @@
 //! up to some maximum. If the reader ever makes a non-sequential read, we abandon the prefetching
 //! and start again with a new GetObject request with minimum read window size.
 //!
-//! In more technical details, the prefetcher creates a RequestTask when receiving the first read
-//! request from the file system or after it has just been reset. The RequestTask consists of two main
+//! In more technical details, the prefetcher creates a Cursor when receiving the first read
+//! request from the file system or after it has just been reset. The Cursor manages the read
+//! position, backward seek window, and owns a RequestTask. The RequestTask consists of two main
 //! components.
 //! 1.  An ObjectPartStream that has a role to continuously fetch data from the sources which can be
 //!     either S3 or the cache on disk. The ObjectPartStream is spawned and run in a separate thread
@@ -60,20 +61,6 @@ pub use builder::PrefetcherBuilder;
 pub use cursor::{Cursor, CursorId};
 use part::PartOperationError;
 use part_stream::{PartStream, RequestRange, RequestTaskConfig};
-
-/// Opaque identifier for a file handle, used to attribute prefetch requests to their origin.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct HandleId(u64);
-
-impl HandleId {
-    pub fn new(id: u64) -> Self {
-        Self(id)
-    }
-
-    pub fn as_raw(&self) -> u64 {
-        self.0
-    }
-}
 
 // This is a weird looking number! We really want our first request size to be 1MiB,
 // which is a common IO size. But Linux's readahead will try to read an extra 128k on on
@@ -237,8 +224,8 @@ where
     {
         PrefetchGetObject::new(
             self.part_stream.clone(),
-            self.config,
             self.mem_limiter.clone(),
+            self.config,
             bucket,
             object_id,
             size,
@@ -253,14 +240,14 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     part_stream: PartStream<Client>,
-    config: PrefetcherConfig,
     mem_limiter: Arc<MemoryLimiter>,
-    cursor: Option<Cursor<Client>>,
+    config: PrefetcherConfig,
     bucket: String,
     object_id: ObjectId,
+    size: u64,
+    cursor: Option<Cursor<Client>>,
     // preferred part size in the prefetcher's part queue, not the object part
     preferred_part_size: usize,
-    size: u64,
 }
 
 impl<Client> PrefetchGetObject<Client>
@@ -270,21 +257,21 @@ where
     /// Create and spawn a new prefetching request for an object
     fn new(
         part_stream: PartStream<Client>,
-        config: PrefetcherConfig,
         mem_limiter: Arc<MemoryLimiter>,
+        config: PrefetcherConfig,
         bucket: String,
         object_id: ObjectId,
         size: u64,
     ) -> Self {
         PrefetchGetObject {
             part_stream,
-            config,
             mem_limiter,
-            cursor: None,
-            preferred_part_size: 128 * 1024,
+            config,
             bucket,
             object_id,
             size,
+            cursor: None,
+            preferred_part_size: 128 * 1024,
         }
     }
 
@@ -346,18 +333,20 @@ where
         let max_preferred_part_size = 1024 * 1024;
         self.preferred_part_size = self.preferred_part_size.max(length).min(max_preferred_part_size);
 
+        // Try to use the current cursor, if present. Allows for limited non sequential reads.
         if let Some(ref mut cursor) = self.cursor
             && let Some(result) = cursor.try_read(offset, length).await?
         {
             Ok(result)
         } else {
+            // Otherwise, create a new cursor at `offset` and read from it.
             let cursor = self.cursor.insert(self.create_cursor(offset)?);
             cursor.read(length).await
         }
     }
 
-    /// Spawn a backpressure GetObject request which has a range from current offset to the end of the file.
-    /// We will be using flow-control window to control how much data we want to download into the prefetcher.
+    /// Create a new Cursor and associated backpressure GetObject request which has a range from current offset
+    /// to the end of the file.
     fn create_cursor(&self, offset: u64) -> Result<Cursor<Client>, PrefetchReadError<Client::ClientError>> {
         let start = offset;
         let object_size = self.size as usize;
@@ -387,14 +376,14 @@ where
             max_read_window_size: self.config.max_read_window_size,
             read_window_size_multiplier: self.config.sequential_prefetch_multiplier,
         };
-        let backpressure_task = self.part_stream.spawn_get_object_request(config);
+        let request_task = self.part_stream.spawn_get_object_request(config);
         Ok(Cursor::new(
             cursor_id,
-            backpressure_task,
+            request_task,
+            self.mem_limiter.clone(),
             &self.config,
             self.object_id.clone(),
             offset,
-            self.mem_limiter.clone(),
         ))
     }
 

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -33,7 +33,6 @@
 
 use std::fmt::Debug;
 
-use metrics::{counter, histogram};
 use mountpoint_s3_client::error::{GetObjectError, ObjectClientError};
 use mountpoint_s3_client::{ObjectClient, error_metadata::ProvideErrorMetadata};
 use thiserror::Error;
@@ -43,13 +42,14 @@ use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
 use crate::mem_limiter::MemoryLimiter;
-use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
+use crate::metrics::defs::FUSE_CACHE_HIT;
 use crate::object::ObjectId;
 use crate::sync::Arc;
 
 mod backpressure_controller;
 mod builder;
 mod caching_stream;
+mod cursor;
 mod part;
 mod part_queue;
 mod part_stream;
@@ -57,10 +57,9 @@ mod seek_window;
 mod task;
 
 pub use builder::PrefetcherBuilder;
+use cursor::Cursor;
 use part::PartOperationError;
 use part_stream::{PartStream, RequestRange, RequestTaskConfig};
-use seek_window::SeekWindow;
-use task::RequestTask;
 
 /// Opaque identifier for a file handle, used to attribute prefetch requests to their origin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -281,17 +280,11 @@ where
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
     mem_limiter: Arc<MemoryLimiter>,
-    backpressure_task: Option<RequestTask<Client>>,
-    // Invariant: the offset of the last byte in this window is always
-    // self.next_sequential_read_offset - 1.
-    backward_seek_window: SeekWindow,
+    cursor: Option<Cursor<Client>>,
     bucket: String,
     object_id: ObjectId,
     // preferred part size in the prefetcher's part queue, not the object part
     preferred_part_size: usize,
-    /// Start offset for sequential read, used for calculating contiguous read metric
-    sequential_read_start_offset: u64,
-    next_sequential_read_offset: u64,
     size: u64,
     /// File handle ID that owns this prefetch request, for per-handle memory accounting.
     handle_id: HandleId,
@@ -311,16 +304,12 @@ where
         handle_id: HandleId,
         size: u64,
     ) -> Self {
-        let max_backward_seek_distance = config.max_backward_seek_distance as usize;
         PrefetchGetObject {
             part_stream,
             config,
             mem_limiter,
-            backpressure_task: None,
-            backward_seek_window: SeekWindow::new(max_backward_seek_distance),
+            cursor: None,
             preferred_part_size: 128 * 1024,
-            sequential_read_start_offset: 0,
-            next_sequential_read_offset: 0,
             bucket,
             object_id,
             size,
@@ -339,9 +328,14 @@ where
         trace!(
             offset,
             length,
-            next_seq_offset = self.next_sequential_read_offset,
+            next_seq_offset = self.cursor.as_ref().map(|c| c.current_offset()),
             "read"
         );
+
+        let remaining = self.size.saturating_sub(offset);
+        if remaining == 0 {
+            return Ok(ChecksummedBytes::default());
+        }
 
         match self.try_read(offset, length).await {
             Ok((data, cache_hit)) => {
@@ -360,7 +354,7 @@ where
                 Ok(data)
             }
             Err(err) => {
-                self.reset_prefetch_to_offset(offset);
+                self.reset_prefetch();
                 Err(err)
             }
         }
@@ -381,80 +375,43 @@ where
         let max_preferred_part_size = 1024 * 1024;
         self.preferred_part_size = self.preferred_part_size.max(length).min(max_preferred_part_size);
 
-        let remaining = self.size.saturating_sub(offset);
-        if remaining == 0 {
-            return Ok((ChecksummedBytes::default(), false));
-        }
-        let mut to_read = (length as u64).min(remaining);
-
         // Set the active read range before any blocking. For forward seeks, widen to include
         // the skipped bytes the prefetcher must consume to reach the requested offset.
-        let active_start = self.next_sequential_read_offset.min(offset);
-        let active_size = length + offset.saturating_sub(self.next_sequential_read_offset) as usize;
+        let active_start = self
+            .cursor
+            .as_ref()
+            .map(|c| c.current_offset())
+            .unwrap_or(offset)
+            .min(offset);
+        let active_size = length + offset.saturating_sub(active_start) as usize;
         let _active_read_guard = self
             .mem_limiter
             .set_active_read(self.handle_id, active_start, active_size);
 
-        // Try to seek if this read is not sequential, and if seeking fails, cancel and reset the
-        // prefetcher.
-        if self.next_sequential_read_offset != offset {
-            if self.try_seek(offset).await? {
-                trace!("seek succeeded");
-            } else {
-                trace!(
-                    expected = self.next_sequential_read_offset,
-                    actual = offset,
-                    "out-of-order read, resetting prefetch"
-                );
-                counter!(PREFETCH_RESET_STATE).increment(1);
+        self.cursor_at_offset(offset).await?.read(length).await
+    }
 
-                // This is an approximation, tolerating some seeking caused by concurrent readahead.
-                self.record_contiguous_read_metric();
-                self.reset_prefetch_to_offset(offset);
-            }
-        }
-        assert_eq!(self.next_sequential_read_offset, offset);
+    async fn cursor_at_offset(
+        &mut self,
+        offset: u64,
+    ) -> Result<&mut Cursor<Client>, PrefetchReadError<Client::ClientError>> {
+        let can_reuse = if let Some(ref mut cursor) = self.cursor {
+            cursor.try_seek(offset).await?
+        } else {
+            false
+        };
 
-        if self.backpressure_task.is_none() {
-            self.backpressure_task = Some(self.spawn_read_backpressure_request()?);
+        if !can_reuse {
+            self.cursor = Some(self.create_cursor(offset)?);
         }
 
-        let mut all_parts_from_cache = true;
-        let mut response = ChecksummedBytes::default();
-        while to_read > 0 {
-            let Some(current_task) = self.backpressure_task.as_mut() else {
-                trace!(offset, length, "read beyond object size");
-                break;
-            };
-            debug_assert!(current_task.remaining() > 0);
-
-            let part = current_task.read(to_read as usize).await?;
-            all_parts_from_cache &= part.is_from_cache();
-            self.backward_seek_window.push(part.clone());
-            let part_bytes = part.into_bytes(&self.object_id, self.next_sequential_read_offset)?;
-
-            self.next_sequential_read_offset += part_bytes.len() as u64;
-            // If we can complete the read with just a single buffer, early return to avoid copying
-            // into a new buffer. This should be the common case as long as part size is larger than
-            // read size, which it almost always is for real S3 clients and FUSE.
-            if response.is_empty() && part_bytes.len() == to_read as usize {
-                return Ok((part_bytes, all_parts_from_cache));
-            }
-
-            let part_len = part_bytes.len() as u64;
-            response.extend(part_bytes)?;
-            to_read -= part_len;
-        }
-
-        Ok((response, all_parts_from_cache))
+        Ok(self.cursor.as_mut().unwrap())
     }
 
     /// Spawn a backpressure GetObject request which has a range from current offset to the end of the file.
     /// We will be using flow-control window to control how much data we want to download into the prefetcher.
-    fn spawn_read_backpressure_request(
-        &mut self,
-    ) -> Result<RequestTask<Client>, PrefetchReadError<Client::ClientError>> {
-        let start = self.next_sequential_read_offset;
+    fn create_cursor(&self, offset: u64) -> Result<Cursor<Client>, PrefetchReadError<Client::ClientError>> {
+        let start = offset;
         let object_size = self.size as usize;
         let read_part_size = self.part_stream.client().read_part_size();
         let range = RequestRange::new(object_size, start, object_size);
@@ -480,106 +437,18 @@ where
             max_read_window_size: self.config.max_read_window_size,
             read_window_size_multiplier: self.config.sequential_prefetch_multiplier,
         };
-        Ok(self.part_stream.spawn_get_object_request(config))
+        let backpressure_task = self.part_stream.spawn_get_object_request(config);
+        Ok(Cursor::new(
+            backpressure_task,
+            &self.config,
+            self.object_id.clone(),
+            offset,
+        ))
     }
 
-    /// Reset this prefetch request to a new offset, clearing any existing tasks queued.
-    fn reset_prefetch_to_offset(&mut self, offset: u64) {
-        self.backpressure_task = None;
-        self.backward_seek_window.clear();
-        self.sequential_read_start_offset = offset;
-        self.next_sequential_read_offset = offset;
-    }
-
-    /// Try to seek within the current inflight requests without restarting them. Returns true if
-    /// the seek succeeded, in which case self.next_sequential_read_offset will be updated to the
-    /// new offset. If this returns false, the prefetcher is in an unknown state and must be reset.
-    async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        assert_ne!(offset, self.next_sequential_read_offset);
-        trace!(from = self.next_sequential_read_offset, to = offset, "trying to seek");
-        if offset > self.next_sequential_read_offset {
-            self.try_seek_forward(offset).await
-        } else {
-            self.try_seek_backward(offset).await
-        }
-    }
-
-    async fn try_seek_forward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        assert!(offset > self.next_sequential_read_offset);
-        let total_seek_distance = offset - self.next_sequential_read_offset;
-        histogram!("prefetch.seek_distance", "dir" => "forward").record(total_seek_distance as f64);
-
-        let Some(task) = self.backpressure_task.as_mut() else {
-            // Can't seek if there's no requests in flight at all
-            return Ok(false);
-        };
-
-        // Not enough data in the read window to serve the forward seek
-        if offset >= task.read_window_end_offset() {
-            return Ok(false);
-        }
-
-        // If we have enough bytes already downloaded (`available`) to skip straight to this read, then do
-        // it. Otherwise, we're willing to wait for the bytes to download only if they're coming "soon", where
-        // soon is defined as up to `max_forward_seek_wait_distance` bytes ahead of the available offset.
-        let available_offset = task.available_offset();
-        let available_soon_offset = available_offset.saturating_add(self.config.max_forward_seek_wait_distance);
-        if offset >= available_soon_offset {
-            trace!(
-                requested_offset = offset,
-                available_offset = available_offset,
-                "seek failed: not enough data available"
-            );
-            return Ok(false);
-        }
-        let mut seek_distance = offset - self.next_sequential_read_offset;
-        while seek_distance > 0 {
-            let part = task.read(seek_distance as usize).await?;
-            seek_distance -= part.len() as u64;
-            self.next_sequential_read_offset += part.len() as u64;
-            self.backward_seek_window.push(part);
-        }
-        Ok(true)
-    }
-
-    async fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        assert!(offset < self.next_sequential_read_offset);
-
-        // When the task is None it means either we have just started prefetching or recently reset it,
-        // in both cases the backward seek window would be empty so we can bail out early.
-        let Some(task) = self.backpressure_task.as_mut() else {
-            return Ok(false);
-        };
-        let backwards_length_needed = self.next_sequential_read_offset - offset;
-        histogram!("prefetch.seek_distance", "dir" => "backward").record(backwards_length_needed as f64);
-
-        let Some(parts) = self.backward_seek_window.read_back(backwards_length_needed as usize) else {
-            trace!("seek failed: not enough data in backwards seek window");
-            return Ok(false);
-        };
-        // Re-inject the parts from the seek window back into the part queue.
-        // The pool already tracks the memory for these buffers, so no additional
-        // reservation on the memory limiter is needed.
-        task.push_front(parts).await?;
-        self.next_sequential_read_offset = offset;
-        Ok(true)
-    }
-
-    /// Record the end of a contiguous read.
-    ///
-    /// This should be invoked at the end of each set of contiguous reads, including if no further read occurs.
-    fn record_contiguous_read_metric(&self) {
-        histogram!("prefetch.contiguous_read_len")
-            .record((self.next_sequential_read_offset - self.sequential_read_start_offset) as f64);
-    }
-}
-
-impl<Client> Drop for PrefetchGetObject<Client>
-where
-    Client: ObjectClient + Clone + Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.record_contiguous_read_metric();
+    /// Reset this prefetch request, clearing any existing tasks queued.
+    fn reset_prefetch(&mut self) {
+        self.cursor = None;
     }
 }
 

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -231,13 +231,7 @@ where
     }
 
     /// Start a new prefetch request to the specified object.
-    pub fn prefetch(
-        &self,
-        bucket: String,
-        object_id: ObjectId,
-        handle_id: HandleId,
-        size: u64,
-    ) -> PrefetchGetObject<Client>
+    pub fn prefetch(&self, bucket: String, object_id: ObjectId, size: u64) -> PrefetchGetObject<Client>
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
@@ -247,7 +241,6 @@ where
             self.mem_limiter.clone(),
             bucket,
             object_id,
-            handle_id,
             size,
         )
     }
@@ -268,8 +261,6 @@ where
     // preferred part size in the prefetcher's part queue, not the object part
     preferred_part_size: usize,
     size: u64,
-    /// File handle ID that owns this prefetch request, for per-handle memory accounting.
-    handle_id: HandleId,
 }
 
 impl<Client> PrefetchGetObject<Client>
@@ -283,7 +274,6 @@ where
         mem_limiter: Arc<MemoryLimiter>,
         bucket: String,
         object_id: ObjectId,
-        handle_id: HandleId,
         size: u64,
     ) -> Self {
         PrefetchGetObject {
@@ -295,7 +285,6 @@ where
             bucket,
             object_id,
             size,
-            handle_id,
         }
     }
 
@@ -357,37 +346,14 @@ where
         let max_preferred_part_size = 1024 * 1024;
         self.preferred_part_size = self.preferred_part_size.max(length).min(max_preferred_part_size);
 
-        // Set the active read range before any blocking. For forward seeks, widen to include
-        // the skipped bytes the prefetcher must consume to reach the requested offset.
-        let active_start = self
-            .cursor
-            .as_ref()
-            .map(|c| c.current_offset())
-            .unwrap_or(offset)
-            .min(offset);
-        let active_size = length + offset.saturating_sub(active_start) as usize;
-        let _active_read_guard = self
-            .mem_limiter
-            .set_active_read(self.handle_id, active_start, active_size);
-
-        self.cursor_at_offset(offset).await?.read(length).await
-    }
-
-    async fn cursor_at_offset(
-        &mut self,
-        offset: u64,
-    ) -> Result<&mut Cursor<Client>, PrefetchReadError<Client::ClientError>> {
-        let can_reuse = if let Some(ref mut cursor) = self.cursor {
-            cursor.try_seek(offset).await?
+        if let Some(ref mut cursor) = self.cursor
+            && let Some(result) = cursor.try_read(offset, length).await?
+        {
+            Ok(result)
         } else {
-            false
-        };
-
-        if !can_reuse {
-            self.cursor = Some(self.create_cursor(offset)?);
+            let cursor = self.cursor.insert(self.create_cursor(offset)?);
+            cursor.read(length).await
         }
-
-        Ok(self.cursor.as_mut().unwrap())
     }
 
     /// Spawn a backpressure GetObject request which has a range from current offset to the end of the file.
@@ -428,6 +394,7 @@ where
             &self.config,
             self.object_id.clone(),
             offset,
+            self.mem_limiter.clone(),
         ))
     }
 
@@ -532,8 +499,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = HandleId::new(1);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, size);
 
         let mut next_offset = 0;
         loop {
@@ -614,8 +580,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = HandleId::new(1);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size as u64);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size as u64);
         let result = block_on(request.read(0, read_size));
         assert!(matches!(result, Err(PrefetchReadError::BackpressurePreconditionFailed)));
     }
@@ -700,8 +665,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = HandleId::new(1);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, size);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, size);
 
         let mut next_offset = 0;
         loop {
@@ -831,8 +795,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client, prefetcher_type, prefetcher_config);
         let object_id = ObjectId::new("hello".to_owned(), etag);
-        let fh = HandleId::new(1);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
 
         for (offset, length) in reads {
             assert!(offset < object_size);
@@ -995,8 +958,7 @@ mod tests {
         let prefetcher = build_prefetcher(client, PrefetcherType::Default, Default::default());
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
 
             // The first read should trigger the prefetcher to try and get the whole object (in 2 parts).
             _ = request.read(0, 1).await.expect("first read should succeed");
@@ -1059,8 +1021,7 @@ mod tests {
 
         block_on(async {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
 
             // First read will terminate early
             assert!(matches!(
@@ -1115,8 +1076,7 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in first_read_size + 1..OBJECT_SIZE {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
             }
@@ -1151,8 +1111,7 @@ mod tests {
         // Try every possible seek from first_read_size
         for offset in 0..first_read_size {
             let object_id = ObjectId::new("hello".to_owned(), etag.clone());
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, OBJECT_SIZE as u64);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
             if first_read_size > 0 {
                 let _first_read = block_on(request.read(0, first_read_size)).unwrap();
             }
@@ -1193,8 +1152,7 @@ mod tests {
 
         let prefetcher = build_prefetcher(client.clone(), PrefetcherType::Default, prefetcher_config);
         let object_id = ObjectId::new("test-object".to_owned(), etag);
-        let fh = HandleId::new(1);
-        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
 
         // Perform sequential reads to test the download functionality
         let mut next_offset = 0;
@@ -1263,8 +1221,7 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
 
             let mut next_offset = 0;
             loop {
@@ -1326,8 +1283,7 @@ mod tests {
             let prefetcher =
                 Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
-            let fh = HandleId::new(1);
-            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
+            let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, object_size);
 
             let num_reads = rng.gen_range(10usize..50);
             for _ in 0..num_reads {

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -292,7 +292,6 @@ where
     /// Start offset for sequential read, used for calculating contiguous read metric
     sequential_read_start_offset: u64,
     next_sequential_read_offset: u64,
-    next_request_offset: u64,
     size: u64,
     /// File handle ID that owns this prefetch request, for per-handle memory accounting.
     handle_id: HandleId,
@@ -322,7 +321,6 @@ where
             preferred_part_size: 128 * 1024,
             sequential_read_start_offset: 0,
             next_sequential_read_offset: 0,
-            next_request_offset: 0,
             bucket,
             object_id,
             size,
@@ -491,7 +489,6 @@ where
         self.backward_seek_window.clear();
         self.sequential_read_start_offset = offset;
         self.next_sequential_read_offset = offset;
-        self.next_request_offset = offset;
     }
 
     /// Try to seek within the current inflight requests without restarting them. Returns true if

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -57,7 +57,7 @@ mod seek_window;
 mod task;
 
 pub use builder::PrefetcherBuilder;
-use cursor::Cursor;
+pub use cursor::{Cursor, CursorId};
 use part::PartOperationError;
 use part_stream::{PartStream, RequestRange, RequestTaskConfig};
 
@@ -67,24 +67,6 @@ pub struct HandleId(u64);
 
 impl HandleId {
     pub fn new(id: u64) -> Self {
-        Self(id)
-    }
-
-    pub fn as_raw(&self) -> u64 {
-        self.0
-    }
-}
-
-/// Opaque identifier for a single prefetch request (i.e., one `BackpressureController` lifetime).
-/// Generated fresh on each `RequestTask` creation so that late `on_reserve` callbacks from a
-/// cancelled CRT meta-request cannot incorrectly decrement a re-created entry for the same handle.
-/// A cursor consists of a RequestTask and a SeekWindow
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CursorId(u64);
-
-impl CursorId {
-    /// Reconstruct a `CursorId` from a raw `u64` (e.g., from CRT `custom_id`).
-    pub fn new_from_raw(id: u64) -> Self {
         Self(id)
     }
 
@@ -427,7 +409,9 @@ where
             None => return Err(PrefetchReadError::BackpressurePreconditionFailed),
         };
 
+        let cursor_id = self.mem_limiter.next_cursor_id();
         let config = RequestTaskConfig {
+            cursor_id,
             bucket: self.bucket.clone(),
             object_id: self.object_id.clone(),
             range,
@@ -439,6 +423,7 @@ where
         };
         let backpressure_task = self.part_stream.spawn_get_object_request(config);
         Ok(Cursor::new(
+            cursor_id,
             backpressure_task,
             &self.config,
             self.object_id.clone(),

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -106,7 +106,8 @@ pub struct BackpressureController {
     ///
     /// The request can return data up to this offset *exclusively*.
     request_end_offset: u64,
-    /// Memory limiter is used to guide decisions on how much data to prefetch.
+    /// Memory limiter is used to guide decisions on how much data to prefetch and to track
+    /// per-cursor memory reservations.
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
     mem_limiter: Arc<MemoryLimiter>,

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -9,6 +9,7 @@ use crate::mem_limiter::{BufferArea, MemoryLimiter};
 
 use super::CursorId;
 use super::PrefetchReadError;
+use super::part_stream::RequestTaskConfig;
 
 #[derive(Debug)]
 pub enum BackpressureFeedbackEvent {
@@ -51,6 +52,8 @@ impl ReadWindowAlignmentConfig {
 }
 
 pub struct BackpressureConfig {
+    /// Id of the associated Cursor
+    pub cursor_id: CursorId,
     /// Backpressure's initial read window size
     pub initial_read_window_size: usize,
     /// Minimum read window size that the backpressure controller is allowed to scale down to
@@ -63,6 +66,20 @@ pub struct BackpressureConfig {
     pub request_range: Range<u64>,
     /// Enable alignment of read window end to part boundary
     pub read_window_alignment_config: ReadWindowAlignmentConfig,
+}
+
+impl BackpressureConfig {
+    pub fn new(config: &RequestTaskConfig, read_window_alignment_config: ReadWindowAlignmentConfig) -> Self {
+        Self {
+            cursor_id: config.cursor_id,
+            initial_read_window_size: config.initial_read_window_size(),
+            min_read_window_size: config.read_part_size,
+            max_read_window_size: config.max_read_window_size,
+            read_window_size_multiplier: config.read_window_size_multiplier,
+            request_range: config.range.into(),
+            read_window_alignment_config,
+        }
+    }
 }
 
 /// A [BackpressureController] should be given to consumers of a byte stream.
@@ -128,9 +145,12 @@ pub fn new_backpressure_controller(
 ) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
-    let cursor_id = mem_limiter.next_cursor_id();
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    mem_limiter.reserve(cursor_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
+    mem_limiter.reserve(
+        config.cursor_id,
+        BufferArea::Prefetch,
+        config.initial_read_window_size as u64,
+    );
 
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
@@ -144,7 +164,7 @@ pub fn new_backpressure_controller(
         read_window_end_offset,
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
-        cursor_id,
+        cursor_id: config.cursor_id,
         mem_limiter,
         read_window_alignment_config: config.read_window_alignment_config,
     };
@@ -155,7 +175,7 @@ pub fn new_backpressure_controller(
         read_window_increment_queue,
         read_window_end_offset,
         request_end_offset: config.request_range.end,
-        cursor_id,
+        cursor_id: config.cursor_id,
     };
 
     (controller, limiter)
@@ -402,6 +422,7 @@ mod tests {
     fn test_read_window_scale_up(initial_read_window_size: usize, read_window_size_multiplier: usize) {
         let request_range = 0..(5 * 1024 * 1024 * 1024);
         let backpressure_config = BackpressureConfig {
+            cursor_id: CursorId::new_from_raw(0),
             initial_read_window_size,
             min_read_window_size: 8 * 1024 * 1024,
             max_read_window_size: 2 * 1024 * 1024 * 1024,
@@ -430,6 +451,7 @@ mod tests {
     fn test_read_window_scale_down(initial_read_window_size: usize, read_window_size_multiplier: usize) {
         let request_range = 0..(5 * 1024 * 1024 * 1024);
         let backpressure_config = BackpressureConfig {
+            cursor_id: CursorId::new_from_raw(0),
             initial_read_window_size,
             min_read_window_size: 8 * 1024 * 1024,
             max_read_window_size: 2 * 1024 * 1024 * 1024,
@@ -460,6 +482,7 @@ mod tests {
         // OK, back to basics. Just reproduce what happened, verify it passes after the fix.
         #[allow(clippy::identity_op)]
         let backpressure_config = BackpressureConfig {
+            cursor_id: CursorId::new_from_raw(0),
             initial_read_window_size: 1 * MIB,
             min_read_window_size: 8 * MIB,
             max_read_window_size: 2 * GIB,

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -52,14 +52,10 @@ where
     fn spawn_get_object_request(&self, config: RequestTaskConfig) -> RequestTask<Client> {
         let range = config.range;
 
-        let backpressure_config = BackpressureConfig {
-            initial_read_window_size: config.initial_read_window_size(),
-            min_read_window_size: config.read_part_size,
-            max_read_window_size: config.max_read_window_size,
-            read_window_size_multiplier: config.read_window_size_multiplier,
-            request_range: range.into(),
-            read_window_alignment_config: ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
-        };
+        let backpressure_config = BackpressureConfig::new(
+            &config,
+            ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
+        );
         let (backpressure_controller, backpressure_limiter) =
             new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
@@ -427,6 +423,7 @@ mod tests {
         mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter},
         memory::PagedPool,
         object::ObjectId,
+        prefetch::CursorId,
     };
 
     use super::*;
@@ -483,6 +480,7 @@ mod tests {
             // First request (from client)
             let get_object_counter = mock_client.new_counter(Operation::GetObject);
             let config = RequestTaskConfig {
+                cursor_id: CursorId::new_from_raw(0),
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
                 range,
@@ -509,6 +507,7 @@ mod tests {
             // Second request (from cache)
             let get_object_counter = mock_client.new_counter(Operation::GetObject);
             let config = RequestTaskConfig {
+                cursor_id: CursorId::new_from_raw(0),
                 bucket: bucket.to_owned(),
                 object_id: id.clone(),
                 range,
@@ -562,6 +561,7 @@ mod tests {
         for offset in [0, 512 * KB, 1 * MB, 4 * MB, 9 * MB] {
             for preferred_size in [1 * KB, 512 * KB, 4 * MB, 12 * MB, 16 * MB] {
                 let config = RequestTaskConfig {
+                    cursor_id: CursorId::new_from_raw(0),
                     bucket: bucket.to_owned(),
                     object_id: id.clone(),
                     range: RequestRange::new(object_size, offset as u64, preferred_size),

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -29,6 +29,7 @@ where
     sequential_read_start_offset: u64,
     next_sequential_read_offset: u64,
     object_id: ObjectId,
+    cursor_id: CursorId,
 }
 
 impl<Client> Cursor<Client>
@@ -36,12 +37,14 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     pub fn new(
+        cursor_id: CursorId,
         backpressure_task: RequestTask<Client>,
         config: &PrefetcherConfig,
         object_id: ObjectId,
         offset: u64,
     ) -> Self {
         Self {
+            cursor_id,
             backpressure_task,
             backward_seek_window: SeekWindow::new(config.max_backward_seek_distance as usize),
             max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
@@ -64,6 +67,7 @@ where
         if remaining == 0 {
             return Ok((ChecksummedBytes::default(), false));
         }
+
         let mut to_read = (length as u64).min(remaining);
         let mut all_parts_from_cache = true;
         let mut response = ChecksummedBytes::default();
@@ -169,5 +173,20 @@ where
     fn drop(&mut self) {
         histogram!("prefetch.contiguous_read_len")
             .record((self.next_sequential_read_offset - self.sequential_read_start_offset) as f64);
+    }
+}
+
+/// Opaque identifier for a cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CursorId(u64);
+
+impl CursorId {
+    /// Reconstruct a `CursorId` from a raw `u64` (e.g., from CRT `custom_id`).
+    pub fn new_from_raw(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn as_raw(&self) -> u64 {
+        self.0
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -99,10 +99,16 @@ where
 
         if !self.try_seek(offset).await? {
             // Seek failed
+            trace!(
+                expected = self.current_offset,
+                actual = offset,
+                "out-of-order read, resetting prefetch"
+            );
+            counter!(PREFETCH_RESET_STATE).increment(1);
             return Ok(None);
         }
 
-        Ok(Some(self.read(length).await?))
+        Ok(Some(self.do_read(length).await?))
     }
 
     async fn do_read(
@@ -149,22 +155,10 @@ where
         }
 
         trace!(from = self.current_offset, to = offset, "trying to seek");
-        let result = if offset > self.current_offset {
+        if offset > self.current_offset {
             self.try_seek_forward(offset).await
         } else {
             self.try_seek_backward(offset).await
-        };
-
-        if result? {
-            Ok(true)
-        } else {
-            trace!(
-                expected = self.current_offset,
-                actual = offset,
-                "out-of-order read, resetting prefetch"
-            );
-            counter!(PREFETCH_RESET_STATE).increment(1);
-            Ok(false)
         }
     }
 

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -3,8 +3,10 @@ use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
 use crate::checksums::ChecksummedBytes;
+use crate::mem_limiter::MemoryLimiter;
 use crate::metrics::defs::PREFETCH_RESET_STATE;
 use crate::object::ObjectId;
+use crate::sync::Arc;
 
 use super::seek_window::SeekWindow;
 use super::task::RequestTask;
@@ -30,6 +32,7 @@ where
     next_sequential_read_offset: u64,
     object_id: ObjectId,
     cursor_id: CursorId,
+    mem_limiter: Arc<MemoryLimiter>,
 }
 
 impl<Client> Cursor<Client>
@@ -42,6 +45,7 @@ where
         config: &PrefetcherConfig,
         object_id: ObjectId,
         offset: u64,
+        mem_limiter: Arc<MemoryLimiter>,
     ) -> Self {
         Self {
             cursor_id,
@@ -51,6 +55,7 @@ where
             sequential_read_start_offset: offset,
             next_sequential_read_offset: offset,
             object_id,
+            mem_limiter,
         }
     }
 
@@ -59,6 +64,38 @@ where
     }
 
     pub async fn read(
+        &mut self,
+        length: usize,
+    ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
+        let _active_read_guard =
+            self.mem_limiter
+                .set_active_read(self.cursor_id, self.next_sequential_read_offset, length);
+
+        self.do_read(length).await
+    }
+
+    pub async fn try_read(
+        &mut self,
+        offset: u64,
+        length: usize,
+    ) -> Result<Option<(ChecksummedBytes, bool)>, PrefetchReadError<Client::ClientError>> {
+        // Set the active read range before any blocking. For forward seeks, widen to include
+        // the skipped bytes the prefetcher must consume to reach the requested offset.
+        let active_start = self.next_sequential_read_offset.min(offset);
+        let active_size = length + offset.saturating_sub(active_start) as usize;
+        let _active_read_guard = self
+            .mem_limiter
+            .set_active_read(self.cursor_id, active_start, active_size);
+
+        if !self.try_seek(offset).await? {
+            // Seek failed
+            return Ok(None);
+        }
+
+        Ok(Some(self.read(length).await?))
+    }
+
+    async fn do_read(
         &mut self,
         length: usize,
     ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
@@ -96,7 +133,7 @@ where
     }
 
     /// Try to seek within the current inflight requests without restarting them.
-    pub async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+    async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
         if offset == self.next_sequential_read_offset {
             return Ok(true);
         }

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -1,0 +1,173 @@
+use metrics::{counter, histogram};
+use mountpoint_s3_client::ObjectClient;
+use tracing::trace;
+
+use crate::checksums::ChecksummedBytes;
+use crate::metrics::defs::PREFETCH_RESET_STATE;
+use crate::object::ObjectId;
+
+use super::seek_window::SeekWindow;
+use super::task::RequestTask;
+use super::{PrefetchReadError, PrefetcherConfig};
+
+/// A read cursor for a single sequential prefetch sequence. Manages the active request task,
+/// backward seek window, read position, and all read/seek logic. Dropping a cursor records the
+/// contiguous read metric and releases the in-flight request.
+#[derive(Debug)]
+pub struct Cursor<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    backpressure_task: RequestTask<Client>,
+    // Invariant: the offset of the last byte in this window is always
+    // self.next_sequential_read_offset - 1.
+    backward_seek_window: SeekWindow,
+    /// The maximum amount of unavailable data the prefetcher will tolerate during a seek operation
+    /// before resetting and starting a new S3 request.
+    max_forward_seek_wait_distance: u64,
+    /// Start offset for sequential read, used for calculating contiguous read metric
+    sequential_read_start_offset: u64,
+    next_sequential_read_offset: u64,
+    object_id: ObjectId,
+}
+
+impl<Client> Cursor<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    pub fn new(
+        backpressure_task: RequestTask<Client>,
+        config: &PrefetcherConfig,
+        object_id: ObjectId,
+        offset: u64,
+    ) -> Self {
+        Self {
+            backpressure_task,
+            backward_seek_window: SeekWindow::new(config.max_backward_seek_distance as usize),
+            max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
+            sequential_read_start_offset: offset,
+            next_sequential_read_offset: offset,
+            object_id,
+        }
+    }
+
+    pub fn current_offset(&self) -> u64 {
+        self.next_sequential_read_offset
+    }
+
+    pub async fn read(
+        &mut self,
+        length: usize,
+    ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
+        let offset = self.next_sequential_read_offset;
+        let remaining = self.backpressure_task.end_offset().saturating_sub(offset);
+        if remaining == 0 {
+            return Ok((ChecksummedBytes::default(), false));
+        }
+        let mut to_read = (length as u64).min(remaining);
+        let mut all_parts_from_cache = true;
+        let mut response = ChecksummedBytes::default();
+        while to_read > 0 {
+            debug_assert!(self.backpressure_task.remaining() > 0);
+
+            let part = self.backpressure_task.read(to_read as usize).await?;
+            all_parts_from_cache &= part.is_from_cache();
+            self.backward_seek_window.push(part.clone());
+            let part_bytes = part.into_bytes(&self.object_id, self.next_sequential_read_offset)?;
+
+            self.next_sequential_read_offset += part_bytes.len() as u64;
+            // If we can complete the read with just a single buffer, early return to avoid copying
+            // into a new buffer. This should be the common case as long as part size is larger than
+            // read size, which it almost always is for real S3 clients and FUSE.
+            if response.is_empty() && part_bytes.len() == to_read as usize {
+                return Ok((part_bytes, all_parts_from_cache));
+            }
+
+            let part_len = part_bytes.len() as u64;
+            response.extend(part_bytes)?;
+            to_read -= part_len;
+        }
+
+        Ok((response, all_parts_from_cache))
+    }
+
+    /// Try to seek within the current inflight requests without restarting them.
+    pub async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+        if offset == self.next_sequential_read_offset {
+            return Ok(true);
+        }
+
+        trace!(from = self.next_sequential_read_offset, to = offset, "trying to seek");
+        let result = if offset > self.next_sequential_read_offset {
+            self.try_seek_forward(offset).await
+        } else {
+            self.try_seek_backward(offset).await
+        };
+
+        if result? {
+            Ok(true)
+        } else {
+            trace!(
+                expected = self.next_sequential_read_offset,
+                actual = offset,
+                "out-of-order read, resetting prefetch"
+            );
+            counter!(PREFETCH_RESET_STATE).increment(1);
+            Ok(false)
+        }
+    }
+
+    async fn try_seek_forward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+        assert!(offset > self.next_sequential_read_offset);
+        let total_seek_distance = offset - self.next_sequential_read_offset;
+        histogram!("prefetch.seek_distance", "dir" => "forward").record(total_seek_distance as f64);
+
+        if offset >= self.backpressure_task.read_window_end_offset() {
+            return Ok(false);
+        }
+
+        let available_offset = self.backpressure_task.available_offset();
+        let available_soon_offset = available_offset.saturating_add(self.max_forward_seek_wait_distance);
+        if offset >= available_soon_offset {
+            trace!(
+                requested_offset = offset,
+                available_offset = available_offset,
+                "seek failed: not enough data available"
+            );
+            return Ok(false);
+        }
+        let mut seek_distance = offset - self.next_sequential_read_offset;
+        while seek_distance > 0 {
+            let part = self.backpressure_task.read(seek_distance as usize).await?;
+            seek_distance -= part.len() as u64;
+            self.next_sequential_read_offset += part.len() as u64;
+            self.backward_seek_window.push(part);
+        }
+        Ok(true)
+    }
+
+    async fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+        assert!(offset < self.next_sequential_read_offset);
+
+        let backwards_length_needed = self.next_sequential_read_offset - offset;
+        histogram!("prefetch.seek_distance", "dir" => "backward").record(backwards_length_needed as f64);
+
+        let Some(parts) = self.backward_seek_window.read_back(backwards_length_needed as usize) else {
+            trace!("seek failed: not enough data in backwards seek window");
+            return Ok(false);
+        };
+        self.backpressure_task.push_front(parts).await?;
+        self.next_sequential_read_offset = offset;
+        Ok(true)
+    }
+}
+
+impl<Client> Drop for Cursor<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        histogram!("prefetch.contiguous_read_len")
+            .record((self.next_sequential_read_offset - self.sequential_read_start_offset) as f64);
+    }
+}

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -20,60 +20,70 @@ pub struct Cursor<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
-    backpressure_task: RequestTask<Client>,
-    // Invariant: the offset of the last byte in this window is always
-    // self.next_sequential_read_offset - 1.
+    /// Unique id for this cursor
+    cursor_id: CursorId,
+    /// Id of the object to download
+    object_id: ObjectId,
+    /// Start offset for sequential read, used for calculating contiguous read metric
+    start_offset: u64,
+    /// Associated memory limiter
+    mem_limiter: Arc<MemoryLimiter>,
+    /// Background task to request data
+    request_task: RequestTask<Client>,
+    /// Holds data for backward seeks
+    ///
+    /// **Invariant**: the offset of the last byte in this window is always `self.current_offset - 1`.
     backward_seek_window: SeekWindow,
     /// The maximum amount of unavailable data the prefetcher will tolerate during a seek operation
     /// before resetting and starting a new S3 request.
     max_forward_seek_wait_distance: u64,
-    /// Start offset for sequential read, used for calculating contiguous read metric
-    sequential_read_start_offset: u64,
-    next_sequential_read_offset: u64,
-    object_id: ObjectId,
-    cursor_id: CursorId,
-    mem_limiter: Arc<MemoryLimiter>,
+    /// Current offset of this cursor
+    current_offset: u64,
 }
 
 impl<Client> Cursor<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
+    /// Create a new cursor at the given offset.
     pub fn new(
         cursor_id: CursorId,
-        backpressure_task: RequestTask<Client>,
+        request_task: RequestTask<Client>,
+        mem_limiter: Arc<MemoryLimiter>,
         config: &PrefetcherConfig,
         object_id: ObjectId,
         offset: u64,
-        mem_limiter: Arc<MemoryLimiter>,
     ) -> Self {
         Self {
             cursor_id,
-            backpressure_task,
+            object_id,
+            start_offset: offset,
+            mem_limiter,
+            request_task,
             backward_seek_window: SeekWindow::new(config.max_backward_seek_distance as usize),
             max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
-            sequential_read_start_offset: offset,
-            next_sequential_read_offset: offset,
-            object_id,
-            mem_limiter,
+            current_offset: offset,
         }
     }
 
+    /// The current offset for this cursor.
     pub fn current_offset(&self) -> u64 {
-        self.next_sequential_read_offset
+        self.current_offset
     }
 
+    /// Read at the current offset.
     pub async fn read(
         &mut self,
         length: usize,
     ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
-        let _active_read_guard =
-            self.mem_limiter
-                .set_active_read(self.cursor_id, self.next_sequential_read_offset, length);
+        let _active_read_guard = self
+            .mem_limiter
+            .set_active_read(self.cursor_id, self.current_offset, length);
 
         self.do_read(length).await
     }
 
+    /// Try reading at the given offset. Returns `None` if unable to seek to the offset.
     pub async fn try_read(
         &mut self,
         offset: u64,
@@ -81,7 +91,7 @@ where
     ) -> Result<Option<(ChecksummedBytes, bool)>, PrefetchReadError<Client::ClientError>> {
         // Set the active read range before any blocking. For forward seeks, widen to include
         // the skipped bytes the prefetcher must consume to reach the requested offset.
-        let active_start = self.next_sequential_read_offset.min(offset);
+        let active_start = self.current_offset.min(offset);
         let active_size = length + offset.saturating_sub(active_start) as usize;
         let _active_read_guard = self
             .mem_limiter
@@ -99,8 +109,8 @@ where
         &mut self,
         length: usize,
     ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
-        let offset = self.next_sequential_read_offset;
-        let remaining = self.backpressure_task.end_offset().saturating_sub(offset);
+        let offset = self.current_offset;
+        let remaining = self.request_task.end_offset().saturating_sub(offset);
         if remaining == 0 {
             return Ok((ChecksummedBytes::default(), false));
         }
@@ -109,14 +119,14 @@ where
         let mut all_parts_from_cache = true;
         let mut response = ChecksummedBytes::default();
         while to_read > 0 {
-            debug_assert!(self.backpressure_task.remaining() > 0);
+            debug_assert!(self.request_task.remaining() > 0);
 
-            let part = self.backpressure_task.read(to_read as usize).await?;
+            let part = self.request_task.read(to_read as usize).await?;
             all_parts_from_cache &= part.is_from_cache();
             self.backward_seek_window.push(part.clone());
-            let part_bytes = part.into_bytes(&self.object_id, self.next_sequential_read_offset)?;
+            let part_bytes = part.into_bytes(&self.object_id, self.current_offset)?;
 
-            self.next_sequential_read_offset += part_bytes.len() as u64;
+            self.current_offset += part_bytes.len() as u64;
             // If we can complete the read with just a single buffer, early return to avoid copying
             // into a new buffer. This should be the common case as long as part size is larger than
             // read size, which it almost always is for real S3 clients and FUSE.
@@ -134,12 +144,12 @@ where
 
     /// Try to seek within the current inflight requests without restarting them.
     async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        if offset == self.next_sequential_read_offset {
+        if offset == self.current_offset {
             return Ok(true);
         }
 
-        trace!(from = self.next_sequential_read_offset, to = offset, "trying to seek");
-        let result = if offset > self.next_sequential_read_offset {
+        trace!(from = self.current_offset, to = offset, "trying to seek");
+        let result = if offset > self.current_offset {
             self.try_seek_forward(offset).await
         } else {
             self.try_seek_backward(offset).await
@@ -149,7 +159,7 @@ where
             Ok(true)
         } else {
             trace!(
-                expected = self.next_sequential_read_offset,
+                expected = self.current_offset,
                 actual = offset,
                 "out-of-order read, resetting prefetch"
             );
@@ -159,15 +169,15 @@ where
     }
 
     async fn try_seek_forward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        assert!(offset > self.next_sequential_read_offset);
-        let total_seek_distance = offset - self.next_sequential_read_offset;
+        assert!(offset > self.current_offset);
+        let total_seek_distance = offset - self.current_offset;
         histogram!("prefetch.seek_distance", "dir" => "forward").record(total_seek_distance as f64);
 
-        if offset >= self.backpressure_task.read_window_end_offset() {
+        if offset >= self.request_task.read_window_end_offset() {
             return Ok(false);
         }
 
-        let available_offset = self.backpressure_task.available_offset();
+        let available_offset = self.request_task.available_offset();
         let available_soon_offset = available_offset.saturating_add(self.max_forward_seek_wait_distance);
         if offset >= available_soon_offset {
             trace!(
@@ -177,28 +187,28 @@ where
             );
             return Ok(false);
         }
-        let mut seek_distance = offset - self.next_sequential_read_offset;
+        let mut seek_distance = offset - self.current_offset;
         while seek_distance > 0 {
-            let part = self.backpressure_task.read(seek_distance as usize).await?;
+            let part = self.request_task.read(seek_distance as usize).await?;
             seek_distance -= part.len() as u64;
-            self.next_sequential_read_offset += part.len() as u64;
+            self.current_offset += part.len() as u64;
             self.backward_seek_window.push(part);
         }
         Ok(true)
     }
 
     async fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
-        assert!(offset < self.next_sequential_read_offset);
+        assert!(offset < self.current_offset);
 
-        let backwards_length_needed = self.next_sequential_read_offset - offset;
+        let backwards_length_needed = self.current_offset - offset;
         histogram!("prefetch.seek_distance", "dir" => "backward").record(backwards_length_needed as f64);
 
         let Some(parts) = self.backward_seek_window.read_back(backwards_length_needed as usize) else {
             trace!("seek failed: not enough data in backwards seek window");
             return Ok(false);
         };
-        self.backpressure_task.push_front(parts).await?;
-        self.next_sequential_read_offset = offset;
+        self.request_task.push_front(parts).await?;
+        self.current_offset = offset;
         Ok(true)
     }
 }
@@ -208,8 +218,7 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        histogram!("prefetch.contiguous_read_len")
-            .record((self.next_sequential_read_offset - self.sequential_read_start_offset) as f64);
+        histogram!("prefetch.contiguous_read_len").record((self.current_offset - self.start_offset) as f64);
     }
 }
 

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -35,6 +35,7 @@ pub trait ObjectPartStream<Client: ObjectClient + Clone + Send + Sync + 'static>
 #[derive(Clone, Debug)]
 /// The configs for spawning a task in [ObjectPartStream::spawn_get_object_request].
 pub struct RequestTaskConfig {
+    pub cursor_id: CursorId,
     pub bucket: String,
     pub object_id: ObjectId,
     pub range: RequestRange,
@@ -234,19 +235,13 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
 
         let range = config.range;
 
-        let backpressure_config = BackpressureConfig {
-            initial_read_window_size: config.initial_read_window_size(),
-            // We don't want to completely block the stream so let's use
-            // the read part size as minimum read window.
-            min_read_window_size: config.read_part_size,
-            max_read_window_size: config.max_read_window_size,
-            read_window_size_multiplier: config.read_window_size_multiplier,
-            request_range: range.into(),
-            read_window_alignment_config: ReadWindowAlignmentConfig::AlignToPartSize {
+        let backpressure_config = BackpressureConfig::new(
+            &config,
+            ReadWindowAlignmentConfig::AlignToPartSize {
                 from_offset: range.start() + config.initial_request_size as u64,
                 part_size: config.read_part_size as u64,
             },
-        };
+        );
         let (backpressure_controller, mut backpressure_limiter) =
             new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();

--- a/mountpoint-s3/tests/metrics/otel_export.sh
+++ b/mountpoint-s3/tests/metrics/otel_export.sh
@@ -94,7 +94,7 @@ trigger_metrics() {
   dd if=/dev/urandom of="${test_file}" bs=128k count=500 2>/dev/null
   sync
   {
-    for skip in {1..8} {490..500}; do
+    for skip in 0 10 100 500; do
       dd bs=128k skip=$skip count=1 iflag=direct 2>/dev/null || true
     done
   } < "${test_file}" > /dev/null


### PR DESCRIPTION
Extract a `Cursor` abstraction from `PrefetchGetObject` to encapsulate read position, backward seek window, and request task management. Each cursor is assigned a unique `CursorId` (generated by `MemoryLimiter`) which replaces `HandleId` for memory reservation tracking and active read detection, giving the buffer pruning logic accurate per-request visibility into which ranges are actively being waited on.

Rustdoc comments updated to reflect the new cursor-based model.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
