### PR TITLE
Limit memory allocations instead of buffer acquisitions

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -75,7 +75,7 @@ struct ConfigOptions {
     user_agent_prefix: Option<String>,
     part_size: Option<usize>,
     /// Target memory limit (in bytes) that Mountpoint will try to enforce
-    memory_limit_bytes: Option<u64>,
+    memory_limit_bytes: Option<usize>,
 
     // File system options
     dir_mode: Option<u16>,

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -122,12 +122,12 @@ fn parse_duration(arg: &str) -> Result<Duration, String> {
 }
 
 impl CliArgs {
-    fn memory_target_in_bytes(&self) -> u64 {
+    fn memory_target_in_bytes(&self) -> usize {
         if let Some(target) = self.max_memory_target {
-            target * 1024 * 1024
+            target as usize * 1024 * 1024
         } else {
             // Default to 95% of total system memory (cgroup-aware)
-            (effective_total_memory() as f64 * 0.95) as u64
+            (effective_total_memory() as f64 * 0.95) as usize
         }
     }
 

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -64,7 +64,7 @@ impl Executor {
             ChecksumAlgorithm::Off => None,
         };
 
-        let memory_target_bytes = (max_memory_target * 1024 * 1024) as u64;
+        let memory_target_bytes = max_memory_target * 1024 * 1024;
         let pool = PagedPool::config()
             .with_candidate_sizes([read_part_size, write_part_size])
             .with_memory_limit(memory_target_bytes)

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -61,7 +61,7 @@ struct UploadBenchmarkArgs {
         help = "Maximum memory usage target for Mountpoint's memory limiter [default: 95% of total system memory]",
         value_name = "MiB"
     )]
-    pub max_memory_target: Option<u64>,
+    pub max_memory_target: Option<usize>,
 
     #[clap(long, help = "Write part size for the upload", default_value = "8388608")]
     pub write_part_size: usize,
@@ -100,7 +100,7 @@ fn main() {
         target * 1024 * 1024
     } else {
         // Default to 95% of total system memory (cgroup-aware)
-        (effective_total_memory() as f64 * 0.95) as u64
+        (effective_total_memory() as f64 * 0.95) as usize
     };
     let pool = PagedPool::config()
         .with_candidate_sizes([args.write_part_size])

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -1120,7 +1120,7 @@ mod tests {
         // `additional_mem_reserved = max(mem_limit/8, 128 MiB) = 128 MiB`, and `part_size = 32 MiB`,
         // the formula `(mem_limit - additional_mem_reserved) / part_size` gives
         // `(256 - 128) / 32 = 4` concurrent writers.
-        const MEM_LIMIT: u64 = 256 * 1024 * 1024;
+        const MEM_LIMIT: usize = 256 * 1024 * 1024;
         const PART_SIZE: usize = 32 * 1024 * 1024;
         const EXPECTED_CAP: usize = 4;
 

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -75,7 +75,7 @@ struct AllocationQueueInner {
 impl std::fmt::Debug for AllocationQueue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AllocationQueue")
-            .field("has_pending", &self.has_pending.load(Ordering::Relaxed))
+            .field("has_pending", &self.has_pending.load(Ordering::SeqCst))
             .finish_non_exhaustive()
     }
 }
@@ -135,7 +135,7 @@ impl AllocationQueue {
         };
 
         let mut inner = self.inner.lock().unwrap();
-        self.has_pending.store(true, Ordering::Release);
+        self.has_pending.store(true, Ordering::SeqCst);
         match priority {
             AllocationPriority::High => inner.high.push_back(entry),
             AllocationPriority::Low => inner.low.push_back(entry),
@@ -192,7 +192,7 @@ impl AllocationQueue {
 
         let front = inner.high.front().or_else(|| inner.low.front());
         let Some(front) = front else {
-            self.has_pending.store(false, Ordering::Release);
+            self.has_pending.store(false, Ordering::SeqCst);
             return None;
         };
 
@@ -201,7 +201,7 @@ impl AllocationQueue {
         }
         let entry = inner.high.pop_front().or_else(|| inner.low.pop_front());
         if inner.high.is_empty() && inner.low.is_empty() {
-            self.has_pending.store(false, Ordering::Release);
+            self.has_pending.store(false, Ordering::SeqCst);
         }
         entry
     }
@@ -226,7 +226,7 @@ impl AllocationQueue {
             }
         }
         if inner.high.is_empty() && inner.low.is_empty() {
-            self.has_pending.store(false, Ordering::Release);
+            self.has_pending.store(false, Ordering::SeqCst);
         }
     }
 
@@ -236,7 +236,7 @@ impl AllocationQueue {
     /// whether new requests must go through the queue (to respect priority ordering
     /// of existing waiters).
     pub fn has_pending(&self) -> bool {
-        self.has_pending.load(Ordering::Acquire)
+        self.has_pending.load(Ordering::SeqCst)
     }
 
     /// `Instant` at which the next-to-be-served live entry was queued.

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -242,7 +242,7 @@ mod tests {
 
     fn make_buffer(size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(size);
-        let ptr = page.try_reserve(BufferKind::Other).unwrap();
+        let ptr = page.try_acquire(BufferKind::Other).unwrap();
         PoolBuffer::new_primary(ptr, size)
     }
 

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 use futures::channel::oneshot;
+use tracing::trace;
 
 use crate::prefetch::CursorId;
 use crate::sync::Mutex;
@@ -154,7 +155,7 @@ impl AllocationQueue {
             return false;
         }
 
-        // TODO(memory-limiter): consider refactoring try_front_if or even inlining.
+        // TODO(memory-limiter): consider refactoring or inlining try_front_if.
         let mut buffer = None;
         let entry = self.pop_front_if(|pending| {
             buffer = try_get_buffer(pending);
@@ -162,8 +163,12 @@ impl AllocationQueue {
         });
         if let Some(entry) = entry
             && let Some(buffer) = buffer
-            && entry.fulfill(buffer).is_ok()
         {
+            if let Err(cancelled) = entry.fulfill(buffer) {
+                // Drop buffer, but still succeed.
+                trace!(size = cancelled.len(), "request cancelled after acquiring buffer");
+                drop(cancelled);
+            }
             true
         } else {
             false

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -153,10 +153,7 @@ impl AllocationQueue {
     ///
     /// Returns `None` if both queues are empty or the predicate returns `false`.
     /// Sets `has_pending` to `false` if both queues become empty after removal.
-    pub fn pop_front_if(
-        &self,
-        predicate: impl FnOnce(usize, BufferKind, Option<CursorId>) -> bool,
-    ) -> Option<PendingAllocation> {
+    pub fn pop_front_if(&self, predicate: impl FnOnce(&PendingAllocation) -> bool) -> Option<PendingAllocation> {
         let mut inner = self.inner.lock().unwrap();
 
         // Prune cancelled entries from the front of each queue.
@@ -173,7 +170,7 @@ impl AllocationQueue {
             return None;
         };
 
-        if !predicate(front.size, front.kind, front.cursor_id) {
+        if !predicate(front) {
             return None;
         }
         let entry = inner.high.pop_front().or_else(|| inner.low.pop_front());
@@ -247,7 +244,7 @@ mod tests {
     }
 
     /// Helper: always-true predicate (unconditionally pop).
-    fn always(_size: usize, _kind: BufferKind, _cursor: Option<CursorId>) -> bool {
+    fn always(_pending: &PendingAllocation) -> bool {
         true
     }
 
@@ -280,7 +277,7 @@ mod tests {
         let queue = AllocationQueue::new();
         let _rx = queue.push_high(Some(CursorId::new_from_raw(1)), 1024, BufferKind::GetObject);
 
-        let result = queue.pop_front_if(|_size, _kind, _cursor| false);
+        let result = queue.pop_front_if(|_pending| false);
         assert!(result.is_none());
         assert!(queue.has_pending()); // still there
     }
@@ -373,7 +370,7 @@ mod tests {
 
         drop(rx_large);
 
-        let entry = queue.pop_front_if(|size, _, _| size <= 1024 * 1024);
+        let entry = queue.pop_front_if(|pending| pending.size <= 1024 * 1024);
         assert!(entry.is_some());
         assert_eq!(entry.unwrap().cursor_id, Some(CursorId::new_from_raw(2)));
     }

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -144,6 +144,32 @@ impl AllocationQueue {
         receiver
     }
 
+    /// Fullfil the pending allocation at the front of the queue using the result of `try_get_buffer`.
+    ///
+    /// Returns `false` if the queue was empty or `try_get_buffer` returned `None`.
+    ///
+    /// Skips (and removes) cancelled entries in the queue.
+    pub fn try_fulfill_front(&self, try_get_buffer: impl FnOnce(&PendingAllocation) -> Option<PoolBuffer>) -> bool {
+        if !self.has_pending() {
+            return false;
+        }
+
+        // TODO(memory-limiter): consider refactoring try_front_if or even inlining.
+        let mut buffer = None;
+        let entry = self.pop_front_if(|pending| {
+            buffer = try_get_buffer(pending);
+            buffer.is_some()
+        });
+        if let Some(entry) = entry
+            && let Some(buffer) = buffer
+            && entry.fulfill(buffer).is_ok()
+        {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Atomically peeks at the front entry and removes it if `predicate` returns `true`.
     ///
     /// Checks the high-priority list first, then low. Cancelled entries (where the
@@ -153,7 +179,7 @@ impl AllocationQueue {
     ///
     /// Returns `None` if both queues are empty or the predicate returns `false`.
     /// Sets `has_pending` to `false` if both queues become empty after removal.
-    pub fn pop_front_if(&self, predicate: impl FnOnce(&PendingAllocation) -> bool) -> Option<PendingAllocation> {
+    fn pop_front_if(&self, predicate: impl FnOnce(&PendingAllocation) -> bool) -> Option<PendingAllocation> {
         let mut inner = self.inner.lock().unwrap();
 
         // Prune cancelled entries from the front of each queue.

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -1,4 +1,4 @@
-use std::alloc::Layout;
+use std::alloc::{self, Layout};
 use std::io::Read;
 use std::ops::{Deref, DerefMut};
 
@@ -48,7 +48,7 @@ impl PoolBuffer {
     pub fn capacity(&self) -> usize {
         match &self.0 {
             PoolBufferInner::Primary { size, .. } => *size,
-            PoolBufferInner::Secondary(boxed) => boxed.layout.size(),
+            PoolBufferInner::Secondary(boxed) => boxed.ptr.size(),
         }
     }
 
@@ -66,10 +66,7 @@ impl Deref for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => {
-                // SAFETY: returned slice will be valid until this buffer is dropped.
-                unsafe { std::slice::from_raw_parts(boxed.bytes, boxed.layout.size()) }
-            }
+            PoolBufferInner::Secondary(boxed) => boxed.ptr.as_ref(),
         }
     }
 }
@@ -81,10 +78,7 @@ impl DerefMut for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts_mut(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => {
-                // SAFETY: returned slice will be valid until this buffer is dropped.
-                unsafe { std::slice::from_raw_parts_mut(boxed.bytes, boxed.layout.size()) }
-            }
+            PoolBufferInner::Secondary(boxed) => boxed.ptr.as_mut(),
         }
     }
 }
@@ -185,8 +179,7 @@ impl AsMut<[u8]> for PoolBufferMut {
 
 #[derive(Debug)]
 struct FreeBuffer {
-    bytes: *mut u8,
-    layout: Layout,
+    ptr: BufferPtr,
     kind: BufferKind,
     limiter: Arc<MemoryLimiter>,
     /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
@@ -201,11 +194,10 @@ impl FreeBuffer {
         pool: Weak<PagedPoolInner>,
         forced: bool,
     ) -> Option<Self> {
-        let (bytes, layout) = limiter.try_allocate(size, forced)?;
-        limiter.acquire_bytes(layout.size(), kind);
+        let ptr = limiter.try_allocate(size, forced)?;
+        limiter.acquire_bytes(ptr.size(), kind);
         Some(Self {
-            bytes,
-            layout,
+            ptr,
             kind,
             limiter,
             pool,
@@ -218,11 +210,87 @@ unsafe impl Send for FreeBuffer {}
 
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
-        self.limiter.release_bytes(self.layout.size(), self.kind);
-        self.limiter.deallocate(self.bytes, self.layout);
+        self.limiter.release_bytes(self.ptr.size(), self.kind);
+        self.limiter.deallocate(&mut self.ptr);
         if let Some(pool) = self.pool.upgrade() {
             pool.try_wake_pending();
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct BufferPtr {
+    bytes: *mut u8,
+    layout: Layout,
+}
+
+// SAFETY: access to the buffer and release on drop can be performed from another thread.
+unsafe impl Send for BufferPtr {}
+
+impl BufferPtr {
+    pub fn allocate(size: usize) -> Self {
+        let layout = Layout::array::<u8>(size).unwrap();
+
+        let bytes = if layout.size() == 0 {
+            std::ptr::null_mut()
+        } else {
+            // SAFETY: layout has non-zero size.
+            let bytes = unsafe { alloc::alloc(layout) };
+            if bytes.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+            bytes
+        };
+
+        Self { bytes, layout }
+    }
+
+    pub fn deallocate(&mut self) {
+        if self.bytes.is_null() {
+            return;
+        }
+
+        // SAFETY: `bytes` was allocated using `layout` in `allocate`.
+        unsafe {
+            alloc::dealloc(self.bytes, self.layout);
+        }
+        self.bytes = std::ptr::null_mut();
+    }
+
+    pub fn as_raw_ptr(&self) -> *mut u8 {
+        self.bytes
+    }
+
+    pub fn size(&self) -> usize {
+        self.layout.size()
+    }
+}
+
+impl Drop for BufferPtr {
+    fn drop(&mut self) {
+        self.deallocate();
+    }
+}
+
+impl AsMut<[u8]> for BufferPtr {
+    fn as_mut(&mut self) -> &mut [u8] {
+        if self.bytes.is_null() {
+            return &mut [];
+        }
+
+        // SAFETY: returned slice will be valid until this buffer is deallocated.
+        unsafe { std::slice::from_raw_parts_mut(self.bytes, self.layout.size()) }
+    }
+}
+
+impl AsRef<[u8]> for BufferPtr {
+    fn as_ref(&self) -> &[u8] {
+        if self.bytes.is_null() {
+            return &[];
+        }
+
+        // SAFETY: returned slice will be valid until this buffer is deallocated.
+        unsafe { std::slice::from_raw_parts(self.bytes, self.layout.size()) }
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -48,7 +48,7 @@ impl PoolBuffer {
     pub fn capacity(&self) -> usize {
         match &self.0 {
             PoolBufferInner::Primary { size, .. } => *size,
-            PoolBufferInner::Secondary(boxed) => boxed.ptr.size(),
+            PoolBufferInner::Secondary(boxed) => boxed.size(),
         }
     }
 
@@ -192,6 +192,10 @@ impl ManagedBuffer {
 
     pub fn as_raw_ptr(&self) -> *mut u8 {
         self.ptr.raw
+    }
+
+    fn size(&self) -> usize {
+        self.ptr.size()
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -4,11 +4,10 @@ use std::ops::{Deref, DerefMut};
 
 use bytes::Bytes;
 
-use crate::sync::{Arc, Weak};
+use crate::sync::Arc;
 
 use super::limiter::MemoryLimiter;
 use super::pages::PagedBufferPtr;
-use super::pool::PagedPoolInner;
 use super::stats::BufferKind;
 
 /// A buffer backed by the pool.
@@ -37,11 +36,10 @@ impl PoolBuffer {
         size: usize,
         kind: BufferKind,
         limiter: Arc<MemoryLimiter>,
-        pool: Weak<PagedPoolInner>,
         forced: bool,
     ) -> Option<Self> {
         Some(Self(PoolBufferInner::Secondary(FreeBuffer::try_new(
-            size, kind, limiter, pool, forced,
+            size, kind, limiter, forced,
         )?)))
     }
 
@@ -182,26 +180,13 @@ struct FreeBuffer {
     ptr: BufferPtr,
     kind: BufferKind,
     limiter: Arc<MemoryLimiter>,
-    /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
-    pool: Weak<PagedPoolInner>,
 }
 
 impl FreeBuffer {
-    fn try_new(
-        size: usize,
-        kind: BufferKind,
-        limiter: Arc<MemoryLimiter>,
-        pool: Weak<PagedPoolInner>,
-        forced: bool,
-    ) -> Option<Self> {
+    fn try_new(size: usize, kind: BufferKind, limiter: Arc<MemoryLimiter>, forced: bool) -> Option<Self> {
         let ptr = limiter.try_allocate(size, forced)?;
         limiter.acquire_bytes(ptr.size(), kind);
-        Some(Self {
-            ptr,
-            kind,
-            limiter,
-            pool,
-        })
+        Some(Self { ptr, kind, limiter })
     }
 }
 
@@ -210,11 +195,8 @@ unsafe impl Send for FreeBuffer {}
 
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
-        self.limiter.release_bytes(self.ptr.size(), self.kind);
         self.limiter.deallocate(&mut self.ptr);
-        if let Some(pool) = self.pool.upgrade() {
-            pool.try_wake_pending();
-        }
+        self.limiter.release_bytes(self.ptr.size(), self.kind);
     }
 }
 
@@ -299,7 +281,6 @@ mod tests {
     use super::super::pages::Page;
 
     use super::*;
-    use crate::sync::Weak;
 
     use test_case::{test_case, test_matrix};
 
@@ -316,8 +297,7 @@ mod tests {
         PoolBuffer::try_new_secondary(
             buffer_size,
             BufferKind::Other,
-            Arc::new(MemoryLimiter::new(u64::MAX)),
-            Weak::new(),
+            Arc::new(MemoryLimiter::new(u64::MAX, Default::default())),
             true,
         )
         .unwrap()

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -202,7 +202,7 @@ impl FreeBuffer {
         forced: bool,
     ) -> Option<Self> {
         let (bytes, layout) = limiter.try_allocate(size, forced)?;
-        limiter.stats().acquire_bytes(layout.size(), kind);
+        limiter.acquire_bytes(layout.size(), kind);
         Some(Self {
             bytes,
             layout,
@@ -218,8 +218,8 @@ unsafe impl Send for FreeBuffer {}
 
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
-        self.limiter.stats().release_bytes(self.layout.size(), self.kind);
-        self.limiter.stats().deallocate(self.bytes, self.layout);
+        self.limiter.release_bytes(self.layout.size(), self.kind);
+        self.limiter.deallocate(self.bytes, self.layout);
         if let Some(pool) = self.pool.upgrade() {
             pool.try_wake_pending();
         }

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -302,7 +302,7 @@ mod tests {
         PoolBuffer::try_new_secondary(
             buffer_size,
             BufferKind::Other,
-            Arc::new(MemoryLimiter::new(u64::MAX, Default::default())),
+            Arc::new(MemoryLimiter::new(usize::MAX, Default::default())),
             true,
         )
         .unwrap()

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -184,6 +184,7 @@ struct FreeBuffer {
 impl FreeBuffer {
     fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>, pool: Weak<PagedPoolInner>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
+        stats.allocate_bytes(data.len());
         stats.reserve_bytes(data.len(), kind);
         Self {
             data,
@@ -197,6 +198,7 @@ impl FreeBuffer {
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
         self.stats.release_bytes(self.data.len(), self.kind);
+        self.stats.deallocate_bytes(self.data.len());
         if let Some(pool) = self.pool.upgrade() {
             pool.try_wake_pending();
         }

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -185,7 +185,7 @@ impl FreeBuffer {
     fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>, pool: Weak<PagedPoolInner>) -> Self {
         let data = vec![0u8; size].into_boxed_slice();
         stats.allocate_bytes(data.len());
-        stats.reserve_bytes(data.len(), kind);
+        stats.acquire_bytes(data.len(), kind);
         Self {
             data,
             kind,
@@ -217,7 +217,7 @@ mod tests {
     fn primary(buffer_size: usize) -> PoolBuffer {
         let page = Page::new_for_tests(buffer_size);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_acquire(BufferKind::Other)
             .expect("should be able to reserve a buffer from a new page");
 
         PoolBuffer::new_primary(buffer_ptr, buffer_size)

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -6,9 +6,10 @@ use bytes::Bytes;
 
 use crate::sync::{Arc, Weak};
 
+use super::limiter::MemoryLimiter;
 use super::pages::PagedBufferPtr;
 use super::pool::PagedPoolInner;
-use super::stats::{BufferKind, PoolStats};
+use super::stats::BufferKind;
 
 /// A buffer backed by the pool.
 ///
@@ -32,13 +33,16 @@ impl PoolBuffer {
         Self(PoolBufferInner::Primary { buffer_ptr, size })
     }
 
-    pub(super) fn new_secondary(
+    pub(super) fn try_new_secondary(
         size: usize,
         kind: BufferKind,
-        stats: Arc<PoolStats>,
+        limiter: Arc<MemoryLimiter>,
         pool: Weak<PagedPoolInner>,
-    ) -> Self {
-        Self(PoolBufferInner::Secondary(FreeBuffer::new(size, kind, stats, pool)))
+        forced: bool,
+    ) -> Option<Self> {
+        Some(Self(PoolBufferInner::Secondary(FreeBuffer::try_new(
+            size, kind, limiter, pool, forced,
+        )?)))
     }
 
     pub fn capacity(&self) -> usize {
@@ -184,22 +188,28 @@ struct FreeBuffer {
     bytes: *mut u8,
     layout: Layout,
     kind: BufferKind,
-    stats: Arc<PoolStats>,
+    limiter: Arc<MemoryLimiter>,
     /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
     pool: Weak<PagedPoolInner>,
 }
 
 impl FreeBuffer {
-    fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>, pool: Weak<PagedPoolInner>) -> Self {
-        let (bytes, layout) = stats.allocate(size);
-        stats.acquire_bytes(layout.size(), kind);
-        Self {
+    fn try_new(
+        size: usize,
+        kind: BufferKind,
+        limiter: Arc<MemoryLimiter>,
+        pool: Weak<PagedPoolInner>,
+        forced: bool,
+    ) -> Option<Self> {
+        let (bytes, layout) = limiter.try_allocate(size, forced)?;
+        limiter.stats().acquire_bytes(layout.size(), kind);
+        Some(Self {
             bytes,
             layout,
             kind,
-            stats,
+            limiter,
             pool,
-        }
+        })
     }
 }
 
@@ -208,8 +218,8 @@ unsafe impl Send for FreeBuffer {}
 
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
-        self.stats.release_bytes(self.layout.size(), self.kind);
-        self.stats.deallocate(self.bytes, self.layout);
+        self.limiter.stats().release_bytes(self.layout.size(), self.kind);
+        self.limiter.stats().deallocate(self.bytes, self.layout);
         if let Some(pool) = self.pool.upgrade() {
             pool.try_wake_pending();
         }
@@ -235,12 +245,14 @@ mod tests {
     }
 
     fn secondary(buffer_size: usize) -> PoolBuffer {
-        PoolBuffer::new_secondary(
+        PoolBuffer::try_new_secondary(
             buffer_size,
             BufferKind::Other,
-            Arc::new(PoolStats::default()),
+            Arc::new(MemoryLimiter::new(u64::MAX)),
             Weak::new(),
+            true,
         )
+        .unwrap()
     }
 
     #[test_case(primary)]

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -23,7 +23,7 @@ enum PoolBufferInner {
     /// Buffer from the paged pool.
     Primary { buffer_ptr: PagedBufferPtr, size: usize },
     /// Buffer allocated independently.
-    Secondary(FreeBuffer),
+    Secondary(ManagedBuffer),
 }
 
 impl PoolBuffer {
@@ -38,8 +38,10 @@ impl PoolBuffer {
         limiter: Arc<MemoryLimiter>,
         forced: bool,
     ) -> Option<Self> {
-        Some(Self(PoolBufferInner::Secondary(FreeBuffer::try_new(
-            size, kind, limiter, forced,
+        Some(Self(PoolBufferInner::Secondary(limiter.try_allocate(
+            size,
+            Some(kind),
+            forced,
         )?)))
     }
 
@@ -64,7 +66,7 @@ impl Deref for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => boxed.ptr.as_ref(),
+            PoolBufferInner::Secondary(boxed) => boxed.as_ref(),
         }
     }
 }
@@ -76,7 +78,7 @@ impl DerefMut for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts_mut(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => boxed.ptr.as_mut(),
+            PoolBufferInner::Secondary(boxed) => boxed.as_mut(),
         }
     }
 }
@@ -176,33 +178,54 @@ impl AsMut<[u8]> for PoolBufferMut {
 }
 
 #[derive(Debug)]
-struct FreeBuffer {
+pub struct ManagedBuffer {
     ptr: BufferPtr,
-    kind: BufferKind,
+    kind: Option<BufferKind>,
     limiter: Arc<MemoryLimiter>,
 }
 
-impl FreeBuffer {
-    fn try_new(size: usize, kind: BufferKind, limiter: Arc<MemoryLimiter>, forced: bool) -> Option<Self> {
-        let ptr = limiter.try_allocate(size, forced)?;
-        limiter.acquire_bytes(ptr.size(), kind);
-        Some(Self { ptr, kind, limiter })
+impl ManagedBuffer {
+    pub fn new(size: usize, kind: Option<BufferKind>, limiter: Arc<MemoryLimiter>) -> Self {
+        let ptr = BufferPtr::allocate(size);
+        Self { ptr, kind, limiter }
+    }
+
+    pub fn as_raw_ptr(&self) -> *mut u8 {
+        self.ptr.raw
     }
 }
 
-// SAFETY: access to the buffer and release on drop can be performed from another thread.
-unsafe impl Send for FreeBuffer {}
-
-impl Drop for FreeBuffer {
+impl Drop for ManagedBuffer {
     fn drop(&mut self) {
-        self.limiter.deallocate(&mut self.ptr);
-        self.limiter.release_bytes(self.ptr.size(), self.kind);
+        self.limiter.deallocate(self.ptr.take(), self.kind);
+    }
+}
+
+impl AsMut<[u8]> for ManagedBuffer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        if self.ptr.raw.is_null() {
+            return &mut [];
+        }
+
+        // SAFETY: returned slice will be valid until this buffer is deallocated.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.raw, self.ptr.layout.size()) }
+    }
+}
+
+impl AsRef<[u8]> for ManagedBuffer {
+    fn as_ref(&self) -> &[u8] {
+        if self.ptr.raw.is_null() {
+            return &[];
+        }
+
+        // SAFETY: returned slice will be valid until this buffer is deallocated.
+        unsafe { std::slice::from_raw_parts(self.ptr.raw, self.ptr.layout.size()) }
     }
 }
 
 #[derive(Debug)]
 pub struct BufferPtr {
-    bytes: *mut u8,
+    raw: *mut u8,
     layout: Layout,
 }
 
@@ -210,10 +233,10 @@ pub struct BufferPtr {
 unsafe impl Send for BufferPtr {}
 
 impl BufferPtr {
-    pub fn allocate(size: usize) -> Self {
+    fn allocate(size: usize) -> Self {
         let layout = Layout::array::<u8>(size).unwrap();
 
-        let bytes = if layout.size() == 0 {
+        let raw = if layout.size() == 0 {
             std::ptr::null_mut()
         } else {
             // SAFETY: layout has non-zero size.
@@ -224,23 +247,15 @@ impl BufferPtr {
             bytes
         };
 
-        Self { bytes, layout }
+        Self { raw, layout }
     }
 
-    pub fn deallocate(&mut self) {
-        if self.bytes.is_null() {
-            return;
+    fn take(&mut self) -> Self {
+        let raw = std::mem::take(&mut self.raw);
+        Self {
+            raw,
+            layout: self.layout,
         }
-
-        // SAFETY: `bytes` was allocated using `layout` in `allocate`.
-        unsafe {
-            alloc::dealloc(self.bytes, self.layout);
-        }
-        self.bytes = std::ptr::null_mut();
-    }
-
-    pub fn as_raw_ptr(&self) -> *mut u8 {
-        self.bytes
     }
 
     pub fn size(&self) -> usize {
@@ -250,29 +265,15 @@ impl BufferPtr {
 
 impl Drop for BufferPtr {
     fn drop(&mut self) {
-        self.deallocate();
-    }
-}
-
-impl AsMut<[u8]> for BufferPtr {
-    fn as_mut(&mut self) -> &mut [u8] {
-        if self.bytes.is_null() {
-            return &mut [];
+        let raw = std::mem::take(&mut self.raw);
+        if raw.is_null() {
+            return;
         }
 
-        // SAFETY: returned slice will be valid until this buffer is deallocated.
-        unsafe { std::slice::from_raw_parts_mut(self.bytes, self.layout.size()) }
-    }
-}
-
-impl AsRef<[u8]> for BufferPtr {
-    fn as_ref(&self) -> &[u8] {
-        if self.bytes.is_null() {
-            return &[];
+        // SAFETY: `raw` was allocated using `layout` in `allocate`.
+        unsafe {
+            alloc::dealloc(raw, self.layout);
         }
-
-        // SAFETY: returned slice will be valid until this buffer is deallocated.
-        unsafe { std::slice::from_raw_parts(self.bytes, self.layout.size()) }
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -302,7 +302,7 @@ mod tests {
         PoolBuffer::try_new_secondary(
             buffer_size,
             BufferKind::Other,
-            Arc::new(MemoryLimiter::new(usize::MAX, Default::default())),
+            Arc::new(MemoryLimiter::new(usize::MAX)),
             true,
         )
         .unwrap()

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -1,3 +1,4 @@
+use std::alloc::Layout;
 use std::io::Read;
 use std::ops::{Deref, DerefMut};
 
@@ -43,7 +44,7 @@ impl PoolBuffer {
     pub fn capacity(&self) -> usize {
         match &self.0 {
             PoolBufferInner::Primary { size, .. } => *size,
-            PoolBufferInner::Secondary(boxed) => boxed.data.len(),
+            PoolBufferInner::Secondary(boxed) => boxed.layout.size(),
         }
     }
 
@@ -61,7 +62,10 @@ impl Deref for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => &boxed.data,
+            PoolBufferInner::Secondary(boxed) => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts(boxed.bytes, boxed.layout.size()) }
+            }
         }
     }
 }
@@ -73,7 +77,10 @@ impl DerefMut for PoolBuffer {
                 // SAFETY: returned slice will be valid until this buffer is dropped.
                 unsafe { std::slice::from_raw_parts_mut(buffer_ptr.as_raw_ptr(), *size) }
             }
-            PoolBufferInner::Secondary(boxed) => &mut boxed.data,
+            PoolBufferInner::Secondary(boxed) => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts_mut(boxed.bytes, boxed.layout.size()) }
+            }
         }
     }
 }
@@ -174,7 +181,8 @@ impl AsMut<[u8]> for PoolBufferMut {
 
 #[derive(Debug)]
 struct FreeBuffer {
-    data: Box<[u8]>,
+    bytes: *mut u8,
+    layout: Layout,
     kind: BufferKind,
     stats: Arc<PoolStats>,
     /// Weak reference back to the pool so this buffer's drop can wake pending allocations.
@@ -183,11 +191,11 @@ struct FreeBuffer {
 
 impl FreeBuffer {
     fn new(size: usize, kind: BufferKind, stats: Arc<PoolStats>, pool: Weak<PagedPoolInner>) -> Self {
-        let data = vec![0u8; size].into_boxed_slice();
-        stats.allocate_bytes(data.len());
-        stats.acquire_bytes(data.len(), kind);
+        let (bytes, layout) = stats.allocate(size);
+        stats.acquire_bytes(layout.size(), kind);
         Self {
-            data,
+            bytes,
+            layout,
             kind,
             stats,
             pool,
@@ -195,10 +203,13 @@ impl FreeBuffer {
     }
 }
 
+// SAFETY: access to the buffer and release on drop can be performed from another thread.
+unsafe impl Send for FreeBuffer {}
+
 impl Drop for FreeBuffer {
     fn drop(&mut self) {
-        self.stats.release_bytes(self.data.len(), self.kind);
-        self.stats.deallocate_bytes(self.data.len());
+        self.stats.release_bytes(self.layout.size(), self.kind);
+        self.stats.deallocate(self.bytes, self.layout);
         if let Some(pool) = self.pool.upgrade() {
             pool.try_wake_pending();
         }

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -14,7 +14,7 @@ use super::PagedPool;
 use super::buffers::{BufferPtr, ManagedBuffer};
 use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
-pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
+pub const MINIMUM_MEM_LIMIT: usize = 512 * 1024 * 1024;
 
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
@@ -56,15 +56,15 @@ impl BufferArea {
 #[derive(Debug)]
 pub struct MemoryLimiter {
     /// Target memory limit.
-    mem_limit: u64,
+    mem_limit: usize,
     /// Additional reserved memory for other non-buffer usage like storing metadata
-    additional_mem_reserved: u64,
+    additional_mem_reserved: usize,
     /// Memory allocated by the pool.
     allocated_bytes: AtomicUsize,
     /// Memory in use by [`BufferKind`].
     acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
     /// Total reserved memory. Used in budget checks.
-    mem_reserved: Arc<AtomicU64>,
+    mem_reserved: Arc<AtomicUsize>,
     /// Unified per-cursor state. Cursors own a strong reference to their state.
     cursors: Arc<DashMap<CursorId, Weak<CursorState>>>,
     /// Counter for generating unique [CursorId]s.
@@ -82,7 +82,7 @@ pub struct MemoryLimiter {
 }
 
 impl MemoryLimiter {
-    pub fn new(mem_limit: u64, pending_signal: Arc<WakeSignal>) -> Self {
+    pub fn new(mem_limit: usize, pending_signal: Arc<WakeSignal>) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -107,33 +107,33 @@ impl MemoryLimiter {
 
     /// The configured memory limit in bytes. Note this is the total memory target including
     /// non-buffer overhead, not the budget available for data buffers — see [`Self::data_buffer_budget`].
-    pub fn mem_limit(&self) -> u64 {
+    pub fn mem_limit(&self) -> usize {
         self.mem_limit
     }
 
     /// The static memory budget available for data buffers, i.e. `mem_limit - additional_mem_reserved`.
     /// This is the upper bound on buffer-backed allocations and is used by
     /// [`crate::memory::WriteHandleLimiter`] to derive its cap.
-    pub fn data_buffer_budget(&self) -> u64 {
+    pub fn data_buffer_budget(&self) -> usize {
         self.mem_limit.saturating_sub(self.additional_mem_reserved)
     }
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond
     /// the configured memory limit.
-    fn reserve(&self, area: BufferArea, size: u64) {
+    fn reserve(&self, area: BufferArea, size: usize) {
         self.mem_reserved.fetch_add(size, Ordering::SeqCst);
         metrics::gauge!("mem.bytes_reserved", "area" => area.as_str()).increment(size as f64);
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    fn try_reserve(&self, area: BufferArea, size: u64) -> bool {
+    fn try_reserve(&self, area: BufferArea, size: usize) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let pool_mem_reserved = self.allocated_bytes() as u64;
+            let mem_allocated = self.allocated_bytes();
             let new_total_mem_usage = new_mem_reserved
-                .saturating_add(pool_mem_reserved)
+                .saturating_add(mem_allocated)
                 .saturating_add(self.additional_mem_reserved);
             if new_total_mem_usage > self.mem_limit {
                 trace!(new_total_mem_usage, "not enough memory to reserve");
@@ -160,7 +160,7 @@ impl MemoryLimiter {
     }
 
     /// Release all remaining reservation for a cursor and remove it from tracking.
-    fn release_cursor(&self, cursor_id: CursorId, cursor_reserved: &AtomicU64) {
+    fn release_cursor(&self, cursor_id: CursorId, cursor_reserved: &AtomicUsize) {
         if self.cursors.remove(&cursor_id).is_some() {
             let remaining = cursor_reserved.swap(0, Ordering::SeqCst);
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
@@ -178,8 +178,8 @@ impl MemoryLimiter {
     }
 
     /// Query available memory tracked by the memory limiter.
-    pub fn available_mem(&self) -> u64 {
-        let mem_allocated = self.allocated_bytes() as u64;
+    pub fn available_mem(&self) -> usize {
+        let mem_allocated = self.allocated_bytes();
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         self.mem_limit
             .saturating_sub(mem_reserved)
@@ -233,7 +233,7 @@ impl MemoryLimiter {
         };
         let mut current = state.mem_reserved.load(Ordering::SeqCst);
         let decremented = loop {
-            let new_val = current.saturating_sub(bytes as u64);
+            let new_val = current.saturating_sub(bytes);
             match state
                 .mem_reserved
                 .compare_exchange_weak(current, new_val, Ordering::SeqCst, Ordering::SeqCst)
@@ -258,8 +258,8 @@ impl MemoryLimiter {
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
             loop {
                 let new_mem_allocated = mem_allocated.saturating_add(size);
-                let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved as usize);
-                if new_total_mem_usage > self.mem_limit as usize {
+                let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved);
+                if new_total_mem_usage > self.mem_limit {
                     trace!(new_total_mem_usage, "not enough memory to allocate");
                     metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
                     return None;
@@ -453,7 +453,7 @@ pub struct CursorState {
     /// The unique identifier for this cursor.
     cursor_id: CursorId,
     /// Reservation balance (bytes of intent not yet converted to pool allocations).
-    mem_reserved: AtomicU64,
+    mem_reserved: AtomicUsize,
     /// Whether this cursor is currently servicing a FUSE read, plus the tick
     /// at which its last read ended (`0` before the first read).
     read_state: Mutex<ReadState>,
@@ -467,7 +467,7 @@ impl CursorState {
         Self {
             pool,
             cursor_id,
-            mem_reserved: AtomicU64::new(0),
+            mem_reserved: Default::default(),
             read_state: Mutex::new(ReadState::Last { tick: 0 }),
             reset_fn: Mutex::new(None),
         }
@@ -479,13 +479,13 @@ impl CursorState {
     }
 
     /// Reserve memory unconditionally. Increments both the per-cursor and global counters.
-    pub fn reserve(&self, size: u64) {
+    pub fn reserve(&self, size: usize) {
         self.pool.limiter().reserve(BufferArea::Prefetch, size);
         self.mem_reserved.fetch_add(size, Ordering::SeqCst);
     }
 
     /// Try to reserve memory. Returns false if the budget would be exceeded.
-    pub fn try_reserve(&self, size: u64) -> bool {
+    pub fn try_reserve(&self, size: usize) -> bool {
         if !self.pool.limiter().try_reserve(BufferArea::Prefetch, size) {
             return false;
         }
@@ -494,7 +494,7 @@ impl CursorState {
     }
 
     /// Query available memory tracked by the associated memory limiter.
-    pub fn available_mem(&self) -> u64 {
+    pub fn available_mem(&self) -> usize {
         self.pool.available_mem()
     }
 }
@@ -735,20 +735,20 @@ mod tests {
         let initial_available = limiter.available_mem();
 
         // Reserve intent — available decreases
-        cursor.reserve(buffer_size as u64);
-        assert_eq!(limiter.available_mem(), initial_available - buffer_size as u64);
+        cursor.reserve(buffer_size);
+        assert_eq!(limiter.available_mem(), initial_available - buffer_size);
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
 
         // Pool allocates (on_pool_acquire converts intent to pool stats)
         let buffer = pool.get_buffer_mut(buffer_size, BufferKind::GetObject, Some(cursor.id()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), buffer_size);
-        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
+        assert_eq!(limiter.available_mem(), initial_available - page_size);
 
         // Drop the buffer — pool stats decrease
         drop(buffer);
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
-        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
+        assert_eq!(limiter.available_mem(), initial_available - page_size);
 
         // Trim the pool - available goes back up
         assert!(pool.trim());
@@ -774,7 +774,7 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // But available_mem should decrease (pool stats increased)
-        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
+        assert_eq!(limiter.available_mem(), initial_available - page_size);
 
         // Drop the buffer and trim — available goes back up
         drop(buffer);

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -243,6 +243,7 @@ impl MemoryLimiter {
             }
         };
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
+        metrics::gauge!("mem.bytes_reserved", "area" => BufferArea::Prefetch.as_str()).decrement(decremented as f64);
     }
 
     pub fn try_allocate(

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -1,3 +1,4 @@
+use std::alloc::{self, Layout};
 use std::time::Instant;
 
 use dashmap::DashMap;
@@ -71,6 +72,7 @@ pub struct MemoryLimiter {
     /// Once the inner tick is running it polls every [`PRUNING_TICK`](super::maintenance::PRUNING_TICK)
     /// regardless.
     pruning_signal: Arc<WakeSignal>,
+    stats: PoolStats,
 }
 
 impl MemoryLimiter {
@@ -91,6 +93,7 @@ impl MemoryLimiter {
             next_read_tick: AtomicU64::new(1),
             additional_mem_reserved,
             pruning_signal: Arc::new(WakeSignal::new()),
+            stats: Default::default(),
         }
     }
 
@@ -115,12 +118,12 @@ impl MemoryLimiter {
     }
 
     /// Reserve the memory for future uses. If there is not enough memory returns `false`.
-    fn try_reserve(&self, area: BufferArea, size: u64, stats: &PoolStats) -> bool {
+    fn try_reserve(&self, area: BufferArea, size: u64) -> bool {
         let start = Instant::now();
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let pool_mem_reserved = self.allocated_memory(stats);
+            let pool_mem_reserved = self.allocated_memory();
             let new_total_mem_usage = new_mem_reserved
                 .saturating_add(pool_mem_reserved)
                 .saturating_add(self.additional_mem_reserved);
@@ -166,9 +169,13 @@ impl MemoryLimiter {
     }
 
     /// Query available memory tracked by the memory limiter.
-    pub fn available_mem(&self, stats: &PoolStats) -> u64 {
+    pub fn available_mem(&self) -> u64 {
+        let mem_allocated = self.allocated_memory();
+        self.available_mem_inner(mem_allocated)
+    }
+
+    fn available_mem_inner(&self, mem_allocated: u64) -> u64 {
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
-        let mem_allocated = self.allocated_memory(stats);
         self.mem_limit
             .saturating_sub(mem_reserved)
             .saturating_sub(mem_allocated)
@@ -233,9 +240,54 @@ impl MemoryLimiter {
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
+    pub(super) fn stats(&self) -> &PoolStats {
+        &self.stats
+    }
+
+    pub(super) fn try_allocate(&self, size: usize, forced: bool) -> Option<(*mut u8, Layout)> {
+        if forced {
+            self.stats.allocated_bytes.fetch_add(size, Ordering::SeqCst);
+        } else {
+            let start = Instant::now();
+            let mut mem_allocated = self.stats.allocated_bytes.load(Ordering::SeqCst);
+            loop {
+                let new_mem_allocated = mem_allocated.saturating_add(size);
+                let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved as usize);
+                if new_total_mem_usage > self.mem_limit as usize {
+                    trace!(new_total_mem_usage, "not enough memory to allocate");
+                    metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
+                    return None;
+                }
+                // Check that the value we have read is still the same before updating it
+                match self.stats.allocated_bytes.compare_exchange_weak(
+                    mem_allocated,
+                    new_mem_allocated,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => {
+                        metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
+                        break;
+                    }
+                    Err(current) => mem_allocated = current, // another thread updated the atomic before us, trying again
+                }
+            }
+        }
+
+        let layout = Layout::array::<u8>(size).unwrap();
+
+        // SAFETY: layout has non-zero size.
+        let bytes = unsafe { alloc::alloc(layout) };
+        if bytes.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
+
+        Some((bytes, layout))
+    }
+
     /// Get allocated memory from the pool.
-    fn allocated_memory(&self, stats: &PoolStats) -> u64 {
-        stats.allocated_bytes() as u64
+    fn allocated_memory(&self) -> u64 {
+        self.stats.allocated_bytes() as u64
     }
 
     // -----------------------------------------------------------------------
@@ -398,11 +450,7 @@ impl CursorState {
 
     /// Try to reserve memory. Returns false if the budget would be exceeded.
     pub fn try_reserve(&self, size: u64) -> bool {
-        if !self
-            .pool
-            .limiter()
-            .try_reserve(BufferArea::Prefetch, size, self.pool.stats())
-        {
+        if !self.pool.limiter().try_reserve(BufferArea::Prefetch, size) {
             return false;
         }
         self.mem_reserved.fetch_add(size, Ordering::SeqCst);
@@ -640,53 +688,64 @@ mod tests {
 
     #[test]
     fn test_available_mem_accounts_for_pool_allocations() {
+        let buffer_size = 1024;
+        let page_size = buffer_size * super::super::pages::Page::BUFFERS_PER_PAGE;
+
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([buffer_size])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();
         let cursor = pool.create_cursor().state();
-        let stats = pool.stats();
 
-        let initial_available = limiter.available_mem(stats);
+        let initial_available = limiter.available_mem();
 
         // Reserve intent — available decreases
-        cursor.reserve(1024);
-        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
+        cursor.reserve(buffer_size as u64);
+        assert_eq!(limiter.available_mem(), initial_available - buffer_size as u64);
+        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), 0);
 
-        // Pool allocates (on_pool_reserve converts intent to pool stats) — available stays the same
-        // because mem_reserved decreases by 1024 while pool stats increase by 1024.
-        let buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor.id()));
+        // Pool allocates (on_pool_acquire converts intent to pool stats)
+        let buffer = pool.get_buffer_mut(buffer_size, BufferKind::GetObject, Some(cursor.id()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
+        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), buffer_size);
+        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
 
-        // Drop the buffer — pool stats decrease, available goes back up
+        // Drop the buffer — pool stats decrease
         drop(buffer);
-        assert_eq!(limiter.available_mem(stats), initial_available);
+        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), 0);
+        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
+
+        // Trim the pool - available goes back up
+        assert!(pool.trim());
+        assert_eq!(limiter.available_mem(), initial_available);
     }
 
     #[test]
     fn test_upload_allocation_does_not_affect_mem_reserved() {
+        let buffer_size = 1024;
+        let page_size = buffer_size * super::super::pages::Page::BUFFERS_PER_PAGE;
+
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([buffer_size])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();
-        let stats = pool.stats();
 
-        let initial_available = limiter.available_mem(stats);
+        let initial_available = limiter.available_mem();
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // Upload allocates without cursor_id — should not touch mem_reserved
-        let buffer = pool.get_buffer_mut(1024, BufferKind::Append, None);
+        let buffer = pool.get_buffer_mut(buffer_size, BufferKind::Append, None);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // But available_mem should decrease (pool stats increased)
-        assert_eq!(limiter.available_mem(stats), initial_available - 1024);
+        assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
 
-        // Drop the buffer — available goes back up
+        // Drop the buffer and trim — available goes back up
         drop(buffer);
-        assert_eq!(limiter.available_mem(stats), initial_available);
+        assert!(pool.trim());
+        assert_eq!(limiter.available_mem(), initial_available);
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -387,11 +387,11 @@ impl MemoryLimiter {
 
 impl Drop for MemoryLimiter {
     fn drop(&mut self) {
-        self.trigger_process_pending();
         // Wake the pruning thread so it observes its `Weak` failing to upgrade
         // and exits. Without this, a pruner parked in the outer wait at drop
         // time would never wake.
-        self.pruning_signal.notify();
+        self.trigger_pruning();
+        self.trigger_process_pending();
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -46,7 +46,7 @@ impl BufferArea {
 /// rejected if there is no available memory.
 ///
 /// Release of the reserved memory happens on one of the following events:
-/// 1) the memory pool allocates a buffer: `on_pool_reserve` decrements `mem_reserved` by the
+/// 1) the memory pool allocates a buffer: `on_pool_acquire` decrements `mem_reserved` by the
 ///    allocated size, converting the reservation from "intent" to "actual allocation" tracked by the pool.
 /// 2) the cursor is destroyed (`BackpressureController` will be dropped and `release_cursor` will
 ///    release any remaining unallocated reservation for that cursor).
@@ -55,8 +55,15 @@ impl BufferArea {
 /// requests. Under memory pressure, each instance will limit to a single buffer.
 #[derive(Debug)]
 pub struct MemoryLimiter {
+    /// Target memory limit.
     mem_limit: u64,
-    /// Global total of reserved memory (lock-free). Used in budget checks.
+    /// Additional reserved memory for other non-buffer usage like storing metadata
+    additional_mem_reserved: u64,
+    /// Memory allocated by the pool.
+    allocated_bytes: AtomicUsize,
+    /// Memory in use by [`BufferKind`].
+    acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+    /// Total reserved memory. Used in budget checks.
     mem_reserved: Arc<AtomicU64>,
     /// Unified per-cursor state. Cursors own a strong reference to their state.
     cursors: Arc<DashMap<CursorId, Weak<CursorState>>>,
@@ -66,21 +73,16 @@ pub struct MemoryLimiter {
     /// an active read ends, so the pruner can pick the LRU idle cursor.
     /// Pure ordering — does not represent wall-clock time.
     next_read_tick: AtomicU64,
-    /// Additional reserved memory for other non-buffer usage like storing metadata
-    additional_mem_reserved: u64,
     /// Wakes the background pruning loop's outer wait when memory pressure starts.
     /// Once the inner tick is running it polls every [`PRUNING_TICK`](super::maintenance::PRUNING_TICK)
     /// regardless.
     pruning_signal: Arc<WakeSignal>,
-
-    acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
-    allocated_bytes: AtomicUsize,
-
-    wake_signal: Arc<WakeSignal>,
+    /// Signal to process pending allocations.
+    pending_signal: Arc<WakeSignal>,
 }
 
 impl MemoryLimiter {
-    pub fn new(mem_limit: u64, wake_signal: Arc<WakeSignal>) -> Self {
+    pub fn new(mem_limit: u64, pending_signal: Arc<WakeSignal>) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -91,15 +93,15 @@ impl MemoryLimiter {
         );
         Self {
             mem_limit,
+            additional_mem_reserved,
+            allocated_bytes: Default::default(),
+            acquired_bytes: Default::default(),
             mem_reserved: Default::default(),
             cursors: Default::default(),
             next_cursor_id: AtomicU64::new(1),
             next_read_tick: AtomicU64::new(1),
-            additional_mem_reserved,
             pruning_signal: Arc::new(WakeSignal::new()),
-            acquired_bytes: Default::default(),
-            allocated_bytes: Default::default(),
-            wake_signal,
+            pending_signal,
         }
     }
 
@@ -164,7 +166,7 @@ impl MemoryLimiter {
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => BufferArea::Prefetch.as_str()).decrement(remaining as f64);
         }
-        self.trigger_wake_pending();
+        self.trigger_process_pending();
     }
 
     /// Create a new cursor, insert its state into the map, and return the shared state handle.
@@ -292,7 +294,7 @@ impl MemoryLimiter {
         if let Some(kind) = kind {
             self.release_bytes(size, kind);
         } else {
-            self.trigger_wake_pending();
+            self.trigger_process_pending();
         }
     }
 
@@ -316,11 +318,11 @@ impl MemoryLimiter {
     pub fn release_bytes(&self, bytes: usize, kind: BufferKind) {
         self.acquired_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
         metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).decrement(bytes as f64);
-        self.trigger_wake_pending();
+        self.trigger_process_pending();
     }
 
-    pub fn trigger_wake_pending(&self) {
-        self.wake_signal.notify();
+    pub fn trigger_process_pending(&self) {
+        self.pending_signal.notify();
     }
 
     // -----------------------------------------------------------------------
@@ -385,7 +387,7 @@ impl MemoryLimiter {
 
 impl Drop for MemoryLimiter {
     fn drop(&mut self) {
-        self.trigger_wake_pending();
+        self.trigger_process_pending();
         // Wake the pruning thread so it observes its `Weak` failing to upgrade
         // and exits. Without this, a pruner parked in the outer wait at drop
         // time would never wake.

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -1,4 +1,3 @@
-use std::alloc::{self, Layout};
 use std::time::Instant;
 
 use dashmap::DashMap;
@@ -12,6 +11,7 @@ use crate::sync::{Arc, Mutex, Weak};
 use crate::util::wake_signal::WakeSignal;
 
 use super::PagedPool;
+use super::buffers::BufferPtr;
 use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
@@ -239,7 +239,7 @@ impl MemoryLimiter {
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
-    pub fn try_allocate(&self, size: usize, forced: bool) -> Option<(*mut u8, Layout)> {
+    pub fn try_allocate(&self, size: usize, forced: bool) -> Option<BufferPtr> {
         if forced {
             self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
         } else {
@@ -269,23 +269,13 @@ impl MemoryLimiter {
             }
         }
 
-        let layout = Layout::array::<u8>(size).unwrap();
-
-        // SAFETY: layout has non-zero size.
-        let bytes = unsafe { alloc::alloc(layout) };
-        if bytes.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
-
-        Some((bytes, layout))
+        Some(BufferPtr::allocate(size))
     }
 
-    pub fn deallocate(&self, bytes: *mut u8, layout: Layout) {
-        // SAFETY: `bytes` was allocated using `layout` in `allocate_page`.
-        unsafe {
-            alloc::dealloc(bytes, layout);
-        }
-        self.allocated_bytes.fetch_sub(layout.size(), Ordering::SeqCst);
+    pub fn deallocate(&self, ptr: &mut BufferPtr) {
+        let size = ptr.size();
+        ptr.deallocate();
+        self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
     }
 
     pub fn allocated_bytes(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -171,7 +171,7 @@ impl MemoryLimiter {
 
     /// Create a new cursor, insert its state into the map, and return the shared state handle.
     pub fn create_cursor(&self, pool: &PagedPool) -> CursorHandle {
-        let id = CursorId::new_from_raw(self.next_cursor_id.fetch_add(1, Ordering::Relaxed));
+        let id = CursorId::new_from_raw(self.next_cursor_id.fetch_add(1, Ordering::SeqCst));
         let state = Arc::new(CursorState::new(pool.clone(), id));
         self.cursors.insert(id, Arc::downgrade(&state));
         CursorHandle { state }

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -206,13 +206,13 @@ impl MemoryLimiter {
             .unwrap_or(false)
     }
 
-    /// Called by the pool on every buffer allocation. For download buffers with a known cursor,
-    /// this converts reservation from "intent" (`mem_reserved`) to "actual allocation" (pool stats)
+    /// Called by the pool on every buffer acquisition. For download buffers with a known cursor,
+    /// this converts reservation from "intent" (`mem_reserved`) to "actual acquisition" (pool stats)
     /// by decrementing both the global and per-cursor counters.
     ///
     /// No-op when `cursor_id` is `None` (e.g. uploads) or the cursor has already been removed
     /// by `release_cursor`.
-    pub fn on_pool_reserve(&self, bytes: usize, cursor_id: Option<CursorId>) {
+    pub fn on_pool_acquire(&self, bytes: usize, cursor_id: Option<CursorId>) {
         let Some(state) = cursor_id
             .and_then(|id| self.cursors.get(&id))
             .and_then(|r| r.value().upgrade())

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -131,9 +131,9 @@ impl MemoryLimiter {
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let mem_allocated = self.allocated_bytes();
+            let mem_in_use = self.total_acquired_bytes();
             let new_total_mem_usage = new_mem_reserved
-                .saturating_add(mem_allocated)
+                .saturating_add(mem_in_use)
                 .saturating_add(self.additional_mem_reserved);
             if new_total_mem_usage > self.mem_limit {
                 trace!(new_total_mem_usage, "not enough memory to reserve");
@@ -177,13 +177,13 @@ impl MemoryLimiter {
         CursorHandle { state }
     }
 
-    /// Query available memory tracked by the memory limiter.
-    pub fn available_mem(&self) -> usize {
-        let mem_allocated = self.allocated_bytes();
+    /// Memory that can be reserved while respecting the memory limit.
+    pub fn memory_available_for_reservation(&self) -> usize {
+        let mem_in_use = self.total_acquired_bytes();
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         self.mem_limit
             .saturating_sub(mem_reserved)
-            .saturating_sub(mem_allocated)
+            .saturating_sub(mem_in_use)
             .saturating_sub(self.additional_mem_reserved)
     }
 
@@ -297,10 +297,6 @@ impl MemoryLimiter {
         } else {
             self.trigger_process_pending();
         }
-    }
-
-    pub fn allocated_bytes(&self) -> usize {
-        self.allocated_bytes.load(Ordering::SeqCst)
     }
 
     pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
@@ -494,9 +490,9 @@ impl CursorState {
         true
     }
 
-    /// Query available memory tracked by the associated memory limiter.
-    pub fn available_mem(&self) -> usize {
-        self.pool.available_mem()
+    /// Memory that can be reserved while respecting the memory limit.
+    pub fn memory_available_for_reservation(&self) -> usize {
+        self.pool.limiter().memory_available_for_reservation()
     }
 }
 
@@ -640,7 +636,7 @@ mod tests {
         let cursor = pool.create_cursor().state();
 
         // Fill up to the limit (minus additional_mem_reserved)
-        let available = pool.available_mem();
+        let available = pool.limiter().memory_available_for_reservation();
         cursor.reserve(available);
 
         // Should fail — no room left
@@ -722,9 +718,8 @@ mod tests {
     }
 
     #[test]
-    fn test_available_mem_accounts_for_pool_allocations() {
+    fn test_memory_available_for_reservation() {
         let buffer_size = 1024;
-        let page_size = buffer_size * super::super::pages::Page::BUFFERS_PER_PAGE;
 
         let pool = PagedPool::config()
             .with_candidate_sizes([buffer_size])
@@ -733,33 +728,34 @@ mod tests {
         let limiter = pool.limiter();
         let cursor = pool.create_cursor().state();
 
-        let initial_available = limiter.available_mem();
+        let initial_available = limiter.memory_available_for_reservation();
 
         // Reserve intent — available decreases
         cursor.reserve(buffer_size);
-        assert_eq!(limiter.available_mem(), initial_available - buffer_size);
+        assert_eq!(
+            limiter.memory_available_for_reservation(),
+            initial_available - buffer_size
+        );
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
 
-        // Pool allocates (on_pool_acquire converts intent to pool stats)
+        // Acquire buffer from the pool (on_pool_acquire converts intent to pool stats)
         let buffer = pool.get_buffer_mut(buffer_size, BufferKind::GetObject, Some(cursor.id()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), buffer_size);
-        assert_eq!(limiter.available_mem(), initial_available - page_size);
+        assert_eq!(
+            limiter.memory_available_for_reservation(),
+            initial_available - buffer_size
+        );
 
-        // Drop the buffer — pool stats decrease
+        // Drop the buffer — pool stats decrease and available goes back up
         drop(buffer);
         assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
-        assert_eq!(limiter.available_mem(), initial_available - page_size);
-
-        // Trim the pool - available goes back up
-        assert!(pool.trim());
-        assert_eq!(limiter.available_mem(), initial_available);
+        assert_eq!(limiter.memory_available_for_reservation(), initial_available);
     }
 
     #[test]
     fn test_upload_allocation_does_not_affect_mem_reserved() {
         let buffer_size = 1024;
-        let page_size = buffer_size * super::super::pages::Page::BUFFERS_PER_PAGE;
 
         let pool = PagedPool::config()
             .with_candidate_sizes([buffer_size])
@@ -767,7 +763,7 @@ mod tests {
             .build();
         let limiter = pool.limiter();
 
-        let initial_available = limiter.available_mem();
+        let initial_available = limiter.memory_available_for_reservation();
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // Upload allocates without cursor_id — should not touch mem_reserved
@@ -775,12 +771,14 @@ mod tests {
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
 
         // But available_mem should decrease (pool stats increased)
-        assert_eq!(limiter.available_mem(), initial_available - page_size);
+        assert_eq!(
+            limiter.memory_available_for_reservation(),
+            initial_available - buffer_size
+        );
 
-        // Drop the buffer and trim — available goes back up
+        // Drop the buffer — available goes back up
         drop(buffer);
-        assert!(pool.trim());
-        assert_eq!(limiter.available_mem(), initial_available);
+        assert_eq!(limiter.memory_available_for_reservation(), initial_available);
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -673,7 +673,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_pool_reserve_noop_after_release_cursor() {
+    fn test_on_pool_acquire_noop_after_release_cursor() {
         // Simulates the cancellation race: on_reserve fires after release_cursor
         // removed the entry. The callback should be a no-op.
         let pool = PagedPool::config()
@@ -698,7 +698,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_pool_reserve_saturates_on_over_decrement() {
+    fn test_on_pool_acquire_saturates_on_over_decrement() {
         let pool = PagedPool::config()
             .with_candidate_sizes([1024])
             .with_minimum_memory_limit()
@@ -710,7 +710,7 @@ mod tests {
         cursor.reserve(512);
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 512);
 
-        // Pool allocates 1024 — on_pool_reserve should saturate at 512 (not underflow)
+        // Pool allocates 1024 — on_pool_acquire should saturate at 512 (not underflow)
         let cursor_id = cursor.id();
         let _buffer = pool.get_buffer_mut(1024, BufferKind::GetObject, Some(cursor_id));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -120,7 +120,7 @@ impl MemoryLimiter {
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let pool_mem_reserved = self.pool_mem_reserved(stats);
+            let pool_mem_reserved = self.allocated_memory(stats);
             let new_total_mem_usage = new_mem_reserved
                 .saturating_add(pool_mem_reserved)
                 .saturating_add(self.additional_mem_reserved);
@@ -168,10 +168,10 @@ impl MemoryLimiter {
     /// Query available memory tracked by the memory limiter.
     pub fn available_mem(&self, stats: &PoolStats) -> u64 {
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
-        let pool_mem_reserved = self.pool_mem_reserved(stats);
+        let mem_allocated = self.allocated_memory(stats);
         self.mem_limit
             .saturating_sub(mem_reserved)
-            .saturating_sub(pool_mem_reserved)
+            .saturating_sub(mem_allocated)
             .saturating_sub(self.additional_mem_reserved)
     }
 
@@ -233,10 +233,9 @@ impl MemoryLimiter {
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
-    /// Get reserved memory from the memory pool for buffers not tracked via [Self::mem_reserved].
-    fn pool_mem_reserved(&self, stats: &PoolStats) -> u64 {
-        // All pool buffer kinds are accounted for here.
-        stats.total_reserved_bytes() as u64
+    /// Get allocated memory from the pool.
+    fn allocated_memory(&self, stats: &PoolStats) -> u64 {
+        stats.allocated_bytes() as u64
     }
 
     // -----------------------------------------------------------------------

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -7,12 +7,12 @@ use sysinfo::System;
 use tracing::{debug, trace};
 
 use crate::prefetch::CursorId;
-use crate::sync::atomic::{AtomicU64, Ordering};
+use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::sync::{Arc, Mutex, Weak};
 use crate::util::wake_signal::WakeSignal;
 
 use super::PagedPool;
-use super::stats::PoolStats;
+use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
 
@@ -72,7 +72,9 @@ pub struct MemoryLimiter {
     /// Once the inner tick is running it polls every [`PRUNING_TICK`](super::maintenance::PRUNING_TICK)
     /// regardless.
     pruning_signal: Arc<WakeSignal>,
-    stats: PoolStats,
+
+    acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+    allocated_bytes: AtomicUsize,
 }
 
 impl MemoryLimiter {
@@ -93,7 +95,8 @@ impl MemoryLimiter {
             next_read_tick: AtomicU64::new(1),
             additional_mem_reserved,
             pruning_signal: Arc::new(WakeSignal::new()),
-            stats: Default::default(),
+            acquired_bytes: Default::default(),
+            allocated_bytes: Default::default(),
         }
     }
 
@@ -123,7 +126,7 @@ impl MemoryLimiter {
         let mut mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         loop {
             let new_mem_reserved = mem_reserved.saturating_add(size);
-            let pool_mem_reserved = self.allocated_memory();
+            let pool_mem_reserved = self.allocated_bytes() as u64;
             let new_total_mem_usage = new_mem_reserved
                 .saturating_add(pool_mem_reserved)
                 .saturating_add(self.additional_mem_reserved);
@@ -170,11 +173,7 @@ impl MemoryLimiter {
 
     /// Query available memory tracked by the memory limiter.
     pub fn available_mem(&self) -> u64 {
-        let mem_allocated = self.allocated_memory();
-        self.available_mem_inner(mem_allocated)
-    }
-
-    fn available_mem_inner(&self, mem_allocated: u64) -> u64 {
+        let mem_allocated = self.allocated_bytes() as u64;
         let mem_reserved = self.mem_reserved.load(Ordering::SeqCst);
         self.mem_limit
             .saturating_sub(mem_reserved)
@@ -240,16 +239,12 @@ impl MemoryLimiter {
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
-    pub(super) fn stats(&self) -> &PoolStats {
-        &self.stats
-    }
-
-    pub(super) fn try_allocate(&self, size: usize, forced: bool) -> Option<(*mut u8, Layout)> {
+    pub fn try_allocate(&self, size: usize, forced: bool) -> Option<(*mut u8, Layout)> {
         if forced {
-            self.stats.allocated_bytes.fetch_add(size, Ordering::SeqCst);
+            self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
         } else {
             let start = Instant::now();
-            let mut mem_allocated = self.stats.allocated_bytes.load(Ordering::SeqCst);
+            let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
             loop {
                 let new_mem_allocated = mem_allocated.saturating_add(size);
                 let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved as usize);
@@ -259,7 +254,7 @@ impl MemoryLimiter {
                     return None;
                 }
                 // Check that the value we have read is still the same before updating it
-                match self.stats.allocated_bytes.compare_exchange_weak(
+                match self.allocated_bytes.compare_exchange_weak(
                     mem_allocated,
                     new_mem_allocated,
                     Ordering::SeqCst,
@@ -285,9 +280,34 @@ impl MemoryLimiter {
         Some((bytes, layout))
     }
 
-    /// Get allocated memory from the pool.
-    fn allocated_memory(&self) -> u64 {
-        self.stats.allocated_bytes() as u64
+    pub fn deallocate(&self, bytes: *mut u8, layout: Layout) {
+        // SAFETY: `bytes` was allocated using `layout` in `allocate_page`.
+        unsafe {
+            alloc::dealloc(bytes, layout);
+        }
+        self.allocated_bytes.fetch_sub(layout.size(), Ordering::SeqCst);
+    }
+
+    pub fn allocated_bytes(&self) -> usize {
+        self.allocated_bytes.load(Ordering::SeqCst)
+    }
+
+    pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
+        self.acquired_bytes[kind].load(Ordering::SeqCst)
+    }
+
+    pub fn total_acquired_bytes(&self) -> usize {
+        self.acquired_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
+    }
+
+    pub fn acquire_bytes(&self, bytes: usize, kind: BufferKind) {
+        self.acquired_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
+        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).increment(bytes as f64);
+    }
+
+    pub fn release_bytes(&self, bytes: usize, kind: BufferKind) {
+        self.acquired_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
+        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).decrement(bytes as f64);
     }
 
     // -----------------------------------------------------------------------
@@ -703,17 +723,17 @@ mod tests {
         // Reserve intent — available decreases
         cursor.reserve(buffer_size as u64);
         assert_eq!(limiter.available_mem(), initial_available - buffer_size as u64);
-        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), 0);
+        assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
 
         // Pool allocates (on_pool_acquire converts intent to pool stats)
         let buffer = pool.get_buffer_mut(buffer_size, BufferKind::GetObject, Some(cursor.id()));
         assert_eq!(limiter.mem_reserved.load(Ordering::SeqCst), 0);
-        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), buffer_size);
+        assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), buffer_size);
         assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
 
         // Drop the buffer — pool stats decrease
         drop(buffer);
-        assert_eq!(limiter.stats.acquired_bytes(BufferKind::GetObject), 0);
+        assert_eq!(limiter.acquired_bytes(BufferKind::GetObject), 0);
         assert_eq!(limiter.available_mem(), initial_available - page_size as u64);
 
         // Trim the pool - available goes back up

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -75,10 +75,12 @@ pub struct MemoryLimiter {
 
     acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
     allocated_bytes: AtomicUsize,
+
+    wake_signal: Arc<WakeSignal>,
 }
 
 impl MemoryLimiter {
-    pub fn new(mem_limit: u64) -> Self {
+    pub fn new(mem_limit: u64, wake_signal: Arc<WakeSignal>) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -97,6 +99,7 @@ impl MemoryLimiter {
             pruning_signal: Arc::new(WakeSignal::new()),
             acquired_bytes: Default::default(),
             allocated_bytes: Default::default(),
+            wake_signal,
         }
     }
 
@@ -161,6 +164,7 @@ impl MemoryLimiter {
             self.mem_reserved.fetch_sub(remaining, Ordering::SeqCst);
             metrics::gauge!("mem.bytes_reserved", "area" => BufferArea::Prefetch.as_str()).decrement(remaining as f64);
         }
+        self.trigger_wake_pending();
     }
 
     /// Create a new cursor, insert its state into the map, and return the shared state handle.
@@ -276,6 +280,7 @@ impl MemoryLimiter {
         let size = ptr.size();
         ptr.deallocate();
         self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
+        self.trigger_wake_pending();
     }
 
     pub fn allocated_bytes(&self) -> usize {
@@ -298,6 +303,11 @@ impl MemoryLimiter {
     pub fn release_bytes(&self, bytes: usize, kind: BufferKind) {
         self.acquired_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
         metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).decrement(bytes as f64);
+        self.trigger_wake_pending();
+    }
+
+    pub fn trigger_wake_pending(&self) {
+        self.wake_signal.notify();
     }
 
     // -----------------------------------------------------------------------
@@ -362,6 +372,7 @@ impl MemoryLimiter {
 
 impl Drop for MemoryLimiter {
     fn drop(&mut self) {
+        self.trigger_wake_pending();
         // Wake the pruning thread so it observes its `Weak` failing to upgrade
         // and exits. Without this, a pruner parked in the outer wait at drop
         // time would never wake.
@@ -489,8 +500,6 @@ impl Drop for CursorState {
         // The limiter holds a weak reference to `CursorState`, so this `Drop` runs when all strong
         // references are gone. `release_cursor` removes the reference and decrements the global reservation counter.
         self.pool.limiter().release_cursor(self.cursor_id, &self.mem_reserved);
-        // Releasing the cursor's reservation may have freed memory — wake any pending allocations.
-        self.pool.try_wake_pending();
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -11,7 +11,7 @@ use crate::sync::{Arc, Mutex, Weak};
 use crate::util::wake_signal::WakeSignal;
 
 use super::PagedPool;
-use super::buffers::BufferPtr;
+use super::buffers::{BufferPtr, ManagedBuffer};
 use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
 pub const MINIMUM_MEM_LIMIT: u64 = 512 * 1024 * 1024;
@@ -243,7 +243,12 @@ impl MemoryLimiter {
         self.mem_reserved.fetch_sub(decremented, Ordering::SeqCst);
     }
 
-    pub fn try_allocate(&self, size: usize, forced: bool) -> Option<BufferPtr> {
+    pub fn try_allocate(
+        self: &Arc<Self>,
+        size: usize,
+        kind: Option<BufferKind>,
+        forced: bool,
+    ) -> Option<ManagedBuffer> {
         if forced {
             self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
         } else {
@@ -273,14 +278,22 @@ impl MemoryLimiter {
             }
         }
 
-        Some(BufferPtr::allocate(size))
+        if let Some(kind) = kind {
+            self.acquire_bytes(size, kind);
+        }
+
+        Some(ManagedBuffer::new(size, kind, self.clone()))
     }
 
-    pub fn deallocate(&self, ptr: &mut BufferPtr) {
+    pub fn deallocate(&self, ptr: BufferPtr, kind: Option<BufferKind>) {
         let size = ptr.size();
-        ptr.deallocate();
+        drop(ptr);
         self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
-        self.trigger_wake_pending();
+        if let Some(kind) = kind {
+            self.release_bytes(size, kind);
+        } else {
+            self.trigger_wake_pending();
+        }
     }
 
     pub fn allocated_bytes(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -82,7 +82,7 @@ pub struct MemoryLimiter {
 }
 
 impl MemoryLimiter {
-    pub fn new(mem_limit: usize, pending_signal: Arc<WakeSignal>) -> Self {
+    pub fn new(mem_limit: usize) -> Self {
         let min_reserved = 128 * 1024 * 1024;
         let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
         let formatter = make_format(humansize::BINARY);
@@ -101,7 +101,7 @@ impl MemoryLimiter {
             next_cursor_id: AtomicU64::new(1),
             next_read_tick: AtomicU64::new(1),
             pruning_signal: Arc::new(WakeSignal::new()),
-            pending_signal,
+            pending_signal: Arc::new(WakeSignal::new()),
         }
     }
 
@@ -322,6 +322,11 @@ impl MemoryLimiter {
         self.pending_signal.notify();
     }
 
+    /// Signal to process pending allocations.
+    pub(super) fn pending_signal(&self) -> &Arc<WakeSignal> {
+        &self.pending_signal
+    }
+
     // -----------------------------------------------------------------------
     // Pruning hooks — see `maintenance.rs` for the loop, signal, and round logic.
     // -----------------------------------------------------------------------
@@ -334,12 +339,12 @@ impl MemoryLimiter {
     }
 
     /// Shared notify handle. The pruner needs its own clone to park on.
-    pub(crate) fn pruning_signal(&self) -> &Arc<WakeSignal> {
+    pub(super) fn pruning_signal(&self) -> &Arc<WakeSignal> {
         &self.pruning_signal
     }
 
     /// Returns `true` if any cursor is currently servicing a FUSE read.
-    pub(crate) fn has_active_reads(&self) -> bool {
+    pub(super) fn has_active_reads(&self) -> bool {
         self.cursors.iter().any(|entry| {
             entry
                 .value()
@@ -351,7 +356,7 @@ impl MemoryLimiter {
     /// Reset the least-recently-read idle cursor.
     ///
     /// Returns `true` if a cursor was reset.
-    pub(crate) fn reset_one_idle_cursor(&self) -> bool {
+    pub(super) fn reset_one_idle_cursor(&self) -> bool {
         let lru = self
             .cursors
             .iter()

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -97,13 +97,10 @@ fn maintenance_loop(pool_inner: Weak<PagedPoolInner>, signal: Arc<WakeSignal>, i
 ///   4. Otherwise reset one idle cursor.
 fn run_pruning_round(pool_inner: &Arc<PagedPoolInner>) -> PruningOutcome {
     // 1. Pool trim — idempotent and harmless. Empty pages may now be reusable
-    //    by a different SizePool after a future allocation. If anything was
-    //    freed, wake the allocation queue so pending requests can claim it.
+    //    by a different SizePool after a future allocation.
     //    TODO: Consider doing trim cooldown (i.e. invoke trim less often)
     //    if it's contending too much with reserve read lock.
-    if pool_inner.trim() {
-        pool_inner.try_wake_pending();
-    }
+    pool_inner.trim();
 
     // 2. If no waiter is queued, there's no pressure — exit the inner tick.
     if !pool_inner.is_memory_pressure() {
@@ -182,11 +179,11 @@ mod tests {
     /// buffers so the caller can drop them when the test is done.
     fn fill_and_enqueue_waiter(pool: &PagedPool) -> Vec<Bytes> {
         let mut blockers = Vec::new();
-        while pool.available_mem() >= BUF as u64 {
-            blockers.push(pool.get_buffer_mut(BUF, BufferKind::Other, None).into_bytes());
+        while let Some(buffer) = pool.inner().try_get_buffer(BUF, BufferKind::Other, None, false) {
+            blockers.push(buffer.into_bytes());
         }
         let pool_clone = pool.clone();
-        std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+        std::thread::spawn(move || block_on(pool_clone.get_buffer_mut_async(BUF, BufferKind::GetObject, None)));
         let deadline = Instant::now() + TEST_WAIT_TIMEOUT;
         while !pool.inner().is_memory_pressure() {
             assert!(Instant::now() < deadline, "request did not enter queue");

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -135,13 +135,13 @@ fn run_pruning_round(pool_inner: &Arc<PagedPoolInner>) -> PruningOutcome {
 /// Returns `true` if any in-flight `UploadPart`/`PutObject` is currently
 /// holding a pool buffer that will be released when the request completes.
 ///
-/// TODO: Currently a stub returning `false`.
+/// TODO(memory-limiter): Currently a stub returning `false`.
 /// Tighten to "in-flight UploadPart/PutObject exists":
-///   `reserved_bytes(PutObject) + reserved_bytes(Append)
+///   `acquired_bytes(PutObject) + acquired_bytes(Append)
 ///       > upload_handles_holding_buffers * write_part_size`
 /// Each write handle holds at most one "filling" buffer (FUSE write data
 /// being staged) at any time without an in-flight request, so excess
-/// reserved bytes above that baseline indicate at least one part actually
+/// memory in use above that baseline indicate at least one part actually
 /// uploading. Requires tracking `upload_handles_holding_buffers` (likely
 /// the active-write-handles counter).
 fn has_uploads_in_flight(_pool_inner: &PagedPoolInner) -> bool {

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -166,8 +166,8 @@ mod tests {
     /// Pool sized for one page of `BUF`-byte buffers — small enough that the
     /// "fill all memory" loop in pressure tests is fast in debug builds.
     fn tight_pool() -> PagedPool {
-        let additional_reserved = (BUF as u64 * 16).max(128 * 1024 * 1024);
-        let mem_limit = BUF as u64 * 16 + additional_reserved;
+        let additional_reserved = (BUF * 16).max(128 * 1024 * 1024);
+        let mem_limit = BUF * 16 + additional_reserved;
         PagedPool::config()
             .with_candidate_sizes([BUF])
             .with_memory_limit(mem_limit)

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -154,8 +154,11 @@ mod tests {
     use bytes::Bytes;
     use futures::executor::block_on;
 
-    use super::{PRUNING_STARVATION_THRESHOLD, PruningOutcome, run_pruning_round, spawn_pool_maintenance_thread};
+    use crate::memory::limiter::MemoryLimiter;
+    use crate::memory::pool::PagedPoolInner;
     use crate::memory::{BufferKind, PagedPool};
+
+    use super::{PRUNING_STARVATION_THRESHOLD, PruningOutcome, run_pruning_round, spawn_pool_maintenance_thread};
 
     const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
     /// Long idle interval used in tests where we want the loop to stay
@@ -165,13 +168,17 @@ mod tests {
 
     /// Pool sized for one page of `BUF`-byte buffers — small enough that the
     /// "fill all memory" loop in pressure tests is fast in debug builds.
-    fn tight_pool() -> PagedPool {
+    ///
+    /// **NOTE:** does not spawn background threads.
+    fn tight_pool_no_spawn() -> PagedPool {
         let additional_reserved = (BUF * 16).max(128 * 1024 * 1024);
         let mem_limit = BUF * 16 + additional_reserved;
-        PagedPool::config()
-            .with_candidate_sizes([BUF])
-            .with_memory_limit(mem_limit)
-            .build()
+
+        let limiter = MemoryLimiter::new(mem_limit);
+        let inner_pool = PagedPoolInner::new(&[BUF], Arc::new(limiter));
+        PagedPool {
+            inner: Arc::new(inner_pool),
+        }
     }
 
     /// Fill the pool, spawn a waiter on `acquire_buffer_async`, and block
@@ -197,10 +204,7 @@ mod tests {
     /// and exit. Otherwise the thread leaks until the idle interval elapses.
     #[test]
     fn maintenance_thread_exits_on_pool_drop() {
-        let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
-            .with_minimum_memory_limit()
-            .build();
+        let pool = tight_pool_no_spawn();
         let handle = spawn_pool_maintenance_thread(pool.inner(), TEST_IDLE_INTERVAL);
 
         drop(pool);
@@ -241,7 +245,7 @@ mod tests {
     /// idle cursor to evict, the round defers to natural release.
     #[test]
     fn run_pruning_round_observes_real_queue_pressure() {
-        let pool = tight_pool();
+        let pool = tight_pool_no_spawn();
         let _blockers = fill_and_enqueue_waiter(&pool);
 
         let outcome = run_pruning_round(pool.inner());
@@ -255,7 +259,7 @@ mod tests {
     /// reset_fn firing once the starvation threshold elapses.
     #[test]
     fn acquire_buffer_async_wakes_parked_maintenance_thread() {
-        let pool = tight_pool();
+        let pool = tight_pool_no_spawn();
         let _maintenance = spawn_pool_maintenance_thread(pool.inner(), TEST_IDLE_INTERVAL);
 
         // Idle cursor with a reset_fn — the maintenance thread will reset it
@@ -293,7 +297,7 @@ mod tests {
     /// would normally defer to the natural release path).
     #[test]
     fn run_pruning_round_starvation_resets_idle_cursor_despite_active_read() {
-        let pool = tight_pool();
+        let pool = tight_pool_no_spawn();
 
         // Idle cursor with a registered reset_fn — eligible for eviction.
         let idle = pool.create_cursor();

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -3,9 +3,12 @@ use crate::sync::{Arc, Mutex};
 use super::buffers::ManagedBuffer;
 use super::stats::{BufferKind, SizePoolStats};
 
+/// Maximum number of buffers allowed on a page.
+pub const MAX_BUFFERS_PER_PAGE: usize = u16::BITS as usize;
+
 /// Page in a size pool.
 ///
-/// Each page contains [BUFFERS_PER_PAGE](super::pages::Page::BUFFERS_PER_PAGE) (16)
+/// Each page contains at most 16 ([`MAX_BUFFERS_PER_PAGE`])
 /// buffers of a fixed size.
 #[derive(Debug, Clone)]
 pub struct Page {
@@ -16,6 +19,8 @@ pub struct Page {
 struct PageInner {
     /// Memory buffer for the whole page.
     page_buffer: ManagedBuffer,
+    /// Number of buffers on this page.
+    buffer_count: usize,
     /// Pointer to the last buffer in the page.
     ///
     /// Equals to (BUFFERS_PER_PAGE - 1) * buffer_size. Stored for easy
@@ -36,25 +41,26 @@ unsafe impl Send for PageInner {}
 unsafe impl Sync for PageInner {}
 
 impl Page {
-    pub const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
-
     /// Create a new page and allocate the required memory.
     ///
     /// Returns `None` if the allocation would hit the memory limit.
-    pub fn try_new(stats: Arc<SizePoolStats>) -> Option<Self> {
-        let page_buffer = stats.try_allocate_page(Self::BUFFERS_PER_PAGE)?;
+    pub fn try_new(stats: &Arc<SizePoolStats>, buffer_count: usize) -> Option<Self> {
+        assert!(
+            buffer_count > 0 && buffer_count <= MAX_BUFFERS_PER_PAGE,
+            "buffer_count must be positive and less than {}, but was {}.",
+            MAX_BUFFERS_PER_PAGE,
+            buffer_count
+        );
+        let page_buffer = stats.try_allocate_page(buffer_count)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
-        let last_buffer = unsafe {
-            page_buffer
-                .as_raw_ptr()
-                .add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size)
-        };
+        let last_buffer = unsafe { page_buffer.as_raw_ptr().add((buffer_count - 1) * stats.buffer_size) };
         let inner = PageInner {
             page_buffer,
+            buffer_count,
             last_buffer,
             acquired_bitmask: Default::default(),
-            stats,
+            stats: stats.clone(),
         };
         Some(Page { inner: Arc::new(inner) })
     }
@@ -64,7 +70,7 @@ impl Page {
     /// If this page has an available buffer, it is marked as in use and returned.
     /// Otherwise, returns [None].
     pub fn try_acquire(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
-        let (index, page_status) = consume(&mut self.inner.acquired_bitmask.lock().unwrap())?;
+        let (index, page_status) = consume(&mut self.inner.acquired_bitmask.lock().unwrap(), self.buffer_count())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
@@ -79,6 +85,11 @@ impl Page {
             pool_page: self.clone(),
             kind,
         })
+    }
+
+    /// The total number of buffers on this page.
+    pub fn buffer_count(&self) -> usize {
+        self.inner.buffer_count
     }
 
     /// Release a buffer back to this page.
@@ -132,7 +143,7 @@ impl Page {
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
         let limiter = super::limiter::MemoryLimiter::new(usize::MAX, Default::default());
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
-        Page::try_new(Arc::new(stats)).expect("allocation should succeed with usize::MAX limit")
+        Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE).expect("allocation should succeed with usize::MAX limit")
     }
 }
 
@@ -142,14 +153,14 @@ const FULL_MASK: u16 = u16::MAX;
 ///
 /// Returns the index of the consumed buffer and the previous status of the page,
 /// or `None` if no buffers are available.
-fn consume(bitmask: &mut u16) -> Option<(usize, PageStatus)> {
+fn consume(bitmask: &mut u16, buffer_count: usize) -> Option<(usize, PageStatus)> {
     if *bitmask != FULL_MASK {
         let page_status = if *bitmask == 0 {
             PageStatus::Empty
         } else {
             PageStatus::NonEmpty
         };
-        for index in 0usize..16 {
+        for index in 0..buffer_count {
             let mask = 1u16 << index;
             if *bitmask & mask == 0 {
                 *bitmask |= mask;
@@ -201,7 +212,7 @@ mod tests {
     fn test_reserve_buffers() {
         let page = Page::new_for_tests(1024);
         let mut buffers = Vec::new();
-        for _ in 0..Page::BUFFERS_PER_PAGE {
+        for _ in 0..page.buffer_count() {
             let buffer_ptr = page
                 .try_acquire(BufferKind::Other)
                 .expect("reserving up to 16 buffers from a new page should succeed");

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -1,7 +1,6 @@
-use crate::sync::{Arc, Mutex, Weak};
+use crate::sync::{Arc, Mutex};
 
 use super::buffers::BufferPtr;
-use super::pool::PagedPoolInner;
 use super::stats::{BufferKind, SizePoolStats};
 
 /// Page in a size pool.
@@ -28,8 +27,6 @@ struct PageInner {
     acquired_bitmask: Mutex<u16>,
     /// Shared stats across pages with common `buffer_size`.
     stats: Arc<SizePoolStats>,
-    /// Weak reference back to the pool so buffer drops can wake pending allocations.
-    pool: Weak<PagedPoolInner>,
 }
 
 // SAFETY: access to mutable state in `PageInner` is synchonized internally.
@@ -48,7 +45,7 @@ impl Page {
     pub const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
 
     /// Create a new page and allocate the required memory.
-    pub fn try_new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>, forced: bool) -> Option<Self> {
+    pub fn try_new(stats: Arc<SizePoolStats>, forced: bool) -> Option<Self> {
         let ptr = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
@@ -58,7 +55,6 @@ impl Page {
             last_buffer,
             acquired_bitmask: Default::default(),
             stats,
-            pool,
         };
         Some(Page { inner: Arc::new(inner) })
     }
@@ -99,18 +95,12 @@ impl Page {
         let mut bitmask = self.inner.acquired_bitmask.lock().unwrap();
         *bitmask &= mask;
 
-        self.inner.stats.release_buffer(kind);
         if *bitmask == 0 {
             self.inner.stats.add_empty_page();
         }
-        // Release the bitmask lock before waking pending allocations.
-        // try_wake_pending may try to allocate from this same page which would deadlock
-        // if we held the bitmask lock.
         drop(bitmask);
-        // A primary buffer was freed — wake any pending allocation requests.
-        if let Some(pool) = self.inner.pool.upgrade() {
-            pool.try_wake_pending();
-        }
+
+        self.inner.stats.release_buffer(kind);
     }
 
     /// Invalidate this page if it is empty, i.e. none of its buffers are in use,
@@ -140,9 +130,9 @@ impl Page {
 
     #[cfg(test)]
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
-        let limiter = super::limiter::MemoryLimiter::new(u64::MAX);
+        let limiter = super::limiter::MemoryLimiter::new(u64::MAX, Default::default());
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
-        Page::try_new(Arc::new(stats), Weak::new(), true).unwrap()
+        Page::try_new(Arc::new(stats), true).unwrap()
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -46,6 +46,7 @@ impl Drop for PageInner {
         unsafe {
             alloc::dealloc(self.bytes, self.layout);
         }
+        self.stats.deallocate_page(Page::BUFFERS_PER_PAGE);
     }
 }
 
@@ -64,6 +65,7 @@ impl Page {
         }
 
         metrics::gauge!("pool.allocated_pages", "size" => format!("{}", stats.buffer_size)).increment(1.0);
+        stats.allocate_page(Self::BUFFERS_PER_PAGE);
         stats.add_empty_page();
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
@@ -134,14 +136,16 @@ impl Page {
     /// Returns whether the page was invalidated. If `true` the page is ready to be
     /// removed from the pool.
     pub fn invalidate_if_empty(&self) -> bool {
-        let mut bitmask = self.inner.reserved_bitmask.lock().unwrap();
-        if *bitmask != 0 {
-            return false;
+        {
+            let mut bitmask = self.inner.reserved_bitmask.lock().unwrap();
+            if *bitmask != 0 {
+                return false;
+            }
+            // Mark the page as full, even though no buffer is currently reserved. If a new request
+            // arrives before the page is removed from the pool, it will be denied.
+            *bitmask = FULL_MASK;
         }
         self.inner.stats.remove_empty_page();
-        // Mark the page as full, even though no buffer is currently reserved. If a new request
-        // arrives before the page is removed from the pool, it will be denied.
-        *bitmask = FULL_MASK;
         true
     }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -1,6 +1,6 @@
 use crate::sync::{Arc, Mutex};
 
-use super::buffers::BufferPtr;
+use super::buffers::ManagedBuffer;
 use super::stats::{BufferKind, SizePoolStats};
 
 /// Page in a size pool.
@@ -15,7 +15,7 @@ pub struct Page {
 #[derive(Debug)]
 struct PageInner {
     /// Pointer to the memory for this page.
-    ptr: BufferPtr,
+    ptr: ManagedBuffer,
     /// Pointer to the last buffer in the page.
     ///
     /// Equals to (BUFFERS_PER_PAGE - 1) * buffer_size. Stored for easy
@@ -34,12 +34,6 @@ unsafe impl Send for PageInner {}
 
 // SAFETY: access to mutable state in `PageInner` is synchonized internally.
 unsafe impl Sync for PageInner {}
-
-impl Drop for PageInner {
-    fn drop(&mut self) {
-        self.stats.deallocate_page(&mut self.ptr);
-    }
-}
 
 impl Page {
     pub const BUFFERS_PER_PAGE: usize = u16::BITS as usize;

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -141,7 +141,7 @@ impl Page {
 
     #[cfg(test)]
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
-        let limiter = super::limiter::MemoryLimiter::new(usize::MAX, Default::default());
+        let limiter = super::limiter::MemoryLimiter::new(usize::MAX);
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
         Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE).expect("allocation should succeed with usize::MAX limit")
     }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -26,7 +26,7 @@ struct PageInner {
     /// Track the indices of the buffers in use.
     ///
     /// The size in bits needs to be enough to contain [BUFFERS_PER_PAGE](Page::BUFFERS_PER_PAGE).
-    reserved_bitmask: Mutex<u16>,
+    acquired_bitmask: Mutex<u16>,
     layout: Layout,
     /// Shared stats across pages with common `buffer_size`.
     stats: Arc<SizePoolStats>,
@@ -73,7 +73,7 @@ impl Page {
         let inner = PageInner {
             bytes,
             last_buffer,
-            reserved_bitmask: Default::default(),
+            acquired_bitmask: Default::default(),
             layout,
             stats,
             pool,
@@ -81,17 +81,18 @@ impl Page {
         Page { inner: Arc::new(inner) }
     }
 
-    /// Try to reserve a buffer from this page.
+    /// Try to acquire a buffer from this page.
     ///
-    /// Returns [None] if the page is already full.
-    pub fn try_reserve(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
-        let (index, page_status) = consume(&mut self.inner.reserved_bitmask.lock().unwrap())?;
+    /// If this page has an available buffer, it is marked as in use and returned.
+    /// Otherwise, returns [None].
+    pub fn try_acquire(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
+        let (index, page_status) = consume(&mut self.inner.acquired_bitmask.lock().unwrap())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
             self.inner.stats.remove_empty_page();
         };
 
-        self.inner.stats.add_reserved_buffer(kind);
+        self.inner.stats.acquire_buffer(kind);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
         let ptr = unsafe { self.inner.bytes.add(offset) };
@@ -113,10 +114,10 @@ impl Page {
         let offset = unsafe { ptr.offset_from(self.inner.bytes) };
         let index = offset as usize / self.inner.stats.buffer_size;
         let mask = !(1u16 << index);
-        let mut bitmask = self.inner.reserved_bitmask.lock().unwrap();
+        let mut bitmask = self.inner.acquired_bitmask.lock().unwrap();
         *bitmask &= mask;
 
-        self.inner.stats.remove_reserved_buffer(kind);
+        self.inner.stats.release_buffer(kind);
         if *bitmask == 0 {
             self.inner.stats.add_empty_page();
         }
@@ -130,14 +131,14 @@ impl Page {
         }
     }
 
-    /// Invalidate this page if it is empty, i.e. none of its buffers are reserved,
+    /// Invalidate this page if it is empty, i.e. none of its buffers are in use,
     /// preventing any further use.
     ///
     /// Returns whether the page was invalidated. If `true` the page is ready to be
     /// removed from the pool.
     pub fn invalidate_if_empty(&self) -> bool {
         {
-            let mut bitmask = self.inner.reserved_bitmask.lock().unwrap();
+            let mut bitmask = self.inner.acquired_bitmask.lock().unwrap();
             if *bitmask != 0 {
                 return false;
             }
@@ -151,7 +152,7 @@ impl Page {
 
     #[cfg(test)]
     fn is_empty(&self) -> bool {
-        let bitmask = self.inner.reserved_bitmask.lock().unwrap();
+        let bitmask = self.inner.acquired_bitmask.lock().unwrap();
         *bitmask == 0
     }
 
@@ -230,24 +231,24 @@ mod tests {
         let mut buffers = Vec::new();
         for _ in 0..Page::BUFFERS_PER_PAGE {
             let buffer_ptr = page
-                .try_reserve(BufferKind::Other)
+                .try_acquire(BufferKind::Other)
                 .expect("reserving up to 16 buffers from a new page should succeed");
             buffers.push(buffer_ptr);
         }
 
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_acquire(BufferKind::Other).is_none(),
             "reserving the 17th buffer from a page should return None"
         );
 
         _ = buffers.pop().expect("drop one of the reserved buffers");
 
         buffers.push(
-            page.try_reserve(BufferKind::Other)
+            page.try_acquire(BufferKind::Other)
                 .expect("reserving after dropping 1 buffer should succeed"),
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_acquire(BufferKind::Other).is_none(),
             "reserving when all 16 buffers are in use should return None"
         );
 
@@ -263,7 +264,7 @@ mod tests {
             "invalidation of a new, empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_acquire(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }
@@ -272,7 +273,7 @@ mod tests {
     fn test_invalidate_in_use() {
         let page = Page::new_for_tests(1024);
         let buffer_ptr = page
-            .try_reserve(BufferKind::Other)
+            .try_acquire(BufferKind::Other)
             .expect("reserving from a new page should succeed");
         assert!(!page.invalidate_if_empty(), "invalidation of a page in use should fail");
         drop(buffer_ptr);
@@ -281,7 +282,7 @@ mod tests {
             "invalidation of an empty page should succeed"
         );
         assert!(
-            page.try_reserve(BufferKind::Other).is_none(),
+            page.try_acquire(BufferKind::Other).is_none(),
             "reserving from an invalidated page should return None"
         );
     }

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -1,7 +1,6 @@
-use std::alloc::Layout;
-
 use crate::sync::{Arc, Mutex, Weak};
 
+use super::buffers::BufferPtr;
 use super::pool::PagedPoolInner;
 use super::stats::{BufferKind, SizePoolStats};
 
@@ -17,9 +16,7 @@ pub struct Page {
 #[derive(Debug)]
 struct PageInner {
     /// Pointer to the memory for this page.
-    bytes: *mut u8,
-    /// Memory layout.
-    layout: Layout,
+    ptr: BufferPtr,
     /// Pointer to the last buffer in the page.
     ///
     /// Equals to (BUFFERS_PER_PAGE - 1) * buffer_size. Stored for easy
@@ -43,7 +40,7 @@ unsafe impl Sync for PageInner {}
 
 impl Drop for PageInner {
     fn drop(&mut self) {
-        self.stats.deallocate_page(self.bytes, self.layout);
+        self.stats.deallocate_page(&mut self.ptr);
     }
 }
 
@@ -52,15 +49,14 @@ impl Page {
 
     /// Create a new page and allocate the required memory.
     pub fn try_new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>, forced: bool) -> Option<Self> {
-        let (bytes, layout) = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
+        let ptr = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
-        let last_buffer = unsafe { bytes.add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };
+        let last_buffer = unsafe { ptr.as_raw_ptr().add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };
         let inner = PageInner {
-            bytes,
+            ptr,
             last_buffer,
             acquired_bitmask: Default::default(),
-            layout,
             stats,
             pool,
         };
@@ -81,7 +77,7 @@ impl Page {
         self.inner.stats.acquire_buffer(kind);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
-        let ptr = unsafe { self.inner.bytes.add(offset) };
+        let ptr = unsafe { self.inner.ptr.as_raw_ptr().add(offset) };
         Some(PagedBufferPtr {
             ptr,
             pool_page: self.clone(),
@@ -92,12 +88,12 @@ impl Page {
     /// Release a buffer back to this page.
     fn release(&self, ptr: *mut u8, kind: BufferKind) {
         assert!(
-            ptr >= self.inner.bytes && ptr <= self.inner.last_buffer,
+            ptr >= self.inner.ptr.as_raw_ptr() && ptr <= self.inner.last_buffer,
             "the pointer does not belong to this page"
         );
 
-        // SAFETY: ptr points to the same allocated object as self.inner.bytes.
-        let offset = unsafe { ptr.offset_from(self.inner.bytes) };
+        // SAFETY: ptr points to the same allocated object as self.inner.ptr.
+        let offset = unsafe { ptr.offset_from(self.inner.ptr.as_raw_ptr()) };
         let index = offset as usize / self.inner.stats.buffer_size;
         let mask = !(1u16 << index);
         let mut bitmask = self.inner.acquired_bitmask.lock().unwrap();

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -1,4 +1,4 @@
-use std::alloc::{self, Layout};
+use std::alloc::Layout;
 
 use crate::sync::{Arc, Mutex, Weak};
 
@@ -18,6 +18,8 @@ pub struct Page {
 struct PageInner {
     /// Pointer to the memory for this page.
     bytes: *mut u8,
+    /// Memory layout.
+    layout: Layout,
     /// Pointer to the last buffer in the page.
     ///
     /// Equals to (BUFFERS_PER_PAGE - 1) * buffer_size. Stored for easy
@@ -27,7 +29,6 @@ struct PageInner {
     ///
     /// The size in bits needs to be enough to contain [BUFFERS_PER_PAGE](Page::BUFFERS_PER_PAGE).
     acquired_bitmask: Mutex<u16>,
-    layout: Layout,
     /// Shared stats across pages with common `buffer_size`.
     stats: Arc<SizePoolStats>,
     /// Weak reference back to the pool so buffer drops can wake pending allocations.
@@ -42,11 +43,7 @@ unsafe impl Sync for PageInner {}
 
 impl Drop for PageInner {
     fn drop(&mut self) {
-        // SAFETY: `self.bytes` was allocated using `self.layout` in `Page::new`.
-        unsafe {
-            alloc::dealloc(self.bytes, self.layout);
-        }
-        self.stats.deallocate_page(Page::BUFFERS_PER_PAGE);
+        self.stats.deallocate_page(self.bytes, self.layout);
     }
 }
 
@@ -55,18 +52,7 @@ impl Page {
 
     /// Create a new page and allocate the required memory.
     pub fn new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>) -> Self {
-        assert_ne!(stats.buffer_size, 0);
-        let layout = Layout::array::<[u8; Self::BUFFERS_PER_PAGE]>(stats.buffer_size).unwrap();
-
-        // SAFETY: layout has non-zero size.
-        let bytes = unsafe { alloc::alloc(layout) };
-        if bytes.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
-
-        metrics::gauge!("pool.allocated_pages", "size" => format!("{}", stats.buffer_size)).increment(1.0);
-        stats.allocate_page(Self::BUFFERS_PER_PAGE);
-        stats.add_empty_page();
+        let (bytes, layout) = stats.allocate_page(Self::BUFFERS_PER_PAGE);
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
         let last_buffer = unsafe { bytes.add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -39,8 +39,10 @@ impl Page {
     pub const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
 
     /// Create a new page and allocate the required memory.
-    pub fn try_new(stats: Arc<SizePoolStats>, forced: bool) -> Option<Self> {
-        let page_buffer = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
+    ///
+    /// Returns `None` if the allocation would hit the memory limit.
+    pub fn try_new(stats: Arc<SizePoolStats>) -> Option<Self> {
+        let page_buffer = stats.try_allocate_page(Self::BUFFERS_PER_PAGE)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
         let last_buffer = unsafe {
@@ -130,7 +132,7 @@ impl Page {
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
         let limiter = super::limiter::MemoryLimiter::new(usize::MAX, Default::default());
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
-        Page::try_new(Arc::new(stats), true).unwrap()
+        Page::try_new(Arc::new(stats)).expect("allocation should succeed with usize::MAX limit")
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -14,8 +14,8 @@ pub struct Page {
 
 #[derive(Debug)]
 struct PageInner {
-    /// Pointer to the memory for this page.
-    ptr: ManagedBuffer,
+    /// Memory buffer for the whole page.
+    page_buffer: ManagedBuffer,
     /// Pointer to the last buffer in the page.
     ///
     /// Equals to (BUFFERS_PER_PAGE - 1) * buffer_size. Stored for easy
@@ -40,12 +40,16 @@ impl Page {
 
     /// Create a new page and allocate the required memory.
     pub fn try_new(stats: Arc<SizePoolStats>, forced: bool) -> Option<Self> {
-        let ptr = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
+        let page_buffer = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
-        let last_buffer = unsafe { ptr.as_raw_ptr().add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };
+        let last_buffer = unsafe {
+            page_buffer
+                .as_raw_ptr()
+                .add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size)
+        };
         let inner = PageInner {
-            ptr,
+            page_buffer,
             last_buffer,
             acquired_bitmask: Default::default(),
             stats,
@@ -67,7 +71,7 @@ impl Page {
         self.inner.stats.acquire_buffer(kind);
 
         // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
-        let ptr = unsafe { self.inner.ptr.as_raw_ptr().add(offset) };
+        let ptr = unsafe { self.inner.page_buffer.as_raw_ptr().add(offset) };
         Some(PagedBufferPtr {
             ptr,
             pool_page: self.clone(),
@@ -78,12 +82,12 @@ impl Page {
     /// Release a buffer back to this page.
     fn release(&self, ptr: *mut u8, kind: BufferKind) {
         assert!(
-            ptr >= self.inner.ptr.as_raw_ptr() && ptr <= self.inner.last_buffer,
+            ptr >= self.inner.page_buffer.as_raw_ptr() && ptr <= self.inner.last_buffer,
             "the pointer does not belong to this page"
         );
 
         // SAFETY: ptr points to the same allocated object as self.inner.ptr.
-        let offset = unsafe { ptr.offset_from(self.inner.ptr.as_raw_ptr()) };
+        let offset = unsafe { ptr.offset_from(self.inner.page_buffer.as_raw_ptr()) };
         let index = offset as usize / self.inner.stats.buffer_size;
         let mask = !(1u16 << index);
         let mut bitmask = self.inner.acquired_bitmask.lock().unwrap();

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -48,11 +48,11 @@ impl Drop for PageInner {
 }
 
 impl Page {
-    const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
+    pub const BUFFERS_PER_PAGE: usize = u16::BITS as usize;
 
     /// Create a new page and allocate the required memory.
-    pub fn new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>) -> Self {
-        let (bytes, layout) = stats.allocate_page(Self::BUFFERS_PER_PAGE);
+    pub fn try_new(stats: Arc<SizePoolStats>, pool: Weak<PagedPoolInner>, forced: bool) -> Option<Self> {
+        let (bytes, layout) = stats.try_allocate_page(Self::BUFFERS_PER_PAGE, forced)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
         let last_buffer = unsafe { bytes.add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };
@@ -64,7 +64,7 @@ impl Page {
             stats,
             pool,
         };
-        Page { inner: Arc::new(inner) }
+        Some(Page { inner: Arc::new(inner) })
     }
 
     /// Try to acquire a buffer from this page.
@@ -144,9 +144,9 @@ impl Page {
 
     #[cfg(test)]
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
-        let pool_stats = super::stats::PoolStats::default();
-        let stats = SizePoolStats::new(buffer_size, Arc::new(pool_stats));
-        Page::new(Arc::new(stats), Weak::new())
+        let limiter = super::limiter::MemoryLimiter::new(u64::MAX);
+        let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
+        Page::try_new(Arc::new(stats), Weak::new(), true).unwrap()
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -128,7 +128,7 @@ impl Page {
 
     #[cfg(test)]
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
-        let limiter = super::limiter::MemoryLimiter::new(u64::MAX, Default::default());
+        let limiter = super::limiter::MemoryLimiter::new(usize::MAX, Default::default());
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
         Page::try_new(Arc::new(stats), true).unwrap()
     }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -114,12 +114,12 @@ impl PagedPool {
 
     /// Return the memory in use in bytes for the given kind of buffer.
     pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
-        self.inner.limiter.stats().acquired_bytes(kind)
+        self.inner.limiter.acquired_bytes(kind)
     }
 
     /// Return the total memory in use in bytes across all buffer kinds.
     pub fn total_acquired_bytes(&self) -> usize {
-        self.inner.limiter.stats().total_acquired_bytes()
+        self.inner.limiter.total_acquired_bytes()
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::{Arc, RwLock, Weak};
+use crate::sync::{Arc, RwLock, thread};
+use crate::util::wake_signal::WakeSignal;
 
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
@@ -60,11 +61,6 @@ pub struct PagedPool {
 }
 
 impl PagedPool {
-    /// Creates a [PagedPool] from an [Arc<PagedPoolInner>]. Used by buffer drop impls.
-    pub(super) fn from_inner(inner: Arc<PagedPoolInner>) -> Self {
-        Self { inner }
-    }
-
     /// Configuration for a [PagedPool].
     pub fn config() -> PagedPoolConfig {
         Default::default()
@@ -72,7 +68,9 @@ impl PagedPool {
 
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
-        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit()));
+        let wake_signal = Arc::new(WakeSignal::new());
+
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), wake_signal.clone()));
 
         let ordered_size_pools = config
             .ordered_sizes()
@@ -83,21 +81,28 @@ impl PagedPool {
             })
             .collect();
 
-        let inner = PagedPoolInner {
+        let inner = Arc::new(PagedPoolInner {
             ordered_size_pools,
             limiter,
             allocation_queue: AllocationQueue::new(),
-        };
-        Self { inner: Arc::new(inner) }
+        });
+
+        let weak = Arc::downgrade(&inner);
+        thread::spawn(move || {
+            loop {
+                wake_signal.wait_timeout(Duration::from_secs(1));
+                if let Some(pool) = weak.upgrade() {
+                    pool.try_wake_pending();
+                }
+            }
+        });
+
+        Self { inner }
     }
 
     /// Trim empty pages in the pool.
     pub fn trim(&self) -> bool {
-        let trimmed = self.inner.trim();
-        if trimmed {
-            self.try_wake_pending();
-        }
-        trimmed
+        self.inner.trim()
     }
 
     /// Spawn the background pool maintenance thread. Must be called once after
@@ -137,39 +142,12 @@ impl PagedPool {
         kind: BufferKind,
         cursor_id: Option<CursorId>,
     ) -> PoolBufferMut {
-        let buffer = self.acquire_buffer_async(capacity, kind, cursor_id).await;
+        let buffer = self.inner.get_buffer_async(capacity, kind, cursor_id).await;
         PoolBufferMut::new(buffer)
     }
 
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
-        self.try_get_buffer(size, kind, cursor_id, true).unwrap()
-    }
-
-    fn try_get_buffer(
-        &self,
-        size: usize,
-        kind: BufferKind,
-        cursor_id: Option<CursorId>,
-        forced: bool,
-    ) -> Option<PoolBuffer> {
-        let buffer = match self.inner.get_pool_for_size(size) {
-            Some(pool) => {
-                let buffer_ptr = pool.try_acquire(kind, self, forced)?;
-                metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
-                    .record(size as f64);
-                metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
-                    .record((pool.buffer_size() - size) as f64);
-
-                PoolBuffer::new_primary(buffer_ptr, size)
-            }
-            None => {
-                metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
-                    .record(size as f64);
-                PoolBuffer::try_new_secondary(size, kind, self.inner.limiter.clone(), self.weak_ref(), forced)?
-            }
-        };
-        self.inner.limiter.on_pool_acquire(size, cursor_id);
-        Some(buffer)
+        self.inner.try_get_buffer(size, kind, cursor_id, true).unwrap()
     }
 
     #[cfg(test)]
@@ -226,61 +204,6 @@ impl PagedPool {
         self.inner.limiter.available_mem()
     }
 
-    /// Attempt to fulfill pending allocation requests from the queue.
-    ///
-    /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
-    /// Loops until no more entries can be fulfilled or the queue is empty.
-    pub(super) fn try_wake_pending(&self) {
-        self.inner.try_wake_pending();
-    }
-
-    /// Async buffer allocation through the priority queue.
-    ///
-    /// **Fast path:** if the queue is empty and memory is available, allocates and returns immediately.
-    ///
-    /// **Slow path:** pushes the request into the allocation queue and awaits a buffer.
-    /// Priority is determined from the cursor's active-read state:
-    /// - cursor with an active FUSE read → high priority
-    /// - cursor without an active read (speculative prefetch) → low priority
-    /// - no cursor (upload) → high priority (write syscall is blocked)
-    pub(super) async fn acquire_buffer_async(
-        &self,
-        size: usize,
-        kind: BufferKind,
-        cursor_id: Option<CursorId>,
-    ) -> PoolBuffer {
-        // Fast path: if the queue is empty, try to allocate immediately. The check-and-allocate in
-        // `try_allocate` uses CAS on `pending_allocations`, so concurrent fast-path callers cannot both
-        // observe room for the same bytes and overshoot the limit.
-        if !self.inner.is_memory_pressure()
-            && let Some(buffer) = self.try_get_buffer(size, kind, cursor_id, false)
-        {
-            return buffer;
-        }
-
-        // Determine priority: a cursor with an active FUSE read is High (urgent),
-        // speculative prefetch (cursor with no active read) is Low.
-        // Uploads (no cursor) are always High — a write syscall is blocked.
-        // NOTE: We check if the cursor has an active read, not if this allocation serves it.
-        let rx = match cursor_id {
-            Some(id) if self.inner.limiter.has_active_read(id) => {
-                self.inner.allocation_queue.push_high(cursor_id, size, kind)
-            }
-            Some(id) => self.inner.allocation_queue.push_low(id, size, kind),
-            None => self.inner.allocation_queue.push_high(None, size, kind), // uploads are urgent
-        };
-        // After pushing, try to wake immediately in case memory freed between the fast-path
-        // check above and the push (avoids the race where a buffer drop called try_wake_pending
-        // before the entry was in the queue).
-        self.try_wake_pending();
-        // Nudge the maintenance thread: it may be parked on its long idle interval, in which
-        // case it would otherwise sleep up to that interval before noticing the new waiter.
-        self.inner.limiter.trigger_pruning();
-        // Await the buffer from the queue. Err(Canceled) can only happen during pool shutdown.
-        // TODO(memory-limiter): signal error to CRT via aws_future_s3_buffer_ticket_set_error.
-        rx.await.unwrap_or_else(|_| self.get_buffer(size, kind, cursor_id))
-    }
-
     /// Check if the given cursor has an active read overlapping the specified range.
     pub fn has_active_read_in_range(&self, cursor_id: CursorId, offset: u64, size: usize) -> bool {
         self.inner.limiter.has_active_read_in_range(cursor_id, offset, size)
@@ -296,10 +219,6 @@ impl PagedPool {
 
     pub(super) fn limiter(&self) -> &MemoryLimiter {
         &self.inner.limiter
-    }
-
-    pub(super) fn weak_ref(&self) -> Weak<PagedPoolInner> {
-        Arc::downgrade(&self.inner)
     }
 }
 
@@ -317,7 +236,7 @@ impl MemoryPool for PagedPool {
     async fn get_buffer_async(&self, size: usize, meta_request: &MetaRequest) -> Self::Buffer {
         let kind = meta_request.meta_request_type().into();
         let cursor_id = meta_request.custom_id().map(CursorId::new_from_raw);
-        self.acquire_buffer_async(size, kind, cursor_id).await
+        self.inner.get_buffer_async(size, kind, cursor_id).await
     }
 
     fn trim(&self) -> bool {
@@ -362,6 +281,72 @@ impl PagedPoolInner {
         Some(&self.ordered_size_pools[index])
     }
 
+    /// Get a buffer asynchronously through the priority queue.
+    ///
+    /// **Fast path:** if the queue is empty and memory is available, acquire the buffer and returns immediately.
+    ///
+    /// **Slow path:** pushes the request into the allocation queue and awaits a buffer.
+    /// Priority is determined from the cursor's active-read state:
+    /// - cursor with an active FUSE read → high priority
+    /// - cursor without an active read (speculative prefetch) → low priority
+    /// - no cursor (upload) → high priority (write syscall is blocked)
+    async fn get_buffer_async(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
+        // Fast path: if the queue is empty, try to acquire immediately.
+        if !self.allocation_queue.has_pending()
+            && let Some(buffer) = self.try_get_buffer(size, kind, cursor_id, false)
+        {
+            return buffer;
+        }
+
+        // Determine priority: a cursor with an active FUSE read is High (urgent),
+        // speculative prefetch (cursor with no active read) is Low.
+        // Uploads (no cursor) are always High — a write syscall is blocked.
+        // NOTE: We check if the cursor has an active read, not if this allocation serves it.
+        let rx = match cursor_id {
+            Some(id) if self.limiter.has_active_read(id) => self.allocation_queue.push_high(cursor_id, size, kind),
+            Some(id) => self.allocation_queue.push_low(id, size, kind),
+            None => self.allocation_queue.push_high(None, size, kind), // uploads are urgent
+        };
+        // After pushing, try to wake immediately in case memory freed between the fast-path
+        // check above and the push (avoids the race where a buffer drop called try_wake_pending
+        // before the entry was in the queue).
+        self.limiter.trigger_wake_pending();
+        // Nudge the maintenance thread: it may be parked on its long idle interval, in which
+        // case it would otherwise sleep up to that interval before noticing the new waiter.
+        self.limiter.trigger_pruning();
+        // Await the buffer from the queue. Err(Canceled) can only happen during pool shutdown.
+        // TODO(memory-limiter): signal error to CRT via aws_future_s3_buffer_ticket_set_error.
+        rx.await
+            .unwrap_or_else(|_| self.try_get_buffer(size, kind, cursor_id, true).unwrap())
+    }
+
+    pub(super) fn try_get_buffer(
+        &self,
+        size: usize,
+        kind: BufferKind,
+        cursor_id: Option<CursorId>,
+        forced: bool,
+    ) -> Option<PoolBuffer> {
+        let buffer = match self.get_pool_for_size(size) {
+            Some(pool) => {
+                let buffer_ptr = pool.try_acquire(kind, forced)?;
+                metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
+                    .record(size as f64);
+                metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
+                    .record((pool.buffer_size() - size) as f64);
+
+                PoolBuffer::new_primary(buffer_ptr, size)
+            }
+            None => {
+                metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
+                    .record(size as f64);
+                PoolBuffer::try_new_secondary(size, kind, self.limiter.clone(), forced)?
+            }
+        };
+        self.limiter.on_pool_acquire(size, cursor_id);
+        Some(buffer)
+    }
+
     pub(super) fn trim(&self) -> bool {
         let mut removed = false;
         for pool in &self.ordered_size_pools {
@@ -387,33 +372,34 @@ impl PagedPoolInner {
                 .record(pages_freed as f64);
         }
 
+        self.limiter.trigger_wake_pending();
+
         removed
     }
 
-    pub(super) fn try_wake_pending(self: &Arc<Self>) {
+    /// Attempt to fulfill pending allocation requests from the queue.
+    ///
+    /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
+    /// Loops until no more entries can be fulfilled or the queue is empty.
+    fn try_wake_pending(self: &Arc<Self>) {
         if !self.is_memory_pressure() {
             return;
         }
-        let pool = PagedPool::from_inner(self.clone());
-        let mut undelivered = Vec::new();
 
         loop {
             let mut buffer = None;
             let entry = self.allocation_queue.pop_front_if(|pending| {
-                buffer = pool.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false);
+                buffer = self.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false);
                 buffer.is_some()
             });
             let Some(entry) = entry else { break };
             let Some(buffer) = buffer else { break };
 
             if let Err(buffer) = entry.fulfill(buffer) {
-                undelivered.push(buffer);
+                // We couldn't deliver the buffer, just drop it and continue.
+                drop(buffer);
             }
         }
-        // TODO(memory-limiter): these buffers should be dropped immediately so the freed memory
-        // can serve the next waiter, but dropping them here would recursively call try_wake_pending
-        // (since buffer drop triggers the wake). Decouple by running try_wake_pending concurrently.
-        drop(undelivered);
     }
 }
 
@@ -424,7 +410,7 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn try_acquire(&self, kind: BufferKind, pool: &PagedPool, forced: bool) -> Option<PagedBufferPtr> {
+    fn try_acquire(&self, kind: BufferKind, forced: bool) -> Option<PagedBufferPtr> {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
@@ -443,7 +429,7 @@ impl SizePool {
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
-        let page = Page::try_new(self.stats.clone(), pool.weak_ref(), forced)?;
+        let page = Page::try_new(self.stats.clone(), forced)?;
         let buffer_ptr = page.try_acquire(kind).unwrap();
         write_pages.push(page);
         Some(buffer_ptr)
@@ -690,7 +676,7 @@ mod tests {
         #[test]
         fn test_fast_path_when_room_available() {
             let pool = tight_pool(1024);
-            let buffer = block_on(pool.acquire_buffer_async(256, BufferKind::GetObject, None));
+            let buffer = block_on(pool.inner.get_buffer_async(256, BufferKind::GetObject, None));
             assert!(buffer.capacity() >= 256);
         }
 
@@ -701,14 +687,15 @@ mod tests {
 
             // Fill all available memory.
             let mut blockers = Vec::new();
-            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                 blockers.push(buffer);
             }
 
             // Spawn a request — it should enqueue since there's no room.
             let pool_clone = pool.clone();
-            let _handle =
-                std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+            let _handle = std::thread::spawn(move || {
+                block_on(pool_clone.inner.get_buffer_async(BUF, BufferKind::GetObject, None))
+            });
 
             // Wait for the request to enter the queue (retry for up to 100ms).
             for _ in 0..100 {
@@ -732,12 +719,13 @@ mod tests {
 
             // Fill memory and enqueue a waiter.
             let mut blockers = Vec::new();
-            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                 blockers.push(buffer);
             }
             let pool_clone = pool.clone();
-            let _handle =
-                std::thread::spawn(move || block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None)));
+            let _handle = std::thread::spawn(move || {
+                block_on(pool_clone.inner.get_buffer_async(BUF, BufferKind::GetObject, None))
+            });
             for _ in 0..100 {
                 if pool.inner.is_memory_pressure() {
                     break;
@@ -763,14 +751,14 @@ mod tests {
             let pool = tight_pool(BUF);
 
             let mut blockers = Vec::new();
-            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                 blockers.push(buffer);
             }
 
             let (tx, rx) = std::sync::mpsc::channel();
             let pool_clone = pool.clone();
             std::thread::spawn(move || {
-                let buffer = block_on(pool_clone.acquire_buffer_async(BUF, BufferKind::GetObject, None));
+                let buffer = block_on(pool_clone.inner.get_buffer_async(BUF, BufferKind::GetObject, None));
                 let _ = tx.send(buffer);
             });
 
@@ -794,7 +782,7 @@ mod tests {
 
             // Fill all memory.
             let mut blockers = Vec::new();
-            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                 blockers.push(buffer);
             }
 
@@ -838,7 +826,7 @@ mod tests {
 
             // Fill all memory.
             let mut blockers = Vec::new();
-            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                 blockers.push(buffer);
             }
 
@@ -849,7 +837,11 @@ mod tests {
             let (tx, rx) = std::sync::mpsc::channel();
             let pool1 = pool.clone();
             std::thread::spawn(move || {
-                let buf = block_on(pool1.acquire_buffer_async(BUF, BufferKind::GetObject, Some(cursor_id)));
+                let buf = block_on(
+                    pool1
+                        .inner
+                        .get_buffer_async(BUF, BufferKind::GetObject, Some(cursor_id)),
+                );
                 let _ = tx.send(buf);
             });
             // Wait for it to enter the queue as low priority.
@@ -892,7 +884,7 @@ mod tests {
 
                 // Fill memory leaving exactly one free buffer slot.
                 let mut blockers = Vec::new();
-                while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Other, None, false) {
                     blockers.push(buffer);
                 }
                 let budget_buffers = blockers.len();
@@ -906,7 +898,7 @@ mod tests {
                             let pool = pool.clone();
                             let barrier = barrier.clone();
                             scope.spawn(move || {
-                                let mut fut = Box::pin(pool.acquire_buffer_async(BUF, BufferKind::GetObject, None));
+                                let mut fut = Box::pin(pool.inner.get_buffer_async(BUF, BufferKind::GetObject, None));
                                 // Release all racers into the fast path at once for maximum contention.
                                 barrier.wait();
                                 let waker = futures::task::noop_waker();

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -68,9 +68,9 @@ impl PagedPool {
 
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
-        let wake_signal = Arc::new(WakeSignal::new());
+        let pending_signal = Arc::new(WakeSignal::new());
 
-        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), wake_signal.clone()));
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), pending_signal.clone()));
 
         let ordered_size_pools = config
             .ordered_sizes()
@@ -88,14 +88,18 @@ impl PagedPool {
         });
 
         let weak = Arc::downgrade(&inner);
-        thread::spawn(move || {
-            loop {
-                wake_signal.wait_timeout(Duration::from_secs(1));
-                if let Some(pool) = weak.upgrade() {
+        thread::Builder::new()
+            .name("mem-pool-pending".to_string())
+            .spawn(move || {
+                loop {
+                    pending_signal.wait_timeout(Duration::from_secs(1));
+                    let Some(pool) = weak.upgrade() else {
+                        break;
+                    };
                     pool.process_pending();
                 }
-            }
-        });
+            })
+            .expect("failed to spawn pool process pending thread");
 
         Self { inner }
     }
@@ -147,7 +151,9 @@ impl PagedPool {
     }
 
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
-        self.inner.try_get_buffer(size, kind, cursor_id, true).unwrap()
+        self.inner
+            .try_get_buffer(size, kind, cursor_id, true)
+            .expect("forced allocations cannot fail")
     }
 
     #[cfg(test)]
@@ -316,8 +322,10 @@ impl PagedPoolInner {
         self.limiter.trigger_pruning();
         // Await the buffer from the queue. Err(Canceled) can only happen during pool shutdown.
         // TODO(memory-limiter): signal error to CRT via aws_future_s3_buffer_ticket_set_error.
-        rx.await
-            .unwrap_or_else(|_| self.try_get_buffer(size, kind, cursor_id, true).unwrap())
+        rx.await.unwrap_or_else(|_| {
+            self.try_get_buffer(size, kind, cursor_id, true)
+                .expect("forced allocations cannot fail")
+        })
     }
 
     pub(super) fn try_get_buffer(
@@ -692,8 +700,6 @@ mod tests {
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }
             panic!("request did not enter queue within 100ms");
-
-            // TODO(memory-limiter): review test
         }
 
         /// `is_memory_pressure` reflects the queue's emptiness.

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -3,14 +3,13 @@ use std::time::Duration;
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::{Arc, RwLock, Weak};
 
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::limiter::{CursorHandle, MemoryLimiter};
 use super::pages::{Page, PagedBufferPtr};
-use super::stats::{BufferKind, PoolStats, SizePoolStats};
+use super::stats::{BufferKind, SizePoolStats};
 
 pub use super::limiter::MINIMUM_MEM_LIMIT;
 
@@ -73,24 +72,21 @@ impl PagedPool {
 
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
-        let stats = Arc::new(PoolStats::default());
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit()));
+
         let ordered_size_pools = config
             .ordered_sizes()
             .iter()
             .map(|&buffer_size| SizePool {
                 pages: Default::default(),
-                stats: Arc::new(SizePoolStats::new(buffer_size, stats.clone())),
+                stats: Arc::new(SizePoolStats::new(buffer_size, limiter.clone())),
             })
             .collect();
 
-        let limiter = MemoryLimiter::new(config.memory_limit());
-
         let inner = PagedPoolInner {
             ordered_size_pools,
-            stats,
             limiter,
             allocation_queue: AllocationQueue::new(),
-            pending_allocations: AtomicU64::new(0),
         };
         Self { inner: Arc::new(inner) }
     }
@@ -118,12 +114,12 @@ impl PagedPool {
 
     /// Return the memory in use in bytes for the given kind of buffer.
     pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
-        self.inner.stats.acquired_bytes(kind)
+        self.inner.limiter.stats().acquired_bytes(kind)
     }
 
     /// Return the total memory in use in bytes across all buffer kinds.
     pub fn total_acquired_bytes(&self) -> usize {
-        self.inner.stats.total_acquired_bytes()
+        self.inner.limiter.stats().total_acquired_bytes()
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
@@ -146,23 +142,34 @@ impl PagedPool {
     }
 
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
-        match self.inner.get_pool_for_size(size) {
+        self.try_get_buffer(size, kind, cursor_id, true).unwrap()
+    }
+
+    fn try_get_buffer(
+        &self,
+        size: usize,
+        kind: BufferKind,
+        cursor_id: Option<CursorId>,
+        forced: bool,
+    ) -> Option<PoolBuffer> {
+        let buffer = match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.acquire(kind, Arc::downgrade(&self.inner));
+                let buffer_ptr = pool.try_acquire(kind, self, forced)?;
                 metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
                     .record((pool.buffer_size() - size) as f64);
-                self.inner.limiter.on_pool_acquire(pool.buffer_size(), cursor_id);
+
                 PoolBuffer::new_primary(buffer_ptr, size)
             }
             None => {
                 metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                self.inner.limiter.on_pool_acquire(size, cursor_id);
-                PoolBuffer::new_secondary(size, kind, self.inner.stats.clone(), Arc::downgrade(&self.inner))
+                PoolBuffer::try_new_secondary(size, kind, self.inner.limiter.clone(), self.weak_ref(), forced)?
             }
-        }
+        };
+        self.inner.limiter.on_pool_acquire(size, cursor_id);
+        Some(buffer)
     }
 
     #[cfg(test)]
@@ -216,57 +223,7 @@ impl PagedPool {
 
     /// Query available memory.
     pub fn available_mem(&self) -> u64 {
-        self.inner.limiter.available_mem(&self.inner.stats)
-    }
-
-    /// Returns `true` if the pool can accommodate an additional allocation of `size` bytes.
-    #[cfg(test)]
-    fn can_allocate(&self, size: usize) -> bool {
-        let pending = self.inner.pending_allocations.load(Ordering::SeqCst);
-        self.available_mem().saturating_sub(pending) >= size as u64
-    }
-
-    /// Check available memory and, if there is room, atomically claim the bytes and allocate.
-    /// Returns `None` if the pool cannot accommodate `size` bytes.
-    ///
-    /// The limit check uses a compare-and-swap loop on `pending_allocations` — multiple threads
-    /// can claim bytes concurrently without a mutex. The actual allocation (`get_buffer`) runs
-    /// outside the CAS, so `SizePool::reserve` and secondary allocations proceed in parallel.
-    fn try_allocate(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> Option<PoolBuffer> {
-        // Primary buffers round up to buffer_size; use the actual size for accounting.
-        let alloc_size = self
-            .inner
-            .get_pool_for_size(size)
-            .map(|pool| pool.buffer_size())
-            .unwrap_or(size) as u64;
-
-        // Atomically claim `alloc_size` bytes. Re-read pending on each retry because another
-        // thread may have claimed or freed bytes between iterations.
-        let mut pending = self.inner.pending_allocations.load(Ordering::SeqCst);
-        loop {
-            let available = self.available_mem().saturating_sub(pending);
-            if available < alloc_size {
-                return None;
-            }
-            match self.inner.pending_allocations.compare_exchange_weak(
-                pending,
-                pending + alloc_size,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
-                Ok(_) => break,
-                Err(current) => pending = current,
-            }
-        }
-
-        // Bytes claimed — allocate without holding any lock.
-        // SizePool::reserve uses its own RwLock; secondary allocations are independent.
-        let buffer = self.get_buffer(size, kind, cursor_id);
-
-        // Buffer is now tracked by pool stats; release the pending claim.
-        self.inner.pending_allocations.fetch_sub(alloc_size, Ordering::SeqCst);
-
-        Some(buffer)
+        self.inner.limiter.available_mem()
     }
 
     /// Attempt to fulfill pending allocation requests from the queue.
@@ -296,7 +253,7 @@ impl PagedPool {
         // `try_allocate` uses CAS on `pending_allocations`, so concurrent fast-path callers cannot both
         // observe room for the same bytes and overshoot the limit.
         if !self.inner.is_memory_pressure()
-            && let Some(buffer) = self.try_allocate(size, kind, cursor_id)
+            && let Some(buffer) = self.try_get_buffer(size, kind, cursor_id, false)
         {
             return buffer;
         }
@@ -337,12 +294,12 @@ impl PagedPool {
 
     // ─── Internal components exposed to the rest of the `memory` module. ──────────
 
-    pub(super) fn stats(&self) -> &PoolStats {
-        &self.inner.stats
-    }
-
     pub(super) fn limiter(&self) -> &MemoryLimiter {
         &self.inner.limiter
+    }
+
+    pub(super) fn weak_ref(&self) -> Weak<PagedPoolInner> {
+        Arc::downgrade(&self.inner)
     }
 }
 
@@ -371,13 +328,8 @@ impl MemoryPool for PagedPool {
 #[derive(Debug)]
 pub(super) struct PagedPoolInner {
     ordered_size_pools: Vec<SizePool>,
-    stats: Arc<PoolStats>,
-    limiter: MemoryLimiter,
+    limiter: Arc<MemoryLimiter>,
     allocation_queue: AllocationQueue,
-    /// Tracks bytes that have been claimed (limit check passed) but not yet reflected in pool
-    /// stats. Used to prevent two concurrent callers both observing room for the same bytes.
-    /// Decremented once `get_buffer` completes and pool stats take over.
-    pending_allocations: AtomicU64,
 }
 
 impl PagedPoolInner {
@@ -446,38 +398,13 @@ impl PagedPoolInner {
         let mut undelivered = Vec::new();
 
         loop {
-            // Atomically check and pop the front entry if we can afford it.
-            // The CAS inside pop_front_if re-reads pending after each retry,
-            // so a concurrent claim by another thread is always visible.
-            let entry = self.allocation_queue.pop_front_if(|size, _, _| {
-                let alloc_size = self.get_pool_for_size(size).map(|p| p.buffer_size()).unwrap_or(size) as u64;
-                let mut pending = self.pending_allocations.load(Ordering::SeqCst);
-                loop {
-                    let available = self.limiter.available_mem(&self.stats).saturating_sub(pending);
-                    if available < alloc_size {
-                        return false;
-                    }
-                    match self.pending_allocations.compare_exchange_weak(
-                        pending,
-                        pending + alloc_size,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    ) {
-                        Ok(_) => return true,
-                        Err(current) => pending = current,
-                    }
-                }
+            let mut buffer = None;
+            let entry = self.allocation_queue.pop_front_if(|pending| {
+                buffer = pool.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false);
+                buffer.is_some()
             });
             let Some(entry) = entry else { break };
-
-            let alloc_size = self
-                .get_pool_for_size(entry.size)
-                .map(|p| p.buffer_size())
-                .unwrap_or(entry.size) as u64;
-
-            // Allocate without any lock — SizePool handles concurrency with its own RwLock.
-            let buffer = pool.get_buffer(entry.size, entry.kind, entry.cursor_id);
-            self.pending_allocations.fetch_sub(alloc_size, Ordering::SeqCst);
+            let Some(buffer) = buffer else { break };
 
             if let Err(buffer) = entry.fulfill(buffer) {
                 undelivered.push(buffer);
@@ -497,12 +424,12 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn acquire(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> PagedBufferPtr {
+    fn try_acquire(&self, kind: BufferKind, pool: &PagedPool, forced: bool) -> Option<PagedBufferPtr> {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
             if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter(), kind) {
-                return buffer_ptr;
+                return Some(buffer_ptr);
             }
         }
 
@@ -512,14 +439,14 @@ impl SizePool {
         // reserve already added a new page.
         let mut write_pages = self.pages.write().unwrap();
         if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter(), kind) {
-            return buffer_ptr;
+            return Some(buffer_ptr);
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
-        let page = Page::new(self.stats.clone(), pool);
+        let page = Page::try_new(self.stats.clone(), pool.weak_ref(), forced)?;
         let buffer_ptr = page.try_acquire(kind).unwrap();
         write_pages.push(page);
-        buffer_ptr
+        Some(buffer_ptr)
     }
 
     fn try_get_buffer_ptr<'a>(
@@ -774,8 +701,8 @@ mod tests {
 
             // Fill all available memory.
             let mut blockers = Vec::new();
-            while pool.can_allocate(BUF) {
-                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                blockers.push(buffer);
             }
 
             // Spawn a request — it should enqueue since there's no room.
@@ -791,6 +718,8 @@ mod tests {
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }
             panic!("request did not enter queue within 100ms");
+
+            // TODO(memory-limiter): review test
         }
 
         /// `is_memory_pressure` reflects the queue's emptiness.
@@ -803,8 +732,8 @@ mod tests {
 
             // Fill memory and enqueue a waiter.
             let mut blockers = Vec::new();
-            while pool.can_allocate(BUF) {
-                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                blockers.push(buffer);
             }
             let pool_clone = pool.clone();
             let _handle =
@@ -834,8 +763,8 @@ mod tests {
             let pool = tight_pool(BUF);
 
             let mut blockers = Vec::new();
-            while pool.can_allocate(BUF) {
-                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                blockers.push(buffer);
             }
 
             let (tx, rx) = std::sync::mpsc::channel();
@@ -865,8 +794,8 @@ mod tests {
 
             // Fill all memory.
             let mut blockers = Vec::new();
-            while pool.can_allocate(BUF) {
-                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                blockers.push(buffer);
             }
 
             // Push both requests directly to the queue so ordering is deterministic.
@@ -909,8 +838,8 @@ mod tests {
 
             // Fill all memory.
             let mut blockers = Vec::new();
-            while pool.can_allocate(BUF) {
-                blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+            while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                blockers.push(buffer);
             }
 
             let cursor = pool.create_cursor();
@@ -963,12 +892,11 @@ mod tests {
 
                 // Fill memory leaving exactly one free buffer slot.
                 let mut blockers = Vec::new();
-                while pool.can_allocate(BUF) {
-                    blockers.push(pool.get_buffer(BUF, BufferKind::Other, None));
+                while let Some(buffer) = pool.try_get_buffer(BUF, BufferKind::Other, None, false) {
+                    blockers.push(buffer);
                 }
                 let budget_buffers = blockers.len();
                 blockers.pop(); // free exactly one slot
-                assert!(pool.can_allocate(BUF));
 
                 const RACERS: usize = 16;
                 let barrier = Arc::new(Barrier::new(RACERS));

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -183,12 +183,12 @@ impl PagedPool {
     }
 
     /// The configured memory limit in bytes.
-    pub fn mem_limit(&self) -> u64 {
+    pub fn mem_limit(&self) -> usize {
         self.inner.limiter.mem_limit()
     }
 
     /// The static memory budget available for data buffers, i.e. `mem_limit - additional_mem_reserved`.
-    pub fn data_buffer_budget(&self) -> u64 {
+    pub fn data_buffer_budget(&self) -> usize {
         self.inner.limiter.data_buffer_budget()
     }
 
@@ -206,7 +206,7 @@ impl PagedPool {
     }
 
     /// Query available memory.
-    pub fn available_mem(&self) -> u64 {
+    pub fn available_mem(&self) -> usize {
         self.inner.limiter.available_mem()
     }
 
@@ -451,7 +451,7 @@ impl SizePool {
 #[derive(Debug, Clone)]
 pub struct PagedPoolConfig {
     ordered_sizes: Vec<usize>,
-    mem_limit: u64,
+    mem_limit: usize,
 }
 
 impl Default for PagedPoolConfig {
@@ -478,7 +478,7 @@ impl PagedPoolConfig {
     }
 
     /// Configure the pool with the specified memory limit.
-    pub fn with_memory_limit(&mut self, mem_limit: u64) -> &mut Self {
+    pub fn with_memory_limit(&mut self, mem_limit: usize) -> &mut Self {
         self.mem_limit = mem_limit;
         self
     }
@@ -488,7 +488,7 @@ impl PagedPoolConfig {
     /// This is a convenience for tests and examples that don't need memory budgeting.
     /// The internal limiter uses `u64::MAX` as its limit, so it never rejects reservations.
     pub fn with_no_memory_limit(&mut self) -> &mut Self {
-        self.with_memory_limit(u64::MAX)
+        self.with_memory_limit(usize::MAX)
     }
 
     /// Configure the pool with [MINIMUM_MEM_LIMIT] as the memory limit.
@@ -509,7 +509,7 @@ impl PagedPoolConfig {
         }
     }
 
-    fn memory_limit(&self) -> u64 {
+    fn memory_limit(&self) -> usize {
         self.mem_limit
     }
 }
@@ -660,8 +660,8 @@ mod tests {
         fn tight_pool(buffer_size: usize) -> PagedPool {
             // Use a small limit — just enough for one page (16 buffers) plus overhead.
             // This keeps the "fill all memory" loop fast in debug builds.
-            let additional_reserved = (buffer_size as u64 * 16).max(128 * 1024 * 1024);
-            let mem_limit = buffer_size as u64 * 16 + additional_reserved;
+            let additional_reserved = (buffer_size * 16).max(128 * 1024 * 1024);
+            let mem_limit = buffer_size * 16 + additional_reserved;
             PagedPool::config()
                 .with_candidate_sizes([buffer_size])
                 .with_memory_limit(mem_limit)

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -9,7 +9,7 @@ use crate::util::wake_signal::WakeSignal;
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
 use super::limiter::{CursorHandle, MemoryLimiter};
-use super::pages::{Page, PagedBufferPtr};
+use super::pages::{MAX_BUFFERS_PER_PAGE, Page, PagedBufferPtr};
 use super::stats::{BufferKind, SizePoolStats};
 
 pub use super::limiter::MINIMUM_MEM_LIMIT;
@@ -417,7 +417,7 @@ struct SizePool {
 
 impl SizePool {
     /// Acquire an unused buffer from an existing page if available, or
-    /// from a newly allocated new page.
+    /// from a newly allocated page.
     ///
     /// Returns `None` if allocating a new page would hit the memory limit.
     fn try_acquire(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
@@ -439,10 +439,20 @@ impl SizePool {
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
-        let page = Page::try_new(self.stats.clone())?;
-        let buffer_ptr = page.try_acquire(kind).unwrap();
-        write_pages.push(page);
-        Some(buffer_ptr)
+        // Try to allocate a new page with the maximum buffer count first. If there is not enough
+        // memory, keep retrying by halving the count.
+        let mut buffer_count = MAX_BUFFERS_PER_PAGE;
+        while buffer_count > 0 {
+            let Some(page) = Page::try_new(&self.stats, buffer_count) else {
+                buffer_count /= 2;
+                continue;
+            };
+
+            let buffer_ptr = page.try_acquire(kind).expect("acquire should succeed on a new page");
+            write_pages.push(page);
+            return Some(buffer_ptr);
+        }
+        None
     }
 
     fn try_get_buffer_ptr<'a>(

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -381,24 +381,11 @@ impl PagedPoolInner {
     ///
     /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
     /// Loops until no more entries can be fulfilled or the queue is empty.
-    fn try_wake_pending(self: &Arc<Self>) {
-        if !self.is_memory_pressure() {
-            return;
-        }
-
-        loop {
-            let mut buffer = None;
-            let entry = self.allocation_queue.pop_front_if(|pending| {
-                buffer = self.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false);
-                buffer.is_some()
-            });
-            let Some(entry) = entry else { break };
-            let Some(buffer) = buffer else { break };
-
-            if let Err(buffer) = entry.fulfill(buffer) {
-                // We couldn't deliver the buffer, just drop it and continue.
-                drop(buffer);
-            }
+    fn try_wake_pending(&self) {
+        while self
+            .allocation_queue
+            .try_fulfill_front(|pending| self.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false))
+        {
         }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use mountpoint_s3_client::config::{MemoryPool, MetaRequest};
 
 use crate::prefetch::CursorId;
-use crate::sync::{Arc, RwLock, thread};
-use crate::util::wake_signal::WakeSignal;
+use crate::sync::thread::{self, JoinHandle};
+use crate::sync::{Arc, RwLock};
 
 use super::allocation_queue::AllocationQueue;
 use super::buffers::{PoolBuffer, PoolBufferMut};
@@ -57,7 +57,7 @@ pub const DEFAULT_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 /// [MetaRequestType] to [BufferKind].
 #[derive(Debug, Clone)]
 pub struct PagedPool {
-    inner: Arc<PagedPoolInner>,
+    pub(super) inner: Arc<PagedPoolInner>,
 }
 
 impl PagedPool {
@@ -68,39 +68,12 @@ impl PagedPool {
 
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
-        let pending_signal = Arc::new(WakeSignal::new());
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit()));
 
-        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), pending_signal.clone()));
-
-        let ordered_size_pools = config
-            .ordered_sizes()
-            .iter()
-            .map(|&buffer_size| SizePool {
-                pages: Default::default(),
-                stats: Arc::new(SizePoolStats::new(buffer_size, limiter.clone())),
-            })
-            .collect();
-
-        let inner = Arc::new(PagedPoolInner {
-            ordered_size_pools,
-            limiter,
-            allocation_queue: AllocationQueue::new(),
-        });
+        let inner = Arc::new(PagedPoolInner::new(config.ordered_sizes(), limiter));
 
         // Spawn a background thread to process pending allocation requests.
-        let weak = Arc::downgrade(&inner);
-        thread::Builder::new()
-            .name("mem-pool-pending".to_string())
-            .spawn(move || {
-                loop {
-                    pending_signal.wait_timeout(Duration::from_secs(1));
-                    let Some(pool) = weak.upgrade() else {
-                        break;
-                    };
-                    pool.process_pending();
-                }
-            })
-            .expect("failed to spawn pool process pending thread");
+        inner.spawn_process_pending_thread();
 
         // Spawn the background pool maintenance thread.
         // The thread serves two responsibilities on a single OS thread:
@@ -255,6 +228,22 @@ pub(super) struct PagedPoolInner {
 }
 
 impl PagedPoolInner {
+    pub(super) fn new(ordered_sizes: &[usize], limiter: Arc<MemoryLimiter>) -> Self {
+        let ordered_size_pools = ordered_sizes
+            .iter()
+            .map(|&buffer_size| SizePool {
+                pages: Default::default(),
+                stats: Arc::new(SizePoolStats::new(buffer_size, limiter.clone())),
+            })
+            .collect();
+
+        Self {
+            ordered_size_pools,
+            limiter,
+            allocation_queue: AllocationQueue::new(),
+        }
+    }
+
     /// Reference to the inner [`MemoryLimiter`] for sibling modules (e.g. the maintenance thread).
     pub(super) fn limiter(&self) -> &MemoryLimiter {
         &self.limiter
@@ -403,6 +392,24 @@ impl PagedPoolInner {
             .try_fulfill_front(|pending| self.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false))
         {
         }
+    }
+
+    /// Spawn a background thread to process pending allocation requests.
+    fn spawn_process_pending_thread(self: &Arc<Self>) -> JoinHandle<()> {
+        let weak = Arc::downgrade(self);
+        let pending_signal = self.limiter.pending_signal().clone();
+        thread::Builder::new()
+            .name("mem-pool-pending".to_string())
+            .spawn(move || {
+                loop {
+                    pending_signal.wait_timeout(Duration::from_secs(1));
+                    let Some(pool) = weak.upgrade() else {
+                        break;
+                    };
+                    pool.process_pending();
+                }
+            })
+            .expect("failed to spawn pool process pending thread")
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -92,7 +92,7 @@ impl PagedPool {
             loop {
                 wake_signal.wait_timeout(Duration::from_secs(1));
                 if let Some(pool) = weak.upgrade() {
-                    pool.try_wake_pending();
+                    pool.process_pending();
                 }
             }
         });
@@ -308,9 +308,9 @@ impl PagedPoolInner {
             None => self.allocation_queue.push_high(None, size, kind), // uploads are urgent
         };
         // After pushing, try to wake immediately in case memory freed between the fast-path
-        // check above and the push (avoids the race where a buffer drop called try_wake_pending
+        // check above and the push (avoids the race where a buffer drop called trigger_process_pending
         // before the entry was in the queue).
-        self.limiter.trigger_wake_pending();
+        self.limiter.trigger_process_pending();
         // Nudge the maintenance thread: it may be parked on its long idle interval, in which
         // case it would otherwise sleep up to that interval before noticing the new waiter.
         self.limiter.trigger_pruning();
@@ -372,7 +372,7 @@ impl PagedPoolInner {
                 .record(pages_freed as f64);
         }
 
-        self.limiter.trigger_wake_pending();
+        self.limiter.trigger_process_pending();
 
         removed
     }
@@ -381,7 +381,7 @@ impl PagedPoolInner {
     ///
     /// Called whenever memory is freed — on buffer drop, cursor release, or pool trim.
     /// Loops until no more entries can be fulfilled or the queue is empty.
-    fn try_wake_pending(&self) {
+    fn process_pending(&self) {
         while self
             .allocation_queue
             .try_fulfill_front(|pending| self.try_get_buffer(pending.size, pending.kind, pending.cursor_id, false))

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -87,6 +87,7 @@ impl PagedPool {
             allocation_queue: AllocationQueue::new(),
         });
 
+        // Spawn a background thread to process pending allocation requests.
         let weak = Arc::downgrade(&inner);
         thread::Builder::new()
             .name("mem-pool-pending".to_string())
@@ -101,24 +102,20 @@ impl PagedPool {
             })
             .expect("failed to spawn pool process pending thread");
 
+        // Spawn the background pool maintenance thread.
+        // The thread serves two responsibilities on a single OS thread:
+        //   - **Periodic trim**: every `maintenance_interval`, run [`Self::trim`] to release
+        //     empty pages back to the system allocator.
+        //   - **Pressure pruning**: on [`MemoryLimiter::trigger_pruning`], wake
+        //     immediately and run pruning rounds until the allocation queue drains.
+        super::maintenance::spawn_pool_maintenance_thread(&inner, config.maintenance_interval);
+
         Self { inner }
     }
 
     /// Trim empty pages in the pool.
     pub fn trim(&self) -> bool {
         self.inner.trim()
-    }
-
-    /// Spawn the background pool maintenance thread. Must be called once after
-    /// construction, at filesystem init.
-    ///
-    /// The thread serves two responsibilities on a single OS thread:
-    ///   - **Periodic trim**: every `idle_interval`, run [`Self::trim`] to release
-    ///     empty pages back to the system allocator.
-    ///   - **Pressure pruning**: on [`MemoryLimiter::trigger_pruning`], wake
-    ///     immediately and run pruning rounds until the allocation queue drains.
-    pub fn spawn_pool_maintenance_thread(&self, idle_interval: Duration) {
-        super::maintenance::spawn_pool_maintenance_thread(&self.inner, idle_interval);
     }
 
     /// Return the memory in use in bytes for the given kind of buffer.
@@ -472,11 +469,13 @@ impl SizePool {
 ///
 /// Defaults:
 /// - memory limit: [MINIMUM_MEM_LIMIT],
-/// - buffer size: [DEFAULT_BUFFER_SIZE].
+/// - buffer size: [DEFAULT_BUFFER_SIZE],
+/// - maintenance interval: 60s.
 #[derive(Debug, Clone)]
 pub struct PagedPoolConfig {
     ordered_sizes: Vec<usize>,
     mem_limit: usize,
+    maintenance_interval: Duration,
 }
 
 impl Default for PagedPoolConfig {
@@ -484,6 +483,7 @@ impl Default for PagedPoolConfig {
         Self {
             ordered_sizes: Default::default(),
             mem_limit: MINIMUM_MEM_LIMIT,
+            maintenance_interval: Duration::from_secs(60),
         }
     }
 }
@@ -519,6 +519,12 @@ impl PagedPoolConfig {
     /// Configure the pool with [MINIMUM_MEM_LIMIT] as the memory limit.
     pub fn with_minimum_memory_limit(&mut self) -> &mut Self {
         self.with_memory_limit(MINIMUM_MEM_LIMIT)
+    }
+
+    /// Configure the interval between runs of background maintenance tasks.
+    pub fn with_maintenance_interval(&mut self, interval: Duration) -> &mut Self {
+        self.maintenance_interval = interval;
+        self
     }
 
     /// Build a [PagedPool] with this configuration.
@@ -606,17 +612,15 @@ mod tests {
         }
     }
 
-    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [None, Some(Duration::from_millis(10))])]
-    #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
-    #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
-    fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
+    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [Duration::MAX, Duration::from_millis(10)])]
+    #[test_matrix(&vec![42u8; 1000], &[128, 1024], [Duration::MAX, Duration::from_millis(10)])]
+    #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [Duration::MAX, Duration::from_millis(10)])]
+    fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Duration) {
         let pool = PagedPool::config()
             .with_candidate_sizes(buffer_sizes)
             .with_no_memory_limit()
+            .with_maintenance_interval(schedule)
             .build();
-        if let Some(duration) = schedule {
-            pool.spawn_pool_maintenance_thread(duration);
-        }
 
         let num_threads = 10000;
         thread::scope(|scope| {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -116,14 +116,14 @@ impl PagedPool {
         super::maintenance::spawn_pool_maintenance_thread(&self.inner, idle_interval);
     }
 
-    /// Return the reserved memory in bytes for the given kind of buffer.
-    pub fn reserved_bytes(&self, kind: BufferKind) -> usize {
-        self.inner.stats.reserved_bytes(kind)
+    /// Return the memory in use in bytes for the given kind of buffer.
+    pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
+        self.inner.stats.acquired_bytes(kind)
     }
 
-    /// Return the total reserved memory in bytes across all buffer kinds.
-    pub fn total_reserved_bytes(&self) -> usize {
-        self.inner.stats.total_reserved_bytes()
+    /// Return the total memory in use in bytes across all buffer kinds.
+    pub fn total_acquired_bytes(&self) -> usize {
+        self.inner.stats.total_acquired_bytes()
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
@@ -148,18 +148,18 @@ impl PagedPool {
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         match self.inner.get_pool_for_size(size) {
             Some(pool) => {
-                let buffer_ptr = pool.reserve(kind, Arc::downgrade(&self.inner));
-                metrics::histogram!("pool.reserved_bytes", "type" => "primary", "kind" => kind.as_str())
+                let buffer_ptr = pool.acquire(kind, Arc::downgrade(&self.inner));
+                metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
                     .record(size as f64);
                 metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
                     .record((pool.buffer_size() - size) as f64);
-                self.inner.limiter.on_pool_reserve(pool.buffer_size(), cursor_id);
+                self.inner.limiter.on_pool_acquire(pool.buffer_size(), cursor_id);
                 PoolBuffer::new_primary(buffer_ptr, size)
             }
             None => {
-                metrics::histogram!("pool.reserved_bytes", "type" => "secondary", "kind" => kind.as_str())
+                metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
                     .record(size as f64);
-                self.inner.limiter.on_pool_reserve(size, cursor_id);
+                self.inner.limiter.on_pool_acquire(size, cursor_id);
                 PoolBuffer::new_secondary(size, kind, self.inner.stats.clone(), Arc::downgrade(&self.inner))
             }
         }
@@ -175,11 +175,11 @@ impl PagedPool {
     }
 
     #[cfg(test)]
-    fn reserved_buffer_count(&self, kind: BufferKind) -> usize {
+    fn acquired_buffer_count(&self, kind: BufferKind) -> usize {
         self.inner
             .ordered_size_pools
             .iter()
-            .map(|pool| pool.stats.reserved_buffers(kind))
+            .map(|pool| pool.stats.acquired_buffers(kind))
             .sum()
     }
 
@@ -497,7 +497,7 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn reserve(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> PagedBufferPtr {
+    fn acquire(&self, kind: BufferKind, pool: Weak<PagedPoolInner>) -> PagedBufferPtr {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
@@ -517,7 +517,7 @@ impl SizePool {
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
         let page = Page::new(self.stats.clone(), pool);
-        let buffer_ptr = page.try_reserve(kind).unwrap();
+        let buffer_ptr = page.try_acquire(kind).unwrap();
         write_pages.push(page);
         buffer_ptr
     }
@@ -527,7 +527,7 @@ impl SizePool {
         mut pages: impl Iterator<Item = &'a Page>,
         kind: BufferKind,
     ) -> Option<PagedBufferPtr> {
-        pages.find_map(|page| page.try_reserve(kind))
+        pages.find_map(|page| page.try_acquire(kind))
     }
 
     fn buffer_size(&self) -> usize {
@@ -647,29 +647,29 @@ mod tests {
             let original = vec![1u8; size];
 
             assert_eq!(pool.page_count(), 0);
-            assert_eq!(pool.reserved_buffer_count(BufferKind::Other), 0);
+            assert_eq!(pool.acquired_buffer_count(BufferKind::Other), 0);
 
             let mut buffers = Vec::new();
             for _ in 0..16 {
                 buffers.push(copy_from_slice(&pool, &original));
             }
             assert_eq!(pool.page_count(), 1);
-            assert_eq!(pool.reserved_buffer_count(BufferKind::Other), 16);
+            assert_eq!(pool.acquired_buffer_count(BufferKind::Other), 16);
 
             buffers.push(copy_from_slice(&pool, &original));
             assert_eq!(pool.page_count(), 2);
-            assert_eq!(pool.reserved_buffer_count(BufferKind::Other), 17);
+            assert_eq!(pool.acquired_buffer_count(BufferKind::Other), 17);
 
             assert!(!pool.trim());
 
             drop(buffers);
 
             assert_eq!(pool.page_count(), 2);
-            assert_eq!(pool.reserved_buffer_count(BufferKind::Other), 0);
+            assert_eq!(pool.acquired_buffer_count(BufferKind::Other), 0);
 
             assert!(pool.trim());
             assert_eq!(pool.page_count(), 0);
-            assert_eq!(pool.reserved_buffer_count(BufferKind::Other), 0);
+            assert_eq!(pool.acquired_buffer_count(BufferKind::Other), 0);
         }
     }
 
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reserved_bytes() {
+    fn test_acquired_bytes() {
         let buffer_size = 1024;
         let reservations = HashMap::from([(BufferKind::GetObject, 10), (BufferKind::Other, 20)]);
         let pool = PagedPool::config()
@@ -726,7 +726,7 @@ mod tests {
         }
 
         for (&kind, &count) in &reservations {
-            let reserved = pool.reserved_bytes(kind);
+            let reserved = pool.acquired_bytes(kind);
             assert_eq!(reserved, count * buffer_size);
         }
     }
@@ -1002,7 +1002,7 @@ mod tests {
                 );
                 // And the pool must never have exceeded its buffer budget while the winner holds its buffer.
                 assert_eq!(
-                    pool.reserved_buffer_count(BufferKind::Other) + pool.reserved_buffer_count(BufferKind::GetObject),
+                    pool.acquired_buffer_count(BufferKind::Other) + pool.acquired_buffer_count(BufferKind::GetObject),
                     budget_buffers,
                     "total reserved buffers must not exceed the budget",
                 );

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -328,28 +328,39 @@ impl PagedPoolInner {
         })
     }
 
+    /// Get a buffer from the pool if available or allocates new memory if allowed.
+    ///
+    /// Steps:
+    /// - If the requested size is compatible with the pool configuration:
+    ///   - Return an unused buffer from an existing page if available.
+    ///   - Otherwise, try to allocate a new page within the memory limit:
+    ///     - Return a buffer from the new page if successful.
+    /// - In all other cases:
+    ///   - Try to allocate and return a single buffer.
+    ///     
+    /// Returns `None` if allocating the required memory would exceed the memory limit.
+    ///
+    /// **NOTE:** guarantees to return `Some` if invoked with `ignore_limit == true`.
     pub(super) fn try_get_buffer(
         &self,
         size: usize,
         kind: BufferKind,
         cursor_id: Option<CursorId>,
-        forced: bool,
+        ignore_limit: bool,
     ) -> Option<PoolBuffer> {
-        let buffer = match self.get_pool_for_size(size) {
-            Some(pool) => {
-                let buffer_ptr = pool.try_acquire(kind, forced)?;
-                metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
-                    .record(size as f64);
-                metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
+        let buffer = if let Some(pool) = self.get_pool_for_size(size)
+            && let Some(buffer_ptr) = pool.try_acquire(kind)
+        {
+            metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
+                .record(size as f64);
+            metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
                     .record((pool.buffer_size() - size) as f64);
 
-                PoolBuffer::new_primary(buffer_ptr, size)
-            }
-            None => {
-                metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
-                    .record(size as f64);
-                PoolBuffer::try_new_secondary(size, kind, self.limiter.clone(), forced)?
-            }
+            PoolBuffer::new_primary(buffer_ptr, size)
+        } else {
+            metrics::histogram!("pool.acquired_bytes", "type" => "secondary", "kind" => kind.as_str())
+                .record(size as f64);
+            PoolBuffer::try_new_secondary(size, kind, self.limiter.clone(), ignore_limit)?
         };
         self.limiter.on_pool_acquire(size, cursor_id);
         Some(buffer)
@@ -405,7 +416,11 @@ struct SizePool {
 }
 
 impl SizePool {
-    fn try_acquire(&self, kind: BufferKind, forced: bool) -> Option<PagedBufferPtr> {
+    /// Acquire an unused buffer from an existing page if available, or
+    /// from a newly allocated new page.
+    ///
+    /// Returns `None` if allocating a new page would hit the memory limit.
+    fn try_acquire(&self, kind: BufferKind) -> Option<PagedBufferPtr> {
         {
             // Fast path: reserve a buffer from the existing pages (under a read lock).
             let read_pages = self.pages.read().unwrap();
@@ -424,7 +439,7 @@ impl SizePool {
         }
 
         tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
-        let page = Page::try_new(self.stats.clone(), forced)?;
+        let page = Page::try_new(self.stats.clone())?;
         let buffer_ptr = page.try_acquire(kind).unwrap();
         write_pages.push(page);
         Some(buffer_ptr)

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -132,7 +132,7 @@ impl PagedPool {
     }
 
     /// Get a new empty mutable buffer from the pool with the requested capacity.
-    /// If `cursor_id` is provided, `on_pool_reserve` will decrement the limiter's
+    /// If `cursor_id` is provided, `on_pool_acquire` will decrement the limiter's
     /// reservation counters for per-cursor memory tracking.
     pub fn get_buffer_mut(&self, capacity: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBufferMut {
         let buffer = self.get_buffer(capacity, kind, cursor_id);

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -205,9 +205,9 @@ impl PagedPool {
         self.inner.limiter.request_reset(cursor_id)
     }
 
-    /// Query available memory.
-    pub fn available_mem(&self) -> usize {
-        self.inner.limiter.available_mem()
+    /// Memory that can be reserved while respecting the memory limit.
+    pub fn memory_available_for_reservation(&self) -> usize {
+        self.inner.limiter.memory_available_for_reservation()
     }
 
     /// Check if the given cursor has an active read overlapping the specified range.

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -43,9 +43,9 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<ManagedBuffer> {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
-        let result = self.limiter.try_allocate(size, None, forced)?;
+        let result = self.limiter.try_allocate(size, None, false)?;
         metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
         self.add_empty_page();
         Some(result)

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -5,7 +5,7 @@ use mountpoint_s3_client::config::MetaRequestType;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-use super::buffers::BufferPtr;
+use super::buffers::ManagedBuffer;
 use super::limiter::MemoryLimiter;
 
 /// Usage stats for a specific size pool.
@@ -43,16 +43,12 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<BufferPtr> {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
-        let result = self.limiter.try_allocate(size, forced)?;
+        let result = self.limiter.try_allocate(size, None, forced)?;
         metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
         self.add_empty_page();
         Some(result)
-    }
-
-    pub(super) fn deallocate_page(&self, ptr: &mut BufferPtr) {
-        self.limiter.deallocate(ptr);
     }
 
     #[allow(unused)]

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,3 +1,4 @@
+use std::alloc::{self, Layout};
 use std::ops::Index;
 
 use mountpoint_s3_client::config::MetaRequestType;
@@ -35,12 +36,26 @@ impl PoolStats {
         self.allocated_bytes.load(Ordering::SeqCst)
     }
 
-    pub(super) fn allocate_bytes(&self, size: usize) {
+    pub(super) fn allocate(&self, size: usize) -> (*mut u8, Layout) {
+        let layout = Layout::array::<u8>(size).unwrap();
+
+        // SAFETY: layout has non-zero size.
+        let bytes = unsafe { alloc::alloc(layout) };
+        if bytes.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
+
         self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
+
+        (bytes, layout)
     }
 
-    pub(super) fn deallocate_bytes(&self, size: usize) {
-        self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
+    pub(super) fn deallocate(&self, bytes: *mut u8, layout: Layout) {
+        // SAFETY: `bytes` was allocated using `layout` in `allocate_page`.
+        unsafe {
+            alloc::dealloc(bytes, layout);
+        }
+        self.allocated_bytes.fetch_sub(layout.size(), Ordering::SeqCst);
     }
 }
 
@@ -55,6 +70,8 @@ pub struct SizePoolStats {
 
 impl SizePoolStats {
     pub(super) fn new(buffer_size: usize, pool_stats: Arc<PoolStats>) -> Self {
+        assert_ne!(buffer_size, 0);
+
         Self {
             buffer_size,
             empty_pages: Default::default(),
@@ -77,12 +94,16 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn allocate_page(&self, buffer_count: usize) {
-        self.pool_stats.allocate_bytes(self.buffer_size * buffer_count);
+    pub(super) fn allocate_page(&self, buffer_count: usize) -> (*mut u8, Layout) {
+        let size = self.buffer_size * buffer_count;
+        let result = self.pool_stats.allocate(size);
+        metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
+        self.add_empty_page();
+        result
     }
 
-    pub(super) fn deallocate_page(&self, buffer_count: usize) {
-        self.pool_stats.deallocate_bytes(self.buffer_size * buffer_count);
+    pub(super) fn deallocate_page(&self, bytes: *mut u8, layout: Layout) {
+        self.pool_stats.deallocate(bytes, layout);
     }
 
     #[allow(unused)]

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,11 +1,12 @@
-use std::alloc::Layout;
 use std::ops::Index;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
-use crate::memory::limiter::MemoryLimiter;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
+
+use super::buffers::BufferPtr;
+use super::limiter::MemoryLimiter;
 
 /// Usage stats for a specific size pool.
 #[derive(Debug)]
@@ -42,7 +43,7 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<(*mut u8, Layout)> {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<BufferPtr> {
         let size = self.buffer_size * buffer_count;
         let result = self.limiter.try_allocate(size, forced)?;
         metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
@@ -50,8 +51,8 @@ impl SizePoolStats {
         Some(result)
     }
 
-    pub(super) fn deallocate_page(&self, bytes: *mut u8, layout: Layout) {
-        self.limiter.deallocate(bytes, layout);
+    pub(super) fn deallocate_page(&self, ptr: &mut BufferPtr) {
+        self.limiter.deallocate(ptr);
     }
 
     #[allow(unused)]

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -3,6 +3,7 @@ use std::ops::Index;
 
 use mountpoint_s3_client::config::MetaRequestType;
 
+use crate::memory::limiter::MemoryLimiter;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
@@ -10,7 +11,7 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 #[derive(Debug, Default)]
 pub struct PoolStats {
     acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
-    allocated_bytes: AtomicUsize,
+    pub(super) allocated_bytes: AtomicUsize,
 }
 
 impl PoolStats {
@@ -36,20 +37,6 @@ impl PoolStats {
         self.allocated_bytes.load(Ordering::SeqCst)
     }
 
-    pub(super) fn allocate(&self, size: usize) -> (*mut u8, Layout) {
-        let layout = Layout::array::<u8>(size).unwrap();
-
-        // SAFETY: layout has non-zero size.
-        let bytes = unsafe { alloc::alloc(layout) };
-        if bytes.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
-
-        self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
-
-        (bytes, layout)
-    }
-
     pub(super) fn deallocate(&self, bytes: *mut u8, layout: Layout) {
         // SAFETY: `bytes` was allocated using `layout` in `allocate_page`.
         unsafe {
@@ -65,18 +52,18 @@ pub struct SizePoolStats {
     pub buffer_size: usize,
     empty_pages: AtomicUsize,
     acquired_buffers: [AtomicUsize; BUFFER_KIND_COUNT],
-    pool_stats: Arc<PoolStats>,
+    limiter: Arc<MemoryLimiter>,
 }
 
 impl SizePoolStats {
-    pub(super) fn new(buffer_size: usize, pool_stats: Arc<PoolStats>) -> Self {
+    pub(super) fn new(buffer_size: usize, limiter: Arc<MemoryLimiter>) -> Self {
         assert_ne!(buffer_size, 0);
 
         Self {
             buffer_size,
             empty_pages: Default::default(),
             acquired_buffers: Default::default(),
-            pool_stats,
+            limiter,
         }
     }
 
@@ -94,16 +81,16 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn allocate_page(&self, buffer_count: usize) -> (*mut u8, Layout) {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize, forced: bool) -> Option<(*mut u8, Layout)> {
         let size = self.buffer_size * buffer_count;
-        let result = self.pool_stats.allocate(size);
+        let result = self.limiter.try_allocate(size, forced)?;
         metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
         self.add_empty_page();
-        result
+        Some(result)
     }
 
     pub(super) fn deallocate_page(&self, bytes: *mut u8, layout: Layout) {
-        self.pool_stats.deallocate(bytes, layout);
+        self.limiter.stats().deallocate(bytes, layout);
     }
 
     #[allow(unused)]
@@ -113,12 +100,12 @@ impl SizePoolStats {
 
     pub(super) fn acquire_buffer(&self, kind: BufferKind) {
         self.acquired_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.acquire_bytes(self.buffer_size, kind);
+        self.limiter.stats().acquire_bytes(self.buffer_size, kind);
     }
 
     pub(super) fn release_buffer(&self, kind: BufferKind) {
         self.acquired_buffers[kind].fetch_sub(1, Ordering::SeqCst);
-        self.pool_stats.release_bytes(self.buffer_size, kind);
+        self.limiter.stats().release_bytes(self.buffer_size, kind);
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -1,4 +1,4 @@
-use std::alloc::{self, Layout};
+use std::alloc::Layout;
 use std::ops::Index;
 
 use mountpoint_s3_client::config::MetaRequestType;
@@ -6,45 +6,6 @@ use mountpoint_s3_client::config::MetaRequestType;
 use crate::memory::limiter::MemoryLimiter;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
-
-/// Usage stats for a pool.
-#[derive(Debug, Default)]
-pub struct PoolStats {
-    acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
-    pub(super) allocated_bytes: AtomicUsize,
-}
-
-impl PoolStats {
-    pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
-        self.acquired_bytes[kind].load(Ordering::SeqCst)
-    }
-
-    pub fn total_acquired_bytes(&self) -> usize {
-        self.acquired_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
-    }
-
-    pub(super) fn acquire_bytes(&self, bytes: usize, kind: BufferKind) {
-        self.acquired_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
-        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).increment(bytes as f64);
-    }
-
-    pub(super) fn release_bytes(&self, bytes: usize, kind: BufferKind) {
-        self.acquired_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
-        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).decrement(bytes as f64);
-    }
-
-    pub fn allocated_bytes(&self) -> usize {
-        self.allocated_bytes.load(Ordering::SeqCst)
-    }
-
-    pub(super) fn deallocate(&self, bytes: *mut u8, layout: Layout) {
-        // SAFETY: `bytes` was allocated using `layout` in `allocate_page`.
-        unsafe {
-            alloc::dealloc(bytes, layout);
-        }
-        self.allocated_bytes.fetch_sub(layout.size(), Ordering::SeqCst);
-    }
-}
 
 /// Usage stats for a specific size pool.
 #[derive(Debug)]
@@ -90,7 +51,7 @@ impl SizePoolStats {
     }
 
     pub(super) fn deallocate_page(&self, bytes: *mut u8, layout: Layout) {
-        self.limiter.stats().deallocate(bytes, layout);
+        self.limiter.deallocate(bytes, layout);
     }
 
     #[allow(unused)]
@@ -100,12 +61,12 @@ impl SizePoolStats {
 
     pub(super) fn acquire_buffer(&self, kind: BufferKind) {
         self.acquired_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.limiter.stats().acquire_bytes(self.buffer_size, kind);
+        self.limiter.acquire_bytes(self.buffer_size, kind);
     }
 
     pub(super) fn release_buffer(&self, kind: BufferKind) {
         self.acquired_buffers[kind].fetch_sub(1, Ordering::SeqCst);
-        self.limiter.stats().release_bytes(self.buffer_size, kind);
+        self.limiter.release_bytes(self.buffer_size, kind);
     }
 }
 
@@ -118,7 +79,7 @@ pub enum BufferKind {
     Append,
     Other,
 }
-const BUFFER_KIND_COUNT: usize = BufferKind::Other as usize + 1;
+pub const BUFFER_KIND_COUNT: usize = BufferKind::Other as usize + 1;
 
 impl<T> Index<BufferKind> for [T; BUFFER_KIND_COUNT] {
     type Output = T;

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -8,27 +8,27 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 /// Usage stats for a pool.
 #[derive(Debug, Default)]
 pub struct PoolStats {
-    reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+    acquired_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
     allocated_bytes: AtomicUsize,
 }
 
 impl PoolStats {
-    pub fn reserved_bytes(&self, kind: BufferKind) -> usize {
-        self.reserved_bytes[kind].load(Ordering::SeqCst)
+    pub fn acquired_bytes(&self, kind: BufferKind) -> usize {
+        self.acquired_bytes[kind].load(Ordering::SeqCst)
     }
 
-    pub fn total_reserved_bytes(&self) -> usize {
-        self.reserved_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
+    pub fn total_acquired_bytes(&self) -> usize {
+        self.acquired_bytes.iter().map(|a| a.load(Ordering::SeqCst)).sum()
     }
 
-    pub(super) fn reserve_bytes(&self, bytes: usize, kind: BufferKind) {
-        self.reserved_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
-        metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).increment(bytes as f64);
+    pub(super) fn acquire_bytes(&self, bytes: usize, kind: BufferKind) {
+        self.acquired_bytes[kind].fetch_add(bytes, Ordering::SeqCst);
+        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).increment(bytes as f64);
     }
 
     pub(super) fn release_bytes(&self, bytes: usize, kind: BufferKind) {
-        self.reserved_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
-        metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).decrement(bytes as f64);
+        self.acquired_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
+        metrics::gauge!("pool.bytes_in_use", "kind" => kind.as_str()).decrement(bytes as f64);
     }
 
     pub fn allocated_bytes(&self) -> usize {
@@ -49,7 +49,7 @@ impl PoolStats {
 pub struct SizePoolStats {
     pub buffer_size: usize,
     empty_pages: AtomicUsize,
-    reserved_buffers: [AtomicUsize; BUFFER_KIND_COUNT],
+    acquired_buffers: [AtomicUsize; BUFFER_KIND_COUNT],
     pool_stats: Arc<PoolStats>,
 }
 
@@ -58,7 +58,7 @@ impl SizePoolStats {
         Self {
             buffer_size,
             empty_pages: Default::default(),
-            reserved_buffers: Default::default(),
+            acquired_buffers: Default::default(),
             pool_stats,
         }
     }
@@ -86,17 +86,17 @@ impl SizePoolStats {
     }
 
     #[allow(unused)]
-    pub fn reserved_buffers(&self, kind: BufferKind) -> usize {
-        self.reserved_buffers[kind].load(Ordering::SeqCst)
+    pub fn acquired_buffers(&self, kind: BufferKind) -> usize {
+        self.acquired_buffers[kind].load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_reserved_buffer(&self, kind: BufferKind) {
-        self.reserved_buffers[kind].fetch_add(1, Ordering::SeqCst);
-        self.pool_stats.reserve_bytes(self.buffer_size, kind);
+    pub(super) fn acquire_buffer(&self, kind: BufferKind) {
+        self.acquired_buffers[kind].fetch_add(1, Ordering::SeqCst);
+        self.pool_stats.acquire_bytes(self.buffer_size, kind);
     }
 
-    pub(super) fn remove_reserved_buffer(&self, kind: BufferKind) {
-        self.reserved_buffers[kind].fetch_sub(1, Ordering::SeqCst);
+    pub(super) fn release_buffer(&self, kind: BufferKind) {
+        self.acquired_buffers[kind].fetch_sub(1, Ordering::SeqCst);
         self.pool_stats.release_bytes(self.buffer_size, kind);
     }
 }

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -9,6 +9,7 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 #[derive(Debug, Default)]
 pub struct PoolStats {
     reserved_bytes: [AtomicUsize; BUFFER_KIND_COUNT],
+    allocated_bytes: AtomicUsize,
 }
 
 impl PoolStats {
@@ -28,6 +29,18 @@ impl PoolStats {
     pub(super) fn release_bytes(&self, bytes: usize, kind: BufferKind) {
         self.reserved_bytes[kind].fetch_sub(bytes, Ordering::SeqCst);
         metrics::gauge!("pool.reserved_bytes", "kind" => kind.as_str()).decrement(bytes as f64);
+    }
+
+    pub fn allocated_bytes(&self) -> usize {
+        self.allocated_bytes.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn allocate_bytes(&self, size: usize) {
+        self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
+    }
+
+    pub(super) fn deallocate_bytes(&self, size: usize) {
+        self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
     }
 }
 
@@ -62,6 +75,14 @@ impl SizePoolStats {
     pub(super) fn remove_empty_page(&self) {
         metrics::gauge!("pool.empty_pages", "size" => format!("{}", self.buffer_size)).decrement(1.0);
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn allocate_page(&self, buffer_count: usize) {
+        self.pool_stats.allocate_bytes(self.buffer_size * buffer_count);
+    }
+
+    pub(super) fn deallocate_page(&self, buffer_count: usize) {
+        self.pool_stats.deallocate_bytes(self.buffer_size * buffer_count);
     }
 
     #[allow(unused)]

--- a/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
+++ b/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
@@ -45,8 +45,8 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 #[error("write handle limit reached (max {max})")]
 pub struct WriteHandleLimitError {
     pub max: usize,
-    pub mem_limit_mib: u64,
-    pub write_part_size_mib: u64,
+    pub mem_limit_mib: usize,
+    pub write_part_size_mib: usize,
 }
 
 /// Enforces a hard cap on the number of concurrently open-for-write file handles.
@@ -60,9 +60,9 @@ pub struct WriteHandleLimiter {
     active: Arc<AtomicUsize>,
     /// Memory target in MiB. Cached for the rejection error message — reported using the
     /// `--memory-target` CLI flag's units so the diagnostic is directly actionable.
-    mem_limit_mib: u64,
+    mem_limit_mib: usize,
     /// Write part size in MiB. Cached for the rejection error message.
-    write_part_size_mib: u64,
+    write_part_size_mib: usize,
 }
 
 impl WriteHandleLimiter {
@@ -70,10 +70,10 @@ impl WriteHandleLimiter {
     /// `data_buffer_budget` is the static memory budget available for data buffers, i.e.
     /// `mem_limit - additional_mem_reserved`. `mem_limit` is retained for diagnostics so that
     /// rejection errors quote the same value as the user-facing `--memory-target` flag.
-    pub fn new(mem_limit: u64, data_buffer_budget: u64, write_part_size: usize) -> Self {
-        let max_concurrent_writes = (data_buffer_budget / write_part_size as u64) as usize;
+    pub fn new(mem_limit: usize, data_buffer_budget: usize, write_part_size: usize) -> Self {
+        let max_concurrent_writes = data_buffer_budget / write_part_size;
         let mem_limit_mib = mem_limit / (1024 * 1024);
-        let write_part_size_mib = (write_part_size as u64) / (1024 * 1024);
+        let write_part_size_mib = write_part_size / (1024 * 1024);
         if max_concurrent_writes == 0 {
             warn!(
                 mem_limit_mib,
@@ -150,17 +150,22 @@ mod tests {
 
     use super::*;
 
-    const MIN_LIMIT: u64 = 512 * 1024 * 1024;
-    const MIN_BUDGET: u64 = MIN_LIMIT - 128 * 1024 * 1024;
-    const LARGE_LIMIT: u64 = 4 * 1024 * 1024 * 1024;
-    const LARGE_BUDGET: u64 = LARGE_LIMIT - 512 * 1024 * 1024;
+    const MIN_LIMIT: usize = 512 * 1024 * 1024;
+    const MIN_BUDGET: usize = MIN_LIMIT - 128 * 1024 * 1024;
+    const LARGE_LIMIT: usize = 4 * 1024 * 1024 * 1024;
+    const LARGE_BUDGET: usize = LARGE_LIMIT - 512 * 1024 * 1024;
     const PART_SIZE_8MIB: usize = 8 * 1024 * 1024;
     const PART_SIZE_1GIB: usize = 1024 * 1024 * 1024;
 
     #[test_case(MIN_LIMIT, MIN_BUDGET, PART_SIZE_8MIB, 48; "512MiB_limit_8MiB_part")]
     #[test_case(LARGE_LIMIT, LARGE_BUDGET, PART_SIZE_8MIB, 448; "4GiB_limit_8MiB_part")]
     #[test_case(MIN_LIMIT, MIN_BUDGET, PART_SIZE_1GIB, 0; "part_larger_than_budget_saturates_to_zero")]
-    fn test_max_concurrent_writes(mem_limit: u64, data_buffer_budget: u64, write_part_size: usize, expected: usize) {
+    fn test_max_concurrent_writes(
+        mem_limit: usize,
+        data_buffer_budget: usize,
+        write_part_size: usize,
+        expected: usize,
+    ) {
         let limiter = WriteHandleLimiter::new(mem_limit, data_buffer_budget, write_part_size);
         assert_eq!(limiter.max_concurrent_writes(), expected);
         if expected == 0 {

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -1176,11 +1176,11 @@ mod tests {
                 .expect("cursor should still be populated")
                 .cursor_id();
             let pool = request.part_stream.pool();
-            let available_before = pool.available_mem();
+            let available_before = pool.memory_available_for_reservation();
             assert!(pool.reset_cursor(cursor_id));
 
             // Memory should be reclaimed (reservation released)
-            let available_after = pool.available_mem();
+            let available_after = pool.memory_available_for_reservation();
             assert!(
                 available_after > available_before,
                 "expected memory to be reclaimed: before={available_before}, after={available_after}"

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -139,7 +139,7 @@ pub fn new_backpressure_controller(
     // Minimum window size multiplier as the scaling up and down won't work if the multiplier is 1.
     const MIN_WINDOW_SIZE_MULTIPLIER: usize = 2;
     let read_window_end_offset = config.request_range.start + config.initial_read_window_size as u64;
-    cursor_state.reserve(config.initial_read_window_size as u64);
+    cursor_state.reserve(config.initial_read_window_size);
 
     let cursor_id = cursor_state.id();
     let (read_window_updater, read_window_increment_queue) = unbounded();
@@ -211,14 +211,14 @@ impl BackpressureController {
                     // read window size.
                     if self.preferred_read_window_size <= self.min_read_window_size {
                         trace!(new_read_window_end_offset, "sending a read window increment");
-                        self.cursor_state.reserve(to_increase as u64);
+                        self.cursor_state.reserve(to_increase);
                         self.increment_read_window(to_increase).await;
                         break;
                     }
 
                     // Try to reserve the memory for the length we want to increase before sending the request,
                     // scale down the read window if it fails.
-                    if self.cursor_state.try_reserve(to_increase as u64) {
+                    if self.cursor_state.try_reserve(to_increase) {
                         trace!(new_read_window_end_offset, "sending a read window increment");
                         self.increment_read_window(to_increase).await;
                         break;
@@ -261,7 +261,7 @@ impl BackpressureController {
             // Only scale up when there is enough memory. We don't have to reserve the memory here
             // because only `preferred_read_window_size` is increased but the actual read window will
             // be updated later on `DataRead` event (where we do reserve memory).
-            let to_increase = (new_read_window_size - self.preferred_read_window_size) as u64;
+            let to_increase = new_read_window_size - self.preferred_read_window_size;
             let available_mem = self.cursor_state.available_mem();
             if available_mem >= to_increase {
                 let formatter = make_format(humansize::BINARY);
@@ -508,7 +508,7 @@ mod tests {
     ) -> (BackpressureController, BackpressureLimiter) {
         let pool = PagedPool::config()
             .with_candidate_sizes([8 * 1024 * 1024])
-            .with_memory_limit(backpressure_config.max_read_window_size as u64)
+            .with_memory_limit(backpressure_config.max_read_window_size)
             .build();
         let cursor_state = pool.create_cursor().state();
         new_backpressure_controller(backpressure_config, cursor_state)

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -262,7 +262,7 @@ impl BackpressureController {
             // because only `preferred_read_window_size` is increased but the actual read window will
             // be updated later on `DataRead` event (where we do reserve memory).
             let to_increase = new_read_window_size - self.preferred_read_window_size;
-            let available_mem = self.cursor_state.available_mem();
+            let available_mem = self.cursor_state.memory_available_for_reservation();
             if available_mem >= to_increase {
                 let formatter = make_format(humansize::BINARY);
                 trace!(

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -1139,13 +1139,13 @@ mod tests {
         // so set `mem_limit` just above that floor to leave room for exactly one part.
         // This serializes writes through the allocation queue, exercising the wait-then-wake
         // path on every part.
-        const NON_BUFFER_FLOOR: u64 = 128 * 1024 * 1024;
+        const NON_BUFFER_FLOOR: usize = 128 * 1024 * 1024;
         let pool = PagedPool::config()
             .with_candidate_sizes([part_size])
-            .with_memory_limit(NON_BUFFER_FLOOR + part_size as u64)
+            .with_memory_limit(NON_BUFFER_FLOOR + part_size)
             .build();
 
-        assert_eq!(pool.available_mem(), part_size as u64);
+        assert_eq!(pool.available_mem(), part_size);
 
         let uploader = Uploader::new(
             client.clone(),
@@ -1195,12 +1195,12 @@ mod tests {
         let client = Arc::new(MockClient::config().bucket(bucket).part_size(part_size).build());
         // `MemoryLimiter::new` reserves max(mem_limit/8, 128 MiB) for non-buffer use,
         // so set `mem_limit` just above that floor to leave room for exactly one part.
-        const LIMITER_MIN_RESERVED: u64 = 128 * 1024 * 1024;
+        const LIMITER_MIN_RESERVED: usize = 128 * 1024 * 1024;
         let pool = PagedPool::config()
             .with_candidate_sizes([part_size])
-            .with_memory_limit(LIMITER_MIN_RESERVED + part_size as u64)
+            .with_memory_limit(LIMITER_MIN_RESERVED + part_size)
             .build();
-        assert_eq!(pool.available_mem(), part_size as u64);
+        assert_eq!(pool.available_mem(), part_size);
 
         let uploader = Uploader::new(
             client.clone(),
@@ -1244,6 +1244,6 @@ mod tests {
             assert_eq!(expected, *actual, "content mismatch for {key}");
         }
 
-        assert_eq!(pool.available_mem(), part_size as u64);
+        assert_eq!(pool.available_mem(), part_size);
     }
 }

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -1145,7 +1145,7 @@ mod tests {
             .with_memory_limit(NON_BUFFER_FLOOR + part_size)
             .build();
 
-        assert_eq!(pool.available_mem(), part_size);
+        assert_eq!(pool.memory_available_for_reservation(), part_size);
 
         let uploader = Uploader::new(
             client.clone(),
@@ -1200,7 +1200,7 @@ mod tests {
             .with_candidate_sizes([part_size])
             .with_memory_limit(LIMITER_MIN_RESERVED + part_size)
             .build();
-        assert_eq!(pool.available_mem(), part_size);
+        assert_eq!(pool.memory_available_for_reservation(), part_size);
 
         let uploader = Uploader::new(
             client.clone(),
@@ -1244,6 +1244,6 @@ mod tests {
             assert_eq!(expected, *actual, "content mismatch for {key}");
         }
 
-        assert_eq!(pool.available_mem(), part_size);
+        assert_eq!(pool.memory_available_for_reservation(), part_size);
     }
 }

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -77,7 +77,7 @@ pub struct TestSessionConfig {
     #[cfg(feature = "manifest")]
     pub manifest: Option<Manifest>,
     pub fail_on_non_aligned_read_window: bool,
-    pub mem_limit: u64,
+    pub mem_limit: usize,
 }
 
 impl Default for TestSessionConfig {
@@ -122,7 +122,7 @@ impl TestSessionConfig {
     }
 
     /// Override the memory limit for this test session.
-    pub fn with_mem_limit(mut self, mem_limit: u64) -> Self {
+    pub fn with_mem_limit(mut self, mem_limit: usize) -> Self {
         self.mem_limit = mem_limit;
         self
     }

--- a/mountpoint-s3-fs/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/write_test.rs
@@ -1388,7 +1388,7 @@ fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_
 //   exercising the concurrent-write path without bumping into the cap).
 #[test_case(512 * 1024 * 1024, 48; "minimum_mem_limit_48_writers")]
 #[test_case(2 * 1024 * 1024 * 1024, 224; "2gib_mem_limit_224_writers")]
-fn concurrent_open_for_write_test(mem_limit: u64, max_files: usize) {
+fn concurrent_open_for_write_test(mem_limit: usize, max_files: usize) {
     let test_config = TestSessionConfig {
         mem_limit,
         ..Default::default()
@@ -1433,7 +1433,7 @@ fn concurrent_open_for_write_test(mem_limit: u64, max_files: usize) {
 fn open_for_write_returns_enomem_when_cap_exhausted() {
     // With `mem_limit = 512 MiB`, `additional_mem_reserved = max(mem_limit/8, 128 MiB) = 128 MiB`,
     // and the default `write_part_size = 8 MiB`, the cap is `(512 - 128) / 8 = 48` writers.
-    const MEM_LIMIT: u64 = 512 * 1024 * 1024;
+    const MEM_LIMIT: usize = 512 * 1024 * 1024;
     const CAP: usize = 48;
 
     let test_config = TestSessionConfig {

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -9,6 +9,9 @@ use crate::common::test_recorder::stress::{HdrMetric, HdrRecorder};
 use super::latency::{FileOp, FileOpLatencies};
 use super::report::{format_mib, us_to_ms_str};
 
+const RESERVED_MEMORY_METRIC: &str = "mem.bytes_reserved";
+const IN_USE_MEMORY_METRIC: &str = "pool.bytes_in_use";
+
 /// Collect `(label_value, Arc<HdrMetric>)` for every registered gauge whose name matches
 /// `metric_name` and that carries a label keyed on `label_key`. Lets invariant checks
 /// auto-discover new `area=` / `kind=` values instead of hardcoding the allowlist.
@@ -22,8 +25,7 @@ fn collect_gauges_by_label(
         if key.name() != metric_name {
             return;
         }
-        // Skip non-gauges as same name can be registered as both Gauge and Histogram
-        // (e.g. `pool.reserved_bytes`).
+        // Skip non-gauges as same name can be registered as both Gauge and Histogram.
         if !matches!(metric.as_ref(), HdrMetric::Gauge(_)) {
             return;
         }
@@ -55,7 +57,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     let effective_budget = mem_limit_u64.saturating_sub(additional_mem_reserved);
 
     let mut mem_overshoots: Vec<String> = Vec::new();
-    for (area, metric) in collect_gauges_by_label(recorder, "mem.bytes_reserved", "area") {
+    for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
         let peak = metric.gauge_history().max();
         tracing::info!(
             scenario = scenario_name,
@@ -65,7 +67,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             "stress: peak mem.bytes_reserved"
         );
         check_peak_violation(
-            "mem.bytes_reserved",
+            RESERVED_MEMORY_METRIC,
             "area",
             &area,
             peak,
@@ -77,23 +79,25 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         tracing::warn!(
             scenario = scenario_name,
             overshoots = ?mem_overshoots,
-            "stress: mem.bytes_reserved peak exceeded effective budget {} (informational — reservations may transiently exceed the limit)",
+            "stress: {} peak exceeded effective budget {} (informational — reservations may transiently exceed the limit)",
+            RESERVED_MEMORY_METRIC,
             format_mib(effective_budget),
         );
     }
 
     let mut pool_violations: Vec<String> = Vec::new();
-    for (kind, metric) in collect_gauges_by_label(recorder, "pool.reserved_bytes", "kind") {
+    for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
         let peak = metric.gauge_history().max();
         tracing::info!(
             scenario = scenario_name,
             kind = %kind,
             peak = %format_mib(peak),
             ceiling = %format_mib(effective_budget),
-            "stress: peak pool.reserved_bytes"
+            "stress: peak {}",
+            IN_USE_MEMORY_METRIC,
         );
         check_peak_violation(
-            "pool.reserved_bytes",
+            IN_USE_MEMORY_METRIC,
             "kind",
             &kind,
             peak,
@@ -107,13 +111,15 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         tracing::error!(
             scenario = scenario_name,
             violations = ?pool_violations,
-            "stress: assertion FAILED — peak pool.reserved_bytes invariant (ceiling {})",
+            "stress: assertion FAILED — peak {} invariant (ceiling {})",
+            IN_USE_MEMORY_METRIC,
             format_mib(effective_budget),
         );
     } else {
         tracing::info!(
             scenario = scenario_name,
-            "stress: assertion PASSED — peak pool.reserved_bytes invariant (ceiling {})",
+            "stress: assertion PASSED — peak {} invariant (ceiling {})",
+            IN_USE_MEMORY_METRIC,
             format_mib(effective_budget),
         );
     }
@@ -199,15 +205,15 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
         return;
     };
     let mut leaks: Vec<String> = Vec::new();
-    for (area, metric) in collect_gauges_by_label(recorder, "mem.bytes_reserved", "area") {
+    for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
         let v = metric.gauge();
-        tracing::info!(scenario = scenario_name, area = %area, value = v, "stress: teardown mem.bytes_reserved");
-        check_teardown_leak("mem.bytes_reserved", "area", &area, v, &mut leaks);
+        tracing::info!(scenario = scenario_name, area = %area, value = v, "stress: teardown {}", RESERVED_MEMORY_METRIC);
+        check_teardown_leak(RESERVED_MEMORY_METRIC, "area", &area, v, &mut leaks);
     }
-    for (kind, metric) in collect_gauges_by_label(recorder, "pool.reserved_bytes", "kind") {
+    for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
         let v = metric.gauge();
-        tracing::info!(scenario = scenario_name, kind = %kind, value = v, "stress: teardown pool.reserved_bytes");
-        check_teardown_leak("pool.reserved_bytes", "kind", &kind, v, &mut leaks);
+        tracing::info!(scenario = scenario_name, kind = %kind, value = v, "stress: teardown {}", IN_USE_MEMORY_METRIC);
+        check_teardown_leak(IN_USE_MEMORY_METRIC, "kind", &kind, v, &mut leaks);
     }
     if leaks.is_empty() {
         tracing::info!(

--- a/mountpoint-s3-fs/tests/stress/test_objects.rs
+++ b/mountpoint-s3-fs/tests/stress/test_objects.rs
@@ -87,10 +87,10 @@ const TEST_OBJECT_FILL_BYTE: u8 = 0xA5;
 
 /// Memory budget for the test object uploader: 95% of total system memory, floored at
 /// `MINIMUM_MEM_LIMIT`. Matches the pattern used by Mountpoint.
-fn compute_test_object_mem_budget() -> u64 {
+fn compute_test_object_mem_budget() -> usize {
     use sysinfo::{RefreshKind, System};
     let sys = System::new_with_specifics(RefreshKind::everything());
-    let ninety_five_pct = ((sys.total_memory() as f64) * 0.95) as u64;
+    let ninety_five_pct = ((sys.total_memory() as f64) * 0.95) as usize;
     ninety_five_pct.max(MINIMUM_MEM_LIMIT)
 }
 

--- a/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
+++ b/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
@@ -3,7 +3,7 @@
 //! Extracts peak memory usage (RSS) from `process.memory_usage` log lines.
 //! Optionally, when both `--mem-limit-mib` and `--extra-metrics-out` are provided, also
 //! extracts peak values for labeled metrics `mem.bytes_reserved[area=...]` and
-//! `pool.reserved_bytes[kind=...]` and writes them to the given path.
+//! `pool.bytes_in_use[kind=...]` and writes them to the given path.
 //!
 //! The extra-metrics file is consumed only by the memory-limited CI jobs'
 //! `render-mem-summary.sh` step to populate the GitHub Actions step summary table and
@@ -66,15 +66,15 @@ fn mem_metric_patterns() -> Vec<(&'static str, Regex)> {
         ),
         (
             "peak_pool_get_object_mib",
-            Regex::new(r"pool\.reserved_bytes\[kind=get_object\]:\s(\d+)$").unwrap(),
+            Regex::new(r"pool\.bytes_in_use\[kind=get_object\]:\s(\d+)$").unwrap(),
         ),
         (
             "peak_pool_put_object_mib",
-            Regex::new(r"pool\.reserved_bytes\[kind=put_object\]:\s(\d+)$").unwrap(),
+            Regex::new(r"pool\.bytes_in_use\[kind=put_object\]:\s(\d+)$").unwrap(),
         ),
         (
             "peak_pool_append_mib",
-            Regex::new(r"pool\.reserved_bytes\[kind=append\]:\s(\d+)$").unwrap(),
+            Regex::new(r"pool\.bytes_in_use\[kind=append\]:\s(\d+)$").unwrap(),
         ),
     ]
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -490,15 +490,15 @@ impl CliArgs {
         Ok(s3path)
     }
 
-    pub fn mem_limit(&self) -> u64 {
+    pub fn mem_limit(&self) -> usize {
         let mut mem_limit = MINIMUM_MEM_LIMIT;
 
-        let default_mem_target = (effective_total_memory() as f64 * 0.95) as u64;
+        let default_mem_target = (effective_total_memory() as f64 * 0.95) as usize;
         mem_limit = mem_limit.max(default_mem_target);
 
         #[cfg(feature = "mem_limiter")]
         if let Some(max_mem_target) = self.max_memory_target {
-            mem_limit = max_mem_target * 1024 * 1024;
+            mem_limit = max_mem_target as usize * 1024 * 1024;
         }
 
         mem_limit

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -204,8 +204,8 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
             client_config.part_config.write_size_bytes,
         ])
         .with_memory_limit(args.mem_limit())
+        .with_maintenance_interval(Duration::from_secs(60))
         .build();
-    pool.spawn_pool_maintenance_thread(Duration::from_secs(60));
 
     let s3_path = args.s3_path()?;
     let (client, runtime, s3_personality) =


### PR DESCRIPTION
Move memory limiting to the time of actual heap allocation, rather than on requesting a buffer. When returning an unused buffers from an already allocated page, the pool can avoid checking against the limit.

Also included in this change:
* Vocabulary cleanup in code and metrics: buffers handed out to consumers are now described as "acquired" / "in use" rather than "reserved" , reserve now means only the prefetch *intent* reservation (e.g. `mem_reserved`).
* Processing of pending allocations was moved to a background thread. Releasing a buffer or deallocating memory now only notifies the thread to trigger processing, rather than invoking it directly, thus avoiding recursive calls.
* Fallback mechanism to allocate smaller pages in the memory pool when under memory pressure. Memory pool pages are still created by default with a buffer count of 16, however if the allocation is blocked by the memory limiter, will iteratively scaled down by halving the buffer count, down to a single buffer.
* Merged the functionality of `PoolStats` into `MemoryLimiter`, which now controls all allocations and deallocations and maintains stats like `allocated_bytes` by handing out the new low-level type `ManagedBuffer`.

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
