### PR TITLE
Refactor MemoryLimiter into PagedPool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -431,7 +431,7 @@ jobs:
     - name: Run cgroup-aware memory detection test
       env:
         TEST_CGROUP_MEM_LIMIT_MB: "2048"
-      run: cargo test -p mountpoint-s3-fs --lib mem_limiter::tests::test_effective_total_memory_respects_cgroup
+      run: cargo test -p mountpoint-s3-fs --lib memory::limiter::tests::test_effective_total_memory_respects_cgroup
 
   workflow-complete:
     name: "Tests Workflow Complete"

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -222,7 +222,7 @@ struct CliArgs {
 }
 
 fn create_s3_client_config(region: &str, args: &CliArgs, nics: Vec<String>) -> S3ClientConfig {
-    let pool = PagedPool::new_with_candidate_sizes([args.part_size]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([args.part_size]);
     let mut config = S3ClientConfig::new()
         .endpoint_config(EndpointConfig::new(region))
         .throughput_target_gbps(args.throughput_target_gbps)

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -80,7 +80,7 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
 
     #[cfg(feature = "fs_pool_tests")]
     let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
-        mountpoint_s3_fs::memory::PagedPool::new_with_candidate_sizes([options.part_size()])
+        mountpoint_s3_fs::memory::PagedPool::new_with_candidate_sizes_unlimited([options.part_size()])
     });
 
     config

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -39,7 +39,7 @@ fn cache_read_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Pat
         block_size: BLOCK_SIZE,
         limit: mountpoint_s3_fs::data_cache::CacheLimit::Unbounded,
     };
-    let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE as usize]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE as usize]);
     let cache = DiskDataCache::new(config, pool);
     let cache_key = ObjectId::new("a".into(), ETag::for_tests());
     let bytes = ChecksummedBytes::new(data.to_owned().into());

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -143,7 +143,7 @@ fn mount_file_system(
     throughput_target_gbps: Option<f64>,
 ) -> FuseSession {
     let part_size = 8 * 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([part_size]);
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
     config = config
         .read_backpressure(true)

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -143,7 +143,7 @@ fn mount_file_system(
     throughput_target_gbps: Option<f64>,
 ) -> FuseSession {
     let part_size = 8 * 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
     config = config
         .read_backpressure(true)

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -310,7 +310,7 @@ fn mount_filesystem(
 
     // Create the client and runtime
     let client_config = config.build_client_config()?;
-    let pool = PagedPool::new_with_candidate_sizes([client_config.part_config.read_size_bytes]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([client_config.part_config.read_size_bytes]);
     let client = client_config
         .create_client(pool.clone(), None)
         .context("Failed to create S3 client")?;

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -123,9 +123,6 @@ impl ConfigOptions {
         if let Some(gid) = self.gid {
             fs_config.uid = gid;
         }
-        if let Some(memory_limit_bytes) = self.memory_limit_bytes {
-            fs_config.mem_limit = memory_limit_bytes;
-        }
         // For this binary we expect sequential read pattern. Thus, opt-out from the 1MB-initial request,
         // trading-off latency for throughput and more accurate memory limiting.
         fs_config.prefetcher_config.initial_request_size = 0;
@@ -310,7 +307,10 @@ fn mount_filesystem(
 
     // Create the client and runtime
     let client_config = config.build_client_config()?;
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([client_config.part_config.read_size_bytes]);
+    let mem_limit = config
+        .memory_limit_bytes
+        .unwrap_or(mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+    let pool = PagedPool::new_with_candidate_sizes([client_config.part_config.read_size_bytes], mem_limit);
     let client = client_config
         .create_client(pool.clone(), None)
         .context("Failed to create S3 client")?;

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -12,8 +12,8 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::Runtime;
-use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::effective_total_memory;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{HandleId, PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use serde_json::{json, to_writer};
@@ -167,10 +167,12 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     let bucket = args.bucket.as_str();
-    let pool = PagedPool::new_with_candidate_sizes([args.part_size.unwrap_or(8 * 1024 * 1024) as usize]);
+    let pool = PagedPool::new_with_candidate_sizes(
+        [args.part_size.unwrap_or(8 * 1024 * 1024) as usize],
+        args.memory_target_in_bytes(),
+    );
     let client_config = args.s3_client_config().memory_pool(pool.clone());
     let client = S3CrtClient::new(client_config).context("failed to create S3 CRT client")?;
-    let mem_limiter = Arc::new(MemoryLimiter::new(pool, args.memory_target_in_bytes()));
     let runtime = Runtime::new(client.event_loop_group());
 
     // Verify if all objects exist and collect metadata
@@ -195,7 +197,7 @@ fn main() -> anyhow::Result<()> {
         let start = Instant::now();
         let manager = Prefetcher::default_builder(client.clone()).build(
             runtime.clone(),
-            mem_limiter.clone(),
+            pool.clone(),
             PrefetcherConfig::default(),
         );
 

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -1,14 +1,13 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::effective_total_memory;
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{HandleId, Prefetcher, PrefetcherConfig};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
@@ -67,7 +66,8 @@ impl Executor {
             ChecksumAlgorithm::Off => None,
         };
 
-        let pool = PagedPool::new_with_candidate_sizes([read_part_size, write_part_size]);
+        let memory_target_bytes = (max_memory_target * 1024 * 1024) as u64;
+        let pool = PagedPool::new_with_candidate_sizes([read_part_size, write_part_size], memory_target_bytes);
 
         let mut endpoint_config = EndpointConfig::new(region);
         if let Some(url) = &global.endpoint_url {
@@ -94,9 +94,6 @@ impl Executor {
         let client = S3CrtClient::new(client_config)
             .map_err(|e| ExecutionError::ResourceInitError(format!("Failed to create S3 client: {}", e)))?;
 
-        let memory_target_bytes = (max_memory_target * 1024 * 1024) as u64;
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), memory_target_bytes));
-
         let runtime = Runtime::new(client.event_loop_group());
 
         let server_side_encryption = ServerSideEncryption::new(sse_type, global.sse_kms_key_id.clone());
@@ -105,14 +102,12 @@ impl Executor {
             client.clone(),
             runtime.clone(),
             pool.clone(),
-            mem_limiter.clone(),
             UploaderConfig::new(write_part_size)
                 .server_side_encryption(server_side_encryption)
                 .default_checksum_algorithm(checksum_algorithm),
         );
 
-        let prefetcher =
-            Prefetcher::default_builder(client.clone()).build(runtime, mem_limiter, PrefetcherConfig::default());
+        let prefetcher = Prefetcher::default_builder(client.clone()).build(runtime, pool, PrefetcherConfig::default());
 
         Ok(Self {
             client,

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -1,3 +1,7 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
@@ -9,9 +13,6 @@ use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use rand::{RngExt, SeedableRng};
 use rand_pcg::Pcg64;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::time::Instant;
 use thiserror::Error;
 
 use crate::config::{AccessPattern, ChecksumAlgorithm, GlobalConfig, ResolvedJobConfig, SseType, WorkloadType};

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, RustLogAdapter, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::ChecksumAlgorithm;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::mem_limiter::{MemoryLimiter, effective_total_memory};
 use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::effective_total_memory;
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use tracing_subscriber::EnvFilter;
@@ -96,7 +96,13 @@ fn main() {
         let endpoint_uri = Uri::new_from_str(&Allocator::default(), url).expect("Failed to parse endpoint URL");
         endpoint_config = endpoint_config.endpoint(endpoint_uri);
     }
-    let pool = PagedPool::new_with_candidate_sizes([args.write_part_size]);
+    let max_memory_target = if let Some(target) = args.max_memory_target {
+        target * 1024 * 1024
+    } else {
+        // Default to 95% of total system memory (cgroup-aware)
+        (effective_total_memory() as f64 * 0.95) as u64
+    };
+    let pool = PagedPool::new_with_candidate_sizes([args.write_part_size], max_memory_target);
     let config = S3ClientConfig::new()
         .endpoint_config(endpoint_config)
         .throughput_target_gbps(args.throughput_target_gbps as f64)
@@ -107,14 +113,6 @@ fn main() {
     let runtime = Runtime::new(client.event_loop_group());
 
     for i in 0..args.iterations {
-        let max_memory_target = if let Some(target) = args.max_memory_target {
-            target * 1024 * 1024
-        } else {
-            // Default to 95% of total system memory (cgroup-aware)
-            (effective_total_memory() as f64 * 0.95) as u64
-        };
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), max_memory_target));
-
         let buffer_size = args.write_part_size;
         let server_side_encryption = ServerSideEncryption::new(args.sse.clone(), args.sse_kms_key_id.clone());
 
@@ -130,7 +128,6 @@ fn main() {
             client.clone(),
             runtime.clone(),
             pool.clone(),
-            mem_limiter,
             UploaderConfig::new(buffer_size)
                 .server_side_encryption(server_side_encryption)
                 .default_checksum_algorithm(checksum_algorithm),

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn get_path_for_block_key() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new_with_candidate_sizes([1024]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([1024]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn get_path_for_block_key_huge_block_index() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new_with_candidate_sizes([1024]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([1024]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -761,7 +761,7 @@ mod tests {
         let object_2_size = data_2.len();
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes([pool_buffer_size]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([pool_buffer_size]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -848,7 +848,7 @@ mod tests {
         let slice = data.slice(1..5);
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes([8 * 1024 * 1024]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([8 * 1024 * 1024]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -930,7 +930,7 @@ mod tests {
         let small_object_key = ObjectId::new("small".into(), ETag::for_tests());
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -1113,7 +1113,7 @@ mod tests {
         // "Corrupt" the serialized value with an invalid length.
         replace_u64_at(&mut buf, offset, u64::MAX);
 
-        let pool = PagedPool::new_with_candidate_sizes([MAX_LENGTH as usize]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([MAX_LENGTH as usize]);
         let err =
             DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None).expect_err("deserialization should fail");
         match length_to_corrupt {
@@ -1130,7 +1130,7 @@ mod tests {
     fn test_concurrent_access() {
         let block_size = 1024 * 1024;
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes([block_size]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([block_size]);
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -131,7 +131,7 @@ mod tests {
 
     fn create_disk_cache() -> (TempDir, Arc<DiskDataCache>) {
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes([BLOCK_SIZE as usize, PART_SIZE]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE as usize, PART_SIZE]);
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -15,7 +15,6 @@ use tracing::{Level, debug, trace};
 
 use crate::async_util::Runtime;
 use crate::logging;
-use crate::mem_limiter::MemoryLimiter;
 use crate::memory::PagedPool;
 use crate::metablock::{AddDirEntry, AddDirEntryResult, InodeInformation, Metablock, PendingUploadHook, ReadWriteMode};
 pub use crate::metablock::{InodeError, InodeKind, InodeNo};
@@ -150,13 +149,12 @@ where
     ) -> Self {
         trace!(?config, "new filesystem");
 
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), config.mem_limit));
-        let prefetcher = prefetch_builder.build(runtime.clone(), mem_limiter.clone(), config.prefetcher_config);
+        let pool = pool.clone();
+        let prefetcher = prefetch_builder.build(runtime.clone(), pool.clone(), config.prefetcher_config);
         let uploader = Uploader::new(
             client.clone(),
             runtime,
             pool,
-            mem_limiter,
             UploaderConfig::new(client.write_part_size())
                 .storage_class(config.storage_class.to_owned())
                 .server_side_encryption(config.server_side_encryption.clone())
@@ -787,6 +785,7 @@ where
 mod tests {
     use super::*;
 
+    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::prefetch::Prefetcher;
     use crate::s3::{Bucket, S3Path};
     use crate::{Superblock, SuperblockConfig};
@@ -810,7 +809,7 @@ mod tests {
         client.add_object("dir1/file1.bin", MockObject::constant(0xa1, 15, ETag::for_tests()));
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let pool = PagedPool::new_with_candidate_sizes([32]);
+        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let server_side_encryption =
             ServerSideEncryption::new(Some("aws:kms".to_owned()), Some("some_key_alias".to_owned()));
@@ -1074,7 +1073,7 @@ mod tests {
         );
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(10).create().unwrap());
-        let pool = PagedPool::new_with_candidate_sizes([32]);
+        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let fs_config = S3FilesystemConfig {
             allow_overwrite,

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use nix::unistd::{getgid, getuid};
 
 use crate::content_type::ContentTypeDetection;
-use crate::mem_limiter::MINIMUM_MEM_LIMIT;
+use crate::memory::MINIMUM_MEM_LIMIT;
 use crate::metablock::WriteMode;
 use crate::prefetch::PrefetcherConfig;
 use crate::s3::S3Personality;

--- a/mountpoint-s3-fs/src/fs/config.rs
+++ b/mountpoint-s3-fs/src/fs/config.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use nix::unistd::{getgid, getuid};
 
 use crate::content_type::ContentTypeDetection;
-use crate::memory::MINIMUM_MEM_LIMIT;
 use crate::metablock::WriteMode;
 use crate::prefetch::PrefetcherConfig;
 use crate::s3::S3Personality;
@@ -40,8 +39,6 @@ pub struct S3FilesystemConfig {
     pub server_side_encryption: ServerSideEncryption,
     /// Use additional checksums for uploads
     pub use_upload_checksums: bool,
-    /// Memory limit
-    pub mem_limit: u64,
     /// Prefetcher configuration
     pub prefetcher_config: PrefetcherConfig,
     /// Content type inference mode for uploaded objects
@@ -73,7 +70,6 @@ impl Default for S3FilesystemConfig {
             server_side_encryption: Default::default(),
             use_upload_checksums: true,
             content_type_detection: ContentTypeDetection::Disabled,
-            mem_limit: MINIMUM_MEM_LIMIT,
             prefetcher_config: Default::default(),
             max_background_fuse_requests: None,
         }

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -11,7 +11,6 @@ pub mod fuse;
 pub mod logging;
 #[cfg(feature = "manifest")]
 pub mod manifest;
-pub mod mem_limiter;
 pub mod memory;
 pub mod metablock;
 pub mod metrics;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,8 +1,10 @@
 mod buffers;
+pub(crate) mod limiter;
 mod pages;
 mod pool;
-mod stats;
+pub(crate) mod stats;
 
 pub use buffers::{PoolBuffer, PoolBufferMut};
+pub use limiter::{ActiveRead, ActiveReadGuard, BufferArea, MINIMUM_MEM_LIMIT, effective_total_memory};
 pub use pool::PagedPool;
 pub use stats::BufferKind;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,8 +1,8 @@
 mod buffers;
-pub(crate) mod limiter;
+mod limiter;
 mod pages;
 mod pool;
-pub(crate) mod stats;
+mod stats;
 
 pub use buffers::{PoolBuffer, PoolBufferMut};
 pub use limiter::{ActiveRead, ActiveReadGuard, BufferArea, MINIMUM_MEM_LIMIT, effective_total_memory};

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -7,7 +7,6 @@ use crate::sync::Arc;
 
 use super::pages::PagedBufferPtr;
 use super::stats::{BufferKind, PoolStats};
-use crate::prefetch::CursorId;
 
 /// A buffer backed by the pool.
 ///
@@ -31,15 +30,8 @@ impl PoolBuffer {
         Self(PoolBufferInner::Primary { buffer_ptr, size })
     }
 
-    pub(super) fn new_secondary(
-        size: usize,
-        kind: BufferKind,
-        cursor_id: Option<CursorId>,
-        stats: Arc<PoolStats>,
-    ) -> Self {
-        Self(PoolBufferInner::Secondary(FreeBuffer::new(
-            size, kind, cursor_id, stats,
-        )))
+    pub(super) fn new_secondary(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
+        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats)))
     }
 
     pub fn capacity(&self) -> usize {
@@ -182,9 +174,9 @@ struct FreeBuffer {
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, cursor_id: Option<CursorId>, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
-        stats.reserve_bytes(data.len(), kind, cursor_id);
+        stats.reserve_bytes(data.len(), kind);
         Self { data, kind, stats }
     }
 }
@@ -206,14 +198,14 @@ mod tests {
     fn primary(buffer_size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(buffer_size);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other, None)
+            .try_reserve(BufferKind::Other)
             .expect("should be able to reserve a buffer from a new page");
 
         PoolBuffer::new_primary(buffer_ptr, buffer_size)
     }
 
     fn secondary(buffer_size: usize) -> PoolBuffer {
-        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, None, Arc::new(PoolStats::default()))
+        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, Arc::new(PoolStats::default()))
     }
 
     #[test_case(primary)]

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -5,12 +5,25 @@ use humansize::make_format;
 use sysinfo::System;
 use tracing::{debug, trace};
 
-use crate::memory::PagedPool;
 use crate::prefetch::{CursorId, HandleId};
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicU64, Ordering};
 
+use super::stats::PoolStats;
+
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
+
+/// Returns the effective total memory available to this process in bytes.
+///
+/// On Linux, this respects cgroup memory limits when set.
+/// On other platforms, returns the total physical memory.
+pub fn effective_total_memory() -> u64 {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    sys.cgroup_limits()
+        .map(|cg| cg.total_memory)
+        .unwrap_or_else(|| sys.total_memory())
+}
 
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
@@ -51,13 +64,13 @@ impl ActiveRead {
 /// RAII guard that clears the active read for a handle when dropped.
 /// Ensures the active read is always cleared, even on early returns or panics.
 pub struct ActiveReadGuard {
-    mem_limiter: Arc<MemoryLimiter>,
+    active_reads: Arc<DashMap<HandleId, ActiveRead>>,
     handle_id: HandleId,
 }
 
 impl Drop for ActiveReadGuard {
     fn drop(&mut self) {
-        self.mem_limiter.clear_active_read(self.handle_id);
+        self.active_reads.remove(&self.handle_id);
     }
 }
 
@@ -82,8 +95,9 @@ impl Drop for ActiveReadGuard {
 ///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
 /// requests. Under memory pressure, each instance will limit to a single buffer.
+// TODO: Extract ActiveRead tracking into its own struct in a follow-up.
 #[derive(Debug)]
-pub struct MemoryLimiter {
+pub(crate) struct MemoryLimiter {
     mem_limit: u64,
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
@@ -95,16 +109,16 @@ pub struct MemoryLimiter {
     next_cursor_id: AtomicU64,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: u64,
-    /// Memory pool used by the S3 client and disk cache.
-    /// We rely on the pool's stats to account for all buffer allocations (e.g. GetObject, DiskCache, PutObject buffers).
-    pool: PagedPool,
     /// Per-handle active read tracking. When a FUSE read is in progress for a handle,
     /// the requested range is stored here. Absence means the handle is speculative.
-    active_reads: DashMap<HandleId, ActiveRead>,
+    // TODO: Extract ActiveRead tracking into its own struct in a follow-up refactor.
+    active_reads: Arc<DashMap<HandleId, ActiveRead>>,
 }
 
 impl MemoryLimiter {
-    pub fn new(pool: PagedPool, mem_limit: u64) -> Self {
+    /// Create a new `MemoryLimiter` with the given memory limit.
+    /// The `on_pool_reserve` callback is wired externally by `PagedPool` construction.
+    pub(crate) fn new(mem_limit: u64) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -114,37 +128,41 @@ impl MemoryLimiter {
             formatter(additional_mem_reserved)
         );
         let mem_reserved = Arc::new(AtomicU64::new(0));
-        let mem_reserved_cb: Arc<AtomicU64> = mem_reserved.clone();
         let mem_reserved_per_cursor: Arc<DashMap<CursorId, Arc<AtomicU64>>> = Arc::new(DashMap::new());
-        let mem_reserved_per_cursor_cb = mem_reserved_per_cursor.clone();
-        pool.set_on_reserve(Arc::new(move |bytes, cursor_id| {
-            Self::on_pool_reserve(bytes, cursor_id, &mem_reserved_cb, &mem_reserved_per_cursor_cb);
-        }));
         Self {
-            pool,
             mem_limit,
             mem_reserved,
             mem_reserved_per_cursor,
             next_cursor_id: AtomicU64::new(1),
             additional_mem_reserved,
-            active_reads: DashMap::new(),
+            active_reads: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Get a clone of the `mem_reserved` Arc for use in the on_reserve callback.
+    pub(crate) fn mem_reserved_arc(&self) -> Arc<AtomicU64> {
+        self.mem_reserved.clone()
+    }
+
+    /// Get a clone of the `mem_reserved_per_cursor` Arc for use in the on_reserve callback.
+    pub(crate) fn mem_reserved_per_cursor_arc(&self) -> Arc<DashMap<CursorId, Arc<AtomicU64>>> {
+        self.mem_reserved_per_cursor.clone()
     }
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    pub fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
+    pub(crate) fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
         self.add_reservation(cursor_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    pub fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) -> bool {
+    pub(crate) fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64, stats: &PoolStats) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let pool_mem_reserved = self.pool_mem_reserved();
+            let pool_mem_reserved = self.pool_mem_reserved(stats);
             let new_total_mem_usage = new_mem_reserved
                 .saturating_add(pool_mem_reserved)
                 .saturating_add(self.additional_mem_reserved);
@@ -177,7 +195,7 @@ impl MemoryLimiter {
     }
 
     /// Release all remaining reservation for a cursor and remove it from tracking.
-    pub fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
+    pub(crate) fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
         if let Some((_, reservation)) = self.mem_reserved_per_cursor.remove(&cursor_id) {
             let remaining = reservation.swap(0, Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
@@ -186,14 +204,14 @@ impl MemoryLimiter {
     }
 
     /// Generate a new unique [CursorId] for per-cursor memory tracking.
-    pub fn next_cursor_id(&self) -> CursorId {
+    pub(crate) fn next_cursor_id(&self) -> CursorId {
         CursorId::new_from_raw(self.next_cursor_id.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Query available memory tracked by the memory limiter.
-    pub fn available_mem(&self) -> u64 {
+    pub(crate) fn available_mem(&self, stats: &PoolStats) -> u64 {
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
-        let pool_mem_reserved = self.pool_mem_reserved();
+        let pool_mem_reserved = self.pool_mem_reserved(stats);
         self.mem_limit
             .saturating_sub(mem_reserved)
             .saturating_sub(pool_mem_reserved)
@@ -202,21 +220,16 @@ impl MemoryLimiter {
 
     /// Record that a FUSE read is active for the given handle at the specified range.
     /// Returns a guard that will clear the active read when dropped.
-    pub fn set_active_read(self: &Arc<Self>, handle_id: HandleId, offset: u64, size: usize) -> ActiveReadGuard {
+    pub(crate) fn set_active_read(&self, handle_id: HandleId, offset: u64, size: usize) -> ActiveReadGuard {
         self.active_reads.insert(handle_id, ActiveRead { offset, size });
         ActiveReadGuard {
-            mem_limiter: Arc::clone(self),
+            active_reads: self.active_reads.clone(),
             handle_id,
         }
     }
 
-    /// Clear the active read for the given handle (read completed or errored).
-    fn clear_active_read(&self, handle_id: HandleId) {
-        self.active_reads.remove(&handle_id);
-    }
-
     /// Check if the given handle has an active read overlapping the specified range.
-    pub fn has_active_read_in_range(&self, handle_id: HandleId, offset: u64, size: usize) -> bool {
+    pub(crate) fn has_active_read_in_range(&self, handle_id: HandleId, offset: u64, size: usize) -> bool {
         self.active_reads
             .get(&handle_id)
             .map(|r| r.overlaps(offset, size))
@@ -238,7 +251,7 @@ impl MemoryLimiter {
     ///
     /// No-op when `cursor_id` is `None` (e.g. uploads) or the cursor has already been removed
     /// by `release_cursor`.
-    fn on_pool_reserve(
+    pub(crate) fn on_pool_reserve(
         bytes: usize,
         cursor_id: Option<CursorId>,
         mem_reserved: &AtomicU64,
@@ -263,38 +276,40 @@ impl MemoryLimiter {
     }
 
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
-    fn pool_mem_reserved(&self) -> u64 {
+    fn pool_mem_reserved(&self, stats: &PoolStats) -> u64 {
         // All pool buffer kinds are accounted for here.
-        self.pool.total_reserved_bytes() as u64
+        stats.total_reserved_bytes() as u64
     }
 }
 
-/// Returns the effective total memory available to this process in bytes.
-///
-/// On Linux, this respects cgroup memory limits when set.
-/// On other platforms, returns the total physical memory.
-pub fn effective_total_memory() -> u64 {
-    let mut sys = System::new();
-    sys.refresh_memory();
-    sys.cgroup_limits()
-        .map(|cg| cg.total_memory)
-        .unwrap_or_else(|| sys.total_memory())
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::super::stats::PoolStats;
+
+    /// Create a default PoolStats for testing the limiter in isolation.
+    #[allow(dead_code)]
+    pub fn default_pool_stats() -> PoolStats {
+        PoolStats::default()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::memory::{BufferKind, PagedPool};
+    use crate::prefetch::HandleId;
+    use crate::sync::Arc;
+    use crate::sync::atomic::Ordering;
 
     fn new_limiter() -> Arc<MemoryLimiter> {
-        let pool = PagedPool::new_with_candidate_sizes([1024]);
-        Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT))
+        Arc::new(MemoryLimiter::new(MINIMUM_MEM_LIMIT))
     }
 
-    fn new_limiter_with_pool(buffer_size: usize, mem_limit: u64) -> (Arc<MemoryLimiter>, PagedPool) {
-        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
-        let limiter = Arc::new(MemoryLimiter::new(pool.clone(), mem_limit));
-        (limiter, pool)
+    /// Create a pool with its own internal limiter for tests that need to inspect limiter state.
+    /// Returns a reference-counted pointer to the pool's internal limiter and the pool itself.
+    fn new_limiter_with_pool(buffer_size: usize, mem_limit: u64) -> (PagedPool,) {
+        let pool = PagedPool::new_with_candidate_sizes([buffer_size], mem_limit);
+        (pool,)
     }
 
     #[test]
@@ -303,57 +318,58 @@ mod tests {
         let cursor = limiter.next_cursor_id();
 
         limiter.reserve(cursor, BufferArea::Prefetch, 100);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 100);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 100);
 
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_pool_allocation_decrements_mem_reserved() {
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         // Reserve 1024 bytes of intent
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 1024);
 
         // Pool allocation triggers on_reserve callback, decrementing mem_reserved
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_reserve_pool_allocate_release_cursor() {
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         // Reserve 2048 bytes of intent
         limiter.reserve(cursor, BufferArea::Prefetch, 2048);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 2048);
 
         // Pool allocates 1024 — callback decrements both global and per-cursor
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 1024);
 
         // release_cursor releases the remaining per-cursor balance (2048 - 1024 = 1024)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_try_reserve_respects_limit() {
         let limiter = new_limiter();
         let cursor = limiter.next_cursor_id();
+        let stats = crate::memory::stats::PoolStats::default();
 
         // Fill up to the limit (minus additional_mem_reserved)
-        let available = limiter.available_mem();
+        let available = limiter.available_mem(&stats);
         limiter.reserve(cursor, BufferArea::Prefetch, available);
 
         // Should fail — no room left
-        assert!(!limiter.try_reserve(cursor, BufferArea::Prefetch, 1));
+        assert!(!limiter.try_reserve(cursor, BufferArea::Prefetch, 1, &stats));
     }
 
     #[test]
@@ -364,19 +380,14 @@ mod tests {
 
         limiter.reserve(cursor1, BufferArea::Prefetch, 100);
         limiter.reserve(cursor2, BufferArea::Prefetch, 200);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 300);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 300);
 
         // Release cursor1 — only its 100 bytes
         limiter.release_cursor(cursor1, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 200);
-        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor1));
-
-        // Cursor2 still tracked
-        assert!(limiter.mem_reserved_per_cursor.contains_key(&cursor2));
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 200);
 
         limiter.release_cursor(cursor2, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert!(limiter.mem_reserved_per_cursor.is_empty());
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -389,87 +400,87 @@ mod tests {
 
         // Second call is a no-op
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_callback_noop_after_release_cursor() {
-        // Simulates the cancellation race: on_reserve fires after release_cursor
-        // removed the entry. The callback should be a no-op.
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
 
         // Late allocation for the cancelled request — cursor is gone
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
 
         // mem_reserved should stay at 0, not go negative or wrap
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_callback_saturates_on_over_decrement() {
-        // Simulates a late callback trying to decrement more than what remains
-        // in the per-cursor counter (e.g. due to a race with a new cursor reusing
-        // the same entry after release).
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         // Reserve only 512 bytes
         limiter.reserve(cursor, BufferArea::Prefetch, 512);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 512);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 512);
 
         // Pool allocates 1024 — callback should saturate at 512 (not underflow)
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
 
         // release_cursor should subtract 0 (the per-cursor counter is already 0)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn test_available_mem_accounts_for_pool_allocations() {
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
+        let stats = pool.inner_stats();
 
-        let initial_available = limiter.available_mem();
+        let initial_available = limiter.available_mem(stats);
 
         // Reserve intent — available decreases
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
-        assert_eq!(limiter.available_mem(), initial_available - 1024);
+        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
 
         // Pool allocates (on_reserve converts intent to pool stats) — available stays the same
-        // because mem_reserved decreases by 1024 while pool stats increase by 1024.
         let buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert_eq!(limiter.available_mem(), initial_available - 1024);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
 
         // Drop the buffer — pool stats decrease, available goes back up
         drop(buffer);
-        assert_eq!(limiter.available_mem(), initial_available);
+        assert_eq!(limiter.available_mem(stats), initial_available);
     }
 
     #[test]
     fn test_upload_allocation_does_not_affect_mem_reserved() {
-        let (limiter, pool) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let limiter = pool.inner_limiter();
+        let stats = pool.inner_stats();
 
-        let initial_available = limiter.available_mem();
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        let initial_available = limiter.available_mem(stats);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
 
         // Upload allocates without cursor_id — should not touch mem_reserved
         let buffer = pool.get_buffer_mut(1024, BufferKind::Append, None);
-        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
 
         // But available_mem should decrease (pool stats increased)
-        assert_eq!(limiter.available_mem(), initial_available - 1024);
+        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
 
         // Drop the buffer — available goes back up
         drop(buffer);
-        assert_eq!(limiter.available_mem(), initial_available);
+        assert_eq!(limiter.available_mem(stats), initial_available);
     }
 
     #[test]
@@ -519,14 +530,9 @@ mod tests {
     /// When the `TEST_CGROUP_MEM_LIMIT_MB` environment variable is set (e.g. in a
     /// container started with `--memory=4g`), verify that [effective_total_memory]
     /// returns a value equal to the cgroup limit rather than the host's total RAM.
-    ///
-    /// This test is run by the `cgroup-mem-limit` CI job (see `.github/workflows/tests.yml`)
-    /// inside a memory-limited container. Outside that job the env var is unset and the
-    /// test is skipped.
     #[test]
     fn test_effective_total_memory_respects_cgroup() {
         let Ok(expected_str) = std::env::var("TEST_CGROUP_MEM_LIMIT_MB") else {
-            // Nothing to check outside the dedicated CI container job.
             return;
         };
         let expected_bytes: u64 = expected_str.parse::<u64>().expect("invalid TEST_CGROUP_MEM_LIMIT_MB") * 1024 * 1024;
@@ -545,8 +551,6 @@ mod tests {
         let mut sys = System::new();
         sys.refresh_memory();
         if sys.cgroup_limits().is_some() {
-            // A cgroup limit is active on this machine — the fallback path
-            // won't be exercised, so there's nothing to assert here.
             return;
         }
         assert_eq!(

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -531,7 +531,7 @@ mod tests {
         let mut sys = System::new();
         sys.refresh_memory();
         if sys.cgroup_limits().is_some() {
-            // A cgroup limit is active on this machine - the fallback path
+            // A cgroup limit is active on this machine — the fallback path
             // won't be exercised, so there's nothing to assert here.
             return;
         }

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -13,18 +13,6 @@ use super::stats::PoolStats;
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
 
-/// Returns the effective total memory available to this process in bytes.
-///
-/// On Linux, this respects cgroup memory limits when set.
-/// On other platforms, returns the total physical memory.
-pub fn effective_total_memory() -> u64 {
-    let mut sys = System::new();
-    sys.refresh_memory();
-    sys.cgroup_limits()
-        .map(|cg| cg.total_memory)
-        .unwrap_or_else(|| sys.total_memory())
-}
-
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
 pub enum BufferArea {
@@ -114,7 +102,6 @@ pub struct MemoryLimiter {
 }
 
 impl MemoryLimiter {
-    /// Create a new `MemoryLimiter` with the given memory limit.
     pub fn new(mem_limit: u64) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
@@ -264,6 +251,18 @@ impl MemoryLimiter {
     }
 }
 
+/// Returns the effective total memory available to this process in bytes.
+///
+/// On Linux, this respects cgroup memory limits when set.
+/// On other platforms, returns the total physical memory.
+pub fn effective_total_memory() -> u64 {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    sys.cgroup_limits()
+        .map(|cg| cg.total_memory)
+        .unwrap_or_else(|| sys.total_memory())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,6 +349,10 @@ mod tests {
         // Release cursor1 — only its 100 bytes
         limiter.release_cursor(cursor1, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 200);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor1));
+
+        // Cursor2 still tracked
+        assert!(limiter.mem_reserved_per_cursor.contains_key(&cursor2));
 
         limiter.release_cursor(cursor2, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
@@ -372,6 +375,8 @@ mod tests {
 
     #[test]
     fn test_on_pool_reserve_noop_after_release_cursor() {
+        // Simulates the cancellation race: on_pool_reserve fires after release_cursor
+        // removed the entry. The call should be a no-op.
         let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
@@ -526,7 +531,7 @@ mod tests {
         let mut sys = System::new();
         sys.refresh_memory();
         if sys.cgroup_limits().is_some() {
-            // A cgroup limit is active on this machine -- the fallback path
+            // A cgroup limit is active on this machine - the fallback path
             // won't be exercised, so there's nothing to assert here.
             return;
         }

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -115,7 +115,7 @@ pub struct MemoryLimiter {
 
 impl MemoryLimiter {
     /// Create a new `MemoryLimiter` with the given memory limit.
-    pub(crate) fn new(mem_limit: u64) -> Self {
+    pub fn new(mem_limit: u64) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -138,13 +138,13 @@ impl MemoryLimiter {
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    pub(crate) fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
+    pub fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
         self.add_reservation(cursor_id, size);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    pub(crate) fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64, stats: &PoolStats) -> bool {
+    pub fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64, stats: &PoolStats) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
@@ -182,7 +182,7 @@ impl MemoryLimiter {
     }
 
     /// Release all remaining reservation for a cursor and remove it from tracking.
-    pub(crate) fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
+    pub fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
         if let Some((_, reservation)) = self.mem_reserved_per_cursor.remove(&cursor_id) {
             let remaining = reservation.swap(0, Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
@@ -191,12 +191,12 @@ impl MemoryLimiter {
     }
 
     /// Generate a new unique [CursorId] for per-cursor memory tracking.
-    pub(crate) fn next_cursor_id(&self) -> CursorId {
+    pub fn next_cursor_id(&self) -> CursorId {
         CursorId::new_from_raw(self.next_cursor_id.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Query available memory tracked by the memory limiter.
-    pub(crate) fn available_mem(&self, stats: &PoolStats) -> u64 {
+    pub fn available_mem(&self, stats: &PoolStats) -> u64 {
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         let pool_mem_reserved = self.pool_mem_reserved(stats);
         self.mem_limit
@@ -238,7 +238,7 @@ impl MemoryLimiter {
     ///
     /// No-op when `cursor_id` is `None` (e.g. uploads) or the cursor has already been removed
     /// by `release_cursor`.
-    pub(crate) fn on_pool_reserve(&self, bytes: usize, cursor_id: Option<CursorId>) {
+    pub fn on_pool_reserve(&self, bytes: usize, cursor_id: Option<CursorId>) {
         let Some(cursor_id) = cursor_id else {
             return;
         };
@@ -285,6 +285,7 @@ mod tests {
 
         limiter.release_cursor(cursor, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
     }
 
     #[test]
@@ -319,6 +320,7 @@ mod tests {
         // release_cursor releases the remaining per-cursor balance (2048 - 1024 = 1024)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
     }
 
     #[test]
@@ -351,6 +353,7 @@ mod tests {
 
         limiter.release_cursor(cursor2, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(limiter.mem_reserved_per_cursor.is_empty());
     }
 
     #[test]
@@ -364,6 +367,7 @@ mod tests {
         // Second call is a no-op
         limiter.release_cursor(cursor, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
     }
 
     #[test]
@@ -375,6 +379,8 @@ mod tests {
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
         limiter.release_cursor(cursor, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
 
         // Late allocation for the cancelled request — cursor is gone
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
@@ -400,6 +406,7 @@ mod tests {
         // release_cursor should subtract 0 (the per-cursor counter is already 0)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
+        assert!(!limiter.mem_reserved_per_cursor.contains_key(&cursor));
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -88,7 +88,7 @@ impl Drop for ActiveReadGuard {
 /// rejected if there is no available memory.
 ///
 /// Release of the reserved memory happens on one of the following events:
-/// 1) the memory pool allocates a buffer: the `on_reserve` callback decrements `mem_reserved` by the
+/// 1) the memory pool allocates a buffer: `on_pool_reserve` decrements `mem_reserved` by the
 ///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
 /// 2) the prefetcher is destroyed (`BackpressureController` will be dropped and `release_cursor` will
 ///    release any remaining unallocated reservation for that cursor).
@@ -102,7 +102,7 @@ pub(crate) struct MemoryLimiter {
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
     /// Per-cursor reservation tracking. Keyed by CursorId (unique per BackpressureController
-    /// lifetime) so that late on_reserve callbacks from cancelled CRT meta-requests cannot
+    /// lifetime) so that late on_pool_reserve calls from cancelled CRT meta-requests cannot
     /// incorrectly decrement a re-created entry for the same handle.
     mem_reserved_per_cursor: Arc<DashMap<CursorId, Arc<AtomicU64>>>,
     /// Counter for generating unique [CursorId]s.
@@ -117,7 +117,6 @@ pub(crate) struct MemoryLimiter {
 
 impl MemoryLimiter {
     /// Create a new `MemoryLimiter` with the given memory limit.
-    /// The `on_pool_reserve` callback is wired externally by `PagedPool` construction.
     pub(crate) fn new(mem_limit: u64) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
@@ -137,16 +136,6 @@ impl MemoryLimiter {
             additional_mem_reserved,
             active_reads: Arc::new(DashMap::new()),
         }
-    }
-
-    /// Get a clone of the `mem_reserved` Arc for use in the on_reserve callback.
-    pub(crate) fn mem_reserved_arc(&self) -> Arc<AtomicU64> {
-        self.mem_reserved.clone()
-    }
-
-    /// Get a clone of the `mem_reserved_per_cursor` Arc for use in the on_reserve callback.
-    pub(crate) fn mem_reserved_per_cursor_arc(&self) -> Arc<DashMap<CursorId, Arc<AtomicU64>>> {
-        self.mem_reserved_per_cursor.clone()
     }
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
@@ -251,17 +240,12 @@ impl MemoryLimiter {
     ///
     /// No-op when `cursor_id` is `None` (e.g. uploads) or the cursor has already been removed
     /// by `release_cursor`.
-    pub(crate) fn on_pool_reserve(
-        bytes: usize,
-        cursor_id: Option<CursorId>,
-        mem_reserved: &AtomicU64,
-        per_cursor: &DashMap<CursorId, Arc<AtomicU64>>,
-    ) {
+    pub(crate) fn on_pool_reserve(&self, bytes: usize, cursor_id: Option<CursorId>) {
         let Some(cursor_id) = cursor_id else {
             return;
         };
         // Clone the Arc to release the DashMap shard lock before doing atomic operations.
-        let Some(cursor_reservation) = per_cursor.get(&cursor_id).map(|r| r.value().clone()) else {
+        let Some(cursor_reservation) = self.mem_reserved_per_cursor.get(&cursor_id).map(|r| r.value().clone()) else {
             return;
         };
         let mut current = cursor_reservation.load(Ordering::SeqCst);
@@ -272,7 +256,7 @@ impl MemoryLimiter {
                 Err(actual) => current = actual,
             }
         };
-        mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
+        self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
     /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
@@ -300,10 +284,10 @@ mod tests {
         let cursor = limiter.next_cursor_id();
 
         limiter.reserve(cursor, BufferArea::Prefetch, 100);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 100);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 100);
 
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -314,11 +298,11 @@ mod tests {
 
         // Reserve 1024 bytes of intent
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 1024);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
-        // Pool allocation triggers on_reserve callback, decrementing mem_reserved
+        // Pool allocation calls on_pool_reserve, decrementing mem_reserved
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -329,15 +313,15 @@ mod tests {
 
         // Reserve 2048 bytes of intent
         limiter.reserve(cursor, BufferArea::Prefetch, 2048);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 2048);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 2048);
 
-        // Pool allocates 1024 — callback decrements both global and per-cursor
+        // Pool allocates 1024 — on_pool_reserve decrements both global and per-cursor
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 1024);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 1024);
 
         // release_cursor releases the remaining per-cursor balance (2048 - 1024 = 1024)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -362,14 +346,14 @@ mod tests {
 
         limiter.reserve(cursor1, BufferArea::Prefetch, 100);
         limiter.reserve(cursor2, BufferArea::Prefetch, 200);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 300);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 300);
 
         // Release cursor1 — only its 100 bytes
         limiter.release_cursor(cursor1, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 200);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 200);
 
         limiter.release_cursor(cursor2, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -382,43 +366,43 @@ mod tests {
 
         // Second call is a no-op
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
-    fn test_callback_noop_after_release_cursor() {
+    fn test_on_pool_reserve_noop_after_release_cursor() {
         let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // Late allocation for the cancelled request — cursor is gone
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
 
         // mem_reserved should stay at 0, not go negative or wrap
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
-    fn test_callback_saturates_on_over_decrement() {
+    fn test_on_pool_reserve_saturates_on_over_decrement() {
         let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
         // Reserve only 512 bytes
         limiter.reserve(cursor, BufferArea::Prefetch, 512);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 512);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 512);
 
-        // Pool allocates 1024 — callback should saturate at 512 (not underflow)
+        // Pool allocates 1024 — on_pool_reserve should saturate at 512 (not underflow)
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // release_cursor should subtract 0 (the per-cursor counter is already 0)
         limiter.release_cursor(cursor, BufferArea::Prefetch);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -434,9 +418,9 @@ mod tests {
         limiter.reserve(cursor, BufferArea::Prefetch, 1024);
         assert_eq!(limiter.available_mem(stats), initial_available - 1024);
 
-        // Pool allocates (on_reserve converts intent to pool stats) — available stays the same
+        // Pool allocates (on_pool_reserve converts intent to pool stats) — available stays the same
         let buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor));
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
         assert_eq!(limiter.available_mem(stats), initial_available - 1024);
 
         // Drop the buffer — pool stats decrease, available goes back up
@@ -451,11 +435,11 @@ mod tests {
         let stats = pool.inner_stats();
 
         let initial_available = limiter.available_mem(stats);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // Upload allocates without cursor_id — should not touch mem_reserved
         let buffer = pool.get_buffer_mut(1024, BufferKind::Append, None);
-        assert_eq!(limiter.mem_reserved_arc().load(Ordering::SeqCst), 0);
+        assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // But available_mem should decrease (pool stats increased)
         assert_eq!(limiter.available_mem(stats), initial_available - 1024);

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -283,17 +283,6 @@ impl MemoryLimiter {
 }
 
 #[cfg(test)]
-pub(crate) mod test_helpers {
-    use super::super::stats::PoolStats;
-
-    /// Create a default PoolStats for testing the limiter in isolation.
-    #[allow(dead_code)]
-    pub fn default_pool_stats() -> PoolStats {
-        PoolStats::default()
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::memory::{BufferKind, PagedPool};
@@ -303,13 +292,6 @@ mod tests {
 
     fn new_limiter() -> Arc<MemoryLimiter> {
         Arc::new(MemoryLimiter::new(MINIMUM_MEM_LIMIT))
-    }
-
-    /// Create a pool with its own internal limiter for tests that need to inspect limiter state.
-    /// Returns a reference-counted pointer to the pool's internal limiter and the pool itself.
-    fn new_limiter_with_pool(buffer_size: usize, mem_limit: u64) -> (PagedPool,) {
-        let pool = PagedPool::new_with_candidate_sizes([buffer_size], mem_limit);
-        (pool,)
     }
 
     #[test]
@@ -326,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_pool_allocation_decrements_mem_reserved() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
@@ -341,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_reserve_pool_allocate_release_cursor() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
@@ -405,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_callback_noop_after_release_cursor() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
@@ -422,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_callback_saturates_on_over_decrement() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
 
@@ -441,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_available_mem_accounts_for_pool_allocations() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let cursor = limiter.next_cursor_id();
         let stats = pool.inner_stats();
@@ -464,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_upload_allocation_does_not_affect_mem_reserved() {
-        let (pool,) = new_limiter_with_pool(1024, MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
         let limiter = pool.inner_limiter();
         let stats = pool.inner_stats();
 

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -95,9 +95,8 @@ impl Drop for ActiveReadGuard {
 ///
 /// Incremental uploader instances check available memory before allocating buffers to queue append
 /// requests. Under memory pressure, each instance will limit to a single buffer.
-// TODO: Extract ActiveRead tracking into its own struct in a follow-up.
 #[derive(Debug)]
-pub(crate) struct MemoryLimiter {
+pub struct MemoryLimiter {
     mem_limit: u64,
     /// Global total of reserved memory (lock-free). Used in budget checks (try_reserve, available_mem).
     mem_reserved: Arc<AtomicU64>,
@@ -111,7 +110,6 @@ pub(crate) struct MemoryLimiter {
     additional_mem_reserved: u64,
     /// Per-handle active read tracking. When a FUSE read is in progress for a handle,
     /// the requested range is stored here. Absence means the handle is speculative.
-    // TODO: Extract ActiveRead tracking into its own struct in a follow-up refactor.
     active_reads: Arc<DashMap<HandleId, ActiveRead>>,
 }
 
@@ -496,9 +494,14 @@ mod tests {
     /// When the `TEST_CGROUP_MEM_LIMIT_MB` environment variable is set (e.g. in a
     /// container started with `--memory=4g`), verify that [effective_total_memory]
     /// returns a value equal to the cgroup limit rather than the host's total RAM.
+    ///
+    /// This test is run by the `cgroup-mem-limit` CI job (see `.github/workflows/tests.yml`)
+    /// inside a memory-limited container. Outside that job the env var is unset and the
+    /// test is skipped.
     #[test]
     fn test_effective_total_memory_respects_cgroup() {
         let Ok(expected_str) = std::env::var("TEST_CGROUP_MEM_LIMIT_MB") else {
+            // Nothing to check outside the dedicated CI container job.
             return;
         };
         let expected_bytes: u64 = expected_str.parse::<u64>().expect("invalid TEST_CGROUP_MEM_LIMIT_MB") * 1024 * 1024;
@@ -517,6 +520,8 @@ mod tests {
         let mut sys = System::new();
         sys.refresh_memory();
         if sys.cgroup_limits().is_some() {
+            // A cgroup limit is active on this machine -- the fallback path
+            // won't be exercised, so there's nothing to assert here.
             return;
         }
         assert_eq!(

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -3,7 +3,6 @@ use std::alloc::{self, Layout};
 use crate::sync::{Arc, Mutex};
 
 use super::stats::{BufferKind, SizePoolStats};
-use crate::prefetch::CursorId;
 
 /// Page in a size pool.
 ///
@@ -79,14 +78,14 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind, cursor_id: Option<CursorId>) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind, cursor_id);
+        self.inner.stats.add_reserved_buffer(kind);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };
@@ -215,24 +214,24 @@ mod tests {
         let mut buffers = Vec::new();
         for _ in 0..Page::BUFFERS_PER_PAGE {
             let buffer_ptr = page
-                .try_reserve(BufferKind::Other, None)
+                .try_reserve(BufferKind::Other)
                 .expect("reserving up to 16 buffers from a new page should succeed");
             buffers.push(buffer_ptr);
         }
 
         assert!(
-            page.try_reserve(BufferKind::Other, None).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving the 17th buffer from a page should return None"
         );
 
         _ = buffers.pop().expect("drop one of the reserved buffers");
 
         buffers.push(
-            page.try_reserve(BufferKind::Other, None)
+            page.try_reserve(BufferKind::Other)
                 .expect("reserving after dropping 1 buffer should succeed"),
         );
         assert!(
-            page.try_reserve(BufferKind::Other, None).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving when all 16 buffers are in use should return None"
         );
 
@@ -248,7 +247,7 @@ mod tests {
             "invalidation of a new, empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other, None).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }
@@ -257,7 +256,7 @@ mod tests {
     fn test_invalidate_in_use() {
         let page = Page::new_for_tests(1024);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other, None)
+            .try_reserve(BufferKind::Other)
             .expect("reserving from a new page should succeed");
         assert!(!page.invalidate_if_empty(), "invalidation of a page in use should fail");
         drop(buffer_ptr);
@@ -266,7 +265,7 @@ mod tests {
             "invalidation of an empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other, None).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -2,12 +2,13 @@ use std::time::Duration;
 
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
+use crate::prefetch::{CursorId, HandleId};
 use crate::sync::{Arc, RwLock};
 
 use super::buffers::{PoolBuffer, PoolBufferMut};
+use super::limiter::{ActiveReadGuard, BufferArea, MemoryLimiter};
 use super::pages::{Page, PagedBufferPtr};
 use super::stats::{BufferKind, PoolStats, SizePoolStats};
-use crate::prefetch::CursorId;
 
 /// A pool of reusable fixed-size buffers allocated in large pages.
 ///
@@ -62,7 +63,11 @@ impl PagedPool {
     /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE](Self::MAX_BUFFER_SIZE))
     /// or duplicate values for buffer sizes. If no valid value is provided,
     /// uses [DEFAULT_BUFFER_SIZE](Self::DEFAULT_BUFFER_SIZE).
-    pub fn new_with_candidate_sizes(buffer_sizes: impl Into<Vec<usize>>) -> Self {
+    ///
+    /// When `mem_limit` is provided, an internal [MemoryLimiter] is created and the
+    /// `on_reserve` callback is wired automatically. Use `u64::MAX` as the limit
+    /// to effectively disable memory limiting (the limiter will never reject).
+    pub fn new_with_candidate_sizes(buffer_sizes: impl Into<Vec<usize>>, mem_limit: u64) -> Self {
         let mut ordered_sizes: Vec<_> = buffer_sizes.into();
         ordered_sizes.retain(|&size| size > 0 && size <= Self::MAX_BUFFER_SIZE);
         ordered_sizes.dedup();
@@ -80,11 +85,29 @@ impl PagedPool {
             })
             .collect();
 
+        let limiter = MemoryLimiter::new(mem_limit);
+        // Wire the on_reserve callback internally: when the pool allocates a buffer,
+        // the callback decrements the limiter's mem_reserved counters.
+        let mem_reserved_cb = limiter.mem_reserved_arc();
+        let mem_reserved_per_cursor_cb = limiter.mem_reserved_per_cursor_arc();
+        stats.set_on_reserve(Arc::new(move |bytes, cursor_id| {
+            MemoryLimiter::on_pool_reserve(bytes, cursor_id, &mem_reserved_cb, &mem_reserved_per_cursor_cb);
+        }));
+
         let inner = PagedPoolInner {
             ordered_size_pools,
             stats,
+            limiter,
         };
         Self { inner: Arc::new(inner) }
+    }
+
+    /// Create a pool without effective memory limiting.
+    ///
+    /// This is a convenience for tests and examples that don't need memory budgeting.
+    /// The internal limiter uses `u64::MAX` as its limit, so it never rejects reservations.
+    pub fn new_with_candidate_sizes_unlimited(buffer_sizes: impl Into<Vec<usize>>) -> Self {
+        Self::new_with_candidate_sizes(buffer_sizes, u64::MAX)
     }
 
     /// Trim empty pages in the pool.
@@ -114,12 +137,6 @@ impl PagedPool {
     /// Return the total reserved memory in bytes across all buffer kinds.
     pub fn total_reserved_bytes(&self) -> usize {
         self.inner.stats.total_reserved_bytes()
-    }
-
-    /// Register a callback to be invoked whenever bytes are reserved in the pool.
-    /// Must be called before any pool allocations occur to ensure accurate accounting.
-    pub fn set_on_reserve(&self, callback: Arc<dyn Fn(usize, Option<CursorId>) + Send + Sync>) {
-        self.inner.stats.set_on_reserve(callback);
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
@@ -165,6 +182,61 @@ impl PagedPool {
             .map(|pool| pool.stats.reserved_buffers(kind))
             .sum()
     }
+
+    /// Expose the internal stats for testing purposes (e.g., to wire a standalone limiter).
+    #[cfg(test)]
+    pub(crate) fn inner_stats(&self) -> &PoolStats {
+        &self.inner.stats
+    }
+
+    /// Expose the internal limiter for testing purposes.
+    #[cfg(test)]
+    pub(crate) fn inner_limiter(&self) -> &MemoryLimiter {
+        &self.inner.limiter
+    }
+
+    // ─── Delegation methods for MemoryLimiter ───────────────────────────────────
+
+    /// Reserve memory for future uses. Always succeeds (unconditional).
+    /// Delegates to the internal MemoryLimiter.
+    pub fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
+        self.inner.limiter.reserve(cursor_id, area, size);
+    }
+
+    /// Reserve memory if available. Returns `false` if over budget.
+    /// Delegates to the internal MemoryLimiter.
+    pub fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) -> bool {
+        self.inner.limiter.try_reserve(cursor_id, area, size, &self.inner.stats)
+    }
+
+    /// Release all remaining reservation for a cursor and remove it from tracking.
+    /// Delegates to the internal MemoryLimiter.
+    pub fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
+        self.inner.limiter.release_cursor(cursor_id, area);
+    }
+
+    /// Generate a new unique CursorId.
+    /// Delegates to the internal MemoryLimiter.
+    pub fn next_cursor_id(&self) -> CursorId {
+        self.inner.limiter.next_cursor_id()
+    }
+
+    /// Query available memory.
+    /// Delegates to the internal MemoryLimiter.
+    pub fn available_mem(&self) -> u64 {
+        self.inner.limiter.available_mem(&self.inner.stats)
+    }
+
+    /// Record that a FUSE read is active for the given handle.
+    /// Returns a guard that clears the active read on drop.
+    pub fn set_active_read(&self, handle_id: HandleId, offset: u64, size: usize) -> ActiveReadGuard {
+        self.inner.limiter.set_active_read(handle_id, offset, size)
+    }
+
+    /// Check if the given handle has an active read overlapping the specified range.
+    pub fn has_active_read_in_range(&self, handle_id: HandleId, offset: u64, size: usize) -> bool {
+        self.inner.limiter.has_active_read_in_range(handle_id, offset, size)
+    }
 }
 
 impl MemoryPool for PagedPool {
@@ -187,6 +259,9 @@ impl MemoryPool for PagedPool {
 struct PagedPoolInner {
     ordered_size_pools: Vec<SizePool>,
     stats: Arc<PoolStats>,
+    /// Memory limiter owned by the pool. Use `u64::MAX` as the limit to effectively
+    /// disable memory limiting (the limiter will never reject).
+    limiter: MemoryLimiter,
 }
 
 impl PagedPoolInner {
@@ -300,14 +375,14 @@ mod tests {
     #[test_case(&[1, 2, 3], &[5, 10])]
     #[test_case(&vec![42u8; 1000], &[128, 1024])]
     fn test_from_slice(original: &[u8], buffer_sizes: &[usize]) {
-        let pool = PagedPool::new_with_candidate_sizes(buffer_sizes);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
         let bytes = copy_from_slice(&pool, original);
         assert_eq!(original, bytes.as_ref());
     }
 
     #[test_case(&[5, 10, 1024])]
     fn test_pages(buffer_sizes: &[usize]) {
-        let pool = PagedPool::new_with_candidate_sizes(buffer_sizes);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
 
         for &size in buffer_sizes {
             let original = vec![1u8; size];
@@ -343,7 +418,7 @@ mod tests {
     #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
     #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
     fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
-        let pool = PagedPool::new_with_candidate_sizes(buffer_sizes);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
         if let Some(duration) = schedule {
             pool.schedule_trim(duration);
         }
@@ -377,7 +452,7 @@ mod tests {
     fn test_reserved_bytes() {
         let buffer_size = 1024;
         let reservations = HashMap::from([(BufferKind::GetObject, 10), (BufferKind::Other, 20)]);
-        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
+        let pool = PagedPool::new_with_candidate_sizes_unlimited([buffer_size]);
         let mut buffers = Vec::new();
         for (&kind, &count) in &reservations {
             for _ in 0..count {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -183,6 +183,8 @@ impl PagedPool {
             .sum()
     }
 
+    // TODO: Refactor MemoryLimiter unit tests to remove inner_stats and inner_limiter. We should have clearly separated unit tests for the PagedPool and the MemoryLimiter.
+
     /// Expose the internal stats for testing purposes (e.g., to wire a standalone limiter).
     #[cfg(test)]
     pub(crate) fn inner_stats(&self) -> &PoolStats {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -110,10 +110,7 @@ impl PagedPool {
         Self::new_with_candidate_sizes(buffer_sizes, u64::MAX)
     }
 
-    /// Create a pool with the minimum memory limit ([MINIMUM_MEM_LIMIT]).
-    ///
-    /// This is a convenience for tests and examples that need a functioning memory limiter
-    /// but don't need a specific memory target.
+    /// Create a pool with [MINIMUM_MEM_LIMIT] as the memory limit.
     pub fn new_with_candidate_sizes_minimally_limited(buffer_sizes: impl Into<Vec<usize>>) -> Self {
         use super::limiter::MINIMUM_MEM_LIMIT;
         Self::new_with_candidate_sizes(buffer_sizes, MINIMUM_MEM_LIMIT)

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -198,31 +198,26 @@ impl PagedPool {
     // ─── Delegation methods for MemoryLimiter ───────────────────────────────────
 
     /// Reserve memory for future uses. Always succeeds (unconditional).
-    /// Delegates to the internal MemoryLimiter.
     pub fn reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) {
         self.inner.limiter.reserve(cursor_id, area, size);
     }
 
     /// Reserve memory if available. Returns `false` if over budget.
-    /// Delegates to the internal MemoryLimiter.
     pub fn try_reserve(&self, cursor_id: CursorId, area: BufferArea, size: u64) -> bool {
         self.inner.limiter.try_reserve(cursor_id, area, size, &self.inner.stats)
     }
 
     /// Release all remaining reservation for a cursor and remove it from tracking.
-    /// Delegates to the internal MemoryLimiter.
     pub fn release_cursor(&self, cursor_id: CursorId, area: BufferArea) {
         self.inner.limiter.release_cursor(cursor_id, area);
     }
 
     /// Generate a new unique CursorId.
-    /// Delegates to the internal MemoryLimiter.
     pub fn next_cursor_id(&self) -> CursorId {
         self.inner.limiter.next_cursor_id()
     }
 
     /// Query available memory.
-    /// Delegates to the internal MemoryLimiter.
     pub fn available_mem(&self) -> u64 {
         self.inner.limiter.available_mem(&self.inner.stats)
     }
@@ -259,8 +254,6 @@ impl MemoryPool for PagedPool {
 struct PagedPoolInner {
     ordered_size_pools: Vec<SizePool>,
     stats: Arc<PoolStats>,
-    /// Memory limiter owned by the pool. Use `u64::MAX` as the limit to effectively
-    /// disable memory limiting (the limiter will never reject).
     limiter: MemoryLimiter,
 }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -110,6 +110,15 @@ impl PagedPool {
         Self::new_with_candidate_sizes(buffer_sizes, u64::MAX)
     }
 
+    /// Create a pool with the minimum memory limit ([MINIMUM_MEM_LIMIT]).
+    ///
+    /// This is a convenience for tests and examples that need a functioning memory limiter
+    /// but don't need a specific memory target.
+    pub fn new_with_candidate_sizes_minimally_limited(buffer_sizes: impl Into<Vec<usize>>) -> Self {
+        use super::limiter::MINIMUM_MEM_LIMIT;
+        Self::new_with_candidate_sizes(buffer_sizes, MINIMUM_MEM_LIMIT)
+    }
+
     /// Trim empty pages in the pool.
     pub fn trim(&self) -> bool {
         self.inner.trim()

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -64,9 +64,8 @@ impl PagedPool {
     /// or duplicate values for buffer sizes. If no valid value is provided,
     /// uses [DEFAULT_BUFFER_SIZE](Self::DEFAULT_BUFFER_SIZE).
     ///
-    /// When `mem_limit` is provided, an internal [MemoryLimiter] is created and the
-    /// `on_reserve` callback is wired automatically. Use `u64::MAX` as the limit
-    /// to effectively disable memory limiting (the limiter will never reject).
+    /// An internal [MemoryLimiter] is created with the given `mem_limit`.
+    /// Buffer allocations automatically decrement the limiter's reservation counters.
     pub fn new_with_candidate_sizes(buffer_sizes: impl Into<Vec<usize>>, mem_limit: u64) -> Self {
         let mut ordered_sizes: Vec<_> = buffer_sizes.into();
         ordered_sizes.retain(|&size| size > 0 && size <= Self::MAX_BUFFER_SIZE);
@@ -86,13 +85,6 @@ impl PagedPool {
             .collect();
 
         let limiter = MemoryLimiter::new(mem_limit);
-        // Wire the on_reserve callback internally: when the pool allocates a buffer,
-        // the callback decrements the limiter's mem_reserved counters.
-        let mem_reserved_cb = limiter.mem_reserved_arc();
-        let mem_reserved_per_cursor_cb = limiter.mem_reserved_per_cursor_arc();
-        stats.set_on_reserve(Arc::new(move |bytes, cursor_id| {
-            MemoryLimiter::on_pool_reserve(bytes, cursor_id, &mem_reserved_cb, &mem_reserved_per_cursor_cb);
-        }));
 
         let inner = PagedPoolInner {
             ordered_size_pools,
@@ -146,8 +138,8 @@ impl PagedPool {
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `cursor_id` is provided, it will be passed to the `on_reserve` callback
-    /// for per-cursor memory tracking.
+    /// If `cursor_id` is provided, `on_pool_reserve` will decrement the limiter's
+    /// reservation counters for per-cursor memory tracking.
     pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBufferMut {
         let buffer = self.get_buffer(capacity, kind, cursor_id);
         PoolBufferMut::new(buffer)
@@ -156,17 +148,19 @@ impl PagedPool {
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind, cursor_id);
+                let buffer_ptr = pool.reserve(kind);
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
                     .record((pool.buffer_size() - size) as f64);
+                self.inner.limiter.on_pool_reserve(pool.buffer_size(), cursor_id);
                 PoolBuffer::new_primary(buffer_ptr, size)
             }
             None => {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                PoolBuffer::new_secondary(size, kind, cursor_id, self.inner.stats.clone())
+                self.inner.limiter.on_pool_reserve(size, cursor_id);
+                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone())
             }
         }
     }
@@ -320,11 +314,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind, cursor_id: Option<CursorId>) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, cursor_id) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
                 return buffer_ptr;
             }
         }
@@ -334,13 +328,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, cursor_id) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind, cursor_id).unwrap();
+        let buffer_ptr = page.try_reserve(kind).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -349,9 +343,8 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
-        cursor_id: Option<CursorId>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind, cursor_id))
+        pages.find_map(|page| page.try_reserve(kind))
     }
 
     fn buffer_size(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,29 +1,14 @@
 use std::ops::Index;
-use std::sync::OnceLock;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
-use crate::prefetch::CursorId;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-type OnReserveCallback = Arc<dyn Fn(usize, Option<CursorId>) + Send + Sync>;
-
 /// Usage stats for a pool.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct PoolStats {
     reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
-    /// Optional callback invoked whenever bytes are reserved in the pool.
-    on_reserve: OnceLock<OnReserveCallback>,
-}
-
-impl std::fmt::Debug for PoolStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PoolStats")
-            .field("reserved_bytes", &self.reserved_bytes)
-            .field("on_reserve", &self.on_reserve.get().map(|_| "<callback>"))
-            .finish()
-    }
 }
 
 impl PoolStats {
@@ -35,15 +20,8 @@ impl PoolStats {
         self.reserved_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
     }
 
-    pub fn set_on_reserve(&self, callback: OnReserveCallback) {
-        let _ = self.on_reserve.set(callback);
-    }
-
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind, cursor_id: Option<CursorId>) {
+    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
         self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
-        if let Some(cb) = self.on_reserve.get() {
-            cb(bytes, cursor_id);
-        }
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
     }
 
@@ -91,9 +69,9 @@ impl SizePoolStats {
         self.reserved_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind, cursor_id: Option<CursorId>) {
+    pub(super) fn add_reserved_buffer(&self, kind: BufferKind) {
         self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind, cursor_id);
+        self.pool_stats.reserve_bytes(self.buffer_size, kind);
     }
 
     pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -42,10 +42,9 @@ use tracing::trace;
 use crate::checksums::{ChecksummedBytes, IntegrityError};
 use crate::data_cache::DataCache;
 use crate::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
-use crate::mem_limiter::MemoryLimiter;
+use crate::memory::PagedPool;
 use crate::metrics::defs::{FUSE_CACHE_HIT, PREFETCH_RESET_STATE};
 use crate::object::ObjectId;
-use crate::sync::Arc;
 
 mod backpressure_controller;
 mod builder;
@@ -219,7 +218,7 @@ fn determine_max_read_size() -> usize {
 #[derive(Debug)]
 pub struct Prefetcher<Client> {
     part_stream: PartStream<Client>,
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
     config: PrefetcherConfig,
 }
 
@@ -241,10 +240,10 @@ where
     }
 
     /// Create a new [Prefetcher] from the given [ObjectPartStream] instance.
-    pub fn new(part_stream: PartStream<Client>, mem_limiter: Arc<MemoryLimiter>, config: PrefetcherConfig) -> Self {
+    pub fn new(part_stream: PartStream<Client>, pool: PagedPool, config: PrefetcherConfig) -> Self {
         Self {
             part_stream,
-            mem_limiter,
+            pool,
             config,
         }
     }
@@ -263,7 +262,7 @@ where
         PrefetchGetObject::new(
             self.part_stream.clone(),
             self.config,
-            self.mem_limiter.clone(),
+            self.pool.clone(),
             bucket,
             object_id,
             handle_id,
@@ -280,7 +279,7 @@ where
 {
     part_stream: PartStream<Client>,
     config: PrefetcherConfig,
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
     backpressure_task: Option<RequestTask<Client>>,
     // Invariant: the offset of the last byte in this window is always
     // self.next_sequential_read_offset - 1.
@@ -306,7 +305,7 @@ where
     fn new(
         part_stream: PartStream<Client>,
         config: PrefetcherConfig,
-        mem_limiter: Arc<MemoryLimiter>,
+        pool: PagedPool,
         bucket: String,
         object_id: ObjectId,
         handle_id: HandleId,
@@ -316,7 +315,7 @@ where
         PrefetchGetObject {
             part_stream,
             config,
-            mem_limiter,
+            pool,
             backpressure_task: None,
             backward_seek_window: SeekWindow::new(max_backward_seek_distance),
             preferred_part_size: 128 * 1024,
@@ -393,9 +392,7 @@ where
         // the skipped bytes the prefetcher must consume to reach the requested offset.
         let active_start = self.next_sequential_read_offset.min(offset);
         let active_size = length + offset.saturating_sub(self.next_sequential_read_offset) as usize;
-        let _active_read_guard = self
-            .mem_limiter
-            .set_active_read(self.handle_id, active_start, active_size);
+        let _active_read_guard = self.pool.set_active_read(self.handle_id, active_start, active_size);
 
         // Try to seek if this read is not sequential, and if seeking fails, cancel and reset the
         // prefetcher.
@@ -593,7 +590,7 @@ mod tests {
 
     use crate::Runtime;
     use crate::data_cache::InMemoryDataCache;
-    use crate::mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter};
+    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
     use crate::sync::Arc;
 
@@ -644,8 +641,8 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool = PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()]);
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
+        let pool =
+            PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()], MINIMUM_MEM_LIMIT);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let builder = match prefetcher_type {
             PrefetcherType::Default => Prefetcher::default_builder(client),
@@ -654,7 +651,7 @@ mod tests {
                 Prefetcher::caching_builder(cache, client)
             }
         };
-        builder.build(runtime, mem_limiter, prefetcher_config)
+        builder.build(runtime, pool, prefetcher_config)
     }
 
     fn run_sequential_read_test(prefetcher_type: PrefetcherType, size: u64, read_size: usize, test_config: TestConfig) {
@@ -1394,8 +1391,7 @@ mod tests {
                     .initial_read_window_size(part_size)
                     .build(),
             );
-            let pool = PagedPool::new_with_candidate_sizes([part_size]);
-            let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
+            let pool = PagedPool::new_with_candidate_sizes([part_size], MINIMUM_MEM_LIMIT);
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
 
@@ -1410,7 +1406,7 @@ mod tests {
             };
 
             let prefetcher =
-                Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
+                Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), pool, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
             let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);
@@ -1457,8 +1453,7 @@ mod tests {
                     .initial_read_window_size(part_size)
                     .build(),
             );
-            let pool = PagedPool::new_with_candidate_sizes([part_size]);
-            let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
+            let pool = PagedPool::new_with_candidate_sizes([part_size], MINIMUM_MEM_LIMIT);
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
 
@@ -1473,7 +1468,7 @@ mod tests {
             };
 
             let prefetcher =
-                Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), mem_limiter, prefetcher_config);
+                Prefetcher::default_builder(client).build(Runtime::new(ShuttleRuntime), pool, prefetcher_config);
             let object_id = ObjectId::new("hello".to_owned(), file_etag);
             let fh = HandleId::new(1);
             let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, fh, object_size);

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -1,11 +1,11 @@
 use std::ops::Range;
-use std::sync::Arc;
 
 use async_channel::{Receiver, RecvError, Sender, unbounded};
 use humansize::make_format;
 use tracing::trace;
 
-use crate::mem_limiter::{BufferArea, MemoryLimiter};
+use crate::memory::BufferArea;
+use crate::memory::PagedPool;
 
 use super::CursorId;
 use super::PrefetchReadError;
@@ -92,7 +92,7 @@ pub struct BackpressureController {
     /// Memory limiter is used to guide decisions on how much data to prefetch.
     ///
     /// For example, when memory is low we should scale down [Self::preferred_read_window_size].
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
     /// Unique cursor ID for per-cursor memory reservation tracking.
     cursor_id: CursorId,
     /// Enable alignment of read window end to part boundary
@@ -124,13 +124,13 @@ pub struct BackpressureLimiter {
 /// informing a producer (a holder of the [BackpressureLimiter]) when it should provide data more aggressively.
 pub fn new_backpressure_controller(
     config: BackpressureConfig,
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
 ) -> (BackpressureController, BackpressureLimiter) {
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
-    let cursor_id = mem_limiter.next_cursor_id();
+    let cursor_id = pool.next_cursor_id();
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    mem_limiter.reserve(cursor_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
+    pool.reserve(cursor_id, BufferArea::Prefetch, config.initial_read_window_size as u64);
 
     let (read_window_updater, read_window_increment_queue) = unbounded();
     let read_window_increment_queue = ReadWindowIncrementQueue::new(read_window_increment_queue);
@@ -145,7 +145,7 @@ pub fn new_backpressure_controller(
         next_read_offset: config.request_range.start,
         request_end_offset: config.request_range.end,
         cursor_id,
-        mem_limiter,
+        pool,
         read_window_alignment_config: config.read_window_alignment_config,
     };
 
@@ -202,7 +202,7 @@ impl BackpressureController {
                     // read window size.
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         trace!(new_read_window_end_offset, "sending a read window increment");
-                        self.mem_limiter
+                        self.pool
                             .reserve(self.cursor_id, BufferArea::Prefetch, to_increase as u64);
                         self.increment_read_window(to_increase).await;
                         break;
@@ -211,7 +211,7 @@ impl BackpressureController {
                     // Try to reserve the memory for the length we want to increase before sending the request,
                     // scale down the read window if it fails.
                     if self
-                        .mem_limiter
+                        .pool
                         .try_reserve(self.cursor_id, BufferArea::Prefetch, to_increase as u64)
                     {
                         trace!(new_read_window_end_offset, "sending a read window increment");
@@ -257,7 +257,7 @@ impl BackpressureController {
             // because only `preferred_read_window_size` is increased but the actual read window will
             // be updated later on `DataRead` event (where we do reserve memory).
             let to_increase = (new_read_window_size - self.preferred_read_window_size) as u64;
-            let available_mem = self.mem_limiter.available_mem();
+            let available_mem = self.pool.available_mem();
             if available_mem >= to_increase {
                 let formatter = make_format(humansize::BINARY);
                 trace!(
@@ -297,7 +297,7 @@ impl Drop for BackpressureController {
         // Release whatever remains of this cursor's reservation. The per-cursor counter
         // tracks only the unallocated portion — pool allocations already decremented it
         // via the on_reserve callback.
-        self.mem_limiter.release_cursor(self.cursor_id, BufferArea::Prefetch);
+        self.pool.release_cursor(self.cursor_id, BufferArea::Prefetch);
     }
 }
 
@@ -385,13 +385,10 @@ impl ReadWindowIncrementQueue {
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
-
     use futures::executor::block_on;
     use mountpoint_s3_client::mock_client::MockClientError;
     use test_case::test_case;
 
-    use crate::mem_limiter::MemoryLimiter;
     use crate::memory::PagedPool;
     use crate::prefetch::INITIAL_REQUEST_SIZE;
 
@@ -513,11 +510,8 @@ mod tests {
     fn new_backpressure_controller_for_test(
         backpressure_config: BackpressureConfig,
     ) -> (BackpressureController, BackpressureLimiter) {
-        let pool = PagedPool::new_with_candidate_sizes([8 * 1024 * 1024]);
-        let mem_limiter = Arc::new(MemoryLimiter::new(
-            pool,
-            backpressure_config.max_read_window_size as u64,
-        ));
-        new_backpressure_controller(backpressure_config, mem_limiter.clone())
+        let pool =
+            PagedPool::new_with_candidate_sizes([8 * 1024 * 1024], backpressure_config.max_read_window_size as u64);
+        new_backpressure_controller(backpressure_config, pool)
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -268,7 +268,7 @@ impl BackpressureController {
 
     /// Scale up preferred read window size with a multiplier configured at initialization.
     ///
-    /// Fails silently if there is insufficient free memory to perform it according to [Self::mem_limiter].
+    /// Fails silently if there is insufficient free memory to perform it according to [Self::pool].
     fn scale_up(&mut self) {
         if self.preferred_read_window_size < self.max_read_window_size {
             let new_read_window_size = (self.preferred_read_window_size * self.read_window_size_multiplier)

--- a/mountpoint-s3-fs/src/prefetch/builder.rs
+++ b/mountpoint-s3-fs/src/prefetch/builder.rs
@@ -1,8 +1,8 @@
-use crate::{data_cache::DataCache, sync::Arc};
+use crate::data_cache::DataCache;
 
 use mountpoint_s3_client::ObjectClient;
 
-use crate::{Runtime, mem_limiter::MemoryLimiter};
+use crate::{Runtime, memory::PagedPool};
 
 use super::caching_stream::CachingPartStream;
 use super::part_stream::{ClientPartStream, PartStream};
@@ -35,13 +35,8 @@ where
     }
 
     /// Build a [Prefetcher] instance.
-    pub fn build(
-        self,
-        runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter>,
-        prefetcher_config: PrefetcherConfig,
-    ) -> Prefetcher<Client> {
-        self.inner.build(runtime, mem_limiter, prefetcher_config)
+    pub fn build(self, runtime: Runtime, pool: PagedPool, prefetcher_config: PrefetcherConfig) -> Prefetcher<Client> {
+        self.inner.build(runtime, pool, prefetcher_config)
     }
 }
 
@@ -58,7 +53,7 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter>,
+        pool: PagedPool,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client>;
 }
@@ -74,11 +69,11 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter>,
+        pool: PagedPool,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
-        let part_stream = ClientPartStream::new(runtime, self.client, mem_limiter.clone());
-        Prefetcher::new(PartStream::new(part_stream), mem_limiter, prefetcher_config)
+        let part_stream = ClientPartStream::new(runtime, self.client, pool.clone());
+        Prefetcher::new(PartStream::new(part_stream), pool, prefetcher_config)
     }
 }
 
@@ -95,10 +90,10 @@ where
     fn build(
         self: Box<Self>,
         runtime: Runtime,
-        mem_limiter: Arc<MemoryLimiter>,
+        pool: PagedPool,
         prefetcher_config: PrefetcherConfig,
     ) -> Prefetcher<Client> {
-        let part_stream = CachingPartStream::new(runtime, self.client, mem_limiter.clone(), self.cache);
-        Prefetcher::new(PartStream::new(part_stream), mem_limiter, prefetcher_config)
+        let part_stream = CachingPartStream::new(runtime, self.client, pool.clone(), self.cache);
+        Prefetcher::new(PartStream::new(part_stream), pool, prefetcher_config)
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -10,7 +10,7 @@ use tracing::{Instrument, debug_span, trace, warn};
 use crate::async_util::Runtime;
 use crate::checksums::ChecksummedBytes;
 use crate::data_cache::{BlockIndex, DataCache};
-use crate::mem_limiter::MemoryLimiter;
+use crate::memory::PagedPool;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
@@ -30,16 +30,16 @@ pub struct CachingPartStream<Cache, Client: ObjectClient + Clone + Send + Sync +
     cache: Arc<Cache>,
     runtime: Runtime,
     client: Client,
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
 }
 
 impl<Cache, Client: ObjectClient + Clone + Send + Sync + 'static> CachingPartStream<Cache, Client> {
-    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter>, cache: Cache) -> Self {
+    pub fn new(runtime: Runtime, client: Client, pool: PagedPool, cache: Cache) -> Self {
         Self {
             cache: Arc::new(cache),
             runtime,
             client,
-            mem_limiter,
+            pool,
         }
     }
 }
@@ -61,7 +61,7 @@ where
             read_window_alignment_config: ReadWindowAlignmentConfig::Disable, // we don't know where S3 request starts, so can not align the read window
         };
         let (backpressure_controller, backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
+            new_backpressure_controller(backpressure_config, self.pool.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 
@@ -422,12 +422,7 @@ mod tests {
     };
     use test_case::test_case;
 
-    use crate::{
-        data_cache::InMemoryDataCache,
-        mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter},
-        memory::PagedPool,
-        object::ObjectId,
-    };
+    use crate::{data_cache::InMemoryDataCache, memory::MINIMUM_MEM_LIMIT, memory::PagedPool, object::ObjectId};
 
     use super::*;
 
@@ -469,12 +464,11 @@ mod tests {
                 .initial_read_window_size(client_part_size)
                 .build(),
         );
-        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size]);
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
+        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size], MINIMUM_MEM_LIMIT);
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let stream = CachingPartStream::new(runtime, mock_client.clone(), mem_limiter.clone(), cache);
+        let stream = CachingPartStream::new(runtime, mock_client.clone(), pool.clone(), cache);
         let range = RequestRange::new(object_size, offset as u64, preferred_size);
         let expected_start_block = (range.start() as usize).div_euclid(block_size);
         let expected_end_block = (range.end() as usize).div_ceil(block_size);
@@ -552,12 +546,11 @@ mod tests {
                 .initial_read_window_size(client_part_size)
                 .build(),
         );
-        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size]);
-        let mem_limiter = Arc::new(MemoryLimiter::new(pool, MINIMUM_MEM_LIMIT));
+        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size], MINIMUM_MEM_LIMIT);
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let stream = CachingPartStream::new(runtime, mock_client, mem_limiter.clone(), cache);
+        let stream = CachingPartStream::new(runtime, mock_client, pool.clone(), cache);
 
         for offset in [0, 512 * KB, 1 * MB, 4 * MB, 9 * MB] {
             for preferred_size in [1 * KB, 512 * KB, 4 * MB, 12 * MB, 16 * MB] {

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -75,9 +75,7 @@ where
         &mut self,
         length: usize,
     ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
-        let _active_read_guard = self
-            .pool
-            .set_active_read(self.cursor_id, self.current_offset, length);
+        let _active_read_guard = self.pool.set_active_read(self.cursor_id, self.current_offset, length);
 
         self.do_read(length).await
     }
@@ -92,9 +90,7 @@ where
         // the skipped bytes the prefetcher must consume to reach the requested offset.
         let active_start = self.current_offset.min(offset);
         let active_size = length + offset.saturating_sub(active_start) as usize;
-        let _active_read_guard = self
-            .pool
-            .set_active_read(self.cursor_id, active_start, active_size);
+        let _active_read_guard = self.pool.set_active_read(self.cursor_id, active_start, active_size);
 
         if !self.try_seek(offset).await? {
             // Seek failed

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -10,7 +10,7 @@ use tracing::{Instrument, debug_span, error, trace};
 
 use crate::async_util::Runtime;
 use crate::checksums::ChecksummedBytes;
-use crate::mem_limiter::MemoryLimiter;
+use crate::memory::PagedPool;
 use crate::object::ObjectId;
 use crate::prefetch::backpressure_controller::ReadWindowAlignmentConfig;
 
@@ -213,16 +213,12 @@ impl<Client> Debug for PartStream<Client> {
 pub struct ClientPartStream<Client: ObjectClient + Clone + Send + Sync + 'static> {
     runtime: Runtime,
     client: Client,
-    mem_limiter: Arc<MemoryLimiter>,
+    pool: PagedPool,
 }
 
 impl<Client: ObjectClient + Clone + Send + Sync + 'static> ClientPartStream<Client> {
-    pub fn new(runtime: Runtime, client: Client, mem_limiter: Arc<MemoryLimiter>) -> Self {
-        Self {
-            runtime,
-            client,
-            mem_limiter,
-        }
+    pub fn new(runtime: Runtime, client: Client, pool: PagedPool) -> Self {
+        Self { runtime, client, pool }
     }
 }
 
@@ -248,7 +244,7 @@ impl<Client: ObjectClient + Clone + Send + Sync + 'static> ObjectPartStream<Clie
             },
         };
         let (backpressure_controller, mut backpressure_limiter) =
-            new_backpressure_controller(backpressure_config, self.mem_limiter.clone());
+            new_backpressure_controller(backpressure_config, self.pool.clone());
         let (part_queue, part_queue_producer) = unbounded_part_queue();
         trace!(?range, "spawning request");
 

--- a/mountpoint-s3-fs/src/upload.rs
+++ b/mountpoint-s3-fs/src/upload.rs
@@ -9,9 +9,7 @@ use thiserror::Error;
 use crate::async_util::Runtime;
 use crate::content_type::ContentTypeDetection;
 use crate::fs::{ServerSideEncryption, SseCorruptedError};
-use crate::mem_limiter::MemoryLimiter;
 use crate::memory::PagedPool;
-use crate::sync::Arc;
 
 mod atomic;
 pub use atomic::UploadRequest;
@@ -33,7 +31,6 @@ pub struct Uploader<Client: ObjectClient> {
     /// The atomic uploader does not directly reserve buffers, but relies on
     /// the client, which is configured with the same pool in Mountpoint.
     pool: PagedPool,
-    mem_limiter: Arc<MemoryLimiter>,
     storage_class: Option<String>,
     server_side_encryption: ServerSideEncryption,
     buffer_size: usize,
@@ -135,18 +132,11 @@ where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     /// Create a new [Uploader] that will make requests to the given client.
-    pub fn new(
-        client: Client,
-        runtime: Runtime,
-        pool: PagedPool,
-        mem_limiter: Arc<MemoryLimiter>,
-        config: UploaderConfig,
-    ) -> Self {
+    pub fn new(client: Client, runtime: Runtime, pool: PagedPool, config: UploaderConfig) -> Self {
         Self {
             client,
             runtime,
             pool,
-            mem_limiter,
             storage_class: config.storage_class,
             server_side_encryption: config.server_side_encryption,
             buffer_size: config.buffer_size,
@@ -198,7 +188,6 @@ where
             self.client.clone(),
             self.buffer_size,
             self.pool.clone(),
-            self.mem_limiter.clone(),
             params,
         )
     }

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -209,7 +209,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::fs::SseCorruptedError;
-    use crate::mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter};
+    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
     use crate::sync::Arc;
     use crate::upload::{Uploader, UploaderConfig};
@@ -232,14 +232,12 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let buffer_size = client.write_part_size();
-        let pool = PagedPool::new_with_candidate_sizes([buffer_size]);
+        let pool = PagedPool::new_with_candidate_sizes([buffer_size], MINIMUM_MEM_LIMIT);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let mem_limiter = MemoryLimiter::new(pool.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(
             client,
             runtime,
             pool,
-            mem_limiter.into(),
             UploaderConfig::new(buffer_size)
                 .storage_class(storage_class)
                 .server_side_encryption(server_side_encryption)

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -16,9 +16,7 @@ use tracing::{Instrument, debug_span, trace};
 use crate::ServerSideEncryption;
 use crate::async_util::Runtime;
 use crate::content_type::{ContentTypeDetection, infer_content_type};
-use crate::mem_limiter::MemoryLimiter;
 use crate::memory::{BufferKind, PagedPool, PoolBufferMut};
-use crate::sync::Arc;
 
 use super::hasher::ChecksumHasher;
 use super::{ChecksumHasherError, UploadError};
@@ -63,11 +61,10 @@ where
         client: Client,
         buffer_size: usize,
         pool: PagedPool,
-        mem_limiter: Arc<MemoryLimiter>,
         params: AppendUploadQueueParams,
     ) -> Self {
         let offset = params.initial_offset;
-        let upload_queue = AppendUploadQueue::new(runtime, client, pool, mem_limiter, params);
+        let upload_queue = AppendUploadQueue::new(runtime, client, pool, params);
         Self {
             buffer: None,
             upload_queue,
@@ -160,7 +157,6 @@ struct AppendUploadQueue<Client: ObjectClient> {
     /// Channel handle for receiving the events from the background queue.
     event_receiver: Receiver<AppendUploadEvent<Client::ClientError>>,
     pool: PagedPool,
-    mem_limiter: Arc<MemoryLimiter>,
     _task_handle: RemoteHandle<()>,
     /// Algorithm used to compute checksums. Lazily initialized.
     checksum_algorithm: Option<Option<ChecksumAlgorithm>>,
@@ -174,13 +170,7 @@ impl<Client> AppendUploadQueue<Client>
 where
     Client: ObjectClient + Send + Sync + 'static,
 {
-    pub fn new(
-        runtime: &Runtime,
-        client: Client,
-        pool: PagedPool,
-        mem_limiter: Arc<MemoryLimiter>,
-        params: AppendUploadQueueParams,
-    ) -> Self {
+    pub fn new(runtime: &Runtime, client: Client, pool: PagedPool, params: AppendUploadQueueParams) -> Self {
         assert!(params.capacity > 0, "append queue capacity must be greater than 0");
         let span = debug_span!("append", key = params.key, initial_offset = params.initial_offset);
         let (buffer_sender, buffer_receiver) = bounded(params.capacity);
@@ -211,7 +201,6 @@ where
             requests_in_queue: 0,
             checksum_algorithm: None,
             pool,
-            mem_limiter,
             _task_handle: task_handle,
         }
     }
@@ -268,7 +257,7 @@ where
             }
         };
         while self.requests_in_queue > 0 {
-            match UploadBuffer::try_new(capacity, &checksum_algorithm, &self.pool, &self.mem_limiter)? {
+            match UploadBuffer::try_new(capacity, &checksum_algorithm, &self.pool)? {
                 Some(buffer) => return Ok(buffer),
                 None => {
                     // wait for requests in the queue to complete before trying to reserve memory again
@@ -460,9 +449,8 @@ impl UploadBuffer {
         capacity: usize,
         checksum_algorithm: &Option<ChecksumAlgorithm>,
         pool: &PagedPool,
-        mem_limiter: &MemoryLimiter,
     ) -> Result<Option<Self>, ChecksumHasherError> {
-        if mem_limiter.available_mem() >= capacity as u64 {
+        if pool.available_mem() >= capacity as u64 {
             let hasher = ChecksumHasher::new(checksum_algorithm)?;
             let data = pool.get_buffer_mut(capacity, BufferKind::Append, None);
             Ok(Some(Self { data, hasher }))
@@ -499,8 +487,9 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use crate::mem_limiter::MINIMUM_MEM_LIMIT;
+    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
+    use crate::sync::Arc;
 
     use super::super::{Uploader, UploaderConfig};
     use super::*;
@@ -522,14 +511,13 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool = PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()]);
+        let pool =
+            PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()], MINIMUM_MEM_LIMIT);
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let mem_limiter = MemoryLimiter::new(pool.clone(), MINIMUM_MEM_LIMIT);
         Uploader::new(
             client,
             runtime,
             pool,
-            mem_limiter.into(),
             UploaderConfig::new(buffer_size)
                 .server_side_encryption(server_side_encryption.unwrap_or_default())
                 .default_checksum_algorithm(default_checksum_algorithm),
@@ -1188,15 +1176,15 @@ mod tests {
         let key = "hello";
 
         let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
-        let pool = PagedPool::new_with_candidate_sizes([32]);
+        // Use a pool with a very low memory limit (MINIMUM_MEM_LIMIT is the lowest allowed)
+        // to simulate memory pressure. The pool's limiter will report 0 available memory
+        // after accounting for the reserved overhead.
+        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
 
-        // Use a memory limiter with 0 limit
-        let mem_limiter = MemoryLimiter::new(pool.clone(), 0);
         let uploader = Uploader::new(
             client.clone(),
             Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap()),
             pool,
-            mem_limiter.into(),
             UploaderConfig::new(part_size),
         );
 

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -1176,10 +1176,8 @@ mod tests {
         let key = "hello";
 
         let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
-        // Use a pool with a very low memory limit (MINIMUM_MEM_LIMIT is the lowest allowed)
-        // to simulate memory pressure. The pool's limiter will report 0 available memory
-        // after accounting for the reserved overhead.
-        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
+        // Use a pool with 0 memory limit to simulate memory pressure.
+        let pool = PagedPool::new_with_candidate_sizes([32], 0);
 
         let uploader = Uploader::new(
             client.clone(),

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -312,7 +312,8 @@ pub mod mock_session {
         };
 
         let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-        let pool = PagedPool::new_with_candidate_sizes([test_config.part_size]);
+        let pool =
+            PagedPool::new_with_candidate_sizes([test_config.part_size], test_config.filesystem_config.mem_limit);
         let client = Arc::new(
             MockClient::config()
                 .bucket(s3_path.bucket.to_string())
@@ -354,7 +355,10 @@ pub mod mock_session {
             };
 
             let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-            let pool = PagedPool::new_with_candidate_sizes([test_config.cache_block_size, test_config.part_size]);
+            let pool = PagedPool::new_with_candidate_sizes(
+                [test_config.cache_block_size, test_config.part_size],
+                test_config.filesystem_config.mem_limit,
+            );
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = Arc::new(
@@ -507,7 +511,8 @@ pub mod s3_session {
     pub fn new_with_test_client(test_config: TestSessionConfig, sdk_client: Client, s3_path: S3Path) -> TestSession {
         let mount_dir = tempfile::tempdir().unwrap();
 
-        let pool = PagedPool::new_with_candidate_sizes([test_config.part_size]);
+        let pool =
+            PagedPool::new_with_candidate_sizes([test_config.part_size], test_config.filesystem_config.mem_limit);
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
             .endpoint_config(get_test_endpoint_config())
@@ -547,7 +552,10 @@ pub mod s3_session {
             let s3_path = get_test_s3_path(test_name);
             let region = get_test_region();
 
-            let pool = PagedPool::new_with_candidate_sizes([test_config.cache_block_size, test_config.part_size]);
+            let pool = PagedPool::new_with_candidate_sizes(
+                [test_config.cache_block_size, test_config.part_size],
+                test_config.filesystem_config.mem_limit,
+            );
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = create_crt_client(

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -312,8 +312,7 @@ pub mod mock_session {
         };
 
         let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-        let pool =
-            PagedPool::new_with_candidate_sizes([test_config.part_size], test_config.filesystem_config.mem_limit);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([test_config.part_size]);
         let client = Arc::new(
             MockClient::config()
                 .bucket(s3_path.bucket.to_string())
@@ -355,10 +354,10 @@ pub mod mock_session {
             };
 
             let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-            let pool = PagedPool::new_with_candidate_sizes(
-                [test_config.cache_block_size, test_config.part_size],
-                test_config.filesystem_config.mem_limit,
-            );
+            let pool = PagedPool::new_with_candidate_sizes_minimally_limited([
+                test_config.cache_block_size,
+                test_config.part_size,
+            ]);
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = Arc::new(
@@ -511,8 +510,7 @@ pub mod s3_session {
     pub fn new_with_test_client(test_config: TestSessionConfig, sdk_client: Client, s3_path: S3Path) -> TestSession {
         let mount_dir = tempfile::tempdir().unwrap();
 
-        let pool =
-            PagedPool::new_with_candidate_sizes([test_config.part_size], test_config.filesystem_config.mem_limit);
+        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([test_config.part_size]);
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
             .endpoint_config(get_test_endpoint_config())
@@ -552,10 +550,10 @@ pub mod s3_session {
             let s3_path = get_test_s3_path(test_name);
             let region = get_test_region();
 
-            let pool = PagedPool::new_with_candidate_sizes(
-                [test_config.cache_block_size, test_config.part_size],
-                test_config.filesystem_config.mem_limit,
-            );
+            let pool = PagedPool::new_with_candidate_sizes_minimally_limited([
+                test_config.cache_block_size,
+                test_config.part_size,
+            ]);
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = create_crt_client(

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -52,7 +52,7 @@ pub fn make_test_filesystem(
             .initial_read_window_size(256 * 1024)
             .build(),
     );
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size], config.mem_limit);
     let fs = make_test_filesystem_with_client(client.clone(), pool, bucket, prefix, config);
     (client, fs)
 }

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -52,7 +52,7 @@ pub fn make_test_filesystem(
             .initial_read_window_size(256 * 1024)
             .build(),
     );
-    let pool = PagedPool::new_with_candidate_sizes([part_size], config.mem_limit);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let fs = make_test_filesystem_with_client(client.clone(), pool, bucket, prefix, config);
     (client, fs)
 }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -730,7 +730,7 @@ async fn test_upload_aborted_on_write_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -806,7 +806,7 @@ async fn test_upload_aborted_on_fsync_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -867,7 +867,7 @@ async fn test_upload_aborted_on_release_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size]),
+        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -1531,7 +1531,7 @@ async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
     let client_config = S3ClientConfig::default()
         .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true)
@@ -1568,7 +1568,7 @@ async fn test_lookup_forbidden() {
     let policy = deny_single_object_access_policy(&bucket, &key);
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
@@ -1651,7 +1651,7 @@ async fn test_rename_support_is_cached() {
     const FILE_NAME: &str = "a.txt";
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
     let client = Arc::new(
         MockClient::config()
             .bucket(BUCKET_NAME)

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -730,7 +730,7 @@ async fn test_upload_aborted_on_write_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
+        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -806,7 +806,7 @@ async fn test_upload_aborted_on_fsync_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
+        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -867,7 +867,7 @@ async fn test_upload_aborted_on_release_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT),
+        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -1531,7 +1531,7 @@ async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let client_config = S3ClientConfig::default()
         .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true)
@@ -1568,7 +1568,7 @@ async fn test_lookup_forbidden() {
     let policy = deny_single_object_access_policy(&bucket, &key);
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
@@ -1651,7 +1651,7 @@ async fn test_rename_support_is_cached() {
     const FILE_NAME: &str = "a.txt";
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let client = Arc::new(
         MockClient::config()
             .bucket(BUCKET_NAME)

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -57,7 +57,7 @@ async fn express_invalid_block_read() {
     let prefix = get_test_prefix("express_invalid_block_read");
 
     // Mount the bucket
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let cache = CacheTestWrapper::new(ExpressDataCache::new(
         client.clone(),
@@ -119,7 +119,7 @@ async fn express_invalid_block_read() {
 fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -145,7 +145,7 @@ fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) 
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let cache = DiskDataCache::new(cache_config, pool.clone());
 
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -166,7 +166,7 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
     use mountpoint_s3_fs::data_cache::ExpressDataCacheConfig;
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let config = ExpressDataCacheConfig::new(&cache_bucket, &bucket_name)
@@ -181,7 +181,7 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
 #[tokio::test]
 #[cfg(feature = "s3express_tests")]
 async fn express_cache_read_empty() {
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -199,7 +199,7 @@ async fn disk_cache_read_empty() {
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize]);
     let cache = DiskDataCache::new(cache_config, pool);
 
     cache_read_empty(cache, "disk_cache_read_empty").await;
@@ -210,7 +210,7 @@ async fn disk_cache_read_empty() {
 async fn express_cache_verify_fail_non_express() {
     use mountpoint_s3_fs::data_cache::DataCacheError;
 
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let cache_bucket_name = get_standard_bucket();
@@ -259,7 +259,7 @@ async fn express_cache_verify_fail_forbidden() {
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
 
-    let pool = PagedPool::new_with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
     let client = create_crt_client(
         CLIENT_PART_SIZE,
         CLIENT_PART_SIZE,
@@ -369,7 +369,7 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
     let bucket = get_standard_bucket();
     let prefix = get_test_prefix("express_expected_bucket_owner");
     let cache_config = ExpressDataCacheConfig::new(&cache_bucket, &bucket);
-    let pool = PagedPool::new_with_candidate_sizes([cache_config.block_size as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::new_with_candidate_sizes_unlimited([cache_config.block_size as usize, CLIENT_PART_SIZE]);
     let cache = ExpressDataCache::new(client.clone(), cache_config);
     let cache_valid = block_on(cache.verify_cache_valid());
     if owner_checked && !owner_matches {

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -215,7 +215,7 @@ async fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, Moc
         .addressing_style(AddressingStyle::Path) // mock server responds to path style requests only
         .endpoint(endpoint);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
     let client_config = S3ClientConfig::default()
         .endpoint_config(endpoint_config)
         .auth_config(S3ClientAuthConfig::NoSigning)

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -215,7 +215,7 @@ async fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, Moc
         .addressing_style(AddressingStyle::Path) // mock server responds to path style requests only
         .endpoint(endpoint);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes([part_size], mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
     let client_config = S3ClientConfig::default()
         .endpoint_config(endpoint_config)
         .auth_config(S3ClientAuthConfig::NoSigning)

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -12,7 +12,7 @@ use mountpoint_s3_fs::data_cache::{CacheLimit, DataCacheConfig, DiskDataCacheCon
 use mountpoint_s3_fs::fs::{CacheConfig, ServerSideEncryption, TimeToLive};
 use mountpoint_s3_fs::fuse::config::{FuseOptions, FuseSessionConfig, MountPoint};
 use mountpoint_s3_fs::logging::{LoggingConfig, prepare_log_file_name};
-use mountpoint_s3_fs::mem_limiter::{MINIMUM_MEM_LIMIT, effective_total_memory};
+use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, effective_total_memory};
 use mountpoint_s3_fs::s3::config::{ClientConfig, PartConfig, TargetThroughputSetting};
 use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path, S3PathError, S3Personality};
 use mountpoint_s3_fs::{S3FilesystemConfig, autoconfigure, metrics};
@@ -490,7 +490,7 @@ impl CliArgs {
         Ok(s3path)
     }
 
-    fn mem_limit(&self) -> u64 {
+    pub(crate) fn mem_limit(&self) -> u64 {
         let mut mem_limit = MINIMUM_MEM_LIMIT;
 
         let default_mem_target = (effective_total_memory() as f64 * 0.95) as u64;

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -490,7 +490,7 @@ impl CliArgs {
         Ok(s3path)
     }
 
-    pub(crate) fn mem_limit(&self) -> u64 {
+    pub fn mem_limit(&self) -> u64 {
         let mut mem_limit = MINIMUM_MEM_LIMIT;
 
         let default_mem_target = (effective_total_memory() as f64 * 0.95) as u64;

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -542,7 +542,6 @@ impl CliArgs {
         filesystem_config.s3_personality = s3_personality;
         filesystem_config.server_side_encryption = sse;
         filesystem_config.cache_config = self.cache_config();
-        filesystem_config.mem_limit = self.mem_limit();
         filesystem_config.use_upload_checksums = self.should_use_upload_checksum(s3_personality);
         filesystem_config.content_type_detection = if self.infer_content_type {
             ContentTypeDetection::Auto

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -197,11 +197,14 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let client_config = args.client_config(build_info::FULL_VERSION);
 
     // Set up a paged memory pool
-    let pool = PagedPool::new_with_candidate_sizes([
-        args.cache_block_size_in_bytes() as usize,
-        client_config.part_config.read_size_bytes,
-        client_config.part_config.write_size_bytes,
-    ]);
+    let pool = PagedPool::new_with_candidate_sizes(
+        [
+            args.cache_block_size_in_bytes() as usize,
+            client_config.part_config.read_size_bytes,
+            client_config.part_config.write_size_bytes,
+        ],
+        args.mem_limit(),
+    );
     // Schedule trimming of empty memory pages every minutes. We should consider
     // event-based triggers and/or a configurable interval in the future.
     pool.schedule_trim(Duration::from_secs(60));


### PR DESCRIPTION
Moves MemoryLimiter inside PagedPool to improve the ownership model.

Before: MemoryLimiter owned a PagedPool field to read pool stats, while PagedPool called back into MemoryLimiter via a closure to decrement reservations on buffer allocation. Consumers (prefetcher, uploader, filesystem) had to pass both pool and Arc<MemoryLimiter> separately.

After: PagedPool owns the MemoryLimiter internally and calls it directly on buffer allocation — no callback needed. Consumers only need a PagedPool and call pool.reserve(), pool.try_reserve(), pool.available_mem(), etc. directly.

Key changes:
- MemoryLimiter moved from mem_limiter.rs to memory/limiter.rs
- PagedPool::new_with_candidate_sizes now takes a required mem_limit: u64 parameter
- Added PagedPool::new_with_candidate_sizes_unlimited() convenience constructor for tests/examples that don't need memory budgeting
- Uploader::new() no longer takes a mem_limiter parameter
- PrefetcherBuilder::build() takes PagedPool instead of Arc<MemoryLimiter>
- Removed mem_limit from S3FilesystemConfig; pool construction moved to run.rs

Next steps
- [x] Rebase and resolve conflicts
- [x] Consider renaming the mem_limiter feature flag
- [x] Consider removing callback
- [X] Consider second pool convenience constructor with minimum memory limit


### Does this change impact existing behavior?
No. This is a pure refactor — no behavioral changes. The same memory limiting logic runs, the same budget checks apply, the same callbacks fire. Only the ownership structure and call sites changed.

### Does this change need a changelog entry? Does it require a version change?
No. Internal refactor only — no public API changes, no user-facing behavior changes, no CLI changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
