### PR TITLE
Implement cursor reset mechanism

### DIFF
--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -164,6 +164,18 @@ impl MemoryLimiter {
             .saturating_sub(self.additional_mem_reserved)
     }
 
+    /// Reset a cursor: invoke its registered reset callback.
+    pub fn request_reset(&self, cursor_id: CursorId) -> bool {
+        let Some(state) = self.cursors.get(&cursor_id).and_then(|r| r.upgrade()) else {
+            return false;
+        };
+        let reset_fn = state.reset_fn.lock().unwrap();
+        let Some(f) = reset_fn.as_ref() else {
+            return false;
+        };
+        f()
+    }
+
     /// Check if the given cursor has an active read overlapping the specified range.
     pub fn has_active_read_in_range(&self, cursor_id: CursorId, offset: u64, size: usize) -> bool {
         // The weak reference fails to upgrade iff the cursor has already been dropped, which means
@@ -241,9 +253,10 @@ impl ActiveRead {
     }
 }
 
+type ResetFn = Box<dyn Fn() -> bool + Send + Sync>;
+
 /// Per-cursor state shared between the memory pool's limiter,
 /// the BackpressureController, and the Cursor.
-#[derive(Debug)]
 pub struct CursorState {
     /// The memory pool tracking this cursor.
     pool: PagedPool,
@@ -253,6 +266,9 @@ pub struct CursorState {
     mem_reserved: AtomicU64,
     /// Active FUSE read range. None when no read is in progress.
     active_read: Mutex<Option<ActiveRead>>,
+    /// Callback that drops the cursor's expensive inner resources.
+    /// `None` before registration.
+    reset_fn: Mutex<Option<ResetFn>>,
 }
 
 impl CursorState {
@@ -262,6 +278,7 @@ impl CursorState {
             cursor_id,
             mem_reserved: AtomicU64::new(0),
             active_read: Mutex::new(None),
+            reset_fn: Mutex::new(None),
         }
     }
 
@@ -295,6 +312,17 @@ impl CursorState {
     }
 }
 
+impl std::fmt::Debug for CursorState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CursorState")
+            .field("cursor_id", &self.cursor_id)
+            .field("mem_reserved", &self.mem_reserved)
+            .field("active_read", &self.active_read)
+            .field("has_reset_fn", &self.reset_fn.lock().unwrap().is_some())
+            .finish()
+    }
+}
+
 impl Drop for CursorState {
     fn drop(&mut self) {
         // The limiter holds a weak reference to `CursorState`, so this `Drop` runs when all strong
@@ -324,6 +352,12 @@ impl CursorHandle {
     pub fn set_active_read(&self, offset: u64, size: usize) -> ActiveReadGuard {
         *self.state.active_read.lock().unwrap() = Some(ActiveRead { offset, size });
         ActiveReadGuard { state: self.state() }
+    }
+
+    /// Register a callback that will be invoked to drop the cursor's expensive
+    /// inner resources (RequestTask + SeekWindow) on a limiter-initiated reset.
+    pub fn register_reset_fn(&self, f: ResetFn) {
+        *self.state.reset_fn.lock().unwrap() = Some(f);
     }
 }
 
@@ -632,5 +666,16 @@ mod tests {
             sys.total_memory(),
             "without a cgroup limit, effective_total_memory() should equal total physical memory",
         );
+    }
+
+    #[test]
+    fn reset_cursor_returns_false_after_drop() {
+        let pool = new_pool();
+        let cursor = pool.create_cursor();
+        let cursor_id = cursor.id();
+        drop(cursor);
+
+        // Cursor already dropped — weak upgrade fails
+        assert!(!pool.reset_cursor(cursor_id));
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -177,8 +177,9 @@ impl PagedPool {
     }
 
     /// Reset a cursor: immediately drop its in-flight request and buffered data,
-    /// reclaiming all reserved memory. Returns `true` if the cursor was actually
-    /// reset, `false` if already dropped or already reset.
+    /// reclaiming all reserved memory.
+    ///
+    /// Returns whether the cursor was actually reset.
     pub fn reset_cursor(&self, cursor_id: CursorId) -> bool {
         self.inner.limiter.request_reset(cursor_id)
     }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -176,6 +176,13 @@ impl PagedPool {
         self.inner.limiter.create_cursor(self)
     }
 
+    /// Reset a cursor: immediately drop its in-flight request and buffered data,
+    /// reclaiming all reserved memory. Returns `true` if the cursor was actually
+    /// reset, `false` if already dropped or already reset.
+    pub fn reset_cursor(&self, cursor_id: CursorId) -> bool {
+        self.inner.limiter.request_reset(cursor_id)
+    }
+
     /// Query available memory.
     pub fn available_mem(&self) -> u64 {
         self.inner.limiter.available_mem(&self.inner.stats)

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -311,22 +311,27 @@ where
         let max_preferred_part_size = 1024 * 1024;
         self.preferred_part_size = self.preferred_part_size.max(length).min(max_preferred_part_size);
 
-        loop {
-            // Try to use the current cursor, if present. Allows for limited non sequential reads.
-            if let Some(ref mut cursor) = self.cursor
-                && let Some(result) = cursor.try_read(offset, length).await?
-            {
-                return Ok(result);
-            } else {
-                // Otherwise, create a new cursor at `offset` and read from it.
-                self.cursor = Some(self.create_cursor(offset)?);
-            }
+        // Try to use the current cursor, if present. Allows for limited non sequential reads.
+        if let Some(ref mut cursor) = self.cursor
+            && let Some(result) = cursor.try_read(offset, length).await?
+        {
+            Ok(result)
+        } else {
+            // Otherwise, create a new cursor at `offset` and read from it.
+            let (cursor, result) = self.read_from_new_cursor(offset, length).await?;
+            self.cursor = Some(cursor);
+            Ok(result)
         }
     }
 
-    /// Create a new Cursor and associated backpressure GetObject request which has a range from current offset
+    /// Create a new [`Cursor`] and start reading from it.
+    /// The new cursor starts a backpressure GetObject request with a range from current offset
     /// to the end of the file.
-    fn create_cursor(&self, offset: u64) -> Result<Cursor<Client>, PrefetchReadError<Client::ClientError>> {
+    async fn read_from_new_cursor(
+        &self,
+        offset: u64,
+        initial_read_length: usize,
+    ) -> Result<(Cursor<Client>, (ChecksummedBytes, bool)), PrefetchReadError<Client::ClientError>> {
         let object_size = self.size as usize;
         let client = self.part_stream.client();
 
@@ -351,13 +356,15 @@ where
             read_window_size_multiplier: self.config.sequential_prefetch_multiplier,
         };
         let request_task = self.part_stream.spawn_request_task(task_config);
-        Ok(Cursor::new(
+        Cursor::new_and_read(
             request_task,
             cursor_handle,
             &self.config,
             self.object_id.clone(),
             offset,
-        ))
+            initial_read_length,
+        )
+        .await
     }
 
     /// Reset this prefetch request, clearing any existing tasks queued.

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -266,12 +266,7 @@ where
         offset: u64,
         length: usize,
     ) -> Result<ChecksummedBytes, PrefetchReadError<Client::ClientError>> {
-        trace!(
-            offset,
-            length,
-            next_seq_offset = self.cursor.as_ref().map(|c| c.current_offset()),
-            "read"
-        );
+        trace!(offset, length, "read");
 
         let remaining = self.size.saturating_sub(offset);
         if remaining == 0 {
@@ -316,15 +311,16 @@ where
         let max_preferred_part_size = 1024 * 1024;
         self.preferred_part_size = self.preferred_part_size.max(length).min(max_preferred_part_size);
 
-        // Try to use the current cursor, if present. Allows for limited non sequential reads.
-        if let Some(ref mut cursor) = self.cursor
-            && let Some(result) = cursor.try_read(offset, length).await?
-        {
-            Ok(result)
-        } else {
-            // Otherwise, create a new cursor at `offset` and read from it.
-            let cursor = self.cursor.insert(self.create_cursor(offset)?);
-            cursor.read(length).await
+        loop {
+            // Try to use the current cursor, if present. Allows for limited non sequential reads.
+            if let Some(ref mut cursor) = self.cursor
+                && let Some(result) = cursor.try_read(offset, length).await?
+            {
+                return Ok(result);
+            } else {
+                // Otherwise, create a new cursor at `offset` and read from it.
+                self.cursor = Some(self.create_cursor(offset)?);
+            }
         }
     }
 
@@ -1134,6 +1130,62 @@ mod tests {
             next_offset += buf.len() as u64;
         }
         assert_eq!(next_offset, object_size);
+    }
+
+    /// Resetting a cursor mid-read reclaims memory, and the next read transparently
+    /// creates a new cursor and returns correct data.
+    #[test]
+    fn reset_cursor_mid_read_recovers() {
+        const PART_SIZE: usize = 256 * KB;
+        const OBJECT_SIZE: usize = 4 * MB;
+        const READ_SIZE: usize = 256 * KB;
+
+        let client = Arc::new(
+            MockClient::config()
+                .bucket("test-bucket")
+                .part_size(PART_SIZE)
+                .enable_backpressure(true)
+                .initial_read_window_size(PART_SIZE)
+                .build(),
+        );
+        let object = MockObject::ramp(0xaa, OBJECT_SIZE, ETag::for_tests());
+        let expected = object.read(0, READ_SIZE * 2);
+        let etag = object.etag();
+        client.add_object("hello", object);
+
+        let prefetcher = build_prefetcher(client, PrefetcherType::Default, Default::default());
+        let object_id = ObjectId::new("hello".to_owned(), etag);
+        let mut request = prefetcher.prefetch("test-bucket".to_owned(), object_id, OBJECT_SIZE as u64);
+
+        block_on(async {
+            // Read the first chunk
+            let buf = request.read(0, READ_SIZE).await.unwrap();
+            assert_eq!(buf.into_bytes().unwrap()[..], expected[..READ_SIZE]);
+
+            // Reset the cursor via the pool
+            let cursor_id = request
+                .cursor
+                .as_ref()
+                .expect("cursor should still be populated")
+                .cursor_id();
+            let pool = request.part_stream.pool();
+            let available_before = pool.available_mem();
+            assert!(pool.reset_cursor(cursor_id));
+
+            // Memory should be reclaimed (reservation released)
+            let available_after = pool.available_mem();
+            assert!(
+                available_after > available_before,
+                "expected memory to be reclaimed: before={available_before}, after={available_after}"
+            );
+
+            // Second reset should return false
+            assert!(!pool.reset_cursor(cursor_id));
+
+            // Next read should succeed transparently (creates a new cursor)
+            let buf = request.read(READ_SIZE as u64, READ_SIZE).await.unwrap();
+            assert_eq!(buf.into_bytes().unwrap()[..], expected[READ_SIZE..]);
+        });
     }
 
     #[cfg(feature = "shuttle")]

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -6,6 +6,7 @@ use crate::checksums::ChecksummedBytes;
 use crate::memory::CursorHandle;
 use crate::metrics::defs::PREFETCH_RESET_STATE;
 use crate::object::ObjectId;
+use crate::sync::{Arc, AsyncMutex};
 
 use super::seek_window::SeekWindow;
 use super::task::RequestTask;
@@ -21,21 +22,28 @@ where
 {
     /// Id of the object to download
     object_id: ObjectId,
-    /// Start offset for sequential read, used for calculating contiguous read metric
-    start_offset: u64,
-    /// Per-cursor state (reservation + active read tracking)
-    cursor_handle: CursorHandle,
+    /// The expensive resettable resources (RequestTask + SeekWindow).
+    /// `None` after a limiter-initiated reset.
+    inner: Arc<AsyncMutex<Option<CursorInner<Client>>>>,
+    /// The maximum amount of unavailable data the prefetcher will tolerate during a seek operation
+    /// before resetting and starting a new S3 request.
+    max_forward_seek_wait_distance: u64,
+    cursor_id: CursorId,
+}
+
+/// The resettable portion of a cursor: the request task and backward seek buffer.
+#[derive(Debug)]
+struct CursorInner<Client: ObjectClient + Clone + Send + Sync + 'static> {
     /// Background task to request data
     request_task: RequestTask<Client>,
     /// Holds data for backward seeks
     ///
     /// **Invariant**: the offset of the last byte in this window is always `self.current_offset - 1`.
     backward_seek_window: SeekWindow,
-    /// The maximum amount of unavailable data the prefetcher will tolerate during a seek operation
-    /// before resetting and starting a new S3 request.
-    max_forward_seek_wait_distance: u64,
     /// Current offset of this cursor
     current_offset: u64,
+    /// Per-cursor state (reservation + active read tracking)
+    cursor_handle: CursorHandle,
 }
 
 impl<Client> Cursor<Client>
@@ -50,48 +58,67 @@ where
         object_id: ObjectId,
         offset: u64,
     ) -> Self {
-        Self {
-            object_id,
-            start_offset: offset,
-            cursor_handle,
+        let cursor_id = cursor_handle.id();
+        let cursor_inner = CursorInner {
             request_task,
             backward_seek_window: SeekWindow::new(config.max_backward_seek_distance as usize),
-            max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
             current_offset: offset,
+            cursor_handle,
+        };
+
+        // Create the mutex first so it can be shared in the reset callback.
+        let inner = Arc::new(AsyncMutex::new(None));
+        let inner_reset = Arc::downgrade(&inner);
+
+        // Populated the mutex and set up the reset callback.
+        {
+            let mut guard = inner.lock_blocking();
+            let cursor_inner = guard.insert(cursor_inner);
+            cursor_inner.cursor_handle.register_reset_fn(Box::new(move || {
+                if let Some(lock) = inner_reset.upgrade()
+                    && let Some(mut guard) = lock.try_lock()
+                {
+                    let Some(inner) = guard.take() else {
+                        return false;
+                    };
+                    drop(inner);
+                    true
+                } else {
+                    false
+                }
+            }));
+        }
+
+        Self {
+            object_id,
+            inner,
+            max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
+            cursor_id,
         }
     }
 
-    /// The current offset for this cursor.
-    pub fn current_offset(&self) -> u64 {
-        self.current_offset
-    }
-
-    /// Read at the current offset.
-    pub async fn read(
-        &mut self,
-        length: usize,
-    ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
-        let _active_read_guard = self.cursor_handle.set_active_read(self.current_offset, length);
-
-        self.do_read(length).await
-    }
-
-    /// Try reading at the given offset. Returns `None` if unable to seek to the offset.
+    /// Try reading at the given offset. Returns `None` if unable to seek to the offset
+    /// or if the cursor has been reset by the memory limiter.
     pub async fn try_read(
-        &mut self,
+        &self,
         offset: u64,
         length: usize,
     ) -> Result<Option<(ChecksummedBytes, bool)>, PrefetchReadError<Client::ClientError>> {
+        let mut guard = self.inner.lock().await;
+        let Some(inner) = guard.as_mut() else {
+            return Ok(None);
+        };
+
         // Set the active read range before any blocking. For forward seeks, widen to include
         // the skipped bytes the prefetcher must consume to reach the requested offset.
-        let active_start = self.current_offset.min(offset);
+        let active_start = inner.current_offset.min(offset);
         let active_size = length + offset.saturating_sub(active_start) as usize;
-        let _active_read_guard = self.cursor_handle.set_active_read(active_start, active_size);
+        let _active_read_guard = inner.cursor_handle.set_active_read(active_start, active_size);
 
-        if !self.try_seek(offset).await? {
+        if !inner.try_seek(self, offset).await? {
             // Seek failed
             trace!(
-                expected = self.current_offset,
+                expected = inner.current_offset,
                 actual = offset,
                 "out-of-order read, resetting prefetch"
             );
@@ -99,15 +126,24 @@ where
             return Ok(None);
         }
 
-        Ok(Some(self.do_read(length).await?))
+        Ok(Some(inner.do_read(self, length).await?))
     }
 
+    pub fn cursor_id(&self) -> CursorId {
+        self.cursor_id
+    }
+}
+
+impl<Client> CursorInner<Client>
+where
+    Client: ObjectClient + Clone + Send + Sync + 'static,
+{
     async fn do_read(
         &mut self,
+        cursor: &Cursor<Client>,
         length: usize,
     ) -> Result<(ChecksummedBytes, bool), PrefetchReadError<Client::ClientError>> {
-        let offset = self.current_offset;
-        let remaining = self.request_task.end_offset().saturating_sub(offset);
+        let remaining = self.request_task.end_offset().saturating_sub(self.current_offset);
         if remaining == 0 {
             return Ok((ChecksummedBytes::default(), false));
         }
@@ -121,7 +157,7 @@ where
             let part = self.request_task.read(to_read as usize).await?;
             all_parts_from_cache &= part.is_from_cache();
             self.backward_seek_window.push(part.clone());
-            let part_bytes = part.into_bytes(&self.object_id, self.current_offset)?;
+            let part_bytes = part.into_bytes(&cursor.object_id, self.current_offset)?;
 
             self.current_offset += part_bytes.len() as u64;
             // If we can complete the read with just a single buffer, early return to avoid copying
@@ -140,20 +176,29 @@ where
     }
 
     /// Try to seek within the current inflight requests without restarting them.
-    async fn try_seek(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+    async fn try_seek(
+        &mut self,
+        cursor: &Cursor<Client>,
+        offset: u64,
+    ) -> Result<bool, PrefetchReadError<Client::ClientError>> {
         if offset == self.current_offset {
             return Ok(true);
         }
 
         trace!(from = self.current_offset, to = offset, "trying to seek");
         if offset > self.current_offset {
-            self.try_seek_forward(offset).await
+            self.try_seek_forward(offset, cursor.max_forward_seek_wait_distance)
+                .await
         } else {
             self.try_seek_backward(offset).await
         }
     }
 
-    async fn try_seek_forward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
+    async fn try_seek_forward(
+        &mut self,
+        offset: u64,
+        max_forward_seek_wait_distance: u64,
+    ) -> Result<bool, PrefetchReadError<Client::ClientError>> {
         assert!(offset > self.current_offset);
         let total_seek_distance = offset - self.current_offset;
         histogram!("prefetch.seek_distance", "dir" => "forward").record(total_seek_distance as f64);
@@ -161,9 +206,8 @@ where
         if offset >= self.request_task.read_window_end_offset() {
             return Ok(false);
         }
-
         let available_offset = self.request_task.available_offset();
-        let available_soon_offset = available_offset.saturating_add(self.max_forward_seek_wait_distance);
+        let available_soon_offset = available_offset.saturating_add(max_forward_seek_wait_distance);
         if offset >= available_soon_offset {
             trace!(
                 requested_offset = offset,
@@ -172,6 +216,7 @@ where
             );
             return Ok(false);
         }
+
         let mut seek_distance = offset - self.current_offset;
         while seek_distance > 0 {
             let part = self.request_task.read(seek_distance as usize).await?;
@@ -184,7 +229,6 @@ where
 
     async fn try_seek_backward(&mut self, offset: u64) -> Result<bool, PrefetchReadError<Client::ClientError>> {
         assert!(offset < self.current_offset);
-
         let backwards_length_needed = self.current_offset - offset;
         histogram!("prefetch.seek_distance", "dir" => "backward").record(backwards_length_needed as f64);
 
@@ -198,12 +242,13 @@ where
     }
 }
 
-impl<Client> Drop for Cursor<Client>
+impl<Client> Drop for CursorInner<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        histogram!("prefetch.contiguous_read_len").record((self.current_offset - self.start_offset) as f64);
+        histogram!("prefetch.contiguous_read_len")
+            .record((self.current_offset - self.request_task.start_offset()) as f64);
     }
 }
 

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -22,13 +22,14 @@ where
 {
     /// Id of the object to download
     object_id: ObjectId,
+    /// Id of this cursor
+    cursor_id: CursorId,
     /// The expensive resettable resources (RequestTask + SeekWindow).
     /// `None` after a limiter-initiated reset.
     inner: Arc<AsyncMutex<Option<CursorInner<Client>>>>,
     /// The maximum amount of unavailable data the prefetcher will tolerate during a seek operation
     /// before resetting and starting a new S3 request.
     max_forward_seek_wait_distance: u64,
-    cursor_id: CursorId,
 }
 
 /// The resettable portion of a cursor: the request task and backward seek buffer.
@@ -50,14 +51,15 @@ impl<Client> Cursor<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
-    /// Create a new cursor at the given offset.
-    pub fn new(
+    /// Create a new cursor at the given offset and read from it.
+    pub async fn new_and_read(
         request_task: RequestTask<Client>,
         cursor_handle: CursorHandle,
         config: &PrefetcherConfig,
         object_id: ObjectId,
         offset: u64,
-    ) -> Self {
+        initial_read_length: usize,
+    ) -> Result<(Self, (ChecksummedBytes, bool)), PrefetchReadError<Client::ClientError>> {
         let cursor_id = cursor_handle.id();
         let cursor_inner = CursorInner {
             request_task,
@@ -66,35 +68,39 @@ where
             cursor_handle,
         };
 
-        // Create the mutex first so it can be shared in the reset callback.
-        let inner = Arc::new(AsyncMutex::new(None));
-        let inner_reset = Arc::downgrade(&inner);
-
-        // Populated the mutex and set up the reset callback.
-        {
-            let mut guard = inner.lock_blocking();
-            let cursor_inner = guard.insert(cursor_inner);
-            cursor_inner.cursor_handle.register_reset_fn(Box::new(move || {
-                if let Some(lock) = inner_reset.upgrade()
-                    && let Some(mut guard) = lock.try_lock()
-                {
-                    let Some(inner) = guard.take() else {
-                        return false;
-                    };
-                    drop(inner);
-                    true
-                } else {
-                    false
-                }
-            }));
-        }
-
-        Self {
+        let cursor = Self {
             object_id,
-            inner,
-            max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
             cursor_id,
-        }
+            inner: Arc::new(AsyncMutex::new(Some(cursor_inner))),
+            max_forward_seek_wait_distance: config.max_forward_seek_wait_distance,
+        };
+
+        let mut guard = cursor.inner.lock().await;
+        let inner = guard.as_mut().expect("internal cursor should be set");
+
+        // Register reset callback while holding the lock. A reset will not affect the initial read.
+        let inner_reset = Arc::downgrade(&cursor.inner);
+        inner.cursor_handle.register_reset_fn(Box::new(move || {
+            if let Some(lock) = inner_reset.upgrade()
+                && let Some(mut guard) = lock.try_lock()
+            {
+                let Some(inner) = guard.take() else {
+                    return false;
+                };
+                drop(inner);
+                true
+            } else {
+                false
+            }
+        }));
+
+        let _active_read_guard = inner
+            .cursor_handle
+            .set_active_read(inner.current_offset, initial_read_length);
+        let result = inner.do_read(&cursor, initial_read_length).await?;
+        drop(guard);
+
+        Ok((cursor, result))
     }
 
     /// Try reading at the given offset. Returns `None` if unable to seek to the offset


### PR DESCRIPTION
Allow the memory limiter to externally reset a cursor, immediately dropping its in-flight S3 request and buffered data so that reserved memory can be reclaimed under pressure.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
