### PR TITLE
Gate pool allocations through limiter

### DIFF
--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,5 +1,3 @@
-// TODO(memory-limiter): remove once wired into PagedPool
-#[allow(unused)]
 mod allocation_queue;
 mod buffers;
 mod limiter;

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -219,11 +219,10 @@ mod tests {
     use futures::executor::block_on;
 
     use crate::memory::pages::Page;
-    use crate::sync::Weak;
 
     fn make_buffer(size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(size);
-        let ptr = page.try_reserve(BufferKind::Other, Weak::new()).unwrap();
+        let ptr = page.try_reserve(BufferKind::Other).unwrap();
         PoolBuffer::new_primary(ptr, size)
     }
 

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -68,6 +68,14 @@ struct AllocationQueueInner {
     low: VecDeque<PendingAllocation>,
 }
 
+impl std::fmt::Debug for AllocationQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AllocationQueue")
+            .field("has_pending", &self.has_pending.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
 impl Default for AllocationQueue {
     fn default() -> Self {
         Self::new()
@@ -175,6 +183,7 @@ impl AllocationQueue {
     ///
     /// Called when a FUSE read arrives for a cursor that has pending speculative
     /// allocations — those allocations are now urgent.
+    #[allow(dead_code)] // TODO(memory-limiter): wire into set_active_read
     pub fn upgrade(&self, cursor_id: CursorId) {
         let mut inner = self.inner.lock().unwrap();
         let n = inner.low.len();
@@ -210,10 +219,11 @@ mod tests {
     use futures::executor::block_on;
 
     use crate::memory::pages::Page;
+    use crate::sync::Weak;
 
     fn make_buffer(size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(size);
-        let ptr = page.try_reserve(BufferKind::Other).unwrap();
+        let ptr = page.try_reserve(BufferKind::Other, Weak::new()).unwrap();
         PoolBuffer::new_primary(ptr, size)
     }
 

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -183,7 +183,6 @@ impl AllocationQueue {
     ///
     /// Called when a FUSE read arrives for a cursor that has pending speculative
     /// allocations — those allocations are now urgent.
-    #[allow(dead_code)] // TODO(memory-limiter): wire into set_active_read
     pub fn upgrade(&self, cursor_id: CursorId) {
         let mut inner = self.inner.lock().unwrap();
         let n = inner.low.len();

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -3,9 +3,10 @@ use std::ops::{Deref, DerefMut};
 
 use bytes::Bytes;
 
-use crate::sync::Arc;
+use crate::sync::{Arc, Weak};
 
 use super::pages::PagedBufferPtr;
+use super::pool::{PagedPool, PagedPoolInner};
 use super::stats::{BufferKind, PoolStats};
 
 /// A buffer backed by the pool.
@@ -30,8 +31,13 @@ impl PoolBuffer {
         Self(PoolBufferInner::Primary { buffer_ptr, size })
     }
 
-    pub(super) fn new_secondary(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
-        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats)))
+    pub(super) fn new_secondary(
+        size: usize,
+        kind: BufferKind,
+        stats: Arc<PoolStats>,
+        pool: Weak<PagedPoolInner>,
+    ) -> Self {
+        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats, pool)))
     }
 
     pub fn capacity(&self) -> usize {
@@ -171,19 +177,29 @@ struct FreeBuffer {
     data: Box<[u8]>,
     kind: BufferKind,
     stats: Arc<PoolStats>,
+    /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
+    pool: Weak<PagedPoolInner>,
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>) -> Self {
+    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>, pool: Weak<PagedPoolInner>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
         stats.reserve_bytes(data.len(), kind);
-        Self { data, kind, stats }
+        Self {
+            data,
+            kind,
+            stats,
+            pool,
+        }
     }
 }
 
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
         self.stats.release_bytes(self.data.len(), self.kind);
+        if let Some(pool) = self.pool.upgrade() {
+            PagedPool::from_inner(pool).try_wake_pending();
+        }
     }
 }
 
@@ -192,20 +208,26 @@ mod tests {
     use super::super::pages::Page;
 
     use super::*;
+    use crate::sync::Weak;
 
     use test_case::{test_case, test_matrix};
 
     fn primary(buffer_size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(buffer_size);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_reserve(BufferKind::Other, Weak::new())
             .expect("should be able to reserve a buffer from a new page");
 
         PoolBuffer::new_primary(buffer_ptr, buffer_size)
     }
 
     fn secondary(buffer_size: usize) -> PoolBuffer {
-        PoolBuffer::new_secondary(buffer_size, BufferKind::Other, Arc::new(PoolStats::default()))
+        PoolBuffer::new_secondary(
+            buffer_size,
+            BufferKind::Other,
+            Arc::new(PoolStats::default()),
+            Weak::new(),
+        )
     }
 
     #[test_case(primary)]

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use crate::sync::{Arc, Weak};
 
 use super::pages::PagedBufferPtr;
-use super::pool::{PagedPool, PagedPoolInner};
+use super::pool::PagedPoolInner;
 use super::stats::{BufferKind, PoolStats};
 
 /// A buffer backed by the pool.
@@ -198,7 +198,7 @@ impl Drop for FreeBuffer {
     fn drop(&mut self) {
         self.stats.release_bytes(self.data.len(), self.kind);
         if let Some(pool) = self.pool.upgrade() {
-            PagedPool::from_inner(pool).try_wake_pending();
+            pool.try_wake_pending();
         }
     }
 }
@@ -215,7 +215,7 @@ mod tests {
     fn primary(buffer_size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(buffer_size);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other, Weak::new())
+            .try_reserve(BufferKind::Other)
             .expect("should be able to reserve a buffer from a new page");
 
         PoolBuffer::new_primary(buffer_ptr, buffer_size)

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -175,6 +175,15 @@ impl MemoryLimiter {
             .unwrap_or(false)
     }
 
+    /// Check if the given cursor currently has an active FUSE read in progress.
+    pub fn has_active_read(&self, cursor_id: CursorId) -> bool {
+        self.cursors
+            .get(&cursor_id)
+            .and_then(|r| r.upgrade())
+            .map(|s| s.active_read.lock().unwrap().is_some())
+            .unwrap_or(false)
+    }
+
     /// Called by the pool on every buffer allocation. For download buffers with a known cursor,
     /// this converts reservation from "intent" (`mem_reserved`) to "actual allocation" (pool stats)
     /// by decrementing both the global and per-cursor counters.
@@ -300,6 +309,8 @@ impl Drop for CursorState {
         // The limiter holds a weak reference to `CursorState`, so this `Drop` runs when all strong
         // references are gone. `release_cursor` removes the reference and decrements the global reservation counter.
         self.pool.limiter().release_cursor(self.cursor_id, &self.mem_reserved);
+        // Releasing the cursor's reservation may have freed memory — wake any pending allocations.
+        self.pool.try_wake_pending();
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -332,8 +332,12 @@ impl CursorHandle {
     }
 
     /// Record an active FUSE read. Returns a guard that clears it on drop.
+    /// Also upgrades any pending speculative allocation queue entries for this cursor
+    /// to high priority, since a read is now actively waiting.
     pub fn set_active_read(&self, offset: u64, size: usize) -> ActiveReadGuard {
         *self.state.active_read.lock().unwrap() = Some(ActiveRead { offset, size });
+        // Promote any speculative queue entries to high priority.
+        self.state.pool.upgrade_pending(self.state.cursor_id);
         ActiveReadGuard { state: self.state() }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -1,7 +1,8 @@
 use std::alloc::{self, Layout};
 
-use crate::sync::{Arc, Mutex};
+use crate::sync::{Arc, Mutex, Weak};
 
+use super::pool::{PagedPool, PagedPoolInner};
 use super::stats::{BufferKind, SizePoolStats};
 
 /// Page in a size pool.
@@ -78,7 +79,7 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
@@ -93,6 +94,7 @@ impl Page {
             ptr,
             pool_page: self.clone(),
             kind,
+            pool,
         })
     }
 
@@ -183,6 +185,8 @@ pub(super) struct PagedBufferPtr {
     ptr: *mut u8,
     pool_page: Page,
     kind: BufferKind,
+    /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
+    pool: Weak<PagedPoolInner>,
 }
 
 // SAFETY: access to the buffer and release back to the pool page on drop can be performed from another thread.
@@ -191,6 +195,9 @@ unsafe impl Send for PagedBufferPtr {}
 impl Drop for PagedBufferPtr {
     fn drop(&mut self) {
         self.pool_page.release(self.ptr, self.kind);
+        if let Some(pool) = self.pool.upgrade() {
+            PagedPool::from_inner(pool).try_wake_pending();
+        }
     }
 }
 
@@ -214,24 +221,24 @@ mod tests {
         let mut buffers = Vec::new();
         for _ in 0..Page::BUFFERS_PER_PAGE {
             let buffer_ptr = page
-                .try_reserve(BufferKind::Other)
+                .try_reserve(BufferKind::Other, Weak::new())
                 .expect("reserving up to 16 buffers from a new page should succeed");
             buffers.push(buffer_ptr);
         }
 
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
             "reserving the 17th buffer from a page should return None"
         );
 
         _ = buffers.pop().expect("drop one of the reserved buffers");
 
         buffers.push(
-            page.try_reserve(BufferKind::Other)
+            page.try_reserve(BufferKind::Other, Weak::new())
                 .expect("reserving after dropping 1 buffer should succeed"),
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
             "reserving when all 16 buffers are in use should return None"
         );
 
@@ -247,7 +254,7 @@ mod tests {
             "invalidation of a new, empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
             "reserving from an invalidated page should return None"
         );
     }
@@ -256,7 +263,7 @@ mod tests {
     fn test_invalidate_in_use() {
         let page = Page::new_for_tests(1024);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_reserve(BufferKind::Other, Weak::new())
             .expect("reserving from a new page should succeed");
         assert!(!page.invalidate_if_empty(), "invalidation of a page in use should fail");
         drop(buffer_ptr);
@@ -265,7 +272,7 @@ mod tests {
             "invalidation of an empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
             "reserving from an invalidated page should return None"
         );
     }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -97,7 +97,6 @@ impl Page {
             ptr,
             pool_page: self.clone(),
             kind,
-            pool: self.inner.pool.clone(),
         })
     }
 
@@ -118,6 +117,14 @@ impl Page {
         self.inner.stats.remove_reserved_buffer(kind);
         if *bitmask == 0 {
             self.inner.stats.add_empty_page();
+        }
+        // Release the bitmask lock before waking pending allocations.
+        // try_wake_pending may try to allocate from this same page which would deadlock
+        // if we held the bitmask lock.
+        drop(bitmask);
+        // A primary buffer was freed — wake any pending allocation requests.
+        if let Some(pool) = self.inner.pool.upgrade() {
+            pool.try_wake_pending();
         }
     }
 
@@ -188,8 +195,6 @@ pub(super) struct PagedBufferPtr {
     ptr: *mut u8,
     pool_page: Page,
     kind: BufferKind,
-    /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
-    pool: Weak<PagedPoolInner>,
 }
 
 // SAFETY: access to the buffer and release back to the pool page on drop can be performed from another thread.
@@ -198,9 +203,6 @@ unsafe impl Send for PagedBufferPtr {}
 impl Drop for PagedBufferPtr {
     fn drop(&mut self) {
         self.pool_page.release(self.ptr, self.kind);
-        if let Some(pool) = self.pool.upgrade() {
-            pool.try_wake_pending();
-        }
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -2,7 +2,7 @@ use std::alloc::{self, Layout};
 
 use crate::sync::{Arc, Mutex, Weak};
 
-use super::pool::{PagedPool, PagedPoolInner};
+use super::pool::PagedPoolInner;
 use super::stats::{BufferKind, SizePoolStats};
 
 /// Page in a size pool.
@@ -30,6 +30,8 @@ struct PageInner {
     layout: Layout,
     /// Shared stats across pages with common `buffer_size`.
     stats: Arc<SizePoolStats>,
+    /// Weak reference back to the pool so buffer drops can wake pending allocations.
+    pool: Weak<PagedPoolInner>,
 }
 
 // SAFETY: access to mutable state in `PageInner` is synchonized internally.
@@ -51,7 +53,7 @@ impl Page {
     const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
 
     /// Create a new page and allocate the required memory.
-    pub fn new(stats: Arc<SizePoolStats>) -> Self {
+    pub fn new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>) -> Self {
         assert_ne!(stats.buffer_size, 0);
         let layout = Layout::array::<[u8; Self::BUFFERS_PER_PAGE]>(stats.buffer_size).unwrap();
 
@@ -72,6 +74,7 @@ impl Page {
             reserved_bitmask: Default::default(),
             layout,
             stats,
+            pool,
         };
         Page { inner: Arc::new(inner) }
     }
@@ -79,7 +82,7 @@ impl Page {
     /// Try to reserve a buffer from this page.
     ///
     /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> Option<PagedBufferPtr> {
+    pub fn try_reserve(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
         let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
@@ -94,7 +97,7 @@ impl Page {
             ptr,
             pool_page: self.clone(),
             kind,
-            pool,
+            pool: self.inner.pool.clone(),
         })
     }
 
@@ -145,7 +148,7 @@ impl Page {
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
         let pool_stats = super::stats::PoolStats::default();
         let stats = SizePoolStats::new(buffer_size, Arc::new(pool_stats));
-        Page::new(Arc::new(stats))
+        Page::new(Arc::new(stats), Weak::new())
     }
 }
 
@@ -196,7 +199,7 @@ impl Drop for PagedBufferPtr {
     fn drop(&mut self) {
         self.pool_page.release(self.ptr, self.kind);
         if let Some(pool) = self.pool.upgrade() {
-            PagedPool::from_inner(pool).try_wake_pending();
+            pool.try_wake_pending();
         }
     }
 }
@@ -221,24 +224,24 @@ mod tests {
         let mut buffers = Vec::new();
         for _ in 0..Page::BUFFERS_PER_PAGE {
             let buffer_ptr = page
-                .try_reserve(BufferKind::Other, Weak::new())
+                .try_reserve(BufferKind::Other)
                 .expect("reserving up to 16 buffers from a new page should succeed");
             buffers.push(buffer_ptr);
         }
 
         assert!(
-            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving the 17th buffer from a page should return None"
         );
 
         _ = buffers.pop().expect("drop one of the reserved buffers");
 
         buffers.push(
-            page.try_reserve(BufferKind::Other, Weak::new())
+            page.try_reserve(BufferKind::Other)
                 .expect("reserving after dropping 1 buffer should succeed"),
         );
         assert!(
-            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving when all 16 buffers are in use should return None"
         );
 
@@ -254,7 +257,7 @@ mod tests {
             "invalidation of a new, empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }
@@ -263,7 +266,7 @@ mod tests {
     fn test_invalidate_in_use() {
         let page = Page::new_for_tests(1024);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other, Weak::new())
+            .try_reserve(BufferKind::Other)
             .expect("reserving from a new page should succeed");
         assert!(!page.invalidate_if_empty(), "invalidation of a page in use should fail");
         drop(buffer_ptr);
@@ -272,7 +275,7 @@ mod tests {
             "invalidation of an empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other, Weak::new()).is_none(),
+            page.try_reserve(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -274,7 +274,8 @@ impl PagedPool {
         }
 
         // Determine priority: a cursor with an active FUSE read is High (urgent),
-        // everything else is Low (speculative prefetch or upload without a cursor).
+        // speculative prefetch (cursor with no active read) is Low.
+        // Uploads (no cursor) are always High — a write syscall is blocked.
         // NOTE: We check if the cursor has an active read, not if this allocation serves it.
         let rx = match cursor_id {
             Some(id) if self.inner.limiter.has_active_read(id) => {
@@ -295,6 +296,12 @@ impl PagedPool {
     /// Check if the given cursor has an active read overlapping the specified range.
     pub fn has_active_read_in_range(&self, cursor_id: CursorId, offset: u64, size: usize) -> bool {
         self.inner.limiter.has_active_read_in_range(cursor_id, offset, size)
+    }
+
+    /// Promote any pending speculative allocation queue entries for `cursor_id` to high priority.
+    /// Called when a FUSE read arrives for the cursor.
+    pub(super) fn upgrade_pending(&self, cursor_id: CursorId) {
+        self.inner.allocation_queue.upgrade(cursor_id);
     }
 
     // ─── Internal components exposed to the rest of the `memory` module. ──────────
@@ -429,6 +436,9 @@ impl PagedPoolInner {
                 undelivered.push(buffer);
             }
         }
+        // TODO(memory-limiter): these buffers should be dropped immediately so the freed memory
+        // can serve the next waiter, but dropping them here would recursively call try_wake_pending
+        // (since buffer drop triggers the wake). Decouple by running try_wake_pending concurrently.
         drop(undelivered);
     }
 }
@@ -753,7 +763,13 @@ mod tests {
                 let _ = tx.send(buffer);
             });
 
-            std::thread::sleep(std::time::Duration::from_millis(1));
+            // Wait for the request to enter the queue before freeing memory.
+            for _ in 0..1000 {
+                if pool.inner.allocation_queue.has_pending() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
             blockers.pop(); // free one buffer — should wake the pending request
 
             let buffer = rx.recv_timeout(std::time::Duration::from_secs(5)).expect("timed out");
@@ -771,38 +787,78 @@ mod tests {
                 blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
             }
 
-            // Enqueue a low-priority request (speculative, cursor with no active read).
-            let (low_tx, low_rx) = std::sync::mpsc::channel();
-            let pool1 = pool.clone();
-            std::thread::spawn(move || {
-                let buf =
-                    block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(CursorId::new_from_raw(1))));
-                let _ = low_tx.send(buf);
-            });
-            std::thread::sleep(std::time::Duration::from_millis(1));
+            // Push both requests directly to the queue so ordering is deterministic.
+            // Low priority first (speculative read), then high priority (upload).
+            let low_rx = pool
+                .inner
+                .allocation_queue
+                .push_low(CursorId::new_from_raw(1), BUF, BufferKind::GetObject);
+            let high_rx = pool.inner.allocation_queue.push_high(None, BUF, BufferKind::PutObject);
 
-            // Enqueue a high-priority request (upload, no cursor).
-            let (high_tx, high_rx) = std::sync::mpsc::channel();
-            let pool2 = pool.clone();
+            // Receive via threads + mpsc channels so we can use recv_timeout.
+            let (low_tx, low_mpsc) = std::sync::mpsc::channel();
+            let (high_tx, high_mpsc) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
-                let buf = block_on(pool2.acquire_buffer_async(BUF, BufferKind::PutObject, None));
-                let _ = high_tx.send(buf);
+                let _ = low_tx.send(block_on(low_rx).unwrap());
             });
-            std::thread::sleep(std::time::Duration::from_millis(1));
+            std::thread::spawn(move || {
+                let _ = high_tx.send(block_on(high_rx).unwrap());
+            });
 
-            // Free one buffer — high priority should be served first.
+            // Both are now in the queue. Free one buffer — high priority must be served first.
             blockers.pop();
-            let high_buf = high_rx
+            let high_buf = high_mpsc
                 .recv_timeout(std::time::Duration::from_secs(5))
                 .expect("timed out");
             assert!(high_buf.capacity() >= BUF);
 
             // Free another — low priority now gets served.
             blockers.pop();
-            let low_buf = low_rx
+            let low_buf = low_mpsc
                 .recv_timeout(std::time::Duration::from_secs(5))
                 .expect("timed out");
             assert!(low_buf.capacity() >= BUF);
+        }
+
+        #[test]
+        fn test_set_active_read_upgrades_speculative_to_high() {
+            const BUF: usize = 1024;
+            let pool = tight_pool(BUF);
+
+            // Fill all memory.
+            let mut blockers = Vec::new();
+            while pool.can_allocate(BUF) {
+                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            }
+
+            let cursor = pool.create_cursor();
+            let cursor_id = cursor.id();
+
+            // Push a speculative (low-priority) request for this cursor.
+            let (tx, rx) = std::sync::mpsc::channel();
+            let pool1 = pool.clone();
+            std::thread::spawn(move || {
+                let buf = block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(cursor_id)));
+                let _ = tx.send(buf);
+            });
+            // Wait for it to enter the queue as low priority.
+            for _ in 0..1000 {
+                if pool.inner.allocation_queue.has_pending() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+
+            // Simulate a FUSE read arriving — should upgrade the entry to high priority.
+            let _guard = cursor.set_active_read(0, BUF);
+
+            // Verify the entry is now in the high-priority queue by freeing one buffer
+            // and checking it gets served (would time out if stuck in low queue behind nothing).
+            blockers.pop();
+            let buffer = rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("timed out after upgrade");
+            assert!(buffer.capacity() >= BUF);
         }
 
         /// Reproduces the race where concurrent fast-path allocations could both observe room for

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -205,6 +205,9 @@ impl PagedPool {
     /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
     /// Loops until no more entries can be fulfilled or the queue is empty.
     pub(super) fn try_wake_pending(&self) {
+        if !self.inner.allocation_queue.has_pending() {
+            return;
+        }
         loop {
             let entry = self
                 .inner
@@ -225,9 +228,6 @@ impl PagedPool {
     /// - cursor with an active FUSE read → high priority
     /// - cursor without an active read (speculative prefetch) → low priority
     /// - no cursor (upload) → high priority (write syscall is blocked)
-    ///
-    /// If the receiver is cancelled (cursor dropped while waiting), falls back to a
-    /// direct allocation — the CRT must always receive a buffer.
     async fn acquire_buffer_async(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         // Fast path: if the queue is empty and there is room, allocate immediately.
         if !self.inner.allocation_queue.has_pending() && self.can_allocate(size) {
@@ -243,8 +243,12 @@ impl PagedPool {
             Some(id) => self.inner.allocation_queue.push_low(id, size, kind),
             None => self.inner.allocation_queue.push_high(None, size, kind), // uploads are urgent
         };
-        // The only error is Canceled (cursor dropped while waiting). The CRT must always
-        // receive a buffer, so fall back to a direct allocation.
+        // After pushing, try to wake immediately in case memory freed between the
+        // can_allocate check above and the push (avoids the race where a buffer drop
+        // called try_wake_pending before the entry was in the queue).
+        self.try_wake_pending();
+        // Await the buffer from the queue. Err(Canceled) can only happen during pool shutdown.
+        // TODO(memory-limiter): signal error to CRT via aws_future_s3_buffer_ticket_set_error.
         rx.await.unwrap_or_else(|_| self.get_buffer(size, kind, cursor_id))
     }
 
@@ -522,7 +526,7 @@ mod tests {
         }
     }
 
-    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [None, Some(Duration::from_millis(1))])]
+    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [None, Some(Duration::from_millis(10))])]
     #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
     #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
     fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
@@ -597,12 +601,15 @@ mod tests {
         use futures::executor::block_on;
 
         use super::*;
-        use crate::memory::limiter::MINIMUM_MEM_LIMIT;
 
         fn tight_pool(buffer_size: usize) -> PagedPool {
+            // Use a small limit — just enough for one page (16 buffers) plus overhead.
+            // This keeps the "fill all memory" loop fast in debug builds.
+            let additional_reserved = (buffer_size as u64 * 16).max(128 * 1024 * 1024);
+            let mem_limit = buffer_size as u64 * 16 + additional_reserved;
             PagedPool::config()
                 .with_candidate_sizes([buffer_size])
-                .with_memory_limit(MINIMUM_MEM_LIMIT)
+                .with_memory_limit(mem_limit)
                 .build()
         }
 
@@ -646,7 +653,7 @@ mod tests {
             let handle =
                 std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
 
-            std::thread::sleep(std::time::Duration::from_millis(20));
+            std::thread::sleep(std::time::Duration::from_millis(1));
             blockers.pop(); // free one buffer — should wake the pending request
 
             let buffer = handle.join().unwrap();
@@ -669,13 +676,13 @@ mod tests {
             let low_handle = std::thread::spawn(move || {
                 block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(CursorId::new_from_raw(1))))
             });
-            std::thread::sleep(std::time::Duration::from_millis(10));
+            std::thread::sleep(std::time::Duration::from_millis(1));
 
             // Enqueue a high-priority request (upload, no cursor).
             let pool2 = pool.clone();
             let high_handle =
                 std::thread::spawn(move || block_on(pool2.acquire_buffer_async(BUF, BufferKind::PutObject, None)));
-            std::thread::sleep(std::time::Duration::from_millis(10));
+            std::thread::sleep(std::time::Duration::from_millis(1));
 
             // Free one buffer — high priority should be served first.
             blockers.pop();

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -1,10 +1,12 @@
+use std::future::Future;
 use std::time::Duration;
 
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::{Arc, RwLock};
+use crate::sync::{Arc, RwLock, Weak};
 
+use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::limiter::{CursorHandle, MemoryLimiter};
 use super::pages::{Page, PagedBufferPtr};
@@ -59,6 +61,11 @@ pub struct PagedPool {
 }
 
 impl PagedPool {
+    /// Creates a [PagedPool] from an [Arc<PagedPoolInner>]. Used by buffer drop impls.
+    pub(super) fn from_inner(inner: Arc<PagedPoolInner>) -> Self {
+        Self { inner }
+    }
+
     /// Configuration for a [PagedPool].
     pub fn config() -> PagedPoolConfig {
         Default::default()
@@ -82,13 +89,18 @@ impl PagedPool {
             ordered_size_pools,
             stats,
             limiter,
+            allocation_queue: AllocationQueue::new(),
         };
         Self { inner: Arc::new(inner) }
     }
 
     /// Trim empty pages in the pool.
     pub fn trim(&self) -> bool {
-        self.inner.trim()
+        let trimmed = self.inner.trim();
+        if trimmed {
+            self.try_wake_pending();
+        }
+        trimmed
     }
 
     /// Schedule recurring calls to [trim](Self::trim).
@@ -97,10 +109,12 @@ impl PagedPool {
         std::thread::spawn(move || {
             loop {
                 std::thread::sleep(recurring_time);
-                let Some(pool) = weak.upgrade() else {
+                let Some(inner) = weak.upgrade() else {
                     return;
                 };
-                pool.trim();
+                if inner.trim() {
+                    PagedPool::from_inner(inner).try_wake_pending();
+                }
             }
         });
     }
@@ -126,7 +140,7 @@ impl PagedPool {
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind);
+                let buffer_ptr = pool.reserve(kind, Arc::downgrade(&self.inner));
                 metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
@@ -138,7 +152,7 @@ impl PagedPool {
                 metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
                 self.inner.limiter.on_pool_reserve(size, cursor_id);
-                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone())
+                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone(), Arc::downgrade(&self.inner))
             }
         }
     }
@@ -181,6 +195,59 @@ impl PagedPool {
         self.inner.limiter.available_mem(&self.inner.stats)
     }
 
+    /// Returns `true` if the pool can accommodate an additional allocation of `size` bytes.
+    fn can_allocate(&self, size: usize) -> bool {
+        self.available_mem() >= size as u64
+    }
+
+    /// Attempt to fulfill pending allocation requests from the queue.
+    ///
+    /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
+    /// Loops until no more entries can be fulfilled or the queue is empty.
+    pub(super) fn try_wake_pending(&self) {
+        loop {
+            let entry = self
+                .inner
+                .allocation_queue
+                .pop_front_if(|size, _, _| self.can_allocate(size));
+            let Some(entry) = entry else { break };
+            let buffer = self.get_buffer(entry.size, entry.kind, entry.cursor_id);
+            let _ = entry.fulfill(buffer);
+        }
+    }
+
+    /// Async buffer allocation through the priority queue.
+    ///
+    /// **Fast path:** if the queue is empty and memory is available, allocates and returns immediately.
+    ///
+    /// **Slow path:** pushes the request into the allocation queue and awaits a buffer.
+    /// Priority is determined from the cursor's active-read state:
+    /// - cursor with an active FUSE read → high priority
+    /// - cursor without an active read (speculative prefetch) → low priority
+    /// - no cursor (upload) → high priority (write syscall is blocked)
+    ///
+    /// If the receiver is cancelled (cursor dropped while waiting), falls back to a
+    /// direct allocation — the CRT must always receive a buffer.
+    async fn acquire_buffer_async(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
+        // Fast path: if the queue is empty and there is room, allocate immediately.
+        if !self.inner.allocation_queue.has_pending() && self.can_allocate(size) {
+            return self.get_buffer(size, kind, cursor_id);
+        }
+
+        // Determine priority: a cursor with an active FUSE read is High (urgent),
+        // everything else is Low (speculative prefetch or upload without a cursor).
+        let rx = match cursor_id {
+            Some(id) if self.inner.limiter.has_active_read(id) => {
+                self.inner.allocation_queue.push_high(cursor_id, size, kind)
+            }
+            Some(id) => self.inner.allocation_queue.push_low(id, size, kind),
+            None => self.inner.allocation_queue.push_high(None, size, kind), // uploads are urgent
+        };
+        // The only error is Canceled (cursor dropped while waiting). The CRT must always
+        // receive a buffer, so fall back to a direct allocation.
+        rx.await.unwrap_or_else(|_| self.get_buffer(size, kind, cursor_id))
+    }
+
     /// Check if the given cursor has an active read overlapping the specified range.
     pub fn has_active_read_in_range(&self, cursor_id: CursorId, offset: u64, size: usize) -> bool {
         self.inner.limiter.has_active_read_in_range(cursor_id, offset, size)
@@ -208,16 +275,24 @@ impl MemoryPool for PagedPool {
         )
     }
 
+    fn get_buffer_async(&self, size: usize, meta_request: &MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
+        let kind = meta_request.meta_request_type().into();
+        let cursor_id = meta_request.custom_id().map(CursorId::new_from_raw);
+        let pool = self.clone();
+        async move { pool.acquire_buffer_async(size, kind, cursor_id).await }
+    }
+
     fn trim(&self) -> bool {
         self.trim()
     }
 }
 
 #[derive(Debug)]
-struct PagedPoolInner {
+pub(super) struct PagedPoolInner {
     ordered_size_pools: Vec<SizePool>,
     stats: Arc<PoolStats>,
     limiter: MemoryLimiter,
+    allocation_queue: AllocationQueue,
 }
 
 impl PagedPoolInner {
@@ -270,11 +345,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind) -> PagedBufferPtr {
+    fn reserve(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, pool.clone()) {
                 return buffer_ptr;
             }
         }
@@ -284,13 +359,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, pool.clone()) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind).unwrap();
+        let buffer_ptr = page.try_reserve(kind, pool).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -299,8 +374,9 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
+        pool: Weak<PagedPoolInner>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind))
+        pages.find_map(|page| page.try_reserve(kind, pool.clone()))
     }
 
     fn buffer_size(&self) -> usize {
@@ -515,5 +591,101 @@ mod tests {
         assert!(ordered_sizes.iter().is_sorted(), "Sizes should be sorted");
         let unique: HashSet<_> = ordered_sizes.iter().collect();
         assert_eq!(ordered_sizes.len(), unique.len(), "Sizes should be unique");
+    }
+
+    mod allocation_queue_tests {
+        use futures::executor::block_on;
+
+        use super::*;
+        use crate::memory::limiter::MINIMUM_MEM_LIMIT;
+
+        fn tight_pool(buffer_size: usize) -> PagedPool {
+            PagedPool::config()
+                .with_candidate_sizes([buffer_size])
+                .with_memory_limit(MINIMUM_MEM_LIMIT)
+                .build()
+        }
+
+        #[test]
+        fn test_fast_path_when_room_available() {
+            let pool = tight_pool(1024);
+            let buffer = block_on(pool.acquire_buffer_async(256, BufferKind::GetObject, None));
+            assert!(buffer.capacity() >= 256);
+        }
+
+        #[test]
+        fn test_queues_when_no_room() {
+            const BUF: usize = 1024;
+            let pool = tight_pool(BUF);
+
+            // Fill all available memory.
+            let mut blockers = Vec::new();
+            while pool.can_allocate(BUF) {
+                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            }
+
+            // get_buffer_async should now queue and not resolve.
+            let mut fut = Box::pin(pool.acquire_buffer_async(BUF, BufferKind::GetObject, None));
+            let waker = futures::task::noop_waker();
+            let mut cx = std::task::Context::from_waker(&waker);
+            assert!(std::future::Future::poll(fut.as_mut(), &mut cx).is_pending());
+            assert!(pool.inner.allocation_queue.has_pending());
+        }
+
+        #[test]
+        fn test_wakes_when_buffer_dropped() {
+            const BUF: usize = 1024;
+            let pool = tight_pool(BUF);
+
+            let mut blockers = Vec::new();
+            while pool.can_allocate(BUF) {
+                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            }
+
+            let pool_clone = pool.clone();
+            let handle =
+                std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            blockers.pop(); // free one buffer — should wake the pending request
+
+            let buffer = handle.join().unwrap();
+            assert!(buffer.capacity() >= BUF);
+        }
+
+        #[test]
+        fn test_high_priority_served_before_low() {
+            const BUF: usize = 1024;
+            let pool = tight_pool(BUF);
+
+            // Fill all memory.
+            let mut blockers = Vec::new();
+            while pool.can_allocate(BUF) {
+                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            }
+
+            // Enqueue a low-priority request (speculative, cursor with no active read).
+            let pool1 = pool.clone();
+            let low_handle = std::thread::spawn(move || {
+                block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(CursorId::new_from_raw(1))))
+            });
+            std::thread::sleep(std::time::Duration::from_millis(10));
+
+            // Enqueue a high-priority request (upload, no cursor).
+            let pool2 = pool.clone();
+            let high_handle =
+                std::thread::spawn(move || block_on(pool2.acquire_buffer_async(BUF, BufferKind::PutObject, None)));
+            std::thread::sleep(std::time::Duration::from_millis(10));
+
+            // Free one buffer — high priority should be served first.
+            blockers.pop();
+            let high_buf = high_handle.join().unwrap();
+            assert!(high_buf.capacity() >= BUF);
+
+            // Free another — low priority now gets served.
+            blockers.pop();
+            let low_buf = low_handle.join().unwrap();
+            assert!(low_buf.capacity() >= BUF);
+        }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -1,10 +1,9 @@
-use std::future::Future;
 use std::time::Duration;
 
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::{Arc, RwLock, Weak};
+use crate::sync::{Arc, Mutex, RwLock, Weak};
 
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
@@ -90,6 +89,7 @@ impl PagedPool {
             stats,
             limiter,
             allocation_queue: AllocationQueue::new(),
+            alloc_gate: Mutex::new(()),
         };
         Self { inner: Arc::new(inner) }
     }
@@ -113,7 +113,7 @@ impl PagedPool {
                     return;
                 };
                 if inner.trim() {
-                    PagedPool::from_inner(inner).try_wake_pending();
+                    inner.try_wake_pending();
                 }
             }
         });
@@ -200,23 +200,24 @@ impl PagedPool {
         self.available_mem() >= size as u64
     }
 
+    /// Check available memory and, if there is room, allocate and return a buffer. Returns `None`
+    /// if the pool cannot accommodate `size` bytes.
+    ///
+    /// Both the check and the allocation are performed while holding `alloc_gate`, so this
+    /// check-and-allocate is atomic with respect to other gated allocations: a plain `can_allocate`
+    /// check followed by `get_buffer` would let concurrent callers both observe room for the same
+    /// bytes and overshoot the limit.
+    fn try_allocate(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> Option<PoolBuffer> {
+        let _gate = self.inner.alloc_gate.lock().unwrap();
+        self.can_allocate(size).then(|| self.get_buffer(size, kind, cursor_id))
+    }
+
     /// Attempt to fulfill pending allocation requests from the queue.
     ///
     /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
     /// Loops until no more entries can be fulfilled or the queue is empty.
     pub(super) fn try_wake_pending(&self) {
-        if !self.inner.allocation_queue.has_pending() {
-            return;
-        }
-        loop {
-            let entry = self
-                .inner
-                .allocation_queue
-                .pop_front_if(|size, _, _| self.can_allocate(size));
-            let Some(entry) = entry else { break };
-            let buffer = self.get_buffer(entry.size, entry.kind, entry.cursor_id);
-            let _ = entry.fulfill(buffer);
-        }
+        self.inner.try_wake_pending();
     }
 
     /// Async buffer allocation through the priority queue.
@@ -229,13 +230,18 @@ impl PagedPool {
     /// - cursor without an active read (speculative prefetch) → low priority
     /// - no cursor (upload) → high priority (write syscall is blocked)
     async fn acquire_buffer_async(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
-        // Fast path: if the queue is empty and there is room, allocate immediately.
-        if !self.inner.allocation_queue.has_pending() && self.can_allocate(size) {
-            return self.get_buffer(size, kind, cursor_id);
+        // Fast path: if the queue is empty, try to allocate immediately. The check-and-allocate in
+        // `try_allocate` is serialized by `alloc_gate`, so concurrent fast-path callers cannot both
+        // observe room for the same bytes and overshoot the limit.
+        if !self.inner.allocation_queue.has_pending()
+            && let Some(buffer) = self.try_allocate(size, kind, cursor_id)
+        {
+            return buffer;
         }
 
         // Determine priority: a cursor with an active FUSE read is High (urgent),
         // everything else is Low (speculative prefetch or upload without a cursor).
+        // NOTE: We check if the cursor has an active read, not if this allocation serves it.
         let rx = match cursor_id {
             Some(id) if self.inner.limiter.has_active_read(id) => {
                 self.inner.allocation_queue.push_high(cursor_id, size, kind)
@@ -243,9 +249,9 @@ impl PagedPool {
             Some(id) => self.inner.allocation_queue.push_low(id, size, kind),
             None => self.inner.allocation_queue.push_high(None, size, kind), // uploads are urgent
         };
-        // After pushing, try to wake immediately in case memory freed between the
-        // can_allocate check above and the push (avoids the race where a buffer drop
-        // called try_wake_pending before the entry was in the queue).
+        // After pushing, try to wake immediately in case memory freed between the fast-path
+        // check above and the push (avoids the race where a buffer drop called try_wake_pending
+        // before the entry was in the queue).
         self.try_wake_pending();
         // Await the buffer from the queue. Err(Canceled) can only happen during pool shutdown.
         // TODO(memory-limiter): signal error to CRT via aws_future_s3_buffer_ticket_set_error.
@@ -279,11 +285,10 @@ impl MemoryPool for PagedPool {
         )
     }
 
-    fn get_buffer_async(&self, size: usize, meta_request: &MetaRequest) -> impl Future<Output = Self::Buffer> + Send {
+    async fn get_buffer_async(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
         let kind = meta_request.meta_request_type().into();
         let cursor_id = meta_request.custom_id().map(CursorId::new_from_raw);
-        let pool = self.clone();
-        async move { pool.acquire_buffer_async(size, kind, cursor_id).await }
+        self.acquire_buffer_async(size, kind, cursor_id).await
     }
 
     fn trim(&self) -> bool {
@@ -297,6 +302,14 @@ pub(super) struct PagedPoolInner {
     stats: Arc<PoolStats>,
     limiter: MemoryLimiter,
     allocation_queue: AllocationQueue,
+    /// Serializes the check-and-allocate step for gated (async) allocations.
+    ///
+    /// Checking available memory and reserving a buffer are two separate operations; held across
+    /// both, this gate ensures only one gated allocation commits at a time, so concurrent callers
+    /// cannot both observe room for the same bytes and overshoot the memory limit. Synchronous
+    /// allocations ([`get_buffer`](PagedPool::get_buffer)) intentionally bypass the gate — they are
+    /// not memory-limited.
+    alloc_gate: Mutex<()>,
 }
 
 impl PagedPoolInner {
@@ -340,6 +353,29 @@ impl PagedPoolInner {
 
         removed
     }
+
+    pub(super) fn try_wake_pending(self: &Arc<Self>) {
+        if !self.allocation_queue.has_pending() {
+            return;
+        }
+        let pool = PagedPool::from_inner(self.clone());
+        let mut undelivered = Vec::new();
+        {
+            let _gate = self.alloc_gate.lock().unwrap();
+            loop {
+                let available = self.limiter.available_mem(&self.stats);
+                let entry = self
+                    .allocation_queue
+                    .pop_front_if(|size, _, _| available >= size as u64);
+                let Some(entry) = entry else { break };
+                let buffer = pool.get_buffer(entry.size, entry.kind, entry.cursor_id);
+                if let Err(buffer) = entry.fulfill(buffer) {
+                    undelivered.push(buffer);
+                }
+            }
+        }
+        drop(undelivered);
+    }
 }
 
 #[derive(Debug)]
@@ -353,7 +389,7 @@ impl SizePool {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
-            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind, pool.clone()) {
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
                 return buffer_ptr;
             }
         }
@@ -363,13 +399,13 @@ impl SizePool {
         // in case a buffer became available while we waited for the lock or another concurrent
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
-        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind, pool.clone()) {
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
             return buffer_ptr;
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
-        let page = Page::new(self.stats.clone());
-        let buffer_ptr = page.try_reserve(kind, pool).unwrap();
+        let page = Page::new(self.stats.clone(), pool);
+        let buffer_ptr = page.try_reserve(kind).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -378,9 +414,8 @@ impl SizePool {
         &self,
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
-        pool: Weak<PagedPoolInner>,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind, pool.clone()))
+        pages.find_map(|page| page.try_reserve(kind))
     }
 
     fn buffer_size(&self) -> usize {
@@ -631,12 +666,19 @@ mod tests {
                 blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
             }
 
-            // get_buffer_async should now queue and not resolve.
-            let mut fut = Box::pin(pool.acquire_buffer_async(BUF, BufferKind::GetObject, None));
-            let waker = futures::task::noop_waker();
-            let mut cx = std::task::Context::from_waker(&waker);
-            assert!(std::future::Future::poll(fut.as_mut(), &mut cx).is_pending());
-            assert!(pool.inner.allocation_queue.has_pending());
+            // Spawn a request — it should enqueue since there's no room.
+            let pool_clone = pool.clone();
+            let _handle =
+                std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+
+            // Wait for the request to enter the queue (retry for up to 100ms).
+            for _ in 0..100 {
+                if pool.inner.allocation_queue.has_pending() {
+                    return; // Success
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            panic!("request did not enter queue within 100ms");
         }
 
         #[test]
@@ -649,14 +691,17 @@ mod tests {
                 blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
             }
 
+            let (tx, rx) = std::sync::mpsc::channel();
             let pool_clone = pool.clone();
-            let handle =
-                std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+            std::thread::spawn(move || {
+                let buffer = block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None));
+                let _ = tx.send(buffer);
+            });
 
             std::thread::sleep(std::time::Duration::from_millis(1));
             blockers.pop(); // free one buffer — should wake the pending request
 
-            let buffer = handle.join().unwrap();
+            let buffer = rx.recv_timeout(std::time::Duration::from_secs(5)).expect("timed out");
             assert!(buffer.capacity() >= BUF);
         }
 
@@ -672,27 +717,104 @@ mod tests {
             }
 
             // Enqueue a low-priority request (speculative, cursor with no active read).
+            let (low_tx, low_rx) = std::sync::mpsc::channel();
             let pool1 = pool.clone();
-            let low_handle = std::thread::spawn(move || {
-                block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(CursorId::new_from_raw(1))))
+            std::thread::spawn(move || {
+                let buf =
+                    block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(CursorId::new_from_raw(1))));
+                let _ = low_tx.send(buf);
             });
             std::thread::sleep(std::time::Duration::from_millis(1));
 
             // Enqueue a high-priority request (upload, no cursor).
+            let (high_tx, high_rx) = std::sync::mpsc::channel();
             let pool2 = pool.clone();
-            let high_handle =
-                std::thread::spawn(move || block_on(pool2.acquire_buffer_async(BUF, BufferKind::PutObject, None)));
+            std::thread::spawn(move || {
+                let buf = block_on(pool2.acquire_buffer_async(BUF, BufferKind::PutObject, None));
+                let _ = high_tx.send(buf);
+            });
             std::thread::sleep(std::time::Duration::from_millis(1));
 
             // Free one buffer — high priority should be served first.
             blockers.pop();
-            let high_buf = high_handle.join().unwrap();
+            let high_buf = high_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("timed out");
             assert!(high_buf.capacity() >= BUF);
 
             // Free another — low priority now gets served.
             blockers.pop();
-            let low_buf = low_handle.join().unwrap();
+            let low_buf = low_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("timed out");
             assert!(low_buf.capacity() >= BUF);
+        }
+
+        /// Reproduces the race where concurrent fast-path allocations could both observe room for
+        /// the same bytes and overshoot the memory limit.
+        ///
+        /// We fill memory leaving exactly one free buffer slot, then release many threads
+        /// simultaneously (via a [Barrier]) into the fast path and poll each once. The
+        /// check-and-allocate is serialized by `alloc_gate`, so exactly one thread may allocate the
+        /// last slot; the rest must queue. Before the fix, several threads passed a plain
+        /// `can_allocate` check concurrently and all allocated, reserving more buffers than the
+        /// budget allows.
+        #[test]
+        fn test_fast_path_does_not_overshoot_limit_under_contention() {
+            use std::sync::Barrier;
+
+            const BUF: usize = 1024;
+            // Run several rounds to make the timing-dependent race likely to surface.
+            for _ in 0..50 {
+                let pool = tight_pool(BUF);
+
+                // Fill memory leaving exactly one free buffer slot.
+                let mut blockers = Vec::new();
+                while pool.can_allocate(BUF) {
+                    blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+                }
+                let budget_buffers = blockers.len();
+                blockers.pop(); // free exactly one slot
+                assert!(pool.can_allocate(BUF));
+
+                const RACERS: usize = 16;
+                let barrier = Arc::new(Barrier::new(RACERS));
+                let granted: Vec<PoolBuffer> = std::thread::scope(|scope| {
+                    let handles: Vec<_> = (0..RACERS)
+                        .map(|_| {
+                            let pool = pool.clone();
+                            let barrier = barrier.clone();
+                            scope.spawn(move || {
+                                let mut fut = Box::pin(pool.acquire_buffer_async(BUF, BufferKind::GetObject, None));
+                                // Release all racers into the fast path at once for maximum contention.
+                                barrier.wait();
+                                let waker = futures::task::noop_waker();
+                                let mut cx = std::task::Context::from_waker(&waker);
+                                match std::future::Future::poll(fut.as_mut(), &mut cx) {
+                                    std::task::Poll::Ready(buffer) => Some(buffer),
+                                    std::task::Poll::Pending => None,
+                                }
+                            })
+                        })
+                        .collect();
+                    // Collect the won buffers so they stay reserved while we assert below.
+                    handles.into_iter().filter_map(|h| h.join().unwrap()).collect()
+                });
+
+                // Exactly one racer may take the single free slot; the rest must have queued.
+                assert_eq!(
+                    granted.len(),
+                    1,
+                    "exactly one fast-path allocation should win the last slot"
+                );
+                // And the pool must never have exceeded its buffer budget while the winner holds its buffer.
+                assert_eq!(
+                    pool.reserved_buffer_count(BufferKind::Other) + pool.reserved_buffer_count(BufferKind::GetObject),
+                    budget_buffers,
+                    "total reserved buffers must not exceed the budget",
+                );
+                drop(granted);
+            }
         }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::{Arc, Mutex, RwLock, Weak};
+use crate::sync::atomic::{AtomicU64, Ordering};
+use crate::sync::{Arc, RwLock, Weak};
 
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
@@ -89,7 +90,7 @@ impl PagedPool {
             stats,
             limiter,
             allocation_queue: AllocationQueue::new(),
-            alloc_gate: Mutex::new(()),
+            pending_allocations: AtomicU64::new(0),
         };
         Self { inner: Arc::new(inner) }
     }
@@ -196,20 +197,53 @@ impl PagedPool {
     }
 
     /// Returns `true` if the pool can accommodate an additional allocation of `size` bytes.
+    #[cfg(test)]
     fn can_allocate(&self, size: usize) -> bool {
-        self.available_mem() >= size as u64
+        let pending = self.inner.pending_allocations.load(Ordering::SeqCst);
+        self.available_mem().saturating_sub(pending) >= size as u64
     }
 
-    /// Check available memory and, if there is room, allocate and return a buffer. Returns `None`
-    /// if the pool cannot accommodate `size` bytes.
+    /// Check available memory and, if there is room, atomically claim the bytes and allocate.
+    /// Returns `None` if the pool cannot accommodate `size` bytes.
     ///
-    /// Both the check and the allocation are performed while holding `alloc_gate`, so this
-    /// check-and-allocate is atomic with respect to other gated allocations: a plain `can_allocate`
-    /// check followed by `get_buffer` would let concurrent callers both observe room for the same
-    /// bytes and overshoot the limit.
+    /// The limit check uses a compare-and-swap loop on `pending_allocations` — multiple threads
+    /// can claim bytes concurrently without a mutex. The actual allocation (`get_buffer`) runs
+    /// outside the CAS, so `SizePool::reserve` and secondary allocations proceed in parallel.
     fn try_allocate(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> Option<PoolBuffer> {
-        let _gate = self.inner.alloc_gate.lock().unwrap();
-        self.can_allocate(size).then(|| self.get_buffer(size, kind, cursor_id))
+        // Primary buffers round up to buffer_size; use the actual size for accounting.
+        let alloc_size = self
+            .inner
+            .get_pool_for_size(size)
+            .map(|pool| pool.buffer_size())
+            .unwrap_or(size) as u64;
+
+        // Atomically claim `alloc_size` bytes. Re-read pending on each retry because another
+        // thread may have claimed or freed bytes between iterations.
+        let mut pending = self.inner.pending_allocations.load(Ordering::SeqCst);
+        loop {
+            let available = self.available_mem().saturating_sub(pending);
+            if available < alloc_size {
+                return None;
+            }
+            match self.inner.pending_allocations.compare_exchange_weak(
+                pending,
+                pending + alloc_size,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(current) => pending = current,
+            }
+        }
+
+        // Bytes claimed — allocate without holding any lock.
+        // SizePool::reserve uses its own RwLock; secondary allocations are independent.
+        let buffer = self.get_buffer(size, kind, cursor_id);
+
+        // Buffer is now tracked by pool stats; release the pending claim.
+        self.inner.pending_allocations.fetch_sub(alloc_size, Ordering::SeqCst);
+
+        Some(buffer)
     }
 
     /// Attempt to fulfill pending allocation requests from the queue.
@@ -231,7 +265,7 @@ impl PagedPool {
     /// - no cursor (upload) → high priority (write syscall is blocked)
     async fn acquire_buffer_async(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         // Fast path: if the queue is empty, try to allocate immediately. The check-and-allocate in
-        // `try_allocate` is serialized by `alloc_gate`, so concurrent fast-path callers cannot both
+        // `try_allocate` uses CAS on `pending_allocations`, so concurrent fast-path callers cannot both
         // observe room for the same bytes and overshoot the limit.
         if !self.inner.allocation_queue.has_pending()
             && let Some(buffer) = self.try_allocate(size, kind, cursor_id)
@@ -302,14 +336,10 @@ pub(super) struct PagedPoolInner {
     stats: Arc<PoolStats>,
     limiter: MemoryLimiter,
     allocation_queue: AllocationQueue,
-    /// Serializes the check-and-allocate step for gated (async) allocations.
-    ///
-    /// Checking available memory and reserving a buffer are two separate operations; held across
-    /// both, this gate ensures only one gated allocation commits at a time, so concurrent callers
-    /// cannot both observe room for the same bytes and overshoot the memory limit. Synchronous
-    /// allocations ([`get_buffer`](PagedPool::get_buffer)) intentionally bypass the gate — they are
-    /// not memory-limited.
-    alloc_gate: Mutex<()>,
+    /// Tracks bytes that have been claimed (limit check passed) but not yet reflected in pool
+    /// stats. Used to prevent two concurrent callers both observing room for the same bytes.
+    /// Decremented once `get_buffer` completes and pool stats take over.
+    pending_allocations: AtomicU64,
 }
 
 impl PagedPoolInner {
@@ -360,18 +390,43 @@ impl PagedPoolInner {
         }
         let pool = PagedPool::from_inner(self.clone());
         let mut undelivered = Vec::new();
-        {
-            let _gate = self.alloc_gate.lock().unwrap();
-            loop {
-                let available = self.limiter.available_mem(&self.stats);
-                let entry = self
-                    .allocation_queue
-                    .pop_front_if(|size, _, _| available >= size as u64);
-                let Some(entry) = entry else { break };
-                let buffer = pool.get_buffer(entry.size, entry.kind, entry.cursor_id);
-                if let Err(buffer) = entry.fulfill(buffer) {
-                    undelivered.push(buffer);
+
+        loop {
+            // Atomically check and pop the front entry if we can afford it.
+            // The CAS inside pop_front_if re-reads pending after each retry,
+            // so a concurrent claim by another thread is always visible.
+            let entry = self.allocation_queue.pop_front_if(|size, _, _| {
+                let alloc_size = self.get_pool_for_size(size).map(|p| p.buffer_size()).unwrap_or(size) as u64;
+                let mut pending = self.pending_allocations.load(Ordering::SeqCst);
+                loop {
+                    let available = self.limiter.available_mem(&self.stats).saturating_sub(pending);
+                    if available < alloc_size {
+                        return false;
+                    }
+                    match self.pending_allocations.compare_exchange_weak(
+                        pending,
+                        pending + alloc_size,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    ) {
+                        Ok(_) => return true,
+                        Err(current) => pending = current,
+                    }
                 }
+            });
+            let Some(entry) = entry else { break };
+
+            let alloc_size = self
+                .get_pool_for_size(entry.size)
+                .map(|p| p.buffer_size())
+                .unwrap_or(entry.size) as u64;
+
+            // Allocate without any lock — SizePool handles concurrency with its own RwLock.
+            let buffer = pool.get_buffer(entry.size, entry.kind, entry.cursor_id);
+            self.pending_allocations.fetch_sub(alloc_size, Ordering::SeqCst);
+
+            if let Err(buffer) = entry.fulfill(buffer) {
+                undelivered.push(buffer);
             }
         }
         drop(undelivered);
@@ -755,7 +810,7 @@ mod tests {
         ///
         /// We fill memory leaving exactly one free buffer slot, then release many threads
         /// simultaneously (via a [Barrier]) into the fast path and poll each once. The
-        /// check-and-allocate is serialized by `alloc_gate`, so exactly one thread may allocate the
+        /// The CAS on `pending_allocations` ensures exactly one thread can claim the last slot;
         /// last slot; the rest must queue. Before the fix, several threads passed a plain
         /// `can_allocate` check concurrently and all allocated, reserving more buffers than the
         /// budget allows.


### PR DESCRIPTION
This is the change that actually enforces the memory limit for buffer allocations. Previously, get_buffer_async always allocated immediately regardless of how much memory was already in use. Now, when memory is full, requests wait in the allocation queue and get served in priority order when memory frees up, active reads and uploads
first and speculative prefetch last.

The memory limit check uses a compare-and-swap loop on a pending_allocations counter - no mutex needed. Multiple threads can claim bytes concurrently, only one wins per available slot. The actual allocation proceeds without any external lock since both are already concurrent-safe.
  
The queue is woken whenever memory is freed: when a buffer is dropped (primary or secondary), when a cursor is released, or when the pool is trimmed.

Unit tests added.
  
get_buffer (the sync write path used by uploads) bypasses the queue intentionally - the CRT write path requires synchronous buffer allocation and cannot wait. Upload memory is bounded by the concurrent write-handle limit instead.

### Does this change impact existing behavior?

Yes, async buffer allocations now block under memory pressure instead of allocating unboundedly.

### Does this change need a changelog entry? Does it require a version change?

No, the memory limit isn't user-visible yet. No behavior change for existing users.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
