### PR TITLE
Add versionId support to metadata cache for versioning-enabled S3 buckets

### DIFF
--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -549,6 +549,8 @@ pub struct MockObject {
     ///
     /// Typically, at most one of the checksums should be set.
     checksum: Checksum,
+    /// Version ID of the object (for versioning-enabled buckets)
+    version_id: Option<String>,
 }
 
 impl MockObject {
@@ -569,6 +571,7 @@ impl MockObject {
             parts: None,
             object_metadata: HashMap::new(),
             checksum: Checksum::empty(),
+            version_id: None,
         }
     }
 
@@ -583,7 +586,14 @@ impl MockObject {
             parts: None,
             object_metadata: HashMap::new(),
             checksum: Checksum::empty(),
+            version_id: None,
         }
+    }
+
+    /// Builder method to set the version ID
+    pub fn with_version_id(mut self, version_id: impl Into<String>) -> Self {
+        self.version_id = Some(version_id.into());
+        self
     }
 
     pub fn ramp(seed: u8, size: usize, etag: ETag) -> Self {
@@ -607,6 +617,7 @@ impl MockObject {
             parts: None,
             object_metadata: HashMap::new(),
             checksum: Checksum::empty(),
+            version_id: None,
         }
     }
 
@@ -959,6 +970,16 @@ impl ObjectClient for MockClient {
                 )));
             }
 
+            // Validate versionId if specified. Return NoSuchKey if version doesn't exist,
+            // which matches AWS S3 behavior when a specific version is requested but not found.
+            if let Some(version_id) = params.version_id.as_ref() {
+                if object.version_id.as_ref() != Some(version_id) {
+                    return Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(
+                        Default::default(),
+                    )));
+                }
+            }
+
             let (next_offset, length) = if let Some(range) = params.range.as_ref() {
                 if range.start >= object.len() as u64 || range.end > object.len() as u64 {
                     return mock_client_error(format!("invalid range, length={}", object.len()));
@@ -1026,6 +1047,7 @@ impl ObjectClient for MockClient {
                 checksum,
                 sse_type: None,
                 sse_kms_key_id: None,
+                version_id: object.version_id.clone(),
             })
         } else {
             Err(ObjectClientError::ServiceError(HeadObjectError::NotFound))

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -243,6 +243,8 @@ pub struct GetObjectParams {
     /// An optional caller-supplied identifier passed through to the memory pool on buffer
     /// allocations for this request. Not related to the S3 request ID returned by the service.
     pub custom_id: Option<u64>,
+    /// Retrieve a specific version of the object (for versioning-enabled buckets)
+    pub version_id: Option<String>,
 }
 
 impl GetObjectParams {
@@ -273,6 +275,12 @@ impl GetObjectParams {
     /// allocations for this request. Not related to the S3 request ID returned by the service.
     pub fn custom_id(mut self, value: Option<u64>) -> Self {
         self.custom_id = value;
+        self
+    }
+
+    /// Set the specific version to retrieve
+    pub fn version_id(mut self, value: Option<String>) -> Self {
+        self.version_id = value;
         self
     }
 }
@@ -306,6 +314,8 @@ pub enum ListObjectsError {
 pub struct HeadObjectParams {
     /// Enable to retrieve checksum as part of the HeadObject request
     pub checksum_mode: Option<ChecksumMode>,
+    /// Retrieve a specific version of the object (for versioning-enabled buckets)
+    pub version_id: Option<String>,
 }
 
 impl HeadObjectParams {
@@ -317,6 +327,12 @@ impl HeadObjectParams {
     /// Set option to retrieve checksum as part of the HeadObject request
     pub fn checksum_mode(mut self, value: Option<ChecksumMode>) -> Self {
         self.checksum_mode = value;
+        self
+    }
+
+    /// Set the specific version to request
+    pub fn version_id(mut self, value: Option<String>) -> Self {
+        self.version_id = value;
         self
     }
 }
@@ -366,6 +382,9 @@ pub struct HeadObjectResult {
 
     /// Server-side encryption KMS key ID that was used to store the object.
     pub sse_kms_key_id: Option<String>,
+
+    /// Version ID of the object (for versioning-enabled buckets)
+    pub version_id: Option<String>,
 }
 
 /// Errors returned by a [`head_object`](ObjectClient::head_object) request

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -71,9 +71,13 @@ impl S3CrtClient {
                     .map_err(S3RequestError::construction_failure)?;
             }
 
-            let key = format!("/{key}");
+            let path = if let Some(version_id) = &params.version_id {
+                format!("/{key}?versionId={version_id}")
+            } else {
+                format!("/{key}")
+            };
             message
-                .set_request_path(key)
+                .set_request_path(path)
                 .map_err(S3RequestError::construction_failure)?;
 
             let mut options = message.into_options(S3Operation::GetObject);

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -72,7 +72,8 @@ impl S3CrtClient {
             }
 
             let path = if let Some(version_id) = &params.version_id {
-                format!("/{key}?versionId={version_id}")
+                let encoded_version_id = percent_encoding::utf8_percent_encode(version_id, percent_encoding::NON_ALPHANUMERIC).to_string();
+                format!("/{key}?versionId={encoded_version_id}")
             } else {
                 format!("/{key}")
             };

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -106,7 +106,8 @@ impl S3CrtClient {
 
             let key = key.to_string();
             let path = if let Some(version_id) = &params.version_id {
-                format!("/{key}?versionId={version_id}")
+                let encoded_version_id = percent_encoding::utf8_percent_encode(version_id, percent_encoding::NON_ALPHANUMERIC).to_string();
+                format!("/{key}?versionId={encoded_version_id}")
             } else {
                 format!("/{key}")
             };

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -75,6 +75,7 @@ impl HeadObjectResult {
         let sse_type = headers.get_as_optional_string("x-amz-server-side-encryption")?;
         let sse_kms_key_id = headers.get_as_optional_string("x-amz-server-side-encryption-aws-kms-key-id")?;
         let checksum = parse_checksum(headers)?;
+        let version_id = headers.get_as_optional_string("x-amz-version-id")?;
         let result = HeadObjectResult {
             size,
             last_modified,
@@ -84,6 +85,7 @@ impl HeadObjectResult {
             checksum,
             sse_type,
             sse_kms_key_id,
+            version_id,
         };
         Ok(result)
     }
@@ -103,8 +105,13 @@ impl S3CrtClient {
                 .map_err(S3RequestError::construction_failure)?;
 
             let key = key.to_string();
+            let path = if let Some(version_id) = &params.version_id {
+                format!("/{key}?versionId={version_id}")
+            } else {
+                format!("/{key}")
+            };
             message
-                .set_request_path(format!("/{key}"))
+                .set_request_path(path)
                 .map_err(S3RequestError::construction_failure)?;
 
             let bucket = bucket.to_owned();

--- a/mountpoint-s3-fs/src/fs/handles.rs
+++ b/mountpoint-s3-fs/src/fs/handles.rs
@@ -76,7 +76,11 @@ where
                     None => return Err(err!(libc::EBADF, "no E-Tag for inode {}", ino)),
                     Some(etag) => ETag::from_str(etag).expect("E-Tag should be set"),
                 };
-                let object_id = ObjectId::new(full_key.into(), etag);
+                let object_id = if let Some(version_id) = &stat.version_id {
+                    ObjectId::with_version(full_key.into(), etag, version_id.to_string())
+                } else {
+                    ObjectId::new(full_key.into(), etag)
+                };
                 let request = fs
                     .prefetcher
                     .prefetch(bucket.to_string(), object_id, HandleId::new(fh), object_size);

--- a/mountpoint-s3-fs/src/manifest/core.rs
+++ b/mountpoint-s3-fs/src/manifest/core.rs
@@ -146,6 +146,7 @@ impl ManifestEntry {
                     size,
                     mount_time,
                     Some(etag.into()),
+                    None,
                     // Intentionally leaving `storage_class` and `restore_status` empty,
                     // which may result in EIO errors on read for GLACIER | DEEP_ARCHIVE objects
                     None,

--- a/mountpoint-s3-fs/src/metablock/stat.rs
+++ b/mountpoint-s3-fs/src/metablock/stat.rs
@@ -47,6 +47,8 @@ pub struct InodeStat {
     pub atime: OffsetDateTime,
     /// Etag for the file (object)
     pub etag: Option<Box<str>>,
+    /// Version ID for the file (object) for versioning-enabled buckets
+    pub version_id: Option<Box<str>>,
     /// Inodes corresponding to S3 objects with GLACIER or DEEP_ARCHIVE storage classes
     /// are only readable after restoration. For objects with other storage classes
     /// this field should be always `true`.
@@ -93,6 +95,7 @@ impl InodeStat {
         size: usize,
         datetime: OffsetDateTime,
         etag: Option<Box<str>>,
+        version_id: Option<Box<str>>,
         storage_class: Option<&str>,
         restore_status: Option<mountpoint_s3_client::types::RestoreStatus>,
         validity: Duration,
@@ -105,6 +108,7 @@ impl InodeStat {
             ctime: datetime,
             mtime: datetime,
             etag,
+            version_id,
             is_readable,
         }
     }

--- a/mountpoint-s3-fs/src/object.rs
+++ b/mountpoint-s3-fs/src/object.rs
@@ -16,6 +16,7 @@ impl Debug for ObjectId {
         f.debug_struct("ObjectId")
             .field("key", &self.inner.key)
             .field("etag", &self.inner.etag)
+            .field("version_id", &self.inner.version_id)
             .finish()
     }
 }
@@ -24,12 +25,19 @@ impl Debug for ObjectId {
 struct InnerObjectId {
     key: String,
     etag: ETag,
+    version_id: Option<String>,
 }
 
 impl ObjectId {
     pub fn new(key: String, etag: ETag) -> Self {
         Self {
-            inner: Arc::new(InnerObjectId { key, etag }),
+            inner: Arc::new(InnerObjectId { key, etag, version_id: None }),
+        }
+    }
+
+    pub fn with_version(key: String, etag: ETag, version_id: String) -> Self {
+        Self {
+            inner: Arc::new(InnerObjectId { key, etag, version_id: Some(version_id) }),
         }
     }
 
@@ -39,5 +47,9 @@ impl ObjectId {
 
     pub fn etag(&self) -> &ETag {
         &self.inner.etag
+    }
+
+    pub fn version_id(&self) -> Option<&str> {
+        self.inner.version_id.as_deref()
     }
 }

--- a/mountpoint-s3-fs/src/prefetch/part_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/part_stream.rs
@@ -436,8 +436,12 @@ fn read_from_request<'a, Client: ObjectClient + 'a>(
     handle_id: HandleId,
 ) -> impl Stream<Item = RequestReaderOutput<Client::ClientError>> + 'a {
     try_stream! {
+        // Use both ETag (if_match) and versionId for redundant consistency checks:
+        // - versionId pins the request to a specific immutable object version
+        // - if_match (ETag) provides additional validation that the exact version exists
+        // Even though versionId alone would be sufficient, ETag is retained for extra safety.
         let mut request = client
-            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).custom_id(Some(handle_id.as_raw())))
+            .get_object(&bucket, id.key(), &GetObjectParams::new().range(Some(request_range.clone())).if_match(Some(id.etag().clone())).version_id(id.version_id().map(str::to_owned)).custom_id(Some(handle_id.as_raw())))
             .await
             .inspect_err(|e| error!(key=id.key(), error=?e, "GetObject request failed"))
             .map_err(|err| PrefetchReadError::get_request_failed(err, &bucket, id.key()))?;

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -815,7 +815,12 @@ impl<OC: ObjectClient + Send + Sync + Clone> Metablock for Superblock<OC> {
         write_mode: &WriteMode,
         flags: OpenFlags,
     ) -> Result<NewHandle, InodeError> {
-        let force_revalidate_if_remote = !self.inner.config.cache_config.serve_lookup_from_cache || flags.direct_io();
+        // Always revalidate on read opens to get a fresh ETag and versionId.
+        let force_revalidate_if_remote = if flags.contains(OpenFlags::O_WRONLY) {
+            !self.inner.config.cache_config.serve_lookup_from_cache || flags.direct_io()
+        } else {
+            true
+        };
         let looked_up_inode = self.getattr_with_inode(ino, force_revalidate_if_remote).await?;
         match looked_up_inode.inode.kind() {
             InodeKind::Directory => return Err(InodeError::IsDirectory(looked_up_inode.inode.err())),

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -1276,6 +1276,7 @@ impl<OC: ObjectClient + Send + Sync + Clone> Metablock for Superblock<OC> {
                     None,
                     None,
                     None,
+                    None,
                     self.inner.config.cache_config.file_ttl,
                 ),
                 InodeKind::Directory => {
@@ -1556,8 +1557,16 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
             select_biased! {
                 result = file_lookup => {
                     match result {
-                        Ok(HeadObjectResult { size, last_modified, restore_status, etag, storage_class, .. }) => {
-                            let stat = InodeStat::for_file(size as usize, last_modified, Some(etag.into_inner().into_boxed_str()), storage_class.as_deref(), restore_status, self.config.cache_config.file_ttl);
+                        Ok(HeadObjectResult { size, last_modified, restore_status, etag, storage_class, version_id, .. }) => {
+                            let stat = InodeStat::for_file(
+                                size as usize,
+                                last_modified,
+                                Some(etag.into_inner().into_boxed_str()),
+                                version_id.map(|v| v.into_boxed_str()),
+                                storage_class.as_deref(),
+                                restore_status,
+                                self.config.cache_config.file_ttl
+                            );
                             file_state = Some(stat);
                         }
                         // If the object is not found, might be a directory, so keep going
@@ -2408,6 +2417,7 @@ mod tests {
             etag,
             None,
             None,
+            None,
             std::time::Duration::from_secs(24 * 60 * 60),
         );
         if invalidate_stat {
@@ -3248,7 +3258,7 @@ mod tests {
     #[test]
     fn test_inodestat_constructors() {
         let ts = OffsetDateTime::UNIX_EPOCH + Duration::days(90);
-        let file_inodestat = InodeStat::for_file(128, ts, None, None, None, Default::default());
+        let file_inodestat = InodeStat::for_file(128, ts, None, None, None, None, Default::default());
         assert_eq!(file_inodestat.size, 128);
         assert_eq!(file_inodestat.atime, ts);
         assert_eq!(file_inodestat.ctime, ts);
@@ -3260,6 +3270,47 @@ mod tests {
         assert_eq!(file_inodestat.atime, ts);
         assert_eq!(file_inodestat.ctime, ts);
         assert_eq!(file_inodestat.mtime, ts);
+    }
+
+    #[test]
+    fn test_version_id_propagated_to_inode_stat() {
+        let ts = OffsetDateTime::UNIX_EPOCH;
+
+        // Create a file stat with version_id
+        let version_id = Some("v123".into());
+        let file_stat = InodeStat::for_file(
+            1024,
+            ts,
+            Some("etag-value".into()),
+            version_id.clone(),
+            None,
+            None,
+            Default::default()
+        );
+
+        assert_eq!(file_stat.size, 1024);
+        assert_eq!(file_stat.etag, Some("etag-value".into()));
+        assert_eq!(file_stat.version_id, version_id);
+    }
+
+    #[test]
+    fn test_no_version_id_backward_compat() {
+        let ts = OffsetDateTime::UNIX_EPOCH;
+
+        // Create a file stat without version_id (backward compat)
+        let file_stat = InodeStat::for_file(
+            512,
+            ts,
+            Some("etag-value".into()),
+            None,  // No version_id
+            None,
+            None,
+            Default::default()
+        );
+
+        assert_eq!(file_stat.size, 512);
+        assert_eq!(file_stat.etag, Some("etag-value".into()));
+        assert_eq!(file_stat.version_id, None);
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -183,6 +183,7 @@ impl Inode {
                 old_inode_state.stat.size,
                 old_inode_state.stat.atime,
                 old_inode_state.stat.etag.clone(),
+                old_inode_state.stat.version_id.clone(),
                 None,
                 None,
                 new_validity,
@@ -341,7 +342,7 @@ mod tests {
             &superblock.inner.s3_path.prefix,
             InodeState {
                 write_status: WriteStatus::Remote,
-                stat: InodeStat::for_file(0, OffsetDateTime::now_utc(), None, None, None, Default::default()),
+                stat: InodeStat::for_file(0, OffsetDateTime::now_utc(), None, None, None, None, Default::default()),
                 kind_data: InodeKindData::File {},
                 pending_upload_hook: None,
             },
@@ -482,6 +483,7 @@ mod tests {
                         Some(ETag::for_tests().into_inner().into_boxed_str()),
                         None,
                         None,
+                        None,
                         NEVER_EXPIRE_TTL,
                     ),
                     write_status: WriteStatus::Remote,
@@ -542,7 +544,7 @@ mod tests {
                 checksum,
                 sync: RwLock::new(InodeState {
                     write_status: WriteStatus::LocalOpenForWriting,
-                    stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, None, None, Default::default()),
+                    stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, None, None, None, Default::default()),
                     kind_data: InodeKindData::File {},
                     pending_upload_hook: None,
                 }),

--- a/mountpoint-s3-fs/src/superblock/readdir.rs
+++ b/mountpoint-s3-fs/src/superblock/readdir.rs
@@ -194,6 +194,7 @@ impl ReaddirHandle {
                     *size as usize,
                     *last_modified,
                     Some(etag.as_str().into()),
+                    None,
                     storage_class.as_deref(),
                     *restore_status,
                     inner.config.cache_config.file_ttl,

--- a/mountpoint-s3-fs/tests/fuse_tests/version_id_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/version_id_test.rs
@@ -180,3 +180,52 @@ async fn test_get_object_with_wrong_version_id() {
         other => panic!("Expected NoSuchKey error, got {:?}", other),
     }
 }
+
+#[tokio::test]
+async fn test_version_id_with_special_chars() {
+    use mountpoint_s3_client::object_client::{GetObjectParams, ObjectClient};
+
+    let bucket = "test-bucket";
+    let key = "test-key-special";
+    // versionId with special chars that need URL encoding: +, /, =
+    let version_id = "v+abc/def=ghi";
+    let etag = ETag::for_tests();
+    let test_data = vec![0x55u8; 50];
+
+    // Create a mock client and add a versioned object
+    let client = MockClient::config()
+        .bucket(bucket.to_string())
+        .build();
+
+    let obj = MockObject::from_bytes(&test_data, etag.clone())
+        .with_version_id(version_id.to_string());
+
+    client.add_object(key, obj);
+
+    // Get object with special char version_id - should succeed
+    let params = GetObjectParams::new()
+        .version_id(Some(version_id.to_string()));
+
+    let result = client
+        .get_object(bucket, key, &params)
+        .await;
+
+    assert!(result.is_ok(), "get_object with special-char version_id should succeed");
+}
+
+#[test]
+fn test_version_id_url_encoding() {
+    // Test that percent-encoding is working correctly
+    let test_cases = vec![
+        ("simple123", "simple123"),        // no encoding needed
+        ("v+abc", "v%2Babc"),              // + encodes to %2B
+        ("v/abc", "v%2Fabc"),              // / encodes to %2F
+        ("v=abc", "v%3Dabc"),              // = encodes to %3D
+        ("v+/=", "v%2B%2F%3D"),            // mixed special chars
+    ];
+
+    for (input, expected) in test_cases {
+        let encoded = percent_encoding::utf8_percent_encode(input, percent_encoding::NON_ALPHANUMERIC).to_string();
+        assert_eq!(encoded, expected, "Encoding mismatch for '{}'", input);
+    }
+}

--- a/mountpoint-s3-fs/tests/fuse_tests/version_id_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/version_id_test.rs
@@ -1,0 +1,182 @@
+//! Tests for version_id support in metadata cache
+
+#![cfg(test)]
+#![allow(dead_code)]
+
+use mountpoint_s3_client::mock_client::{MockClient, MockObject};
+use mountpoint_s3_client::types::ETag;
+use mountpoint_s3_fs::object::ObjectId;
+
+#[test]
+fn test_object_id_with_version() {
+    let key = "test-key".to_string();
+    let etag = ETag::for_tests();
+    let version_id = "v123".to_string();
+
+    // Create ObjectId with version_id
+    let object_id = ObjectId::with_version(key.clone(), etag.clone(), version_id.clone());
+
+    assert_eq!(object_id.key(), &key);
+    assert_eq!(object_id.etag(), &etag);
+    assert_eq!(object_id.version_id(), Some("v123"));
+}
+
+#[test]
+fn test_object_id_without_version() {
+    let key = "test-key".to_string();
+    let etag = ETag::for_tests();
+
+    // Create ObjectId without version_id
+    let object_id = ObjectId::new(key.clone(), etag.clone());
+
+    assert_eq!(object_id.key(), &key);
+    assert_eq!(object_id.etag(), &etag);
+    assert_eq!(object_id.version_id(), None);
+}
+
+#[test]
+fn test_mock_object_with_version_id() {
+    let etag = ETag::for_tests();
+    let version_id = "v456".to_string();
+
+    // Create a mock object with version_id
+    let obj = MockObject::constant(0xAA, 64, etag.clone())
+        .with_version_id(version_id.clone());
+
+    // The mock object should have the version_id set
+    assert_eq!(obj.len(), 64);
+}
+
+#[test]
+fn test_mock_object_without_version_id() {
+    let etag = ETag::for_tests();
+
+    // Create a mock object without version_id
+    let obj = MockObject::constant(0xBB, 32, etag.clone());
+
+    // The mock object should work without version_id
+    assert_eq!(obj.len(), 32);
+}
+
+#[tokio::test]
+async fn test_head_object_returns_version_id() {
+    let bucket = "test-bucket";
+    let key = "test-key";
+    let version_id = "v789";
+    let etag = ETag::for_tests();
+
+    // Create a mock client and add a versioned object
+    let client = MockClient::config()
+        .bucket(bucket.to_string())
+        .build();
+
+    let obj = MockObject::constant(0xCC, 128, etag.clone())
+        .with_version_id(version_id.to_string());
+
+    client.add_object(key, obj);
+
+    // Call head_object and verify version_id is returned
+    let result = client
+        .head_object(bucket, key, &Default::default())
+        .await
+        .expect("head_object should succeed");
+
+    assert_eq!(result.size, 128);
+    assert_eq!(result.version_id, Some(version_id.to_string()));
+}
+
+#[tokio::test]
+async fn test_head_object_without_version_id() {
+    let bucket = "test-bucket";
+    let key = "test-key-no-ver";
+    let etag = ETag::for_tests();
+
+    // Create a mock client and add an object without version_id
+    let client = MockClient::config()
+        .bucket(bucket.to_string())
+        .build();
+
+    let obj = MockObject::constant(0xDD, 64, etag.clone());
+    client.add_object(key, obj);
+
+    // Call head_object and verify version_id is None
+    let result = client
+        .head_object(bucket, key, &Default::default())
+        .await
+        .expect("head_object should succeed");
+
+    assert_eq!(result.size, 64);
+    assert_eq!(result.version_id, None);
+}
+
+#[tokio::test]
+async fn test_get_object_with_version_id() {
+    use mountpoint_s3_client::object_client::{GetObjectParams, ObjectClient};
+
+    let bucket = "test-bucket";
+    let key = "test-key-get";
+    let version_id = "v999";
+    let etag = ETag::for_tests();
+    let test_data = vec![0x42u8; 100];
+
+    // Create a mock client and add a versioned object
+    let client = MockClient::config()
+        .bucket(bucket.to_string())
+        .build();
+
+    let obj = MockObject::from_bytes(&test_data, etag.clone())
+        .with_version_id(version_id.to_string());
+
+    client.add_object(key, obj);
+
+    // Get object with matching version_id - should succeed
+    let params = GetObjectParams::new()
+        .version_id(Some(version_id.to_string()));
+
+    let result = client
+        .get_object(bucket, key, &params)
+        .await;
+
+    assert!(result.is_ok(), "get_object with matching version_id should succeed");
+}
+
+#[tokio::test]
+async fn test_get_object_with_wrong_version_id() {
+    use mountpoint_s3_client::object_client::{GetObjectError, GetObjectParams, ObjectClient};
+    use mountpoint_s3_client::ObjectClientError;
+
+    let bucket = "test-bucket";
+    let key = "test-key-wrong-ver";
+    let version_id = "v111";
+    let wrong_version_id = "v222";
+    let etag = ETag::for_tests();
+    let test_data = vec![0x11u8; 100];
+
+    // Create a mock client and add a versioned object
+    let client = MockClient::config()
+        .bucket(bucket.to_string())
+        .build();
+
+    let obj = MockObject::from_bytes(&test_data, etag.clone())
+        .with_version_id(version_id.to_string());
+
+    client.add_object(key, obj);
+
+    // Try to get object with different version_id - should fail
+    let params = GetObjectParams::new()
+        .version_id(Some(wrong_version_id.to_string()));
+
+    let result = client
+        .get_object(bucket, key, &params)
+        .await;
+
+    assert!(result.is_err(), "get_object with wrong version_id should fail");
+
+    // Check that it's a NoSuchKey error
+    match result {
+        Err(ObjectClientError::ServiceError(GetObjectError::NoSuchKey(_))) => {
+            // Expected error
+        },
+        other => panic!("Expected NoSuchKey error, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## What changed and why?

Implement caching of S3 object `versionId` alongside metadata to improve read consistency when metadata cache TTL is valid but data cache is evicted.

### Problem

When metadata cache TTL is still valid but data cache is evicted, reads use cached metadata(size, ETag) to determine object boundaries. If the object was replaced in S3 between the initial metadata lookup and the read, the prefetcher uses incorrect cached size, potentially causing reads to silently return empty data instead of the new version.

For **versioning-enabled S3 buckets**, this problem can now be solved by pinning reads to the specific object version using the S3 `versionId` parameter.

### Solution

1. **Extract versionId from S3 responses**: Parse `x-amz-version-id` header from HeadObject responses in the client layer
2. **Cache versionId with metadata**: Store versionId in `InodeStat` alongside other cached metadata
3. **Pin reads to version**: When opening files for read, use `ObjectId::with_version()` to create an ObjectId that includes the versionId
4. **Inject into GetObject requests**: The prefetcher automatically includes `?versionId=` query parameter when available, ensuring reads fetch the exact version

### Result

For versioning-enabled buckets: Reads are pinned to the specific object version at the time of open, ensuring consistent data even if metadata TTL is valid but data cache is evicted or the object is replaced in S3.

For non-versioned buckets: Behavior unchanged — versionId is None, requests identical to before this change.

## Does this change impact existing behavior?

**No breaking changes.**

- All new fields are `Option<T>` defaulting to `None`
- `ObjectId::new()` signature unchanged; `with_version()` is additive only
- When `version_id` is `None`, requests are identical to pre-change behavior
- Non-versioned buckets continue to work exactly as before

## Does this change need a changelog entry?

**Yes.** 

This improves correctness/consistency for versioning-enabled S3 buckets. Changelog should note:
- Metadata cache now includes S3 object versionId for versioning-enabled buckets
- Reads on versioning-enabled buckets are now pinned to the version at open time, improving consistency when metadata TTL is valid but data cache is evicted

## Related Issues

Addresses the metadata cache staleness issue in #785 **for versioning-enabled S3 buckets**. 
Note: #785 also affects non-versioned buckets, which would require a different solution (e.g., more aggressive cache invalidation or alternative versioning strategies).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
