### PR TITLE
Add priority-ordered allocation queue

### DIFF
--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,5 +1,6 @@
+// TODO(memory-limiter): remove once wired into PagedPool
 #[allow(unused)]
-pub(crate) mod allocation_queue;
+mod allocation_queue;
 mod buffers;
 mod limiter;
 mod pages;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,3 +1,5 @@
+#[allow(unused)]
+pub(crate) mod allocation_queue;
 mod buffers;
 mod limiter;
 mod pages;

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -17,7 +17,7 @@ use super::stats::BufferKind;
 /// [`Low`](Self::Low) entries (FIFO). A [`Low`] request can be promoted to
 /// the back of [`High`] via [`AllocationQueue::upgrade`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AllocationPriority {
+enum AllocationPriority {
     Low,
     High,
 }
@@ -86,19 +86,33 @@ impl AllocationQueue {
         }
     }
 
-    /// Enqueue a buffer allocation request. Returns a receiver that resolves to the
-    /// allocated [PoolBuffer] when fulfilled, or `Err(Canceled)` if the sender is dropped.
-    pub fn push(
+    /// Enqueue a high-priority buffer allocation request.
+    /// Returns a receiver that resolves to the allocated [PoolBuffer] when fulfilled,
+    /// or `Err(Canceled)` if the sender is dropped.
+    pub fn push_high(
+        &self,
+        cursor_id: Option<CursorId>,
+        size: usize,
+        kind: BufferKind,
+    ) -> oneshot::Receiver<PoolBuffer> {
+        self.push_inner(AllocationPriority::High, cursor_id, size, kind)
+    }
+
+    /// Enqueue a low-priority buffer allocation request.
+    /// Low-priority requests always have a cursor (speculative prefetch).
+    /// Returns a receiver that resolves to the allocated [PoolBuffer] when fulfilled,
+    /// or `Err(Canceled)` if the sender is dropped.
+    pub fn push_low(&self, cursor_id: CursorId, size: usize, kind: BufferKind) -> oneshot::Receiver<PoolBuffer> {
+        self.push_inner(AllocationPriority::Low, Some(cursor_id), size, kind)
+    }
+
+    fn push_inner(
         &self,
         priority: AllocationPriority,
         cursor_id: Option<CursorId>,
         size: usize,
         kind: BufferKind,
     ) -> oneshot::Receiver<PoolBuffer> {
-        assert!(
-            priority == AllocationPriority::High || cursor_id.is_some(),
-            "Low priority requests must have a cursor_id"
-        );
         let (sender, receiver) = oneshot::channel();
         let entry = PendingAllocation {
             cursor_id,
@@ -119,9 +133,10 @@ impl AllocationQueue {
 
     /// Atomically peeks at the front entry and removes it if `predicate` returns `true`.
     ///
-    /// Checks the high-priority list first, then low. The predicate receives the
-    /// entry's size, kind, and cursor_id so the caller can decide (e.g., check
-    /// `can_allocate(size)`) without a race between peek and pop.
+    /// Checks the high-priority list first, then low. Cancelled entries (where the
+    /// receiver was dropped) are pruned from the front of each queue before checking
+    /// the predicate — this prevents a large cancelled entry from blocking smaller
+    /// live entries behind it.
     ///
     /// Returns `None` if both queues are empty or the predicate returns `false`.
     /// Sets `has_pending` to `false` if both queues become empty after removal.
@@ -130,7 +145,21 @@ impl AllocationQueue {
         predicate: impl FnOnce(usize, BufferKind, Option<CursorId>) -> bool,
     ) -> Option<PendingAllocation> {
         let mut inner = self.inner.lock().unwrap();
-        let front = inner.high.front().or_else(|| inner.low.front())?;
+
+        // Prune cancelled entries from the front of each queue.
+        while inner.high.front().is_some_and(|e| e.sender.is_canceled()) {
+            inner.high.pop_front();
+        }
+        while inner.low.front().is_some_and(|e| e.sender.is_canceled()) {
+            inner.low.pop_front();
+        }
+
+        let front = inner.high.front().or_else(|| inner.low.front());
+        let Some(front) = front else {
+            self.has_pending.store(false, Ordering::Release);
+            return None;
+        };
+
         if !predicate(front.size, front.kind, front.cursor_id) {
             return None;
         }
@@ -151,11 +180,17 @@ impl AllocationQueue {
         let n = inner.low.len();
         for _ in 0..n {
             let entry = inner.low.pop_front().unwrap();
+            if entry.sender.is_canceled() {
+                continue;
+            }
             if entry.cursor_id == Some(cursor_id) {
                 inner.high.push_back(entry);
             } else {
                 inner.low.push_back(entry);
             }
+        }
+        if inner.high.is_empty() && inner.low.is_empty() {
+            self.has_pending.store(false, Ordering::Release);
         }
     }
 
@@ -192,24 +227,14 @@ mod tests {
         let queue = AllocationQueue::new();
         assert!(!queue.has_pending());
 
-        let _rx = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let _rx = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
         assert!(queue.has_pending());
     }
 
     #[test]
     fn test_pop_front_if_fulfills_and_clears_pressure() {
         let queue = AllocationQueue::new();
-        let rx = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let rx = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
 
         let entry = queue.pop_front_if(always).unwrap();
         assert!(!queue.has_pending());
@@ -224,12 +249,7 @@ mod tests {
     #[test]
     fn test_pop_front_if_predicate_false_does_not_remove() {
         let queue = AllocationQueue::new();
-        let _rx = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let _rx = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
 
         let result = queue.pop_front_if(|_size, _kind, _cursor| false);
         assert!(result.is_none());
@@ -240,18 +260,8 @@ mod tests {
     fn test_high_priority_served_before_low() {
         let queue = AllocationQueue::new();
 
-        let _rx_low = queue.push(
-            AllocationPriority::Low,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
-        let _rx_high = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(2)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let _rx_low = queue.push_low(CursorId::new_from_raw(1), 1024, BufferKind::GetObject);
+        let _rx_high = queue.push_high(Some(CursorId::new_from_raw(2)), 1024, BufferKind::GetObject);
 
         let entry = queue.pop_front_if(always).unwrap();
         assert_eq!(entry.cursor_id, Some(CursorId::new_from_raw(2))); // high first
@@ -261,18 +271,8 @@ mod tests {
     fn test_fifo_within_same_priority() {
         let queue = AllocationQueue::new();
 
-        let _rx1 = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
-        let _rx2 = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(2)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let _rx1 = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
+        let _rx2 = queue.push_high(Some(CursorId::new_from_raw(2)), 1024, BufferKind::GetObject);
 
         let first = queue.pop_front_if(always).unwrap();
         let second = queue.pop_front_if(always).unwrap();
@@ -286,8 +286,8 @@ mod tests {
         let cursor_a = CursorId::new_from_raw(1);
         let cursor_b = CursorId::new_from_raw(2);
 
-        let _rx_a = queue.push(AllocationPriority::Low, Some(cursor_a), 1024, BufferKind::GetObject);
-        let _rx_b = queue.push(AllocationPriority::Low, Some(cursor_b), 1024, BufferKind::GetObject);
+        let _rx_a = queue.push_low(cursor_a, 1024, BufferKind::GetObject);
+        let _rx_b = queue.push_low(cursor_b, 1024, BufferKind::GetObject);
 
         queue.upgrade(cursor_a);
 
@@ -301,9 +301,9 @@ mod tests {
         let cursor = CursorId::new_from_raw(1);
         let other = CursorId::new_from_raw(2);
 
-        let _rx1 = queue.push(AllocationPriority::Low, Some(cursor), 1024, BufferKind::GetObject);
-        let _rx2 = queue.push(AllocationPriority::Low, Some(cursor), 2048, BufferKind::GetObject);
-        let _rx_other = queue.push(AllocationPriority::Low, Some(other), 1024, BufferKind::GetObject);
+        let _rx1 = queue.push_low(cursor, 1024, BufferKind::GetObject);
+        let _rx2 = queue.push_low(cursor, 2048, BufferKind::GetObject);
+        let _rx_other = queue.push_low(other, 1024, BufferKind::GetObject);
 
         queue.upgrade(cursor);
 
@@ -322,8 +322,8 @@ mod tests {
         let cursor = CursorId::new_from_raw(1);
 
         // Upload (no cursor_id) in high queue, read in low queue
-        let _rx_upload = queue.push(AllocationPriority::High, None, 8192, BufferKind::PutObject);
-        let _rx_read = queue.push(AllocationPriority::Low, Some(cursor), 1024, BufferKind::GetObject);
+        let _rx_upload = queue.push_high(None, 8192, BufferKind::PutObject);
+        let _rx_read = queue.push_low(cursor, 1024, BufferKind::GetObject);
 
         queue.upgrade(cursor);
 
@@ -336,6 +336,20 @@ mod tests {
     }
 
     #[test]
+    fn test_cancelled_large_entry_does_not_block_smaller_entry() {
+        let queue = AllocationQueue::new();
+
+        let rx_large = queue.push_high(Some(CursorId::new_from_raw(1)), 64 * 1024 * 1024, BufferKind::GetObject);
+        let _rx_small = queue.push_high(Some(CursorId::new_from_raw(2)), 1024, BufferKind::GetObject);
+
+        drop(rx_large);
+
+        let entry = queue.pop_front_if(|size, _, _| size <= 1024 * 1024);
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().cursor_id, Some(CursorId::new_from_raw(2)));
+    }
+
+    #[test]
     fn test_pop_front_if_empty_queue() {
         let queue = AllocationQueue::new();
         assert!(queue.pop_front_if(always).is_none());
@@ -343,19 +357,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dropped_receiver_does_not_block() {
+    fn test_cancelled_entry_pruned_on_pop() {
         let queue = AllocationQueue::new();
-        let rx = queue.push(
-            AllocationPriority::High,
-            Some(CursorId::new_from_raw(1)),
-            1024,
-            BufferKind::GetObject,
-        );
+        let rx = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
         drop(rx);
 
-        let entry = queue.pop_front_if(always).unwrap();
-        let buffer = make_buffer(entry.size);
-        let result = entry.fulfill(buffer);
-        assert!(result.is_err()); // receiver gone, no panic
+        let entry = queue.pop_front_if(always);
+        assert!(entry.is_none());
+        assert!(!queue.has_pending());
     }
 }

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -1,0 +1,332 @@
+//! Priority-ordered allocation queue for buffer requests under memory pressure.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use futures::channel::oneshot;
+
+use crate::prefetch::CursorId;
+
+use super::buffers::PoolBuffer;
+use super::stats::BufferKind;
+
+/// Priority levels for allocation requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllocationPriority {
+    /// Speculative prefetch — nobody is waiting on this data yet.
+    Low,
+    /// Active read or upload — a syscall is blocked waiting for this buffer.
+    High,
+}
+
+/// A single entry in the allocation queue, representing a pending buffer request.
+pub struct PendingAllocation {
+    /// Which cursor is requesting this buffer. `None` for upload requests
+    /// (uploads have no associated cursor).
+    pub cursor_id: Option<CursorId>,
+    /// Size of the buffer the waiter needs, in bytes.
+    pub size: usize,
+    /// The kind of buffer to allocate (e.g. [BufferKind::GetObject], [BufferKind::PutObject]).
+    pub kind: BufferKind,
+    /// Channel sender used to deliver the allocated [PoolBuffer] to the waiter.
+    /// When dropped, the receiver resolves with `Err(Canceled)`.
+    pub sender: oneshot::Sender<PoolBuffer>,
+}
+
+/// A priority-ordered allocation queue with two lanes: high and low.
+///
+/// High-priority requests (active reads, uploads) are served before low-priority
+/// ones (speculative prefetch). Within each lane, requests are served FIFO.
+///
+/// This queue does not allocate buffers or check available memory — it only manages
+/// ordering, signaling, and lifecycle. The pool drives the wake loop by calling
+/// [`pop_front_if`](Self::pop_front_if) with a predicate (e.g., `can_allocate`),
+/// then performing the allocation and delivering the buffer via the entry's sender.
+pub struct AllocationQueue {
+    /// Queue state protected by a mutex.
+    inner: Mutex<AllocationQueueInner>,
+    /// `true` if either queue has pending entries. Allows a lock-free check
+    /// via [`is_memory_pressure`](Self::is_memory_pressure).
+    memory_pressure: AtomicBool,
+}
+
+struct AllocationQueueInner {
+    /// High-priority requests (active reads + uploads). Served first.
+    high: VecDeque<PendingAllocation>,
+    /// Low-priority requests (speculative prefetch). Served when high is empty.
+    low: VecDeque<PendingAllocation>,
+}
+
+impl Default for AllocationQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AllocationQueue {
+    /// Creates a new empty allocation queue.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(AllocationQueueInner {
+                high: VecDeque::new(),
+                low: VecDeque::new(),
+            }),
+            memory_pressure: AtomicBool::new(false),
+        }
+    }
+
+    /// Enqueue a buffer allocation request. Returns a receiver that resolves to the
+    /// allocated [PoolBuffer] when fulfilled, or `Err(Canceled)` if the sender is dropped.
+    pub fn push(
+        &self,
+        priority: AllocationPriority,
+        cursor_id: Option<CursorId>,
+        size: usize,
+        kind: BufferKind,
+    ) -> oneshot::Receiver<PoolBuffer> {
+        let (sender, receiver) = oneshot::channel();
+        let entry = PendingAllocation {
+            cursor_id,
+            size,
+            kind,
+            sender,
+        };
+
+        let mut inner = self.inner.lock().unwrap();
+        match priority {
+            AllocationPriority::High => inner.high.push_back(entry),
+            AllocationPriority::Low => inner.low.push_back(entry),
+        }
+        self.memory_pressure.store(true, Ordering::Release);
+
+        receiver
+    }
+
+    /// Atomically peeks at the front entry and removes it if `predicate` returns `true`.
+    ///
+    /// Checks the high-priority list first, then low. The predicate receives the
+    /// entry's size, kind, and cursor_id so the caller can decide (e.g., check
+    /// `can_allocate(size)`) without a race between peek and pop.
+    ///
+    /// Returns `None` if both queues are empty or the predicate returns `false`.
+    /// Sets `memory_pressure` to `false` if both queues become empty after removal.
+    pub fn pop_front_if(
+        &self,
+        predicate: impl FnOnce(usize, BufferKind, Option<CursorId>) -> bool,
+    ) -> Option<PendingAllocation> {
+        let mut inner = self.inner.lock().unwrap();
+        let front = inner.high.front().or_else(|| inner.low.front())?;
+        if !predicate(front.size, front.kind, front.cursor_id) {
+            return None;
+        }
+        let entry = inner.high.pop_front().or_else(|| inner.low.pop_front());
+        if inner.high.is_empty() && inner.low.is_empty() {
+            self.memory_pressure.store(false, Ordering::Release);
+        }
+        entry
+    }
+
+    /// Moves all entries for `cursor_id` from the low-priority queue to the back
+    /// of the high-priority queue. No-op if no entries match.
+    ///
+    /// Called when a FUSE read arrives for a cursor that has pending speculative
+    /// allocations — those allocations are now urgent.
+    pub fn upgrade(&self, cursor_id: CursorId) {
+        let mut inner = self.inner.lock().unwrap();
+        let mut to_promote = Vec::new();
+        let mut remaining = VecDeque::with_capacity(inner.low.len());
+        for entry in inner.low.drain(..) {
+            if entry.cursor_id == Some(cursor_id) {
+                to_promote.push(entry);
+            } else {
+                remaining.push_back(entry);
+            }
+        }
+        inner.low = remaining;
+        for entry in to_promote {
+            inner.high.push_back(entry);
+        }
+    }
+
+    /// Returns `true` if either queue has pending entries.
+    ///
+    /// This is a lock-free check using an [`AtomicBool`]. Used by the pool to decide
+    /// whether new requests must go through the queue (to respect priority ordering
+    /// of existing waiters).
+    pub fn is_memory_pressure(&self) -> bool {
+        self.memory_pressure.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+
+    use crate::memory::pages::Page;
+
+    fn make_buffer(size: usize) -> PoolBuffer {
+        let page = Page::new_for_tests(size);
+        let ptr = page.try_reserve(BufferKind::Other).unwrap();
+        PoolBuffer::new_primary(ptr, size)
+    }
+
+    /// Helper: always-true predicate (unconditionally pop).
+    fn always(_size: usize, _kind: BufferKind, _cursor: Option<CursorId>) -> bool {
+        true
+    }
+
+    #[test]
+    fn test_push_sets_memory_pressure() {
+        let queue = AllocationQueue::new();
+        assert!(!queue.is_memory_pressure());
+
+        let _rx = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+        assert!(queue.is_memory_pressure());
+    }
+
+    #[test]
+    fn test_pop_front_if_fulfills_and_clears_pressure() {
+        let queue = AllocationQueue::new();
+        let rx = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+
+        let entry = queue.pop_front_if(always).unwrap();
+        assert!(!queue.is_memory_pressure());
+
+        let buffer = make_buffer(entry.size);
+        let _ = entry.sender.send(buffer);
+
+        let result = block_on(rx);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_pop_front_if_predicate_false_does_not_remove() {
+        let queue = AllocationQueue::new();
+        let _rx = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+
+        let result = queue.pop_front_if(|_size, _kind, _cursor| false);
+        assert!(result.is_none());
+        assert!(queue.is_memory_pressure()); // still there
+    }
+
+    #[test]
+    fn test_high_priority_served_before_low() {
+        let queue = AllocationQueue::new();
+
+        let _rx_low = queue.push(
+            AllocationPriority::Low,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+        let _rx_high = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(2)),
+            1024,
+            BufferKind::GetObject,
+        );
+
+        let entry = queue.pop_front_if(always).unwrap();
+        assert_eq!(entry.cursor_id, Some(CursorId::new_from_raw(2))); // high first
+    }
+
+    #[test]
+    fn test_fifo_within_same_priority() {
+        let queue = AllocationQueue::new();
+
+        let _rx1 = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+        let _rx2 = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(2)),
+            1024,
+            BufferKind::GetObject,
+        );
+
+        let first = queue.pop_front_if(always).unwrap();
+        let second = queue.pop_front_if(always).unwrap();
+        assert_eq!(first.cursor_id, Some(CursorId::new_from_raw(1)));
+        assert_eq!(second.cursor_id, Some(CursorId::new_from_raw(2)));
+    }
+
+    #[test]
+    fn test_upgrade_moves_low_to_high() {
+        let queue = AllocationQueue::new();
+        let cursor_a = CursorId::new_from_raw(1);
+        let cursor_b = CursorId::new_from_raw(2);
+
+        let _rx_a = queue.push(AllocationPriority::Low, Some(cursor_a), 1024, BufferKind::GetObject);
+        let _rx_b = queue.push(AllocationPriority::Low, Some(cursor_b), 1024, BufferKind::GetObject);
+
+        queue.upgrade(cursor_a);
+
+        let entry = queue.pop_front_if(always).unwrap();
+        assert_eq!(entry.cursor_id, Some(cursor_a)); // upgraded, served first
+    }
+
+    #[test]
+    fn test_upgrade_multiple_entries_same_cursor() {
+        let queue = AllocationQueue::new();
+        let cursor = CursorId::new_from_raw(1);
+        let other = CursorId::new_from_raw(2);
+
+        let _rx1 = queue.push(AllocationPriority::Low, Some(cursor), 1024, BufferKind::GetObject);
+        let _rx2 = queue.push(AllocationPriority::Low, Some(cursor), 2048, BufferKind::GetObject);
+        let _rx_other = queue.push(AllocationPriority::Low, Some(other), 1024, BufferKind::GetObject);
+
+        queue.upgrade(cursor);
+
+        let e1 = queue.pop_front_if(always).unwrap();
+        let e2 = queue.pop_front_if(always).unwrap();
+        assert_eq!(e1.cursor_id, Some(cursor));
+        assert_eq!(e2.cursor_id, Some(cursor));
+
+        let e3 = queue.pop_front_if(always).unwrap();
+        assert_eq!(e3.cursor_id, Some(other));
+    }
+
+    #[test]
+    fn test_pop_front_if_empty_queue() {
+        let queue = AllocationQueue::new();
+        assert!(queue.pop_front_if(always).is_none());
+        assert!(!queue.is_memory_pressure());
+    }
+
+    #[test]
+    fn test_dropped_receiver_does_not_block() {
+        let queue = AllocationQueue::new();
+        let rx = queue.push(
+            AllocationPriority::High,
+            Some(CursorId::new_from_raw(1)),
+            1024,
+            BufferKind::GetObject,
+        );
+        drop(rx);
+
+        let entry = queue.pop_front_if(always).unwrap();
+        let buffer = make_buffer(entry.size);
+        let result = entry.sender.send(buffer);
+        assert!(result.is_err()); // receiver gone, no panic
+    }
+}

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -1,22 +1,24 @@
 //! Priority-ordered allocation queue for buffer requests under memory pressure.
 
 use std::collections::VecDeque;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::channel::oneshot;
 
 use crate::prefetch::CursorId;
+use crate::sync::Mutex;
+use crate::sync::atomic::{AtomicBool, Ordering};
 
 use super::buffers::PoolBuffer;
 use super::stats::BufferKind;
 
-/// Priority levels for allocation requests.
+/// Priority for an allocation request.
+///
+/// The queue serves all [`High`](Self::High) entries (FIFO) before any
+/// [`Low`](Self::Low) entries (FIFO). A [`Low`] request can be promoted to
+/// the back of [`High`] via [`AllocationQueue::upgrade`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AllocationPriority {
-    /// Speculative prefetch — nobody is waiting on this data yet.
     Low,
-    /// Active read or upload — a syscall is blocked waiting for this buffer.
     High,
 }
 
@@ -31,7 +33,15 @@ pub struct PendingAllocation {
     pub kind: BufferKind,
     /// Channel sender used to deliver the allocated [PoolBuffer] to the waiter.
     /// When dropped, the receiver resolves with `Err(Canceled)`.
-    pub sender: oneshot::Sender<PoolBuffer>,
+    sender: oneshot::Sender<PoolBuffer>,
+}
+
+impl PendingAllocation {
+    /// Deliver the allocated buffer to the waiter.
+    /// Returns `Err(buffer)` if the receiver was dropped (caller cancelled).
+    pub fn fulfill(self, buffer: PoolBuffer) -> Result<(), PoolBuffer> {
+        self.sender.send(buffer)
+    }
 }
 
 /// A priority-ordered allocation queue with two lanes: high and low.
@@ -47,8 +57,8 @@ pub struct AllocationQueue {
     /// Queue state protected by a mutex.
     inner: Mutex<AllocationQueueInner>,
     /// `true` if either queue has pending entries. Allows a lock-free check
-    /// via [`is_memory_pressure`](Self::is_memory_pressure).
-    memory_pressure: AtomicBool,
+    /// via [`has_pending`](Self::has_pending).
+    has_pending: AtomicBool,
 }
 
 struct AllocationQueueInner {
@@ -72,7 +82,7 @@ impl AllocationQueue {
                 high: VecDeque::new(),
                 low: VecDeque::new(),
             }),
-            memory_pressure: AtomicBool::new(false),
+            has_pending: AtomicBool::new(false),
         }
     }
 
@@ -85,6 +95,10 @@ impl AllocationQueue {
         size: usize,
         kind: BufferKind,
     ) -> oneshot::Receiver<PoolBuffer> {
+        assert!(
+            priority == AllocationPriority::High || cursor_id.is_some(),
+            "Low priority requests must have a cursor_id"
+        );
         let (sender, receiver) = oneshot::channel();
         let entry = PendingAllocation {
             cursor_id,
@@ -94,11 +108,11 @@ impl AllocationQueue {
         };
 
         let mut inner = self.inner.lock().unwrap();
+        self.has_pending.store(true, Ordering::Release);
         match priority {
             AllocationPriority::High => inner.high.push_back(entry),
             AllocationPriority::Low => inner.low.push_back(entry),
         }
-        self.memory_pressure.store(true, Ordering::Release);
 
         receiver
     }
@@ -110,7 +124,7 @@ impl AllocationQueue {
     /// `can_allocate(size)`) without a race between peek and pop.
     ///
     /// Returns `None` if both queues are empty or the predicate returns `false`.
-    /// Sets `memory_pressure` to `false` if both queues become empty after removal.
+    /// Sets `has_pending` to `false` if both queues become empty after removal.
     pub fn pop_front_if(
         &self,
         predicate: impl FnOnce(usize, BufferKind, Option<CursorId>) -> bool,
@@ -122,7 +136,7 @@ impl AllocationQueue {
         }
         let entry = inner.high.pop_front().or_else(|| inner.low.pop_front());
         if inner.high.is_empty() && inner.low.is_empty() {
-            self.memory_pressure.store(false, Ordering::Release);
+            self.has_pending.store(false, Ordering::Release);
         }
         entry
     }
@@ -134,18 +148,14 @@ impl AllocationQueue {
     /// allocations — those allocations are now urgent.
     pub fn upgrade(&self, cursor_id: CursorId) {
         let mut inner = self.inner.lock().unwrap();
-        let mut to_promote = Vec::new();
-        let mut remaining = VecDeque::with_capacity(inner.low.len());
-        for entry in inner.low.drain(..) {
+        let n = inner.low.len();
+        for _ in 0..n {
+            let entry = inner.low.pop_front().unwrap();
             if entry.cursor_id == Some(cursor_id) {
-                to_promote.push(entry);
+                inner.high.push_back(entry);
             } else {
-                remaining.push_back(entry);
+                inner.low.push_back(entry);
             }
-        }
-        inner.low = remaining;
-        for entry in to_promote {
-            inner.high.push_back(entry);
         }
     }
 
@@ -154,8 +164,8 @@ impl AllocationQueue {
     /// This is a lock-free check using an [`AtomicBool`]. Used by the pool to decide
     /// whether new requests must go through the queue (to respect priority ordering
     /// of existing waiters).
-    pub fn is_memory_pressure(&self) -> bool {
-        self.memory_pressure.load(Ordering::Acquire)
+    pub fn has_pending(&self) -> bool {
+        self.has_pending.load(Ordering::Acquire)
     }
 }
 
@@ -178,9 +188,9 @@ mod tests {
     }
 
     #[test]
-    fn test_push_sets_memory_pressure() {
+    fn test_push_sets_has_pending() {
         let queue = AllocationQueue::new();
-        assert!(!queue.is_memory_pressure());
+        assert!(!queue.has_pending());
 
         let _rx = queue.push(
             AllocationPriority::High,
@@ -188,7 +198,7 @@ mod tests {
             1024,
             BufferKind::GetObject,
         );
-        assert!(queue.is_memory_pressure());
+        assert!(queue.has_pending());
     }
 
     #[test]
@@ -202,10 +212,10 @@ mod tests {
         );
 
         let entry = queue.pop_front_if(always).unwrap();
-        assert!(!queue.is_memory_pressure());
+        assert!(!queue.has_pending());
 
         let buffer = make_buffer(entry.size);
-        let _ = entry.sender.send(buffer);
+        let _ = entry.fulfill(buffer);
 
         let result = block_on(rx);
         assert!(result.is_ok());
@@ -223,7 +233,7 @@ mod tests {
 
         let result = queue.pop_front_if(|_size, _kind, _cursor| false);
         assert!(result.is_none());
-        assert!(queue.is_memory_pressure()); // still there
+        assert!(queue.has_pending()); // still there
     }
 
     #[test]
@@ -307,10 +317,29 @@ mod tests {
     }
 
     #[test]
+    fn test_upgrade_does_not_affect_uploads() {
+        let queue = AllocationQueue::new();
+        let cursor = CursorId::new_from_raw(1);
+
+        // Upload (no cursor_id) in high queue, read in low queue
+        let _rx_upload = queue.push(AllocationPriority::High, None, 8192, BufferKind::PutObject);
+        let _rx_read = queue.push(AllocationPriority::Low, Some(cursor), 1024, BufferKind::GetObject);
+
+        queue.upgrade(cursor);
+
+        // Upload is still first (was already high), then promoted read
+        let e1 = queue.pop_front_if(always).unwrap();
+        assert_eq!(e1.cursor_id, None); // upload, still at front of high
+
+        let e2 = queue.pop_front_if(always).unwrap();
+        assert_eq!(e2.cursor_id, Some(cursor)); // promoted read, back of high
+    }
+
+    #[test]
     fn test_pop_front_if_empty_queue() {
         let queue = AllocationQueue::new();
         assert!(queue.pop_front_if(always).is_none());
-        assert!(!queue.is_memory_pressure());
+        assert!(!queue.has_pending());
     }
 
     #[test]
@@ -326,7 +355,7 @@ mod tests {
 
         let entry = queue.pop_front_if(always).unwrap();
         let buffer = make_buffer(entry.size);
-        let result = entry.sender.send(buffer);
+        let result = entry.fulfill(buffer);
         assert!(result.is_err()); // receiver gone, no panic
     }
 }


### PR DESCRIPTION
This adds a priority-ordered allocation queue (memory/allocation_queue.rs) that will be used to manage buffer allocation requests when memory is full. Instead of failing when there's no memory available, requests can now wait in the queue and get served in priority order - high priority and low priority.
  
The queue exposes `push_high`, `push_low`, `pop_front_if`, `upgrade`, `has_pending` and `fulfill`. It doesn't allocate buffers or check available memory itself, the pool will drive the wake loop by calling `pop_front_if` with a `can_allocate` predicate, then allocating and delivering the buffer. The wiring into the pool is separate work.

### Does this change impact existing behavior?

No. This is a new standalone module with no callers yet. Existing behavior is unchanged.

### Does this change need a changelog entry? Does it require a version change?

No, these are internal changes to the memory limiter with no user-visible behavior change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
