### PR TITLE
Introduce a builder to create PagedPool instances

### DIFF
--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -222,7 +222,10 @@ struct CliArgs {
 }
 
 fn create_s3_client_config(region: &str, args: &CliArgs, nics: Vec<String>) -> S3ClientConfig {
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([args.part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([args.part_size])
+        .with_no_memory_limit()
+        .build();
     let mut config = S3ClientConfig::new()
         .endpoint_config(EndpointConfig::new(region))
         .throughput_target_gbps(args.throughput_target_gbps)

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -80,7 +80,10 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
 
     #[cfg(feature = "fs_pool_tests")]
     let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
-        mountpoint_s3_fs::memory::PagedPool::new_with_candidate_sizes_unlimited([options.part_size()])
+        mountpoint_s3_fs::memory::PagedPool::config()
+            .with_candidate_sizes([options.part_size()])
+            .with_no_memory_limit()
+            .build()
     });
 
     config

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -39,7 +39,10 @@ fn cache_read_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Pat
         block_size: BLOCK_SIZE,
         limit: mountpoint_s3_fs::data_cache::CacheLimit::Unbounded,
     };
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE as usize]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([BLOCK_SIZE as usize])
+        .with_no_memory_limit()
+        .build();
     let cache = DiskDataCache::new(config, pool);
     let cache_key = ObjectId::new("a".into(), ETag::for_tests());
     let bytes = ChecksummedBytes::new(data.to_owned().into());

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -143,7 +143,10 @@ fn mount_file_system(
     throughput_target_gbps: Option<f64>,
 ) -> FuseSession {
     let part_size = 8 * 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));
     config = config
         .read_backpressure(true)

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -310,7 +310,10 @@ fn mount_filesystem(
     let mem_limit = config
         .memory_limit_bytes
         .unwrap_or(mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
-    let pool = PagedPool::new_with_candidate_sizes([client_config.part_config.read_size_bytes], mem_limit);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([client_config.part_config.read_size_bytes])
+        .with_memory_limit(mem_limit)
+        .build();
     let client = client_config
         .create_client(pool.clone(), None)
         .context("Failed to create S3 client")?;

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -167,10 +167,10 @@ fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     let bucket = args.bucket.as_str();
-    let pool = PagedPool::new_with_candidate_sizes(
-        [args.part_size.unwrap_or(8 * 1024 * 1024) as usize],
-        args.memory_target_in_bytes(),
-    );
+    let pool = PagedPool::config()
+        .with_candidate_sizes([args.part_size.unwrap_or(8 * 1024 * 1024) as usize])
+        .with_memory_limit(args.memory_target_in_bytes())
+        .build();
     let client_config = args.s3_client_config().memory_pool(pool.clone());
     let client = S3CrtClient::new(client_config).context("failed to create S3 CRT client")?;
     let runtime = Runtime::new(client.event_loop_group());

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -65,7 +65,10 @@ impl Executor {
         };
 
         let memory_target_bytes = (max_memory_target * 1024 * 1024) as u64;
-        let pool = PagedPool::new_with_candidate_sizes([read_part_size, write_part_size], memory_target_bytes);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([read_part_size, write_part_size])
+            .with_memory_limit(memory_target_bytes)
+            .build();
 
         let mut endpoint_config = EndpointConfig::new(region);
         if let Some(url) = &global.endpoint_url {

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -102,7 +102,10 @@ fn main() {
         // Default to 95% of total system memory (cgroup-aware)
         (effective_total_memory() as f64 * 0.95) as u64
     };
-    let pool = PagedPool::new_with_candidate_sizes([args.write_part_size], max_memory_target);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([args.write_part_size])
+        .with_memory_limit(max_memory_target)
+        .build();
     let config = S3ClientConfig::new()
         .endpoint_config(endpoint_config)
         .throughput_target_gbps(args.throughput_target_gbps as f64)

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -687,7 +687,10 @@ mod tests {
     #[test]
     fn get_path_for_block_key() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_no_memory_limit()
+            .build();
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -719,7 +722,10 @@ mod tests {
     #[test]
     fn get_path_for_block_key_huge_block_index() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_no_memory_limit()
+            .build();
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_dir,
@@ -761,7 +767,10 @@ mod tests {
         let object_2_size = data_2.len();
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([pool_buffer_size]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([pool_buffer_size])
+            .with_no_memory_limit()
+            .build();
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -848,7 +857,10 @@ mod tests {
         let slice = data.slice(1..5);
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([8 * 1024 * 1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_no_memory_limit()
+            .build();
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -930,7 +942,10 @@ mod tests {
         let small_object_key = ObjectId::new("small".into(), ETag::for_tests());
 
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([BLOCK_SIZE])
+            .with_no_memory_limit()
+            .build();
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),
@@ -1113,7 +1128,10 @@ mod tests {
         // "Corrupt" the serialized value with an invalid length.
         replace_u64_at(&mut buf, offset, u64::MAX);
 
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([MAX_LENGTH as usize]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([MAX_LENGTH as usize])
+            .with_no_memory_limit()
+            .build();
         let err =
             DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None).expect_err("deserialization should fail");
         match length_to_corrupt {
@@ -1130,7 +1148,10 @@ mod tests {
     fn test_concurrent_access() {
         let block_size = 1024 * 1024;
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([block_size]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([block_size])
+            .with_no_memory_limit()
+            .build();
         let data_cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -131,7 +131,10 @@ mod tests {
 
     fn create_disk_cache() -> (TempDir, Arc<DiskDataCache>) {
         let cache_directory = tempfile::tempdir().unwrap();
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([BLOCK_SIZE as usize, PART_SIZE]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([BLOCK_SIZE as usize, PART_SIZE])
+            .with_no_memory_limit()
+            .build();
         let cache = DiskDataCache::new(
             DiskDataCacheConfig {
                 cache_directory: cache_directory.path().to_path_buf(),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -785,7 +785,6 @@ where
 mod tests {
     use super::*;
 
-    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::prefetch::Prefetcher;
     use crate::s3::{Bucket, S3Path};
     use crate::{Superblock, SuperblockConfig};
@@ -809,7 +808,10 @@ mod tests {
         client.add_object("dir1/file1.bin", MockObject::constant(0xa1, 15, ETag::for_tests()));
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
-        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([32])
+            .with_minimum_memory_limit()
+            .build();
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let server_side_encryption =
             ServerSideEncryption::new(Some("aws:kms".to_owned()), Some("some_key_alias".to_owned()));
@@ -1073,7 +1075,10 @@ mod tests {
         );
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(10).create().unwrap());
-        let pool = PagedPool::new_with_candidate_sizes([32], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([32])
+            .with_minimum_memory_limit()
+            .build();
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
         let fs_config = S3FilesystemConfig {
             allow_overwrite,

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -334,7 +334,10 @@ mod tests {
     use crate::sync::atomic::Ordering;
 
     fn new_pool() -> PagedPool {
-        PagedPool::new_with_candidate_sizes_minimally_limited([1024])
+        PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_minimum_memory_limit()
+            .build()
     }
 
     #[test]
@@ -430,7 +433,10 @@ mod tests {
     fn test_on_pool_reserve_noop_after_release_cursor() {
         // Simulates the cancellation race: on_reserve fires after release_cursor
         // removed the entry. The callback should be a no-op.
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_minimum_memory_limit()
+            .build();
         let limiter = pool.limiter();
         let cursor = pool.create_cursor().state();
 
@@ -450,7 +456,10 @@ mod tests {
 
     #[test]
     fn test_on_pool_reserve_saturates_on_over_decrement() {
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_minimum_memory_limit()
+            .build();
         let limiter = pool.limiter();
         let cursor = pool.create_cursor().state();
 
@@ -471,7 +480,10 @@ mod tests {
 
     #[test]
     fn test_available_mem_accounts_for_pool_allocations() {
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_minimum_memory_limit()
+            .build();
         let limiter = pool.limiter();
         let cursor = pool.create_cursor().state();
         let stats = pool.stats();
@@ -495,7 +507,10 @@ mod tests {
 
     #[test]
     fn test_upload_allocation_does_not_affect_mem_reserved() {
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([1024]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([1024])
+            .with_minimum_memory_limit()
+            .build();
         let limiter = pool.limiter();
         let stats = pool.stats();
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -10,6 +10,18 @@ use super::limiter::{CursorHandle, MemoryLimiter};
 use super::pages::{Page, PagedBufferPtr};
 use super::stats::{BufferKind, PoolStats, SizePoolStats};
 
+pub use super::limiter::MINIMUM_MEM_LIMIT;
+
+/// Maximum size for a primary buffer.
+///
+/// Buffers larger than this size will be allocated from secondary memory.
+pub const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
+
+/// Default size for a primary buffer.
+///
+/// Used when no other valid buffer size is provided when creating the pool.
+pub const DEFAULT_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+
 /// A pool of reusable fixed-size buffers allocated in large pages.
 ///
 /// This type implements [MemoryPool] and can be configured as a custom memory pool
@@ -47,44 +59,24 @@ pub struct PagedPool {
 }
 
 impl PagedPool {
-    /// Maximum size for a primary buffer.
-    ///
-    /// Buffers larger than this size will be allocated from secondary memory.
-    pub const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
+    /// Configuration for a [PagedPool].
+    pub fn config() -> PagedPoolConfig {
+        Default::default()
+    }
 
-    /// Default size for a primary buffer.
-    ///
-    /// Used when no other valid buffer size is provided when creating the pool.
-    pub const DEFAULT_BUFFER_SIZE: usize = 8 * 1024 * 1024;
-
-    /// Create a new pool, configuring primary memory with the given set of
-    /// buffer sizes, if valid.
-    ///
-    /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE](Self::MAX_BUFFER_SIZE))
-    /// or duplicate values for buffer sizes. If no valid value is provided,
-    /// uses [DEFAULT_BUFFER_SIZE](Self::DEFAULT_BUFFER_SIZE).
-    ///
-    /// An internal [MemoryLimiter] is created with the given `mem_limit`.
-    /// Buffer allocations automatically decrement the limiter's reservation counters.
-    pub fn new_with_candidate_sizes(buffer_sizes: impl Into<Vec<usize>>, mem_limit: u64) -> Self {
-        let mut ordered_sizes: Vec<_> = buffer_sizes.into();
-        ordered_sizes.retain(|&size| size > 0 && size <= Self::MAX_BUFFER_SIZE);
-        ordered_sizes.dedup();
-        ordered_sizes.sort();
-        if ordered_sizes.is_empty() {
-            ordered_sizes.push(Self::DEFAULT_BUFFER_SIZE);
-        }
-
+    /// Create a new [PagedPool] with the given configuration.
+    pub fn new(config: &PagedPoolConfig) -> Self {
         let stats = Arc::new(PoolStats::default());
-        let ordered_size_pools = ordered_sizes
-            .into_iter()
-            .map(|buffer_size| SizePool {
+        let ordered_size_pools = config
+            .ordered_sizes()
+            .iter()
+            .map(|&buffer_size| SizePool {
                 pages: Default::default(),
                 stats: Arc::new(SizePoolStats::new(buffer_size, stats.clone())),
             })
             .collect();
 
-        let limiter = MemoryLimiter::new(mem_limit);
+        let limiter = MemoryLimiter::new(config.memory_limit());
 
         let inner = PagedPoolInner {
             ordered_size_pools,
@@ -92,20 +84,6 @@ impl PagedPool {
             limiter,
         };
         Self { inner: Arc::new(inner) }
-    }
-
-    /// Create a pool without effective memory limiting.
-    ///
-    /// This is a convenience for tests and examples that don't need memory budgeting.
-    /// The internal limiter uses `u64::MAX` as its limit, so it never rejects reservations.
-    pub fn new_with_candidate_sizes_unlimited(buffer_sizes: impl Into<Vec<usize>>) -> Self {
-        Self::new_with_candidate_sizes(buffer_sizes, u64::MAX)
-    }
-
-    /// Create a pool with [MINIMUM_MEM_LIMIT] as the memory limit.
-    pub fn new_with_candidate_sizes_minimally_limited(buffer_sizes: impl Into<Vec<usize>>) -> Self {
-        use super::limiter::MINIMUM_MEM_LIMIT;
-        Self::new_with_candidate_sizes(buffer_sizes, MINIMUM_MEM_LIMIT)
     }
 
     /// Trim empty pages in the pool.
@@ -320,6 +298,68 @@ impl SizePool {
     }
 }
 
+/// Configuration for a [PagedPool].
+///
+/// Defaults:
+/// - memory limit: [MINIMUM_MEM_LIMIT],
+/// - buffer size: [DEFAULT_BUFFER_SIZE].
+#[derive(Debug, Default, Clone)]
+pub struct PagedPoolConfig {
+    ordered_sizes: Vec<usize>,
+    mem_limit: u64,
+}
+
+impl PagedPoolConfig {
+    /// Configure primary memory with the given set of buffer sizes, if valid.
+    ///
+    /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE])
+    /// or duplicate values for buffer sizes. If no valid value is provided,
+    /// uses [DEFAULT_BUFFER_SIZE]).
+    pub fn with_candidate_sizes(&mut self, buffer_sizes: impl Into<Vec<usize>>) -> &mut Self {
+        self.ordered_sizes = buffer_sizes.into();
+        self.ordered_sizes.retain(|&size| size > 0 && size <= MAX_BUFFER_SIZE);
+        self.ordered_sizes.dedup();
+        self.ordered_sizes.sort();
+        self
+    }
+
+    /// Configure the pool with the specified memory limit.
+    pub fn with_memory_limit(&mut self, mem_limit: u64) -> &mut Self {
+        self.mem_limit = mem_limit;
+        self
+    }
+
+    /// Configure the pool without effective memory limiting.
+    ///
+    /// This is a convenience for tests and examples that don't need memory budgeting.
+    /// The internal limiter uses `u64::MAX` as its limit, so it never rejects reservations.
+    pub fn with_no_memory_limit(&mut self) -> &mut Self {
+        self.with_memory_limit(u64::MAX)
+    }
+
+    /// Configure the pool with [MINIMUM_MEM_LIMIT] as the memory limit.
+    pub fn with_minimum_memory_limit(&mut self) -> &mut Self {
+        self.with_memory_limit(MINIMUM_MEM_LIMIT)
+    }
+
+    /// Build a [PagedPool] with this configuration.
+    pub fn build(&self) -> PagedPool {
+        PagedPool::new(self)
+    }
+
+    fn ordered_sizes(&self) -> &[usize] {
+        if self.ordered_sizes.is_empty() {
+            &[DEFAULT_BUFFER_SIZE]
+        } else {
+            &self.ordered_sizes
+        }
+    }
+
+    fn memory_limit(&self) -> u64 {
+        self.mem_limit.max(MINIMUM_MEM_LIMIT)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -342,14 +382,20 @@ mod tests {
     #[test_case(&[1, 2, 3], &[5, 10])]
     #[test_case(&vec![42u8; 1000], &[128, 1024])]
     fn test_from_slice(original: &[u8], buffer_sizes: &[usize]) {
-        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
+        let pool = PagedPool::config()
+            .with_candidate_sizes(buffer_sizes)
+            .with_no_memory_limit()
+            .build();
         let bytes = copy_from_slice(&pool, original);
         assert_eq!(original, bytes.as_ref());
     }
 
     #[test_case(&[5, 10, 1024])]
     fn test_pages(buffer_sizes: &[usize]) {
-        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
+        let pool = PagedPool::config()
+            .with_candidate_sizes(buffer_sizes)
+            .with_no_memory_limit()
+            .build();
 
         for &size in buffer_sizes {
             let original = vec![1u8; size];
@@ -385,7 +431,10 @@ mod tests {
     #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
     #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
     fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
-        let pool = PagedPool::new_with_candidate_sizes_unlimited(buffer_sizes);
+        let pool = PagedPool::config()
+            .with_candidate_sizes(buffer_sizes)
+            .with_no_memory_limit()
+            .build();
         if let Some(duration) = schedule {
             pool.schedule_trim(duration);
         }
@@ -419,7 +468,10 @@ mod tests {
     fn test_reserved_bytes() {
         let buffer_size = 1024;
         let reservations = HashMap::from([(BufferKind::GetObject, 10), (BufferKind::Other, 20)]);
-        let pool = PagedPool::new_with_candidate_sizes_unlimited([buffer_size]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([buffer_size])
+            .with_no_memory_limit()
+            .build();
         let mut buffers = Vec::new();
         for (&kind, &count) in &reservations {
             for _ in 0..count {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -314,12 +314,12 @@ impl PagedPoolConfig {
     ///
     /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE])
     /// or duplicate values for buffer sizes. If no valid value is provided,
-    /// uses [DEFAULT_BUFFER_SIZE]).
+    /// uses [DEFAULT_BUFFER_SIZE].
     pub fn with_candidate_sizes(&mut self, buffer_sizes: impl Into<Vec<usize>>) -> &mut Self {
         self.ordered_sizes = buffer_sizes.into();
         self.ordered_sizes.retain(|&size| size > 0 && size <= MAX_BUFFER_SIZE);
-        self.ordered_sizes.dedup();
         self.ordered_sizes.sort();
+        self.ordered_sizes.dedup();
         self
     }
 
@@ -362,7 +362,7 @@ impl PagedPoolConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::ops::Deref;
     use std::thread::{self, sleep};
     use std::time::Duration;
@@ -483,5 +483,18 @@ mod tests {
             let reserved = pool.reserved_bytes(kind);
             assert_eq!(reserved, count * buffer_size);
         }
+    }
+
+    #[test_case(&[1024 * 1028, 8 * 1024 * 1028, 8 * 1024 * 1028])]
+    #[test_case(&[10, 8, 10])]
+    #[test_case(&[8, 8, 10])]
+    fn test_ordered_pool_sizes(buffer_sizes: &[usize]) {
+        let mut config = PagedPool::config();
+        config.with_candidate_sizes(buffer_sizes);
+
+        let ordered_sizes = config.ordered_sizes();
+        assert!(ordered_sizes.iter().is_sorted(), "Sizes should be sorted");
+        let unique: HashSet<_> = ordered_sizes.iter().collect();
+        assert_eq!(ordered_sizes.len(), unique.len(), "Sizes should be unique");
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -303,10 +303,19 @@ impl SizePool {
 /// Defaults:
 /// - memory limit: [MINIMUM_MEM_LIMIT],
 /// - buffer size: [DEFAULT_BUFFER_SIZE].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct PagedPoolConfig {
     ordered_sizes: Vec<usize>,
     mem_limit: u64,
+}
+
+impl Default for PagedPoolConfig {
+    fn default() -> Self {
+        Self {
+            ordered_sizes: Default::default(),
+            mem_limit: MINIMUM_MEM_LIMIT,
+        }
+    }
 }
 
 impl PagedPoolConfig {
@@ -356,7 +365,7 @@ impl PagedPoolConfig {
     }
 
     fn memory_limit(&self) -> u64 {
-        self.mem_limit.max(MINIMUM_MEM_LIMIT)
+        self.mem_limit
     }
 }
 

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -377,7 +377,6 @@ mod tests {
 
     use crate::Runtime;
     use crate::data_cache::InMemoryDataCache;
-    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
     use crate::sync::Arc;
 
@@ -428,8 +427,10 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool =
-            PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([client.read_part_size(), client.write_part_size()])
+            .with_minimum_memory_limit()
+            .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let builder = match prefetcher_type {
             PrefetcherType::Default => Prefetcher::default_builder(client),
@@ -1169,7 +1170,10 @@ mod tests {
                     .initial_read_window_size(part_size)
                     .build(),
             );
-            let pool = PagedPool::new_with_candidate_sizes([part_size], MINIMUM_MEM_LIMIT);
+            let pool = PagedPool::config()
+                .with_candidate_sizes([part_size])
+                .with_minimum_memory_limit()
+                .build();
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
 
@@ -1230,7 +1234,10 @@ mod tests {
                     .initial_read_window_size(part_size)
                     .build(),
             );
-            let pool = PagedPool::new_with_candidate_sizes([part_size], MINIMUM_MEM_LIMIT);
+            let pool = PagedPool::config()
+                .with_candidate_sizes([part_size])
+                .with_minimum_memory_limit()
+                .build();
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
             let file_etag = object.etag();
 

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -506,8 +506,10 @@ mod tests {
     fn new_backpressure_controller_for_test(
         backpressure_config: BackpressureConfig,
     ) -> (BackpressureController, BackpressureLimiter) {
-        let pool =
-            PagedPool::new_with_candidate_sizes([8 * 1024 * 1024], backpressure_config.max_read_window_size as u64);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_memory_limit(backpressure_config.max_read_window_size as u64)
+            .build();
         let cursor_state = pool.create_cursor().state();
         new_backpressure_controller(backpressure_config, cursor_state)
     }

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -418,17 +418,13 @@ mod tests {
     use std::{thread, time::Duration};
 
     use futures::executor::{ThreadPool, block_on};
-    use mountpoint_s3_client::{
-        mock_client::{MockClient, MockObject, Operation},
-        types::ETag,
-    };
+    use mountpoint_s3_client::mock_client::{MockClient, MockObject, Operation};
+    use mountpoint_s3_client::types::ETag;
     use test_case::test_case;
 
-    use crate::{
-        data_cache::InMemoryDataCache,
-        memory::{MINIMUM_MEM_LIMIT, PagedPool},
-        object::ObjectId,
-    };
+    use crate::data_cache::InMemoryDataCache;
+    use crate::memory::PagedPool;
+    use crate::object::ObjectId;
 
     use super::*;
 
@@ -470,7 +466,10 @@ mod tests {
                 .initial_read_window_size(client_part_size)
                 .build(),
         );
-        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([block_size, client_part_size])
+            .with_minimum_memory_limit()
+            .build();
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
@@ -554,7 +553,10 @@ mod tests {
                 .initial_read_window_size(client_part_size)
                 .build(),
         );
-        let pool = PagedPool::new_with_candidate_sizes([block_size, client_part_size], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([block_size, client_part_size])
+            .with_minimum_memory_limit()
+            .build();
         mock_client.add_object(key, object.clone());
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -209,7 +209,6 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::fs::SseCorruptedError;
-    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
     use crate::sync::Arc;
     use crate::upload::{Uploader, UploaderConfig};
@@ -232,7 +231,10 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let buffer_size = client.write_part_size();
-        let pool = PagedPool::new_with_candidate_sizes([buffer_size], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([buffer_size])
+            .with_minimum_memory_limit()
+            .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         Uploader::new(
             client,

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -487,7 +487,6 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use crate::memory::MINIMUM_MEM_LIMIT;
     use crate::memory::PagedPool;
     use crate::sync::Arc;
 
@@ -511,8 +510,10 @@ mod tests {
     where
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
-        let pool =
-            PagedPool::new_with_candidate_sizes([client.read_part_size(), client.write_part_size()], MINIMUM_MEM_LIMIT);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([client.read_part_size(), client.write_part_size()])
+            .with_minimum_memory_limit()
+            .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         Uploader::new(
             client,
@@ -1177,7 +1178,10 @@ mod tests {
 
         let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
         // Use a pool with 0 memory limit to simulate memory pressure.
-        let pool = PagedPool::new_with_candidate_sizes([32], 0);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([32])
+            .with_memory_limit(0)
+            .build();
 
         let uploader = Uploader::new(
             client.clone(),

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -1169,19 +1169,21 @@ mod tests {
         assert_eq!(expected_content, *actual);
     }
 
-    #[test_case(1024, 128, 10)]
-    #[test_case(1024, 4096, 20)]
+    #[test_case(8 * 1024, 128, 10)]
+    #[test_case(8 * 1024, 16 * 1024, 20)]
     #[tokio::test]
     async fn test_append_on_low_memory(part_size: usize, write_size: usize, part_count: usize) {
         let bucket = "bucket";
         let key = "hello";
 
-        let client = Arc::new(MockClient::config().bucket(bucket).part_size(32).build());
+        let client = Arc::new(MockClient::config().bucket(bucket).part_size(part_size).build());
         // Use a pool with 0 memory limit to simulate memory pressure.
         let pool = PagedPool::config()
-            .with_candidate_sizes([32])
+            .with_candidate_sizes([part_size])
             .with_memory_limit(0)
             .build();
+
+        assert_eq!(pool.available_mem(), 0);
 
         let uploader = Uploader::new(
             client.clone(),

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -312,7 +312,10 @@ pub mod mock_session {
         };
 
         let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([test_config.part_size]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([test_config.part_size])
+            .with_minimum_memory_limit()
+            .build();
         let client = Arc::new(
             MockClient::config()
                 .bucket(s3_path.bucket.to_string())
@@ -354,10 +357,10 @@ pub mod mock_session {
             };
 
             let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
-            let pool = PagedPool::new_with_candidate_sizes_minimally_limited([
-                test_config.cache_block_size,
-                test_config.part_size,
-            ]);
+            let pool = PagedPool::config()
+                .with_minimum_memory_limit()
+                .with_candidate_sizes([test_config.cache_block_size, test_config.part_size])
+                .build();
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = Arc::new(
@@ -510,7 +513,10 @@ pub mod s3_session {
     pub fn new_with_test_client(test_config: TestSessionConfig, sdk_client: Client, s3_path: S3Path) -> TestSession {
         let mount_dir = tempfile::tempdir().unwrap();
 
-        let pool = PagedPool::new_with_candidate_sizes_minimally_limited([test_config.part_size]);
+        let pool = PagedPool::config()
+            .with_candidate_sizes([test_config.part_size])
+            .with_minimum_memory_limit()
+            .build();
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
             .endpoint_config(get_test_endpoint_config())
@@ -550,10 +556,10 @@ pub mod s3_session {
             let s3_path = get_test_s3_path(test_name);
             let region = get_test_region();
 
-            let pool = PagedPool::new_with_candidate_sizes_minimally_limited([
-                test_config.cache_block_size,
-                test_config.part_size,
-            ]);
+            let pool = PagedPool::config()
+                .with_minimum_memory_limit()
+                .with_candidate_sizes([test_config.cache_block_size, test_config.part_size])
+                .build();
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
 
             let client = create_crt_client(

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -52,7 +52,10 @@ pub fn make_test_filesystem(
             .initial_read_window_size(256 * 1024)
             .build(),
     );
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let fs = make_test_filesystem_with_client(client.clone(), pool, bucket, prefix, config);
     (client, fs)
 }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -730,7 +730,10 @@ async fn test_upload_aborted_on_write_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
+        PagedPool::config()
+            .with_candidate_sizes([part_size])
+            .with_minimum_memory_limit()
+            .build(),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -806,7 +809,10 @@ async fn test_upload_aborted_on_fsync_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
+        PagedPool::config()
+            .with_candidate_sizes([part_size])
+            .with_minimum_memory_limit()
+            .build(),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -867,7 +873,10 @@ async fn test_upload_aborted_on_release_failure() {
     );
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
-        PagedPool::new_with_candidate_sizes_minimally_limited([part_size]),
+        PagedPool::config()
+            .with_candidate_sizes([part_size])
+            .with_minimum_memory_limit()
+            .build(),
         BUCKET_NAME,
         &Default::default(),
         Default::default(),
@@ -1531,7 +1540,10 @@ async fn test_lookup_404_not_an_error() {
     let name = "test_lookup_404_not_an_error";
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let client_config = S3ClientConfig::default()
         .endpoint_config(get_test_endpoint_config())
         .read_backpressure(true)
@@ -1568,7 +1580,10 @@ async fn test_lookup_forbidden() {
     let policy = deny_single_object_access_policy(&bucket, &key);
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
     let client_config = S3ClientConfig::default()
         .auth_config(auth_config)
@@ -1651,7 +1666,10 @@ async fn test_rename_support_is_cached() {
     const FILE_NAME: &str = "a.txt";
 
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let client = Arc::new(
         MockClient::config()
             .bucket(BUCKET_NAME)

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -57,7 +57,10 @@ async fn express_invalid_block_read() {
     let prefix = get_test_prefix("express_invalid_block_read");
 
     // Mount the bucket
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let cache = CacheTestWrapper::new(ExpressDataCache::new(
         client.clone(),
@@ -119,7 +122,10 @@ async fn express_invalid_block_read() {
 fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) {
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -145,7 +151,10 @@ fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) 
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let cache = DiskDataCache::new(cache_config, pool.clone());
 
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -166,7 +175,10 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
     use mountpoint_s3_fs::data_cache::ExpressDataCacheConfig;
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
     let bucket_name = get_standard_bucket();
     let config = ExpressDataCacheConfig::new(&cache_bucket, &bucket_name)
@@ -181,7 +193,10 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
 #[tokio::test]
 #[cfg(feature = "s3express_tests")]
 async fn express_cache_read_empty() {
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let express_bucket_name = get_express_bucket();
@@ -199,7 +214,10 @@ async fn disk_cache_read_empty() {
         block_size: CACHE_BLOCK_SIZE,
         limit: Default::default(),
     };
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize])
+        .with_no_memory_limit()
+        .build();
     let cache = DiskDataCache::new(cache_config, pool);
 
     cache_read_empty(cache, "disk_cache_read_empty").await;
@@ -210,7 +228,10 @@ async fn disk_cache_read_empty() {
 async fn express_cache_verify_fail_non_express() {
     use mountpoint_s3_fs::data_cache::DataCacheError;
 
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
     let bucket_name = get_standard_bucket();
     let cache_bucket_name = get_standard_bucket();
@@ -259,7 +280,10 @@ async fn express_cache_verify_fail_forbidden() {
     };
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
 
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let client = create_crt_client(
         CLIENT_PART_SIZE,
         CLIENT_PART_SIZE,
@@ -369,7 +393,10 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
     let bucket = get_standard_bucket();
     let prefix = get_test_prefix("express_expected_bucket_owner");
     let cache_config = ExpressDataCacheConfig::new(&cache_bucket, &bucket);
-    let pool = PagedPool::new_with_candidate_sizes_unlimited([cache_config.block_size as usize, CLIENT_PART_SIZE]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([cache_config.block_size as usize, CLIENT_PART_SIZE])
+        .with_no_memory_limit()
+        .build();
     let cache = ExpressDataCache::new(client.clone(), cache_config);
     let cache_valid = block_on(cache.verify_cache_valid());
     if owner_checked && !owner_matches {

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -215,7 +215,10 @@ async fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, Moc
         .addressing_style(AddressingStyle::Path) // mock server responds to path style requests only
         .endpoint(endpoint);
     let part_size = 1024 * 1024;
-    let pool = PagedPool::new_with_candidate_sizes_minimally_limited([part_size]);
+    let pool = PagedPool::config()
+        .with_candidate_sizes([part_size])
+        .with_minimum_memory_limit()
+        .build();
     let client_config = S3ClientConfig::default()
         .endpoint_config(endpoint_config)
         .auth_config(S3ClientAuthConfig::NoSigning)

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -197,14 +197,14 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let client_config = args.client_config(build_info::FULL_VERSION);
 
     // Set up a paged memory pool
-    let pool = PagedPool::new_with_candidate_sizes(
-        [
+    let pool = PagedPool::config()
+        .with_candidate_sizes([
             args.cache_block_size_in_bytes() as usize,
             client_config.part_config.read_size_bytes,
             client_config.part_config.write_size_bytes,
-        ],
-        args.mem_limit(),
-    );
+        ])
+        .with_memory_limit(args.mem_limit())
+        .build();
     // Schedule trimming of empty memory pages every minutes. We should consider
     // event-based triggers and/or a configurable interval in the future.
     pool.schedule_trim(Duration::from_secs(60));


### PR DESCRIPTION
Replaces the 3 `new_with_candidate_sizes_` constructors by introducing `PagedPoolConfig`. 

### Does this change impact existing behavior?

No functional changes.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
