### PR TITLE
fix: correct spelling across markdown and rust files

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -213,7 +213,7 @@ If necessary, you can use the `--endpoint-url` command-line argument to fully ov
 We also support the `AWS_ENDPOINT_URL` environment variable. The endpoint determination follows this order:
 - Use the CLI parameter `endpoint-url` if provided.
 - Use `AWS_ENDPOINT_URL` if provided.
-- Fallback to automically inferring the endpoint.
+- Fallback to automatically inferring the endpoint.
 
 ### Data encryption
 
@@ -496,7 +496,7 @@ It can be set to a positive numerical value in seconds, or to one of the pre-con
 
 > [!WARNING]
 > Caching of metadata entries relaxes the strong read-after-write consistency offered by Amazon S3 and Mountpoint in its default configuration.
-> See the [consistency and concurrency section of the semantics documentaton](./SEMANTICS.md#consistency-and-concurrency) for more details.
+> See the [consistency and concurrency section of the semantics documentation](./SEMANTICS.md#consistency-and-concurrency) for more details.
 
 The `--metadata-ttl` flag is used to control how long Mountpoint considers it's file system metadata (file existence, size, object etag, etc) accurate before re-fetching from S3.
 When configured, on its own or in conjunction with local cache or shared cache, Mountpoint will typically perform fewer requests to the mounted S3 bucket, but will not guarantee that the information it reports

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -196,7 +196,7 @@ mountpoint_s3_fs::fuse: setattr failed: inode error: inode 21 (full key "init.tx
 ## Invalid Hostname for DNS resolution
 
 Mountpoint by default resolves endpoint for requests in [virtual hosted style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
-If your storage provider does not support virtual style hosted bucket, you may recieve the following error:
+If your storage provider does not support virtual style hosted bucket, you may receive the following error:
 
 ```
 Error: Failed to create S3 client

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -939,7 +939,7 @@ pub struct ObjectInfo {
     pub checksum_algorithms: Vec<ChecksumAlgorithm>,
 }
 
-/// All possible object attributes that can be retrived from [ObjectClient::get_object_attributes].
+/// All possible object attributes that can be retrieved from [ObjectClient::get_object_attributes].
 /// Fields that you do not specify are not returned.
 #[derive(Debug)]
 pub enum ObjectAttribute {
@@ -1011,7 +1011,7 @@ impl Checksum {
         // We assume that at most one checksum will be set.
         let mut algorithms = Vec::with_capacity(1);
 
-        // Pattern match forces us to accomodate any new fields when added.
+        // Pattern match forces us to accommodate any new fields when added.
         let Self {
             checksum_crc64nvme,
             checksum_crc32,

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -94,7 +94,7 @@ impl S3CrtClient {
                     // then on_meta_request_result will send an error.
                     if (200..300).contains(&status) {
                         // Headers can be returned multiple times, but the metadata/checksums don't change.
-                        // We only send the first occurence to the channel.
+                        // We only send the first occurrence to the channel.
                         if let Some(headers_sender) = headers_sender.take() {
                             _ = headers_sender.unbounded_send(S3GetObjectEvent::Headers(headers.clone()));
                         }

--- a/mountpoint-s3-crt-sys/build.rs
+++ b/mountpoint-s3-crt-sys/build.rs
@@ -354,7 +354,7 @@ fn static_link_modifiers_for_lib(library_name: &str) -> &'static str {
 /// `MOUNTPOINT_CRT_INCLUDE_DIR` variable must point to the directory the CRT headers were installed
 /// to. The build still needs access to the Git submodules for any private CRT headers we use, but
 /// the code from the submodules won't be compiled. When `MOUNTPOINT_CRT_LIB_DIR` is set,
-/// by default the CRT libraries will be dynmically linked. Static linking occurs when the
+/// by default the CRT libraries will be dynamically linked. Static linking occurs when the
 /// `MOUNTPOINT_CRT_LIB_LINK_STATIC` is set.
 ///
 /// Note that `MOUNTPOINT_CRT_LIB_DIR` requires a compatible version of the CRT libraries. The CRT

--- a/mountpoint-s3-crt-sys/src/logging_shim.rs
+++ b/mountpoint-s3-crt-sys/src/logging_shim.rs
@@ -1,5 +1,5 @@
 //! A small shim that the `mountpoint-s3-crt` crate uses to connect to a logging implementation. The
-//! CRT's logging implementation uses varargs, but Rust hasn't stablized those, so we need a small C
+//! CRT's logging implementation uses varargs, but Rust hasn't stabilized those, so we need a small C
 //! trampoline to translate varargs to Rust strings.
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/mountpoint-s3-crt/examples/download_crt.rs
+++ b/mountpoint-s3-crt/examples/download_crt.rs
@@ -222,7 +222,7 @@ struct CliArgs {
 }
 
 fn main() -> anyhow::Result<()> {
-    RustLogAdapter::try_init().context("failed to inititalize RustLogAdapter")?;
+    RustLogAdapter::try_init().context("failed to initialize RustLogAdapter")?;
     tracing_subscriber::fmt::try_init().map_err(|e| anyhow!("failed to initialize tracing subscriber: {:?}", e))?;
 
     let args = CliArgs::parse();

--- a/mountpoint-s3-crt/src/io/host_resolver.rs
+++ b/mountpoint-s3-crt/src/io/host_resolver.rs
@@ -1,4 +1,4 @@
-//! An asychronous DNS resolver
+//! An asynchronous DNS resolver
 
 use crate::CrtError as _;
 use crate::common::allocator::Allocator;

--- a/mountpoint-s3-crt/src/s3/client.rs
+++ b/mountpoint-s3-crt/src/s3/client.rs
@@ -653,7 +653,7 @@ unsafe extern "C" fn meta_request_shutdown_callback(user_data: *mut libc::c_void
     // in MetaRequestOptions::new.
     let user_data = unsafe { MetaRequestOptionsInner::from_user_data_ptr_owned(user_data) };
 
-    // SAFETY: at this point, we shouldn't receieve any more callbacks for this request.
+    // SAFETY: at this point, we shouldn't receive any more callbacks for this request.
     std::mem::drop(user_data);
 }
 

--- a/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
+++ b/mountpoint-s3-crt/src/s3/endpoint_resolver.rs
@@ -219,7 +219,7 @@ mod test {
     #[test_case("s3-bucket-test", "cn-north-1", "https://s3-bucket-test.s3.cn-north-1.amazonaws.com.cn"; "regions outside aws partition")]
     #[test_case("s3-bucket-test", "eu-west-1", "https://s3-bucket-test.s3.eu-west-1.amazonaws.com"; "regions within aws partition")]
     #[test_case("s3-bucket-test", "us-gov-west-1", "https://s3-bucket-test.s3.us-gov-west-1.amazonaws.com"; "regions in aws-us-gov partition")]
-    #[test_case("s3-bucket.test", "eu-west-1", "https://s3.eu-west-1.amazonaws.com/s3-bucket.test"; "bucket name with . to check default behviour for aliases")]
+    #[test_case("s3-bucket.test", "eu-west-1", "https://s3.eu-west-1.amazonaws.com/s3-bucket.test"; "bucket name with . to check default behaviour for aliases")]
     #[test_case("mountpoint-o-o000s3-bucket-test0000000000000000000000000--op-s3", "us-east-1", "https://mountpoint-o-o000s3-bucket-test0000000000000000000000000--op-s3.op-000s3-bucket-test.s3-outposts.us-east-1.amazonaws.com"; "Outpost Access Point alias")]
     #[test_case("arn:aws:s3::accountID:accesspoint/s3-bucket-test.mrap", "eu-west-1", "https://s3-bucket-test.mrap.accesspoint.s3-global.amazonaws.com"; "ARN as bucket name")]
     #[test_case("s3-bucket-test", "invalid-region", "https://s3-bucket-test.s3.invalid-region.amazonaws.com"; "invalid region name")]
@@ -320,7 +320,7 @@ mod test {
             .unwrap();
         let err = endpoint_rule_engine
             .resolve(endpoint_request_context)
-            .expect_err("Ednpoint should not be formed without region specified");
+            .expect_err("Endpoint should not be formed without region specified");
         assert_eq!(
             err,
             ResolverError::EndpointNotResolved("A region must be set when sending requests to S3.".to_owned())

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -116,7 +116,7 @@ pub struct StatFs {
     pub block_size: u32,
     /// Maximum name length
     pub maximum_name_length: u32,
-    /// Fragement size
+    /// Fragment size
     pub fragment_size: u32,
 }
 
@@ -180,7 +180,7 @@ where
 
     pub async fn init(&self, config: &mut KernelConfig) -> Result<(), libc::c_int> {
         let _ = config.add_capabilities(fuser::consts::FUSE_DO_READDIRPLUS);
-        // Set max_background FUSE parameter to 64 by default, may be overriden with config setting or by an environment variable.
+        // Set max_background FUSE parameter to 64 by default, may be overridden with config setting or by an environment variable.
         if let Some(max_background) = self.config.max_background_fuse_requests() {
             let old = config
                 .set_max_background(max_background)

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -54,7 +54,7 @@ impl BufferArea {
 ///                                     mem reserved by the backpressure controller
 ///                                     (on `BackpressureFeedbackEvent`)
 ///
-/// Incremental uploder instances may try to reserve multiple buffers to queue append requests. Under memory pressure,
+/// Incremental uploader instances may try to reserve multiple buffers to queue append requests. Under memory pressure,
 /// each instance will limit to a single buffer.
 #[derive(Debug)]
 pub struct MemoryLimiter {

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -31,10 +31,10 @@ struct PageInner {
     stats: Arc<SizePoolStats>,
 }
 
-// SAFETY: access to mutable state in `PageInner` is synchonized internally.
+// SAFETY: access to mutable state in `PageInner` is synchronized internally.
 unsafe impl Send for PageInner {}
 
-// SAFETY: access to mutable state in `PageInner` is synchonized internally.
+// SAFETY: access to mutable state in `PageInner` is synchronized internally.
 unsafe impl Sync for PageInner {}
 
 impl Drop for PageInner {

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -1317,10 +1317,10 @@ mod tests {
     #[test_case(8 * MB, 8 * MB, 1 * MB + 128 * KB; "default")]
     #[test_case(8 * MB, 8 * MB, 0; "no initial request")]
     #[test_case(1 * KB, 1 * MB, 10 * MB; "initial request larger than part size")]
-    #[test_case(16 * MB, 8 * MB, 1 * MB + 128 * KB; "larger intial read window")]
-    #[test_case(16 * MB, 8 * MB, 0; "larger intial read window w/o initial request")]
-    #[test_case(1 * KB, 8 * MB, 1 * MB + 128 * KB; "smaller intial read window")]
-    #[test_case(1 * KB, 8 * MB, 0; "smaller intial read window w/o initial request")]
+    #[test_case(16 * MB, 8 * MB, 1 * MB + 128 * KB; "larger initial read window")]
+    #[test_case(16 * MB, 8 * MB, 0; "larger initial read window w/o initial request")]
+    #[test_case(1 * KB, 8 * MB, 1 * MB + 128 * KB; "smaller initial read window")]
+    #[test_case(1 * KB, 8 * MB, 0; "smaller initial read window w/o initial request")]
     fn test_initial_reqeust_size(initial_read_window_size: usize, part_size: usize, initial_request_size: usize) {
         let object_size = (16 * MB) as u64;
 

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -1108,7 +1108,7 @@ impl<OC: ObjectClient + Send + Sync + Clone> Metablock for Superblock<OC> {
             // the directory entries and don't want to keep them all in memory. But one common case
             // we've seen (https://github.com/awslabs/mountpoint-s3/issues/477) is applications that
             // request offset 0 twice in a row. So we remember the last response and, if repeated,
-            // we return it again. Last response may also be used partially, if an interrupt occured
+            // we return it again. Last response may also be used partially, if an interrupt occurred
             // (https://github.com/awslabs/mountpoint-s3/issues/955), which caused entries from it to
             // be only partially fetched by kernel.
 

--- a/mountpoint-s3-fs/tests/common/cache.rs
+++ b/mountpoint-s3-fs/tests/common/cache.rs
@@ -19,7 +19,7 @@ pub struct CacheTestWrapper<Cache> {
 
 struct CacheTestWrapperInner<Cache> {
     cache: Cache,
-    /// Number of times the `get_block` succeded and returned data
+    /// Number of times the `get_block` succeeded and returned data
     get_block_hit_count: AtomicU64,
     /// Number of times the `get_block` failed because of an invalid block
     get_block_invalid_count: AtomicU64,
@@ -63,7 +63,7 @@ impl<Cache> CacheTestWrapper<Cache> {
         }
     }
 
-    /// Number of times the `get_block` succeded and returned data
+    /// Number of times the `get_block` succeeded and returned data
     pub fn get_block_hit_count(&self) -> u64 {
         self.inner.get_block_hit_count.load(Ordering::SeqCst)
     }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -1586,7 +1586,7 @@ async fn test_lookup_forbidden() {
         .await
         .expect("uploading an object must succeeed");
 
-    // try to lookup file with a S3 policy that dissallows that
+    // try to lookup file with a S3 policy that disallows that
     let fs = make_test_filesystem_with_client(
         client,
         pool,
@@ -1603,7 +1603,7 @@ async fn test_lookup_forbidden() {
         *metadata,
         ErrorMetadata {
             client_error_meta: ClientErrorMetadata {
-                http_code: Some(403), // here we assume that HeadObject failes with 403 code
+                http_code: Some(403), // here we assume that HeadObject fails with 403 code
                 error_code: None,
                 error_message: None,
             },

--- a/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/rename_test.rs
@@ -458,7 +458,7 @@ where
         vec!["other.txt", "writing-after-move.txt"],
         "should only see existing files and new renamed file"
     );
-    debug!("test successfull");
+    debug!("test successful");
 }
 
 #[cfg(feature = "s3express_tests")]
@@ -600,7 +600,7 @@ fn rename_same_file_test_mock(prefix: &str) {
 }
 
 /**
- * Semantics Issue: What hapens, when we call rename on a direcotry with itself as an argument?
+ * Semantics Issue: What happens, when we call rename on a directory with itself as an argument?
  */
 fn rename_dir_noop_accepted_test<F>(creator_fn: F, prefix: &str)
 where
@@ -982,14 +982,15 @@ where
         &mount_point.join("b.txt"),
         nix::fcntl::RenameFlags::RENAME_NOREPLACE,
     );
-    result_noreplace.expect_err("RENAME_NOREPLACE not handled correctly, since rename succeded when it shouldn't have");
+    result_noreplace
+        .expect_err("RENAME_NOREPLACE not handled correctly, since rename succeeded when it shouldn't have");
 
     let result_noreplace = renameat2_wrapper(
         &mount_point.join("a.txt"),
         &mount_point.join("b.txt"),
         RenameFlags::empty(),
     );
-    result_noreplace.expect("Without RENAME_NOREPLACE overwriting rename should succeded");
+    result_noreplace.expect("Without RENAME_NOREPLACE overwriting rename should succeeded");
 }
 
 #[cfg(target_os = "linux")]
@@ -1254,7 +1255,7 @@ where
     }
     // Rename it
     {
-        fs::rename(mount_point.join("a.txt"), mount_point.join("dir/b.txt")).expect("rename successfull");
+        fs::rename(mount_point.join("a.txt"), mount_point.join("dir/b.txt")).expect("rename successful");
     }
     // Append to it again
     {
@@ -1267,7 +1268,7 @@ where
         file.sync_all().unwrap();
         drop(file);
     }
-    fs::rename(mount_point.join("dir/b.txt"), mount_point.join("dir/c.txt")).expect("rename successfull");
+    fs::rename(mount_point.join("dir/b.txt"), mount_point.join("dir/c.txt")).expect("rename successful");
     // Verify the contents
     // Wait for a few seconds
     let contents = fs::read_to_string(mount_point.join("dir/c.txt")).expect("read should succeed");
@@ -1992,7 +1993,7 @@ struct FsState {
     b_has_a_content: bool, // true if b exists and has a's content
 }
 
-/// Takes a path and generates cooresponding FsState
+/// Takes a path and generates corresponding FsState
 fn get_fs_state(mount_point: &Path) -> FsState {
     let a_path = mount_point.join("a.txt");
     let b_path = mount_point.join("b.txt");

--- a/mountpoint-s3-fuser/deny.toml
+++ b/mountpoint-s3-fuser/deny.toml
@@ -38,7 +38,7 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# List of explicitly allowed licenses
+# List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [

--- a/mountpoint-s3-fuser/deny.toml
+++ b/mountpoint-s3-fuser/deny.toml
@@ -38,7 +38,7 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [

--- a/mountpoint-s3-fuser/src/lib.rs
+++ b/mountpoint-s3-fuser/src/lib.rs
@@ -527,7 +527,7 @@ pub trait Filesystem {
     /// will be undefined if the open method didn't set any value.
     ///
     /// write_flags: will contain FUSE_WRITE_CACHE, if this write is from the page cache. If set,
-    /// the pid, uid, gid, and fh may not match the value that would have been sent if write cachin
+    /// the pid, uid, gid, and fh may not match the value that would have been sent if write caching
     /// is disabled
     /// flags: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9
     /// lock_owner: only supported with ABI >= 7.9

--- a/mountpoint-s3-fuser/src/lib.rs
+++ b/mountpoint-s3-fuser/src/lib.rs
@@ -527,7 +527,7 @@ pub trait Filesystem {
     /// will be undefined if the open method didn't set any value.
     ///
     /// write_flags: will contain FUSE_WRITE_CACHE, if this write is from the page cache. If set,
-    /// the pid, uid, gid, and fh may not match the value that would have been sent if write caching
+    /// the pid, uid, gid, and fh may not match the value that would have been sent if write cachin
     /// is disabled
     /// flags: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9
     /// lock_owner: only supported with ABI >= 7.9

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -153,7 +153,7 @@ cache_benchmark () {
     fi
 
     mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
-    # creates a cache directoy with the suffix of the mount directory
+    # creates a cache directory with the suffix of the mount directory
     cache_dir=$(mktemp -d -p $local_storage -t `basename "${mount_dir}"`-cache-XXXXXXXXXXXX)
 
     job_name=$(basename "${job_file}")

--- a/mountpoint-s3/tests/fstab/spawn_mounts.sh
+++ b/mountpoint-s3/tests/fstab/spawn_mounts.sh
@@ -16,7 +16,7 @@ function spawn_mounts() {
   # systemd-fstab-generator takes two environment variables as input: 'SYSTEMD_FSTAB' and 'SYSTEMD_PROC_CMDLINE'
   # SYSTEMD_FSTAB is the path to the fstab file to use, if we don't want to use the system-wide one
   # SYSTEMD_PROC_CMDLINE is an alternative to the kernal's command line arguments.
-  # We don't want the state of the kernal arguments to impact our generation, so we mock it out
+  # We don't want the state of the kernel arguments to impact our generation, so we mock it out
   export SYSTEMD_FSTAB=$(mktemp)
   echo "$FSTAB_CONTENT" > "$SYSTEMD_FSTAB"
   export SYSTEMD_PROC_CMDLINE=""

--- a/package/package.py
+++ b/package/package.py
@@ -135,7 +135,7 @@ def build_mountpoint_binary(metadata: BuildMetadata, args: argparse.Namespace) -
     target_dir = os.path.join(metadata.buildroot, "cargo-target")
     env["CARGO_TARGET_DIR"] = target_dir
     if args.official:
-        # Set empty value to indicate official AWS release without specifc release target
+        # Set empty value to indicate official AWS release without specific release target
         env["MOUNTPOINT_S3_AWS_RELEASE_TARGET"] = ""
     for var in ["CC", "CXX", "LD_LIBRARY_PATH"]:
         if var in os.environ:


### PR DESCRIPTION
Corrected all typos across project except for `CHANGELOG.md` files. I was reading through the code and I noticed them all over the place.

### Does this change impact existing behavior?

No. All rust tests pass running them locally.

### Does this change need a changelog entry? Does it require a version change?

No. It is purely spelling fixes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
