### PR TITLE
Merge main into feature/memory-limit

### DIFF
--- a/.github/actions/scripts/render-mem-summary.sh
+++ b/.github/actions/scripts/render-mem-summary.sh
@@ -16,13 +16,13 @@ fi
 
 out="## Memory Breach Detection
 
-| Test | Peak RSS (MiB) | Memory Limit (MiB) | Status | Peak Prefetch Reserved (MiB) | Peak Upload Reserved (MiB) | Peak Pool GetObject (MiB) | Peak Pool PutObject (MiB) |
-|---|---|---|---|---|---|---|---|
+| Test | Peak RSS (MiB) | Memory Limit (MiB) | Status | Peak Prefetch Reserved (MiB) | Peak Upload Reserved (MiB) | Peak Pool GetObject (MiB) | Peak Pool PutObject (MiB) | Peak Pool Append (MiB) |
+|---|---|---|---|---|---|---|---|---|
 "
 for f in "${files[@]}"; do
   row=$(jq -r '
     (if .breached then "❌ BREACHED" else "✅ OK" end) as $status
-    | "| \(.test) | \(.peak_rss_mib) | \(.mem_limit_mib) | \($status) | \(.peak_prefetch_reserved_mib // "N/A") | \(.peak_upload_reserved_mib // "N/A") | \(.peak_pool_get_object_mib // "N/A") | \(.peak_pool_put_object_mib // "N/A") |"
+    | "| \(.test) | \(.peak_rss_mib) | \(.mem_limit_mib) | \($status) | \(.peak_prefetch_reserved_mib // "N/A") | \(.peak_upload_reserved_mib // "N/A") | \(.peak_pool_get_object_mib // "N/A") | \(.peak_pool_put_object_mib // "N/A") | \(.peak_pool_append_mib // "N/A") |"
   ' "$f")
   out+="${row}
 "

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   S3_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
-  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
@@ -94,6 +93,7 @@ jobs:
     - name: Run Benchmark
       env:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'
@@ -181,6 +181,8 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
+      env:
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}latency-bench/
       run: mountpoint-s3/scripts/fs_latency_bench.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix
@@ -267,6 +269,7 @@ jobs:
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary
       if: matrix.variant == 'mem-limited'

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -24,7 +24,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   S3_BUCKET_NAME: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_BUCKET_NAME }}
-  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_BUCKET_BENCH_FILE: ${{ vars.BENCH_FILE_NAME || 'bench100GB.bin' }}
   S3_BUCKET_SMALL_BENCH_FILE: ${{ vars.SMALL_BENCH_FILE_NAME || 'bench5MB.bin' }}
   # Optional endpoint url, can be empty
@@ -54,15 +53,35 @@ jobs:
           - variant: default
             features: ""
             max_memory_target_mib: ""
+            extra_args: ""
+            bench_categories: ""
             name_suffix: ""
             data_path_suffix: ""
             results_subdir_suffix: ""
           - variant: mem-limited
             features: "--features mem_limiter"
             max_memory_target_mib: "512"
+            extra_args: ""
+            bench_categories: ""
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
             results_subdir_suffix: "-mem-limited"
+          - variant: incremental-upload
+            features: ""
+            max_memory_target_mib: ""
+            extra_args: "--incremental-upload"
+            bench_categories: "write mix"
+            name_suffix: ", Incremental Upload"
+            data_path_suffix: "/incremental_upload"
+            results_subdir_suffix: "-incremental-upload"
+          - variant: incremental-upload-mem-limited
+            features: "--features mem_limiter"
+            max_memory_target_mib: "512"
+            extra_args: "--incremental-upload"
+            bench_categories: "write mix"
+            name_suffix: ", Incremental Upload, Memory-Limited"
+            data_path_suffix: "/incremental_upload/mem_limited"
+            results_subdir_suffix: "-incremental-upload-mem-limited"
 
     steps:
     - name: Configure AWS credentials
@@ -94,9 +113,12 @@ jobs:
     - name: Run Benchmark
       env:
         S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_MOUNTPOINT_EXTRA_ARGS: ${{ matrix.extra_args }}
+        S3_BENCH_CATEGORIES: ${{ matrix.bench_categories }}
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
-      if: matrix.variant == 'mem-limited'
+      if: matrix.max_memory_target_mib != ''
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix
@@ -180,6 +202,8 @@ jobs:
     - name: Build
       run: cargo build --release
     - name: Run Benchmark
+      env:
+        S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}latency-bench/
       run: mountpoint-s3/scripts/fs_latency_bench.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Send issue notification to Slack
         if: github.event_name == 'issues'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook
@@ -27,7 +27,7 @@ jobs:
 
       - name: Send pull request notification to Slack
         if: github.event_name == 'pull_request_target'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
           webhook-type: incoming-webhook

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,88 @@
+name: Stress Tests
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+      ref:
+        required: true
+        type: string
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  # Narrow filter: silent by default, our harness and helper modules at info. This keeps
+  # the end-of-run tracing dump visible while suppressing CRT warn/error noise
+  # (credential-chain probes, 404 heads, CRT ERROR on recoverable conditions) that would
+  # dominate a long run's CI log without signaling a real failure.
+  RUST_LOG: "warn,stress_tests=info,awscrt=off"
+  S3_BUCKET_NAME: ${{ vars.S3_BENCH_BUCKET_NAME }}
+  S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
+  S3_ENDPOINT_URL: ${{ vars.S3_BENCH_ENDPOINT_URL }}
+  S3_REGION: ${{ vars.S3_BENCH_REGION }}
+  STRESS_DURATION_SECS: "900"
+
+jobs:
+  approval:
+    name: Approval Gate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Approval Gate
+        run: echo "Approved!"
+
+  stress:
+    name: Stress (${{ matrix.scenario }})
+    runs-on: [self-hosted, linux, x64, nvme-high-performance]
+    needs: approval
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - sustained_reads
+          - sustained_writes
+          - mixed_rw
+          - idle_and_churn
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.ACTIONS_BENCH_IAM_ROLE }}
+          aws-region: ${{ vars.S3_BENCH_REGION }}
+          role-duration-seconds: 21600
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+          persist-credentials: false
+      - name: Install operating system dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          fuseVersion: 2
+          libunwind: true
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - name: Run stress scenario
+        run: |
+          cargo nextest run \
+            --release \
+            --package mountpoint-s3-fs \
+            --features stress_tests \
+            --test stress_tests \
+            --test-threads=1 \
+            --success-output final \
+            --failure-output final \
+            'stress::scenarios::${{ matrix.scenario }}'

--- a/.github/workflows/stress_pr.yml
+++ b/.github/workflows/stress_pr.yml
@@ -1,0 +1,18 @@
+name: Stress Tests (PR)
+
+on:
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  stress:
+    name: Stress Tests
+    uses: ./.github/workflows/stress.yml
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'stress') }}
+    with:
+      environment: PR stress
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/doc/BENCHMARKING.md
+++ b/doc/BENCHMARKING.md
@@ -29,6 +29,8 @@ We keep the records of benchmarking results in `gh-pages` branch and the perform
 - [throughput chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/bench/mem_limited/)
 - [throughput (with cache) chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/cache_bench/mem_limited/)
 - [throughput (s3-express) chart (memory-limited)](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/mem_limited/)
+- [throughput (s3-express, incremental upload) chart](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/incremental_upload/)
+- [throughput (s3-express, incremental upload, memory-limited) chart](https://awslabs.github.io/mountpoint-s3/dev/s3-express/bench/incremental_upload/mem_limited/)
 
 ### Running the benchmark
 While our benchmark script is written for CI testing only, it is possible to run manually.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -40,17 +40,22 @@ For public buckets that do not require AWS credentials, you can use the `--no-si
 ### IAM permissions
 
 Amazon S3 offers both resource-based access policies attached to your S3 buckets (*bucket policies*) and user policies attached to IAM users (*user policies*). You can use either or both of these access policy options to control access to your S3 objects with Mountpoint.
+The permissions required to successfully mount your bucket and perform file system operations via Mountpoint differ between general purpose and directory buckets.
+Additionally, depending on the [file system configuration flags](#file-system-configuration) passed at mount time, some permissions may or may not be necessary.
 
-The IAM credentials you use with Mountpoint must have permission for the `s3:ListBucket` action for the S3 bucket you mount. To be able to read files with Mountpoint, you also need permission for the `s3:GetObject` action for the objects you read.
+#### General purpose buckets
 
-By default, Mountpoint allows writing new files to your S3 bucket, and does not allow deleting existing files. You can disable writing new files, or enable deleting existing files, with [file system configuration flags](#file-system-configuration). Writing files requires permission for the `s3:PutObject` and `s3:AbortMultipartUpload` actions. Deleting existing files requires permission for the `s3:DeleteObject` action.
+On general purpose buckets, the IAM credentials you use with Mountpoint must have permission for the `s3:ListBucket` action for the S3 bucket you mount. To be able to read files with Mountpoint, you also need permission for the `s3:GetObject` action for the objects you read.
+
+By default, Mountpoint allows writing new files to your S3 bucket, and does not allow deleting existing files. You can disable writing new files, or enable deleting existing files, with [file system configuration flags](#file-modifications-and-deletions). Writing files requires permission for the `s3:PutObject` and `s3:AbortMultipartUpload` actions. Deleting existing files requires permission for the `s3:DeleteObject` action.
+
+If you only [mount a prefix of your S3 bucket](#mounting-a-bucket-prefix) rather than the entire bucket, you need these IAM permissions only for the prefix you mount. You can scope down your IAM permissions to a prefix using the `Resource` element of the policy statement for most of these permissions, but for `s3:ListBucket` you must use the `s3:prefix` condition key instead.
 
 If you are using server-side encryption with KMS (SSE-KMS), you will need additional permissions for KMS operations when reading or writing to objects.
 To read objects that are server-side encrypted with SSE-KMS, you will need permission for the `kms:Decrypt` action for the keys used to encrypt the objects.
 To upload new objects that will be encrypted with SSE-KMS, you will need permission for both the `kms:Decrypt` and `kms:GenerateDataKey` actions on the key used to encrypt the object.
 More details on permissions required when using SSE-KMS can be found in the [SSE-KMS section of the S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html).
 
-If you only [mount a prefix of your S3 bucket](#mounting-a-bucket-prefix) rather than the entire bucket, you need these IAM permissions only for the prefix you mount. You can scope down your IAM permissions to a prefix using the `Resource` element of the policy statement for most of these permissions, but for `s3:ListBucket` you must use the `s3:prefix` condition key instead.
 
 Here is an example least-privilege policy document to add to an IAM user or role that allows full access to your S3 bucket for Mountpoint. Replace `amzn-s3-demo-bucket` with the name of your bucket. Alternatively, you can use the [`AmazonS3FullAccess`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-iam-awsmanpol.html) managed policy, but the managed policy grants more permissions than needed for Mountpoint.
 
@@ -85,7 +90,18 @@ Here is an example least-privilege policy document to add to an IAM user or role
 }
 ```
 
-Directory buckets, introduced with the S3 Express One Zone storage class, use a different authentication mechanism from general purpose buckets. Instead of using `s3:*` actions, you should allow the `s3express:CreateSession` action. Here is an example of least-privilege policy document.
+Mountpoint also respects [access control lists (ACLs) applied to objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html) in your S3 bucket, but does not allow you to automatically attach ACLs to objects created with Mountpoint. A majority of modern use cases in Amazon S3 no longer require the use of ACLs. We recommend that you keep ACLs disabled for your S3 bucket, and instead use bucket policies to control access to your objects.
+
+#### Directory buckets
+
+Directory buckets, introduced with the S3 Express One Zone storage class, use a different authentication mechanism from general purpose buckets.
+Instead of using `s3:*` actions, you should allow the `s3express:CreateSession` action.
+This will permit the principal to create an S3 Express session, allowing Mountpoint to perform any supported operation against the bucket.
+To further restrict what operations the principal can perform, you can use Mountpoint with access points for directory buckets.
+With access points for directory buckets, you can use the access point scope to restrict access to specific prefixes or API operations.
+Please refer to the Amazon S3 User Guide for more information, specifically [Security for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-directory-buckets-policies.html) and [Working with access points for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-directory-buckets.html).
+
+Below is an example of a least-privilege bucket policy granting read-write, session-based access to the directory bucket.
 
 ```
 {
@@ -99,8 +115,6 @@ Directory buckets, introduced with the S3 Express One Zone storage class, use a 
     ]
 }
 ```
-
-Mountpoint also respects access control lists (ACLs) applied to objects in your S3 bucket, but does not allow you to automatically attach ACLs to objects created with Mountpoint. A majority of modern use cases in Amazon S3 no longer require the use of ACLs. We recommend that you keep ACLs disabled for your S3 bucket, and instead use bucket policies to control access to your objects.
 
 ## S3 bucket configuration
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Allow mounting on top of `autofs` managed directories. ([#1762](https://github.com/awslabs/mountpoint-s3/pull/1762))
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add `S3FilesystemConfig::content_type_detection` option to configure automatic content type inference for new uploads. When set to `ContentTypeDetection::Auto`, Mountpoint will infer the `Content-Type` of new objects based on their file extension. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
 * Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. Some FUSE operations have a new log printed where they didn't already have one. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add `S3FilesystemConfig::content_type_detection` option to configure automatic content type inference for new uploads. When set to `ContentTypeDetection::Auto`, Mountpoint will infer the `Content-Type` of new objects based on their file extension. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
+* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. Some FUSE operations have a new log printed where they didn't already have one. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
 
 ## v0.9.3 (April 28, 2026)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -102,6 +102,7 @@ s3_tests = []
 s3express_tests = []
 shuttle = []
 second_account_tests = []
+stress_tests = ["s3_tests", "fuse_tests"]
 
 [[example]]
 name = "mount_from_config"

--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 use time::OffsetDateTime;
-use tracing::{Instrument, field, instrument};
+use tracing::{Instrument, debug, field, instrument};
 
 use crate::fs::{
     DirectoryEntry, DirectoryReplier, InodeNo, S3Filesystem, ToErrno, error_metadata::MOUNTPOINT_EVENT_READY,
@@ -101,44 +101,48 @@ impl<Client> Filesystem for S3FuseFilesystem<Client>
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
-    #[instrument(level="warn", skip_all, fields(req=req.unique()))]
-    fn init(&self, req: &Request<'_>, config: &mut KernelConfig) -> Result<(), libc::c_int> {
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), pid=_req.pid()))]
+    fn init(&self, _req: &Request<'_>, config: &mut KernelConfig) -> Result<(), libc::c_int> {
         if let Some(error_logger) = self.error_logger.as_ref() {
             error_logger.event("mount", MOUNTPOINT_EVENT_READY);
         }
         block_on(self.fs.init(config).in_current_span())
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=?name, pid=req.pid()))]
     fn lookup(&self, req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEntry) {
+        debug!("New request");
         match block_on(self.fs.lookup(parent, name).in_current_span()) {
             Ok(entry) => reply.entry(&entry.ttl, &entry.attr, entry.generation),
             Err(e) => fuse_error!("lookup", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty, pid=req.pid()))]
     fn getattr(&self, req: &Request<'_>, ino: InodeNo, _fh: Option<u64>, reply: ReplyAttr) {
+        debug!("New request");
         match block_on(self.fs.getattr(ino).in_current_span()) {
             Ok(attr) => reply.attr(&attr.ttl, &attr.attr),
             Err(e) => fuse_error!("getattr", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino, nlookup, name=field::Empty))]
-    fn forget(&self, req: &Request<'_>, ino: u64, nlookup: u64) {
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino, nlookup, name=field::Empty, pid=_req.pid()))]
+    fn forget(&self, _req: &Request<'_>, ino: u64, nlookup: u64) {
+        debug!("New request");
         block_on(self.fs.forget(ino, nlookup));
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, pid=req.pid(), name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty, pid=req.pid()))]
     fn open(&self, req: &Request<'_>, ino: InodeNo, flags: i32, reply: ReplyOpen) {
+        debug!("New request");
         match block_on(self.fs.open(ino, flags.into(), req.pid()).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
             Err(e) => fuse_error!("open", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, size=size, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, size=size, name=field::Empty, pid=req.pid()))]
     fn read(
         &self,
         req: &Request<'_>,
@@ -150,6 +154,7 @@ where
         lock: Option<u64>,
         reply: ReplyData,
     ) {
+        debug!("New request");
         let mut bytes_sent = 0;
 
         match block_on(self.fs.read(ino, fh, offset, size, flags, lock).in_current_span()) {
@@ -164,16 +169,18 @@ where
         metrics::histogram!(FUSE_IO_SIZE, ATTR_FUSE_REQUEST => "read").record(bytes_sent as f64);
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, name=field::Empty, pid=req.pid()))]
     fn opendir(&self, req: &Request<'_>, parent: InodeNo, flags: i32, reply: ReplyOpen) {
+        debug!("New request");
         match block_on(self.fs.opendir(parent, flags).in_current_span()) {
             Ok(opened) => reply.opened(opened.fh, opened.flags),
             Err(e) => fuse_error!("opendir", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset, pid=req.pid()))]
     fn readdir(&self, req: &Request<'_>, parent: InodeNo, fh: u64, offset: i64, mut reply: fuser::ReplyDirectory) {
+        debug!("New request");
         struct ReplyDirectory<'a> {
             inner: &'a mut fuser::ReplyDirectory,
             count: &'a mut usize,
@@ -204,7 +211,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=parent, fh=fh, offset=offset, pid=req.pid()))]
     fn readdirplus(
         &self,
         req: &Request<'_>,
@@ -213,6 +220,7 @@ where
         offset: i64,
         mut reply: fuser::ReplyDirectoryPlus,
     ) {
+        debug!("New request");
         struct ReplyDirectoryPlus<'a> {
             inner: &'a mut fuser::ReplyDirectoryPlus,
             count: &'a mut usize,
@@ -250,23 +258,25 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, datasync=datasync, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, datasync=datasync, name=field::Empty, pid=req.pid()))]
     fn fsync(&self, req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+        debug!("New request");
         match block_on(self.fs.fsync(ino, fh, datasync).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("fsync", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, pid=req.pid(), name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, name=field::Empty, pid=req.pid()))]
     fn flush(&self, req: &Request<'_>, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
+        debug!("New request");
         match block_on(self.fs.flush(ino, fh, lock_owner, req.pid()).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("flush", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, name=field::Empty, pid=req.pid()))]
     fn release(
         &self,
         req: &Request<'_>,
@@ -277,21 +287,23 @@ where
         flush: bool,
         reply: ReplyEmpty,
     ) {
+        debug!("New request");
         match block_on(self.fs.release(ino, fh, flags, lock_owner, flush).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("release", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, name=field::Empty, pid=req.pid()))]
     fn releasedir(&self, req: &Request<'_>, ino: u64, fh: u64, flags: i32, reply: ReplyEmpty) {
+        debug!("New request");
         match block_on(self.fs.releasedir(ino, fh, flags).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("releasedir", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, pid=req.pid()))]
     fn mknod(
         &self,
         req: &Request<'_>,
@@ -302,6 +314,7 @@ where
         rdev: u32,
         reply: ReplyEntry,
     ) {
+        debug!("New request");
         // mode_t is u32 on Linux but u16 on macOS, so cast it here
         let mode = mode as libc::mode_t;
 
@@ -311,8 +324,9 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, pid=req.pid()))]
     fn mkdir(&self, req: &Request<'_>, parent: u64, name: &OsStr, mode: u32, umask: u32, reply: ReplyEntry) {
+        debug!("New request");
         // mode_t is u32 on Linux but u16 on macOS, so cast it here
         let mode = mode as libc::mode_t;
 
@@ -322,7 +336,7 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), pid=req.pid(), name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=fh, offset=offset, length=data.len(), name=field::Empty, pid=req.pid()))]
     fn write(
         &self,
         req: &Request<'_>,
@@ -335,6 +349,7 @@ where
         lock_owner: Option<u64>,
         reply: ReplyWrite,
     ) {
+        debug!("New request");
         match block_on(
             self.fs
                 .write(ino, fh, offset, data, write_flags, flags, lock_owner)
@@ -349,23 +364,25 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, pid=req.pid()))]
     fn rmdir(&self, req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+        debug!("New request");
         match block_on(self.fs.rmdir(parent, name).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("rmdir", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, pid=req.pid()))]
     fn unlink(&self, req: &Request<'_>, parent: InodeNo, name: &OsStr, reply: ReplyEmpty) {
+        debug!("New request");
         match block_on(self.fs.unlink(parent, name).in_current_span()) {
             Ok(()) => reply.ok(),
             Err(e) => fuse_error!("unlink", reply, e, self, req),
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, name=field::Empty))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, fh=_fh, name=field::Empty, pid=req.pid()))]
     fn setattr(
         &self,
         req: &Request<'_>,
@@ -384,6 +401,7 @@ where
         flags: Option<u32>,
         reply: ReplyAttr,
     ) {
+        debug!("New request");
         let atime = atime.map(|t| match t {
             TimeOrNow::SpecificTime(st) => OffsetDateTime::from(st),
             TimeOrNow::Now => OffsetDateTime::now_utc(),
@@ -398,20 +416,7 @@ where
         }
     }
 
-    // Everything below here is stubs for unsupported functions so we log them correctly
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn readlink(&self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
-        fuse_unsupported!("readlink", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name, link=?link))]
-    fn symlink(&self, _req: &Request<'_>, parent: u64, name: &OsStr, link: &Path, reply: ReplyEntry) {
-        // Userspace expects EPERM for link/symlink if unsupported
-        fuse_unsupported!("symlink", reply, libc::EPERM);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname, pid=req.pid()))]
     fn rename(
         &self,
         req: &Request<'_>,
@@ -422,6 +427,7 @@ where
         flags: u32,
         reply: ReplyEmpty,
     ) {
+        debug!("New request");
         match block_on(
             self.fs
                 .rename(parent, name, newparent, newname, flags.into())
@@ -432,183 +438,9 @@ where
         }
     }
 
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, newparent=newparent, newname=?newname))]
-    fn link(&self, _req: &Request<'_>, ino: u64, newparent: u64, newname: &OsStr, reply: ReplyEntry) {
-        // Userspace expects EPERM for link/symlink if unsupported
-        fuse_unsupported!("link", reply, libc::EPERM);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, datasync=datasync))]
-    fn fsyncdir(&self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
-        fuse_unsupported!("fsyncdir", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
-    fn setxattr(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        name: &OsStr,
-        _value: &[u8],
-        _flags: i32,
-        _position: u32,
-        reply: ReplyEmpty,
-    ) {
-        fuse_unsupported!("setxattr", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
-    fn getxattr(&self, _req: &Request<'_>, ino: u64, name: &OsStr, _size: u32, reply: ReplyXattr) {
-        fuse_unsupported!("getxattr", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn listxattr(&self, _req: &Request<'_>, ino: u64, _size: u32, reply: ReplyXattr) {
-        fuse_unsupported!("listxattr", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, name=?name))]
-    fn removexattr(&self, _req: &Request<'_>, ino: u64, name: &OsStr, reply: ReplyEmpty) {
-        fuse_unsupported!("removexattr", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, mask=mask))]
-    fn access(&self, _req: &Request<'_>, ino: u64, mask: i32, reply: ReplyEmpty) {
-        fuse_unsupported!("access", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name))]
-    fn create(
-        &self,
-        _req: &Request<'_>,
-        parent: u64,
-        name: &OsStr,
-        _mode: u32,
-        _umask: u32,
-        _flags: i32,
-        reply: ReplyCreate,
-    ) {
-        fuse_unsupported!("create", reply, libc::ENOSYS, tracing::Level::DEBUG);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, pid=pid))]
-    fn getlk(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _typ: i32,
-        pid: u32,
-        reply: ReplyLock,
-    ) {
-        fuse_unsupported!("getlk", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, pid=pid))]
-    fn setlk(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _typ: i32,
-        pid: u32,
-        _sleep: bool,
-        reply: ReplyEmpty,
-    ) {
-        fuse_unsupported!("setlk", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn bmap(&self, _req: &Request<'_>, ino: u64, _blocksize: u32, _idx: u64, reply: ReplyBmap) {
-        fuse_unsupported!("bmap", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, cmd=cmd))]
-    fn ioctl(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        _flags: u32,
-        cmd: u32,
-        _in_data: &[u8],
-        _out_size: u32,
-        reply: ReplyIoctl,
-    ) {
-        fuse_unsupported!("ioctl", reply, libc::ENOSYS, tracing::Level::DEBUG);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, length=length))]
-    fn fallocate(
-        &self,
-        _req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
-        length: i64,
-        _mode: i32,
-        reply: ReplyEmpty,
-    ) {
-        fuse_unsupported!("fallocate", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino, fh=fh, offset=offset, whence=whence))]
-    fn lseek(&self, _req: &Request<'_>, ino: u64, fh: u64, offset: i64, whence: i32, reply: ReplyLseek) {
-        fuse_unsupported!("lseek", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino_in=ino_in, fh_in=fh_in, offset_in=offset_in, ino_out=ino_out, fh_out=fh_out, offset_out=offset_out, len=len))]
-    fn copy_file_range(
-        &self,
-        _req: &Request<'_>,
-        ino_in: u64,
-        fh_in: u64,
-        offset_in: i64,
-        ino_out: u64,
-        fh_out: u64,
-        offset_out: i64,
-        len: u64,
-        _flags: u32,
-        reply: ReplyWrite,
-    ) {
-        fuse_unsupported!("copy_file_range", reply);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), name=?name))]
-    fn setvolname(&self, _req: &Request<'_>, name: &OsStr, reply: ReplyEmpty) {
-        fuse_unsupported!("setvolname", reply);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=parent, name=?name, newparent=newparent, newname=?newname))]
-    fn exchange(
-        &self,
-        _req: &Request<'_>,
-        parent: u64,
-        name: &OsStr,
-        newparent: u64,
-        newname: &OsStr,
-        _options: u64,
-        reply: ReplyEmpty,
-    ) {
-        fuse_unsupported!("exchange", reply);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=ino))]
-    fn getxtimes(&self, _req: &Request<'_>, ino: u64, reply: ReplyXTimes) {
-        fuse_unsupported!("getxtimes", reply);
-    }
-
-    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino))]
+    #[instrument(level="warn", skip_all, fields(req=req.unique(), ino=ino, pid=req.pid()))]
     fn statfs(&self, req: &Request<'_>, ino: u64, reply: ReplyStatfs) {
+        debug!("New request");
         match block_on(self.fs.statfs(ino).in_current_span()) {
             Ok(statfs) => reply.statfs(
                 statfs.total_blocks,
@@ -622,5 +454,193 @@ where
             ),
             Err(e) => fuse_error!("statfs", reply, e, self, req),
         }
+    }
+
+    // Everything below here is stubs for unsupported functions so we log them correctly
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, pid=_req.pid()))]
+    fn readlink(&self, _req: &Request<'_>, _ino: u64, reply: ReplyData) {
+        fuse_unsupported!("readlink", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=_parent, name=?_name, link=?_link, pid=_req.pid()))]
+    fn symlink(&self, _req: &Request<'_>, _parent: u64, _name: &OsStr, _link: &Path, reply: ReplyEntry) {
+        // Userspace expects EPERM for link/symlink if unsupported
+        fuse_unsupported!("symlink", reply, libc::EPERM);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, newparent=_newparent, newname=?_newname, pid=_req.pid()))]
+    fn link(&self, _req: &Request<'_>, _ino: u64, _newparent: u64, _newname: &OsStr, reply: ReplyEntry) {
+        // Userspace expects EPERM for link/symlink if unsupported
+        fuse_unsupported!("link", reply, libc::EPERM);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, datasync=_datasync, pid=_req.pid()))]
+    fn fsyncdir(&self, _req: &Request<'_>, _ino: u64, _fh: u64, _datasync: bool, reply: ReplyEmpty) {
+        fuse_unsupported!("fsyncdir", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, name=?_name, pid=_req.pid()))]
+    fn setxattr(
+        &self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _name: &OsStr,
+        _value: &[u8],
+        _flags: i32,
+        _position: u32,
+        reply: ReplyEmpty,
+    ) {
+        fuse_unsupported!("setxattr", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, name=?_name, pid=_req.pid()))]
+    fn getxattr(&self, _req: &Request<'_>, _ino: u64, _name: &OsStr, _size: u32, reply: ReplyXattr) {
+        fuse_unsupported!("getxattr", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, pid=_req.pid()))]
+    fn listxattr(&self, _req: &Request<'_>, _ino: u64, _size: u32, reply: ReplyXattr) {
+        fuse_unsupported!("listxattr", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, name=?_name, pid=_req.pid()))]
+    fn removexattr(&self, _req: &Request<'_>, _ino: u64, _name: &OsStr, reply: ReplyEmpty) {
+        fuse_unsupported!("removexattr", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, mask=_mask, pid=_req.pid()))]
+    fn access(&self, _req: &Request<'_>, _ino: u64, _mask: i32, reply: ReplyEmpty) {
+        fuse_unsupported!("access", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=_parent, name=?_name, pid=_req.pid()))]
+    fn create(
+        &self,
+        _req: &Request<'_>,
+        _parent: u64,
+        _name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        _flags: i32,
+        reply: ReplyCreate,
+    ) {
+        fuse_unsupported!("create", reply, libc::ENOSYS, tracing::Level::DEBUG);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, pid=pid))]
+    fn getlk(
+        &self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: i32,
+        pid: u32,
+        reply: ReplyLock,
+    ) {
+        fuse_unsupported!("getlk", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, pid=pid))]
+    fn setlk(
+        &self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: i32,
+        pid: u32,
+        _sleep: bool,
+        reply: ReplyEmpty,
+    ) {
+        fuse_unsupported!("setlk", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, pid=_req.pid()))]
+    fn bmap(&self, _req: &Request<'_>, _ino: u64, _blocksize: u32, _idx: u64, reply: ReplyBmap) {
+        fuse_unsupported!("bmap", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, cmd=_cmd, pid=_req.pid()))]
+    fn ioctl(
+        &self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _flags: u32,
+        _cmd: u32,
+        _in_data: &[u8],
+        _out_size: u32,
+        reply: ReplyIoctl,
+    ) {
+        fuse_unsupported!("ioctl", reply, libc::ENOSYS, tracing::Level::DEBUG);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, offset=_offset, length=_length, pid=_req.pid()))]
+    fn fallocate(
+        &self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _offset: i64,
+        _length: i64,
+        _mode: i32,
+        reply: ReplyEmpty,
+    ) {
+        fuse_unsupported!("fallocate", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, fh=_fh, offset=_offset, whence=_whence, pid=_req.pid()))]
+    fn lseek(&self, _req: &Request<'_>, _ino: u64, _fh: u64, _offset: i64, _whence: i32, reply: ReplyLseek) {
+        fuse_unsupported!("lseek", reply);
+    }
+
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino_in=_ino_in, fh_in=_fh_in, offset_in=_offset_in, ino_out=_ino_out, fh_out=_fh_out, offset_out=_offset_out, len=_len, pid=_req.pid()))]
+    fn copy_file_range(
+        &self,
+        _req: &Request<'_>,
+        _ino_in: u64,
+        _fh_in: u64,
+        _offset_in: i64,
+        _ino_out: u64,
+        _fh_out: u64,
+        _offset_out: i64,
+        _len: u64,
+        _flags: u32,
+        reply: ReplyWrite,
+    ) {
+        fuse_unsupported!("copy_file_range", reply);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), name=?_name, pid=_req.pid()))]
+    fn setvolname(&self, _req: &Request<'_>, _name: &OsStr, reply: ReplyEmpty) {
+        fuse_unsupported!("setvolname", reply);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), parent=_parent, name=?_name, newparent=_newparent, newname=?_newname, pid=_req.pid()))]
+    fn exchange(
+        &self,
+        _req: &Request<'_>,
+        _parent: u64,
+        _name: &OsStr,
+        _newparent: u64,
+        _newname: &OsStr,
+        _options: u64,
+        reply: ReplyEmpty,
+    ) {
+        fuse_unsupported!("exchange", reply);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[instrument(level="warn", skip_all, fields(req=_req.unique(), ino=_ino, pid=_req.pid()))]
+    fn getxtimes(&self, _req: &Request<'_>, _ino: u64, reply: ReplyXTimes) {
+        fuse_unsupported!("getxtimes", reply);
     }
 }

--- a/mountpoint-s3-fs/src/fuse/config.rs
+++ b/mountpoint-s3-fs/src/fuse/config.rs
@@ -187,7 +187,7 @@ impl MountPoint {
             // some reason.
             match Process::myself().and_then(|me| me.mountinfo()) {
                 Ok(mounts) => {
-                    if mounts.0.iter().any(|mount| mount.mount_point == path) {
+                    if is_mount_point_in_use(&mounts.0, path) {
                         return Err(anyhow!("mount point {} is already mounted", path.display()));
                     }
                 }
@@ -209,6 +209,17 @@ impl std::fmt::Display for MountPoint {
             MountPoint::FileDescriptor(fd) => write!(f, "/dev/fd/{}", fd.as_raw_fd()),
         }
     }
+}
+
+/// Returns true if the given path is already mounted with a non-autofs filesystem.
+///
+/// Directories mounted with `autofs` are not considered in-use because `autofs` is an
+/// automounter that will unmount and remount as needed.
+#[cfg(target_os = "linux")]
+fn is_mount_point_in_use(mounts: &[procfs::process::MountInfo], path: &Path) -> bool {
+    mounts
+        .iter()
+        .any(|mount| mount.mount_point == path && mount.fs_type != "autofs")
 }
 
 /// Parses file descriptor from given mount point.
@@ -237,5 +248,70 @@ mod tests {
     #[test_case("", None; "empty")]
     fn test_parsing_fuse_fd_from_mount_point(mount_point: &str, expected: Option<RawFd>) {
         assert_eq!(expected, parse_fd_from_mount_point(mount_point));
+    }
+
+    #[cfg(target_os = "linux")]
+    mod mount_point_validation {
+        use super::super::*;
+        use procfs::process::MountInfo;
+        use std::path::Path;
+
+        fn mount_info_from_line(line: &str) -> MountInfo {
+            MountInfo::from_line(line).expect("valid mountinfo line")
+        }
+
+        #[test]
+        fn should_not_reject_autofs_mount() {
+            let mounts = vec![mount_info_from_line(
+                "100 1 0:100 / /mnt/auto rw,relatime - autofs systemd-1 rw",
+            )];
+            assert!(
+                !is_mount_point_in_use(&mounts, Path::new("/mnt/auto")),
+                "autofs mount should not be considered in-use"
+            );
+        }
+
+        #[test]
+        fn should_reject_non_autofs_mount() {
+            let mounts = vec![mount_info_from_line(
+                "200 1 0:200 / /mnt/data rw,relatime - ext4 /dev/sda1 rw",
+            )];
+            assert!(
+                is_mount_point_in_use(&mounts, Path::new("/mnt/data")),
+                "non-autofs mount should be considered in-use"
+            );
+        }
+
+        #[test]
+        fn should_not_reject_unrelated_mount() {
+            let mounts = vec![mount_info_from_line(
+                "200 1 0:200 / /mnt/other rw,relatime - ext4 /dev/sda1 rw",
+            )];
+            assert!(
+                !is_mount_point_in_use(&mounts, Path::new("/mnt/data")),
+                "mount at a different path should not affect the target"
+            );
+        }
+
+        #[test]
+        fn should_not_reject_when_no_mounts() {
+            let mounts: Vec<MountInfo> = vec![];
+            assert!(
+                !is_mount_point_in_use(&mounts, Path::new("/mnt/data")),
+                "empty mount list should not reject any path"
+            );
+        }
+
+        #[test]
+        fn should_reject_non_autofs_even_when_autofs_also_present() {
+            let mounts = vec![
+                mount_info_from_line("100 1 0:100 / /mnt/data rw,relatime - autofs systemd-1 rw"),
+                mount_info_from_line("200 1 0:200 / /mnt/data rw,relatime - ext4 /dev/sda1 rw"),
+            ];
+            assert!(
+                is_mount_point_in_use(&mounts, Path::new("/mnt/data")),
+                "should reject when a non-autofs mount exists at the same path"
+            );
+        }
     }
 }

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -118,6 +118,12 @@ impl TestSessionConfig {
         self.fail_on_non_aligned_read_window = enable;
         self
     }
+
+    /// Override the memory limit for this test session.
+    pub fn with_mem_limit(mut self, mem_limit: u64) -> Self {
+        self.filesystem_config.mem_limit = mem_limit;
+        self
+    }
 }
 
 // Holds resources for the testing session and cleans them on drop.

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -123,7 +123,7 @@ impl TestSessionConfig {
 
     /// Override the memory limit for this test session.
     pub fn with_mem_limit(mut self, mem_limit: u64) -> Self {
-        self.filesystem_config.mem_limit = mem_limit;
+        self.mem_limit = mem_limit;
         self
     }
 }

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -157,3 +157,26 @@ fn init_crt() {
     mountpoint_s3_client::config::io_library_init(&mountpoint_s3_client::config::Allocator::default());
     mountpoint_s3_client::config::s3_library_init(&mountpoint_s3_client::config::Allocator::default());
 }
+
+#[cfg(feature = "stress_tests")]
+pub mod stress_recorder {
+    use super::test_recorder::stress::HdrRecorder;
+    use std::sync::OnceLock;
+
+    static RECORDER: OnceLock<HdrRecorder> = OnceLock::new();
+
+    pub fn install() {
+        let recorder = HdrRecorder::default();
+        RECORDER
+            .set(recorder.clone())
+            .map_err(|_| ())
+            .expect("stress_recorder::install() called more than once in this process");
+        metrics::set_global_recorder(recorder)
+            .map_err(|_| ())
+            .expect("a `metrics` global recorder was already installed in this process");
+    }
+
+    pub fn recorder() -> Option<&'static HdrRecorder> {
+        RECORDER.get()
+    }
+}

--- a/mountpoint-s3-fs/tests/common/test_recorder.rs
+++ b/mountpoint-s3-fs/tests/common/test_recorder.rs
@@ -1,25 +1,44 @@
 //! Test utilities for metrics validation
 
+use dashmap::DashMap;
 use metrics::{
     Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
 };
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+/// Return `Some(Arc<M>)` for the unique entry in `map` whose name is `name` and whose label
+/// set exactly matches `labels`. Shared by `TestRecorder` and `HdrRecorder`.
+fn lookup<M>(map: &DashMap<Key, Arc<M>>, name: &str, labels: &[(&str, &str)]) -> Option<Arc<M>> {
+    map.iter()
+        .find(|entry| {
+            let key = entry.key();
+            if key.name() != name {
+                return false;
+            }
+            let actual: Vec<_> = key.labels().map(|l| (l.key(), l.value())).collect();
+            if actual.len() != labels.len() {
+                return false;
+            }
+            labels.iter().all(|(k, v)| actual.contains(&(*k, *v)))
+        })
+        .map(|entry| Arc::clone(entry.value()))
+}
+
+/// Simple `Mutex`-backed metrics storage; intended for low-contention functional tests where
+/// code clarity beats throughput. For high-contention stress runs use [`stress::HdrRecorder`].
 #[derive(Debug, Default, Clone)]
 pub struct TestRecorder {
-    metrics: Arc<Mutex<HashMap<Key, Arc<Metric>>>>,
+    metrics: Arc<DashMap<Key, Arc<Metric>>>,
 }
 
 impl TestRecorder {
     pub fn clear(&self) {
-        let mut metrics = self.metrics.lock().unwrap();
-        metrics.clear();
+        self.metrics.clear();
     }
 
     pub fn print_metrics(&self) {
-        let metrics = self.metrics.lock().unwrap();
-        for (key, metric) in metrics.iter() {
+        for entry in self.metrics.iter() {
+            let (key, metric) = (entry.key(), entry.value());
             match metric.as_ref() {
                 Metric::Histogram(h) => {
                     let h = h.lock().unwrap();
@@ -38,25 +57,7 @@ impl TestRecorder {
     }
 
     pub fn get(&self, name: &str, labels: &[(&str, &str)]) -> Option<Arc<Metric>> {
-        let metrics = self.metrics.lock().unwrap();
-        metrics
-            .iter()
-            .find(|(key, _)| {
-                if key.name() != name {
-                    return false;
-                }
-
-                let actual_labels: Vec<_> = key.labels().map(|l| (l.key(), l.value())).collect();
-
-                // Must have exact same number of labels
-                if actual_labels.len() != labels.len() {
-                    return false;
-                }
-
-                // Every expected label must be in the actual labels
-                labels.iter().all(|(k, v)| actual_labels.contains(&(*k, *v)))
-            })
-            .map(|(_, metric)| Arc::clone(metric))
+        lookup(&self.metrics, name, labels)
     }
 }
 
@@ -96,27 +97,30 @@ impl Recorder for TestRecorder {
     fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
 
     fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        let mut metrics = self.metrics.lock().unwrap();
-        let metric = metrics
+        let metric = self
+            .metrics
             .entry(key.clone())
-            .or_insert(Arc::new(Metric::Counter(Default::default())));
-        Counter::from_arc(metric.clone())
+            .or_insert_with(|| Arc::new(Metric::Counter(Default::default())))
+            .clone();
+        Counter::from_arc(metric)
     }
 
     fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
-        let mut metrics = self.metrics.lock().unwrap();
-        let metric = metrics
+        let metric = self
+            .metrics
             .entry(key.clone())
-            .or_insert(Arc::new(Metric::Gauge(Default::default())));
-        Gauge::from_arc(metric.clone())
+            .or_insert_with(|| Arc::new(Metric::Gauge(Default::default())))
+            .clone();
+        Gauge::from_arc(metric)
     }
 
     fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
-        let mut metrics = self.metrics.lock().unwrap();
-        let metric = metrics
+        let metric = self
+            .metrics
             .entry(key.clone())
-            .or_insert(Arc::new(Metric::Histogram(Default::default())));
-        Histogram::from_arc(metric.clone())
+            .or_insert_with(|| Arc::new(Metric::Histogram(Default::default())))
+            .clone();
+        Histogram::from_arc(metric)
     }
 }
 
@@ -167,5 +171,213 @@ impl HistogramFn for Metric {
             panic!("expected histogram");
         };
         histogram.lock().unwrap().push(value);
+    }
+}
+
+/// HDR-backed recorder used by stress tests. Histograms use `hdrhistogram` for bounded-memory
+/// percentile storage; counters are lock-free `AtomicU64` (matching prod); gauges keep both a
+/// current value and a full HDR history so assertions can read the true peak without sampling
+/// races.
+#[cfg(feature = "stress_tests")]
+pub mod stress {
+    use super::*;
+    use hdrhistogram::Histogram as HdrHistogram;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Upper bound of the HDR histogram — 10 minutes expressed as µs. Records beyond this
+    /// are clamped down so we never panic during recording.
+    pub const HDR_HIGH: u64 = 600_000_000;
+
+    fn new_hdr() -> HdrHistogram<u64> {
+        HdrHistogram::<u64>::new_with_bounds(1, HDR_HIGH, 3).expect("HDR bounds valid")
+    }
+
+    /// Clamp an `f64` into `[0, hist.high()]` as `u64`. NaN and negatives become 0; values
+    /// above the histogram's upper bound are clamped down so recording can never fail.
+    fn clamp(value: f64, hist: &HdrHistogram<u64>) -> u64 {
+        let high = hist.high();
+        if value.is_nan() || value < 0.0 {
+            0
+        } else if value > high as f64 {
+            high
+        } else {
+            value as u64
+        }
+    }
+
+    /// Lock-free counters + HDR-backed histograms and gauge history; intended for long,
+    /// high-contention stress runs where recorder overhead must be bounded. For low-contention
+    /// functional tests use [`super::TestRecorder`].
+    #[derive(Debug, Default, Clone)]
+    pub struct HdrRecorder {
+        metrics: Arc<DashMap<Key, Arc<HdrMetric>>>,
+    }
+
+    impl HdrRecorder {
+        pub fn get(&self, name: &str, labels: &[(&str, &str)]) -> Option<Arc<HdrMetric>> {
+            lookup(&self.metrics, name, labels)
+        }
+
+        /// Call `f` for every registered metric. Holds a read-side `DashMap` reference per
+        /// entry — callers must not re-enter the recorder from `f`.
+        pub fn for_each(&self, mut f: impl FnMut(&Key, &Arc<HdrMetric>)) {
+            for entry in self.metrics.iter() {
+                f(entry.key(), entry.value());
+            }
+        }
+    }
+
+    /// State behind a [`HdrMetric::Gauge`]. Holds both the latest point-in-time value and
+    /// a history of every value the gauge has taken on since installation. The history lets
+    /// tests assert true peak/percentiles of the gauge; the current
+    /// value is still needed for teardown invariants assertions.
+    #[derive(Debug)]
+    pub struct GaugeState {
+        pub current: f64,
+        pub history: HdrHistogram<u64>,
+    }
+
+    impl Default for GaugeState {
+        fn default() -> Self {
+            Self {
+                current: 0.0,
+                history: new_hdr(),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum HdrMetric {
+        Histogram(Mutex<HdrHistogram<u64>>),
+        Counter(AtomicU64),
+        Gauge(Mutex<GaugeState>),
+    }
+
+    impl HdrMetric {
+        pub fn gauge(&self) -> f64 {
+            match self {
+                HdrMetric::Gauge(g) => g.lock().unwrap().current,
+                _ => panic!("expected gauge"),
+            }
+        }
+
+        /// Clone of the full history of values this gauge has been set to since installation.
+        /// Use `.max()` on the returned histogram to get the true peak without sampling races.
+        pub fn gauge_history(&self) -> HdrHistogram<u64> {
+            match self {
+                HdrMetric::Gauge(g) => g.lock().unwrap().history.clone(),
+                _ => panic!("expected gauge"),
+            }
+        }
+
+        pub fn counter(&self) -> u64 {
+            match self {
+                HdrMetric::Counter(c) => c.load(Ordering::Relaxed),
+                _ => panic!("expected counter"),
+            }
+        }
+
+        pub fn histogram_clone(&self) -> HdrHistogram<u64> {
+            match self {
+                HdrMetric::Histogram(h) => h.lock().unwrap().clone(),
+                _ => panic!("expected histogram"),
+            }
+        }
+    }
+
+    impl Recorder for HdrRecorder {
+        fn describe_counter(&self, _k: KeyName, _u: Option<Unit>, _d: SharedString) {}
+        fn describe_gauge(&self, _k: KeyName, _u: Option<Unit>, _d: SharedString) {}
+        fn describe_histogram(&self, _k: KeyName, _u: Option<Unit>, _d: SharedString) {}
+
+        fn register_counter(&self, key: &Key, _m: &Metadata<'_>) -> Counter {
+            let metric = self
+                .metrics
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(HdrMetric::Counter(AtomicU64::new(0))))
+                .clone();
+            Counter::from_arc(metric)
+        }
+
+        fn register_gauge(&self, key: &Key, _m: &Metadata<'_>) -> Gauge {
+            let metric = self
+                .metrics
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(HdrMetric::Gauge(Mutex::new(GaugeState::default()))))
+                .clone();
+            Gauge::from_arc(metric)
+        }
+
+        fn register_histogram(&self, key: &Key, _m: &Metadata<'_>) -> Histogram {
+            let metric = self
+                .metrics
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(HdrMetric::Histogram(Mutex::new(new_hdr()))))
+                .clone();
+            Histogram::from_arc(metric)
+        }
+    }
+
+    impl CounterFn for HdrMetric {
+        fn increment(&self, value: u64) {
+            let HdrMetric::Counter(c) = self else {
+                panic!("expected counter");
+            };
+            c.fetch_add(value, Ordering::Relaxed);
+        }
+        fn absolute(&self, value: u64) {
+            let HdrMetric::Counter(c) = self else {
+                panic!("expected counter");
+            };
+            c.store(value, Ordering::Relaxed);
+        }
+    }
+
+    impl GaugeFn for HdrMetric {
+        fn increment(&self, value: f64) {
+            let HdrMetric::Gauge(g) = self else {
+                panic!("expected gauge");
+            };
+            let mut g = g.lock().unwrap();
+            g.current += value;
+            let current = g.current;
+            record_gauge_sample(&mut g.history, current);
+        }
+        fn decrement(&self, value: f64) {
+            let HdrMetric::Gauge(g) = self else {
+                panic!("expected gauge");
+            };
+            let mut g = g.lock().unwrap();
+            g.current -= value;
+            let current = g.current;
+            record_gauge_sample(&mut g.history, current);
+        }
+        fn set(&self, value: f64) {
+            let HdrMetric::Gauge(g) = self else {
+                panic!("expected gauge");
+            };
+            let mut g = g.lock().unwrap();
+            g.current = value;
+            let current = g.current;
+            record_gauge_sample(&mut g.history, current);
+        }
+    }
+
+    /// Record a gauge's post-mutation value into its history histogram.
+    fn record_gauge_sample(history: &mut HdrHistogram<u64>, value: f64) {
+        let clamped = clamp(value, history);
+        history.record(clamped).ok();
+    }
+
+    impl HistogramFn for HdrMetric {
+        fn record(&self, value: f64) {
+            let HdrMetric::Histogram(h) = self else {
+                panic!("expected histogram");
+            };
+            let mut h = h.lock().unwrap();
+            let clamped = clamp(value, &h);
+            // Cannot fail: `clamped` is within [0, high()].
+            h.record(clamped).ok();
+        }
     }
 }

--- a/mountpoint-s3-fs/tests/stress/README.md
+++ b/mountpoint-s3-fs/tests/stress/README.md
@@ -1,0 +1,104 @@
+# Stress Tests
+
+Long-running tests that sustain concurrent load against real S3 to shake out
+deadlocks, per-worker stalls, tail-latency regressions, and memory issues.
+
+## What it asserts
+
+- No file I/O errors.
+- Aggregated per file I/O p100 latency is within `Scenario::max_latency(op)`.
+- No worker stall longer than `Worker::max_idle()`.
+- At teardown, every reservation gauge is back to zero.
+- Peak memory usage (reserved and RSS).
+
+## Environment variables
+
+| Variable                | Required | Description                                         |
+|-------------------------|----------|-----------------------------------------------------|
+| `S3_BUCKET_NAME`        | yes      | Bucket to use for test objects and ephemeral keys   |
+| `S3_REGION`             | yes      | Region of the bucket                                |
+| `S3_BUCKET_TEST_PREFIX` | no       | Defaults to `mountpoint-test/`; must end in `/`     |
+| AWS credentials         | yes      | Standard SDK resolution (`AWS_PROFILE`, static keys, instance role, etc.) |
+| `STRESS_DURATION_SECS`  | no       | Per-scenario duration in seconds; default 30        |
+
+## How to run
+
+A single scenario:
+
+```
+cargo nextest run --release \
+    --features stress_tests \
+    --package mountpoint-s3-fs \
+    'stress::scenarios::sustained_reads' \
+    --success-output final --failure-output final
+```
+
+All scenarios sequentially:
+
+```
+cargo nextest run --release \
+    --features stress_tests \
+    --package mountpoint-s3-fs \
+    'stress::' \
+    --test-threads=1 \
+    --success-output final --failure-output final
+```
+
+## Adding a new scenario
+
+1. Pick the workers that describe the load. Reuse existing ones
+   (`SequentialReader`, `Writer`, `Idle`, `Churn`) or add a new type under
+   `tests/stress/workers/`.
+2. Create `tests/stress/scenarios/my_scenario.rs` containing one
+   `#[test]` function that:
+   - Builds a `Vec<Arc<dyn Worker>>` using `repeat_n` / `chain` /
+     `repeat_with` as needed.
+   - Builds a `Scenario` value (name, session config, workers,
+     `max_latency`).
+   - Calls `harness::run(scenario)`.
+3. Register the module in `tests/stress/scenarios.rs`.
+
+## Adding a new worker kind
+
+1. Create `tests/stress/workers/my_worker.rs` with a
+   `struct MyWorker { ... }` implementing `Worker`.
+2. In `run`, wrap every file-system operation in
+   `latencies.time(FileOp::_, || ...)` so the harness can aggregate per-op
+   latency distributions. Use `FileOp::CloseRead` / `FileOp::CloseWrite`
+   depending on the handle mode.
+3. For shared read inputs, prefer the dataset descriptors in
+   `workers/common.rs`:
+   - `SharedObject { key, size }` for a single pre-uploaded object.
+   - `SharedObjectPool { key_prefix, count, size }` for a family of
+     identically-sized keys; `pool.pick_key(iter, instance)` returns a
+     pseudo-random key seeded by `(iter, instance)`, and `pool.manifest()`
+     returns the `(key, size)` entries for every key in the pool.
+   Store the descriptor as a field on the worker and derive
+   `shared_objects()` from it:
+   ```rust
+   pub struct MyReader {
+       pub target: SharedObject,
+   }
+
+   impl Worker for MyReader {
+       fn shared_objects(&self) -> Vec<(String, usize)> {
+           vec![(self.target.key.to_string(), self.target.size)]
+       }
+       // ...
+   }
+   ```
+   The harness unions the manifest across every worker in the scenario,
+   de-dupes by key (asserting any two entries agree on size), and calls
+   `ensure_shared_objects` exactly once before spawning threads. It's fine
+   for two worker kinds (e.g. `Idle` and `Churn`) to declare overlapping
+   sets — they'll be collapsed to a single upload pass. Open the file
+   through the mount at
+   `mount_path.join(test_objects::SHARED_OBJECTS_PREFIX).join(key)`. For
+   ephemeral writes, use `test_objects::ephemeral_key(scope, suffix)` to
+   get a flat, per-run-nonced key that cannot collide with shared objects,
+   prior runs, or concurrent runs.
+4. Increment the `progress` counter frequently (the watchdog polls it) and
+   check `stop.load(Ordering::Relaxed)` between ops. Panic on I/O errors —
+   scenarios are sized so the operations always succeed against a healthy
+   session.
+5. Re-export the type from `tests/stress/workers.rs`.

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -52,7 +52,7 @@ pub fn run(scenario: Scenario) {
         max_latency,
     } = scenario;
 
-    let mem_limit = session_config.filesystem_config.mem_limit as f64;
+    let mem_limit = session_config.mem_limit as f64;
     let num_workers = workers.len();
     assert!(
         num_workers > 0,

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -1,0 +1,233 @@
+//! Core harness for stress scenarios.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path};
+
+use crate::common::fuse;
+use crate::common::stress_recorder;
+use crate::stress::test_objects::ensure_shared_objects;
+
+mod invariants;
+mod latency;
+mod memory_monitor;
+mod report;
+mod scenario;
+mod watchdog;
+mod worker;
+use invariants::{
+    assert_p100_latency, assert_peak_reserved_invariant, assert_peak_rss_invariant, assert_teardown_invariants,
+};
+pub use latency::{FileOp, FileOpLatencies};
+use memory_monitor::spawn_memory_monitor;
+use report::dump_summary;
+pub use scenario::{Scenario, default_max_latency};
+use watchdog::{NO_STALL, spawn_watchdog};
+pub use worker::Worker;
+
+/// Default scenario duration if `STRESS_DURATION_SECS` is unset.
+const DEFAULT_DURATION_SECS: u64 = 30;
+
+/// Return the `S3Path` every stress scenario mounts at: `<S3_BUCKET_NAME>/<S3_BUCKET_TEST_PREFIX>`
+fn stress_mount_s3_path() -> S3Path {
+    let bucket = crate::common::s3::get_test_bucket();
+    let prefix = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or_else(|_| String::from("mountpoint-test/"));
+    assert!(prefix.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
+    S3Path::new(Bucket::new(bucket).unwrap(), Prefix::new(&prefix).unwrap())
+}
+
+/// Run the given scenario. Reads `STRESS_DURATION_SECS` from env; default 30s.
+pub fn run(scenario: Scenario) {
+    stress_recorder::install();
+
+    let duration = read_duration_env();
+    let Scenario {
+        name: scenario_name,
+        mut session_config,
+        workers,
+        max_latency,
+    } = scenario;
+
+    let mem_limit = session_config.filesystem_config.mem_limit as f64;
+    let num_workers = workers.len();
+    assert!(
+        num_workers > 0,
+        "scenario {scenario_name:?} must declare at least one worker"
+    );
+
+    // Per-kind instance index (0-based within each kind) and human-readable labels
+    // (`kind#instance`) used in log lines and stall messages.
+    let (instances, labels) = assign_instances_and_labels(&workers);
+
+    tracing::info!(
+        scenario = scenario_name,
+        duration_secs = duration.as_secs(),
+        workers = num_workers,
+        "stress: starting"
+    );
+
+    let shared_objects = collect_shared_objects(&workers, scenario_name);
+    let shared_refs: Vec<(&str, usize)> = shared_objects.iter().map(|(k, s)| (k.as_str(), *s)).collect();
+    ensure_shared_objects(&shared_refs);
+
+    let session = {
+        session_config.filesystem_config.allow_delete = true;
+        session_config.filesystem_config.allow_overwrite = true;
+        let s3_path = stress_mount_s3_path();
+        let region = crate::common::s3::get_test_region();
+        let sdk_client = crate::common::tokio_block_on(async { crate::common::s3::get_test_sdk_client(&region).await });
+        fuse::s3_session::new_with_test_client(session_config, sdk_client, s3_path)
+    };
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let progress: Vec<Arc<AtomicU64>> = (0..num_workers).map(|_| Arc::new(AtomicU64::new(0))).collect();
+    let stalled_worker = Arc::new(AtomicUsize::new(NO_STALL));
+
+    let max_idles: Vec<Duration> = workers.iter().map(|w| w.max_idle()).collect();
+    let max_join_wait = max_idles
+        .iter()
+        .copied()
+        .max()
+        .expect("scenario must declare at least one worker");
+
+    let mount_path: std::path::PathBuf = session.mount_path().to_path_buf();
+    let mut handles: Vec<thread::JoinHandle<FileOpLatencies>> = Vec::with_capacity(num_workers);
+    for (worker_id, worker) in workers.iter().enumerate() {
+        let worker = Arc::clone(worker);
+        let stop = stop.clone();
+        let progress = progress[worker_id].clone();
+        let mount_path = mount_path.clone();
+        let instance = instances[worker_id];
+        handles.push(thread::spawn(move || {
+            let mut latencies = FileOpLatencies::new();
+            worker.run(instance, &mount_path, &progress, &mut latencies, &stop);
+            latencies
+        }));
+    }
+
+    let watchdog = spawn_watchdog(
+        scenario_name.to_string(),
+        labels.clone(),
+        max_idles.clone(),
+        progress.clone(),
+        stop.clone(),
+        stalled_worker.clone(),
+    );
+
+    let memory_monitor = spawn_memory_monitor(stop.clone(), Duration::from_millis(100));
+
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        if stalled_worker.load(Ordering::SeqCst) != NO_STALL {
+            break;
+        }
+        thread::sleep(Duration::from_millis(200).min(deadline.saturating_duration_since(Instant::now())));
+    }
+    stop.store(true, Ordering::SeqCst);
+    let _ = watchdog.join();
+    let _ = memory_monitor.join();
+
+    // Bounded join: workers observe `stop` between ops and should finish quickly. If any
+    // are wedged in a kernel FUSE syscall they cannot observe `stop` and `JoinHandle` has
+    // no timeout API, so we poll `is_finished()` up to a deadline. On timeout we drop
+    // (unmount) the session to force EIO/EINTR on stuck syscalls, then panic with the
+    // stuck worker labels.
+    let join_deadline = Instant::now() + max_join_wait;
+    while !handles.iter().all(|h| h.is_finished()) {
+        if Instant::now() >= join_deadline {
+            let stuck: Vec<&str> = handles
+                .iter()
+                .enumerate()
+                .filter_map(|(id, h)| (!h.is_finished()).then_some(labels[id].as_str()))
+                .collect();
+            drop(session);
+            panic!("stress: workers {stuck:?} did not finish within {max_join_wait:?} after stop");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let mut aggregate = FileOpLatencies::new();
+    for (id, handle) in handles.into_iter().enumerate() {
+        let rec = handle
+            .join()
+            .unwrap_or_else(|e| panic!("worker {} panicked: {e:?}", labels[id]));
+        aggregate.merge(&rec);
+    }
+
+    drop(session);
+
+    let stalled = stalled_worker.load(Ordering::SeqCst);
+    if stalled != NO_STALL {
+        panic!(
+            "stress: scenario {scenario_name:?} failed: worker {} stalled for at least {:?}",
+            labels[stalled], max_idles[stalled],
+        );
+    }
+
+    dump_summary(scenario_name, &aggregate);
+
+    tracing::info!("");
+    tracing::info!("=== STRESS [{}] INVARIANT ASSERTIONS ===", scenario_name);
+    assert_peak_reserved_invariant(scenario_name, mem_limit);
+    assert_peak_rss_invariant(scenario_name, mem_limit);
+    assert_teardown_invariants(scenario_name);
+    assert_p100_latency(scenario_name, &aggregate, max_latency);
+    tracing::info!("");
+
+    tracing::info!(scenario = scenario_name, "stress: finished");
+}
+
+/// Compute, for each worker, its 0-based instance index within its kind, along with a
+/// `kind#instance` label used in logs and stall messages.
+fn assign_instances_and_labels(workers: &[Arc<dyn Worker>]) -> (Vec<usize>, Vec<String>) {
+    let mut counts: HashMap<&'static str, usize> = HashMap::new();
+    let mut instances = Vec::with_capacity(workers.len());
+    let mut labels = Vec::with_capacity(workers.len());
+    for w in workers {
+        let kind = w.kind();
+        let instance = *counts.entry(kind).and_modify(|c| *c += 1).or_insert(0);
+        labels.push(format!("{kind}#{instance}"));
+        instances.push(instance);
+    }
+    (instances, labels)
+}
+
+/// Union every worker's shared-objects manifest and de-dupe by key. If two workers
+/// declare the same key with different sizes, panic with a clear message — that's a
+/// scenario bug, not a runtime error we should paper over.
+///
+/// Returns the manifest.
+fn collect_shared_objects(workers: &[Arc<dyn Worker>], scenario_name: &str) -> Vec<(String, usize)> {
+    let mut out: Vec<(String, usize)> = Vec::new();
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    for w in workers {
+        for (key, size) in w.shared_objects() {
+            match seen.get(&key) {
+                Some(&existing_size) => {
+                    assert_eq!(
+                        existing_size, size,
+                        "stress: scenario {scenario_name:?} has conflicting declarations for shared object {key:?}: \
+                         {existing_size} vs {size}"
+                    );
+                }
+                None => {
+                    seen.insert(key.clone(), size);
+                    out.push((key, size));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn read_duration_env() -> Duration {
+    let secs = std::env::var("STRESS_DURATION_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_DURATION_SECS);
+    Duration::from_secs(secs)
+}

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -1,0 +1,274 @@
+//! Teardown-time invariant assertions for stress scenarios.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::common::stress_recorder;
+use crate::common::test_recorder::stress::{HdrMetric, HdrRecorder};
+
+use super::latency::{FileOp, FileOpLatencies};
+use super::report::{format_mib, us_to_ms_str};
+
+/// Collect `(label_value, Arc<HdrMetric>)` for every registered gauge whose name matches
+/// `metric_name` and that carries a label keyed on `label_key`. Lets invariant checks
+/// auto-discover new `area=` / `kind=` values instead of hardcoding the allowlist.
+fn collect_gauges_by_label(
+    recorder: &HdrRecorder,
+    metric_name: &str,
+    label_key: &str,
+) -> Vec<(String, Arc<HdrMetric>)> {
+    let mut out = Vec::new();
+    recorder.for_each(|key, metric| {
+        if key.name() != metric_name {
+            return;
+        }
+        // Skip non-gauges as same name can be registered as both Gauge and Histogram
+        // (e.g. `pool.reserved_bytes`).
+        if !matches!(metric.as_ref(), HdrMetric::Gauge(_)) {
+            return;
+        }
+        let Some(label_value) = key
+            .labels()
+            .find(|l| l.key() == label_key)
+            .map(|l| l.value().to_string())
+        else {
+            return;
+        };
+        out.push((label_value, Arc::clone(metric)));
+    });
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// Assert each individual reserved-memory gauge stayed below the effective budget the
+/// limiter enforces against (`mem_limit - additional_mem_reserved`)
+pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
+    let Some(recorder) = stress_recorder::recorder() else {
+        tracing::warn!(
+            scenario = scenario_name,
+            "stress: no recorder installed, skipping peak-reserved invariant"
+        );
+        return;
+    };
+    let mem_limit_u64 = mem_limit as u64;
+    let additional_mem_reserved = (mem_limit_u64 / 8).max(128 * 1024 * 1024);
+    let effective_budget = mem_limit_u64.saturating_sub(additional_mem_reserved);
+
+    let mut mem_overshoots: Vec<String> = Vec::new();
+    for (area, metric) in collect_gauges_by_label(recorder, "mem.bytes_reserved", "area") {
+        let peak = metric.gauge_history().max();
+        tracing::info!(
+            scenario = scenario_name,
+            area = %area,
+            peak = %format_mib(peak),
+            ceiling = %format_mib(effective_budget),
+            "stress: peak mem.bytes_reserved"
+        );
+        check_peak_violation(
+            "mem.bytes_reserved",
+            "area",
+            &area,
+            peak,
+            effective_budget,
+            &mut mem_overshoots,
+        );
+    }
+    if !mem_overshoots.is_empty() {
+        tracing::warn!(
+            scenario = scenario_name,
+            overshoots = ?mem_overshoots,
+            "stress: mem.bytes_reserved peak exceeded effective budget {} (informational — reservations may transiently exceed the limit)",
+            format_mib(effective_budget),
+        );
+    }
+
+    let mut pool_violations: Vec<String> = Vec::new();
+    for (kind, metric) in collect_gauges_by_label(recorder, "pool.reserved_bytes", "kind") {
+        let peak = metric.gauge_history().max();
+        tracing::info!(
+            scenario = scenario_name,
+            kind = %kind,
+            peak = %format_mib(peak),
+            ceiling = %format_mib(effective_budget),
+            "stress: peak pool.reserved_bytes"
+        );
+        check_peak_violation(
+            "pool.reserved_bytes",
+            "kind",
+            &kind,
+            peak,
+            effective_budget,
+            &mut pool_violations,
+        );
+    }
+    // TODO: promote from logging error to assert once production accounting is tight
+    // enough that breaches indicate real regressions rather than known-gap overshoot.
+    if !pool_violations.is_empty() {
+        tracing::error!(
+            scenario = scenario_name,
+            violations = ?pool_violations,
+            "stress: assertion FAILED — peak pool.reserved_bytes invariant (ceiling {})",
+            format_mib(effective_budget),
+        );
+    } else {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — peak pool.reserved_bytes invariant (ceiling {})",
+            format_mib(effective_budget),
+        );
+    }
+}
+
+/// Push a `{metric}{{{label_key}={label_value}}} peak ... exceeds effective budget ...`
+/// message onto `violations` iff `peak > effective_budget`.
+fn check_peak_violation(
+    metric_name: &str,
+    label_key: &str,
+    label_value: &str,
+    peak: u64,
+    effective_budget: u64,
+    violations: &mut Vec<String>,
+) {
+    if peak > effective_budget {
+        violations.push(format!(
+            "{metric_name}{{{label_key}={label_value}}} peak {} exceeds effective budget {}",
+            format_mib(peak),
+            format_mib(effective_budget),
+        ));
+    }
+}
+
+/// Assert the peak sampled `process.memory_usage` (OS-reported RSS) stayed under
+/// `ceiling_bytes`.
+pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
+    let Some(recorder) = stress_recorder::recorder() else {
+        tracing::warn!(
+            scenario = scenario_name,
+            "stress: no recorder installed, skipping peak-rss invariant"
+        );
+        return;
+    };
+    let Some(metric) = recorder.get("process.memory_usage", &[]) else {
+        tracing::warn!(
+            scenario = scenario_name,
+            "stress: process.memory_usage not recorded, skipping peak-rss invariant"
+        );
+        return;
+    };
+    let peak = metric.gauge_history().max();
+    let ceiling = ceiling_bytes as u64;
+    tracing::info!(
+        scenario = scenario_name,
+        peak = %format_mib(peak),
+        ceiling = %format_mib(ceiling),
+        "stress: peak process.memory_usage"
+    );
+    let mut violations: Vec<String> = Vec::new();
+    if peak > ceiling {
+        violations.push(format!(
+            "process.memory_usage peak {} exceeds mem_limit {}",
+            format_mib(peak),
+            format_mib(ceiling),
+        ));
+    }
+    // TODO: promote from error to assert once production accounting is tight
+    // enough that breaches indicate real regressions rather than known-gap overshoot.
+    if !violations.is_empty() {
+        tracing::error!(
+            scenario = scenario_name,
+            ?violations,
+            "stress: assertion FAILED — peak-rss invariant (ceiling {})",
+            format_mib(ceiling),
+        );
+    } else {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — peak-rss invariant (ceiling {})",
+            format_mib(ceiling),
+        );
+    }
+}
+
+/// After the session is dropped, every reservation-tracking gauge must be back to zero.
+pub fn assert_teardown_invariants(scenario_name: &str) {
+    let Some(recorder) = stress_recorder::recorder() else {
+        tracing::warn!(
+            scenario = scenario_name,
+            "stress: no recorder installed, skipping teardown invariants"
+        );
+        return;
+    };
+    let mut leaks: Vec<String> = Vec::new();
+    for (area, metric) in collect_gauges_by_label(recorder, "mem.bytes_reserved", "area") {
+        let v = metric.gauge();
+        tracing::info!(scenario = scenario_name, area = %area, value = v, "stress: teardown mem.bytes_reserved");
+        check_teardown_leak("mem.bytes_reserved", "area", &area, v, &mut leaks);
+    }
+    for (kind, metric) in collect_gauges_by_label(recorder, "pool.reserved_bytes", "kind") {
+        let v = metric.gauge();
+        tracing::info!(scenario = scenario_name, kind = %kind, value = v, "stress: teardown pool.reserved_bytes");
+        check_teardown_leak("pool.reserved_bytes", "kind", &kind, v, &mut leaks);
+    }
+    if leaks.is_empty() {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — teardown invariants (all reservation gauges back to zero)"
+        );
+    } else {
+        tracing::error!(
+            scenario = scenario_name,
+            ?leaks,
+            "stress: assertion FAILED — teardown invariants"
+        );
+    }
+    assert!(
+        leaks.is_empty(),
+        "teardown invariant violated:\n  {}",
+        leaks.join("\n  ")
+    );
+}
+
+/// Push a `{metric}{{{label_key}={label_value}}} = {v}` message onto `leaks` iff `v != 0`.
+fn check_teardown_leak(metric_name: &str, label_key: &str, label_value: &str, v: f64, leaks: &mut Vec<String>) {
+    if v != 0.0 {
+        leaks.push(format!("{metric_name}{{{label_key}={label_value}}} = {v}"));
+    }
+}
+
+/// Assert that the merged per-op p100 latency is within `max_latency(op)`.
+pub fn assert_p100_latency(scenario_name: &str, aggregate: &FileOpLatencies, max_latency: impl Fn(FileOp) -> Duration) {
+    let mut violations: Vec<String> = Vec::new();
+    for op in FileOp::ALL {
+        let h = aggregate.histogram(op);
+        if h.is_empty() {
+            continue;
+        }
+        let max_us = max_latency(op).as_micros().min(u64::MAX as u128) as u64;
+        let max_observed = h.max();
+        if max_observed > max_us {
+            violations.push(format!(
+                "op={} p100={}ms exceeds max_latency={}ms (count={})",
+                op.name(),
+                us_to_ms_str(max_observed),
+                us_to_ms_str(max_us),
+                h.len(),
+            ));
+        }
+    }
+    if !violations.is_empty() {
+        tracing::error!(
+            scenario = scenario_name,
+            ?violations,
+            "stress: assertion FAILED — p100 latency invariant (per-op ceilings)",
+        );
+        panic!(
+            "stress: scenario {:?} violated p100 latency ceiling:\n  {}",
+            scenario_name,
+            violations.join("\n  "),
+        );
+    }
+    tracing::info!(
+        scenario = scenario_name,
+        "stress: assertion PASSED — p100 latency invariant (per-op ceilings)",
+    );
+}

--- a/mountpoint-s3-fs/tests/stress/harness/latency.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/latency.rs
@@ -1,0 +1,78 @@
+//! Per-op latency histograms timed by scenario workers.
+
+use std::time::Instant;
+
+use hdrhistogram::Histogram as HdrHistogram;
+
+/// File operations timed by [`FileOpLatencies`].
+#[derive(Clone, Copy, Debug)]
+pub enum FileOp {
+    Open = 0,
+    Read = 1,
+    Write = 2,
+    CloseRead = 3,
+    CloseWrite = 4,
+}
+
+impl FileOp {
+    pub const ALL: [FileOp; 5] = [
+        FileOp::Open,
+        FileOp::Read,
+        FileOp::Write,
+        FileOp::CloseRead,
+        FileOp::CloseWrite,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            FileOp::Open => "open",
+            FileOp::Read => "read",
+            FileOp::Write => "write",
+            FileOp::CloseRead => "close_read",
+            FileOp::CloseWrite => "close_write",
+        }
+    }
+}
+
+/// Per-worker op-latency histograms. Each worker owns one; the harness merges them at teardown.
+pub struct FileOpLatencies {
+    histograms: [HdrHistogram<u64>; 5],
+}
+
+impl FileOpLatencies {
+    pub fn new() -> Self {
+        let mk = || HdrHistogram::<u64>::new_with_bounds(1, 600_000_000, 3).expect("HDR bounds valid");
+        Self {
+            histograms: [mk(), mk(), mk(), mk(), mk()],
+        }
+    }
+
+    /// Time `f` and record its elapsed microseconds under `op`.
+    pub fn time<R>(&mut self, op: FileOp, f: impl FnOnce() -> R) -> R {
+        let start = Instant::now();
+        let out = f();
+        let elapsed_us = start.elapsed().as_micros();
+        let h = &mut self.histograms[op as usize];
+        let high = h.high();
+        let v = elapsed_us.min(high as u128) as u64;
+        h.record(v).ok();
+        out
+    }
+
+    pub fn histogram(&self, op: FileOp) -> &HdrHistogram<u64> {
+        &self.histograms[op as usize]
+    }
+
+    pub fn merge(&mut self, other: &FileOpLatencies) {
+        for op in FileOp::ALL {
+            // Safe: both histograms share the same bounds.
+            let _ = self.histograms[op as usize].add(&other.histograms[op as usize]);
+        }
+    }
+}
+
+impl Default for FileOpLatencies {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/mountpoint-s3-fs/tests/stress/harness/memory_monitor.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/memory_monitor.rs
@@ -1,0 +1,39 @@
+//! Memory monitor thread. Populates the `process.memory_usage` gauge with the OS-reported
+//! RSS so teardown invariants can assert on peak process memory.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use mountpoint_s3_fs::metrics::defs::PROCESS_MEMORY_USAGE;
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
+
+/// Spawn a thread that samples the current process's RSS every `interval` and records it
+/// into the `process.memory_usage` gauge, matching the metric name the production binary
+/// emits from `mountpoint_s3_fs::metrics::poll_process_metrics`.
+pub(super) fn spawn_memory_monitor(stop: Arc<AtomicBool>, interval: Duration) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let Ok(pid) = get_current_pid() else {
+            tracing::warn!("stress: get_current_pid failed; memory monitor disabled");
+            return;
+        };
+        let mut sys = System::new();
+        let sample = |sys: &mut System| {
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                false,
+                ProcessRefreshKind::nothing().with_memory(),
+            );
+            if let Some(process) = sys.process(pid) {
+                metrics::gauge!(PROCESS_MEMORY_USAGE).set(process.memory() as f64);
+            }
+        };
+        while !stop.load(Ordering::Relaxed) {
+            sample(&mut sys);
+            thread::sleep(interval);
+        }
+        // Final sample so the teardown peak is captured.
+        sample(&mut sys);
+    })
+}

--- a/mountpoint-s3-fs/tests/stress/harness/report.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/report.rs
@@ -1,0 +1,88 @@
+//! Log-output formatting for scenario summaries.
+
+use crate::common::stress_recorder;
+use crate::common::test_recorder::stress::HdrMetric;
+
+use super::latency::{FileOp, FileOpLatencies};
+
+/// Format a microsecond value as milliseconds with one decimal place.
+pub(super) fn us_to_ms_str(us: u64) -> String {
+    format!("{:.1}", us as f64 / 1000.0)
+}
+
+/// Format a byte count as `<value> MiB` with one decimal place, for readable log output.
+pub(super) fn format_mib(bytes: u64) -> String {
+    format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+/// Print a per-op worker latency table followed by the global HdrRecorder snapshot.
+pub(super) fn dump_summary(scenario_name: &str, aggregate: &FileOpLatencies) {
+    tracing::info!("=== STRESS [{scenario_name}] FILE OP LATENCIES ===");
+    for op in FileOp::ALL {
+        let h = aggregate.histogram(op);
+        let count = h.len();
+        if count == 0 {
+            tracing::info!("op={} count=0", op.name());
+            continue;
+        }
+        tracing::info!(
+            "op={} count={} p50={}ms p90={}ms p99={}ms p100={}ms",
+            op.name(),
+            count,
+            us_to_ms_str(h.value_at_quantile(0.50)),
+            us_to_ms_str(h.value_at_quantile(0.90)),
+            us_to_ms_str(h.value_at_quantile(0.99)),
+            us_to_ms_str(h.max()),
+        );
+    }
+
+    tracing::info!("");
+    tracing::info!("=== STRESS [{scenario_name}] AGGREGATED MOUNTPOINT METRICS ===");
+    let Some(recorder) = stress_recorder::recorder() else {
+        tracing::info!("(no stress recorder installed)");
+        return;
+    };
+    let mut lines: Vec<(String, String)> = Vec::new();
+    recorder.for_each(|key, metric| {
+        let key_str = format!("{key}");
+        let line = match metric.as_ref() {
+            HdrMetric::Histogram(_) => {
+                let h = metric.histogram_clone();
+                let count = h.len();
+                if count == 0 {
+                    format!("hist {key}: count=0")
+                } else {
+                    // Raw HDR values: unit varies per metric (bytes, µs, MiB, count, etc.) —
+                    // the caller interprets from the metric name. Formatting a single unit
+                    // here would be wrong for anything that isn't latency.
+                    format!(
+                        "hist {key}: count={} p50={} p90={} p99={} p100={}",
+                        count,
+                        h.value_at_quantile(0.50),
+                        h.value_at_quantile(0.90),
+                        h.value_at_quantile(0.99),
+                        h.max(),
+                    )
+                }
+            }
+            HdrMetric::Counter(_) => format!("counter {key}: {}", metric.counter()),
+            HdrMetric::Gauge(_) => {
+                let current = metric.gauge();
+                let history = metric.gauge_history();
+                format!(
+                    "gauge {key}: current={current} peak={} samples={} (p50={} p90={} p99={})",
+                    history.max(),
+                    history.len(),
+                    history.value_at_quantile(0.50),
+                    history.value_at_quantile(0.90),
+                    history.value_at_quantile(0.99),
+                )
+            }
+        };
+        lines.push((key_str, line));
+    });
+    lines.sort_by(|a, b| a.0.cmp(&b.0));
+    for (_, line) in lines {
+        tracing::info!("{}", line);
+    }
+}

--- a/mountpoint-s3-fs/tests/stress/harness/scenario.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/scenario.rs
@@ -1,0 +1,30 @@
+//! Scenario — description of one stress run.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::common::fuse::TestSessionConfig;
+
+use super::latency::FileOp;
+use super::worker::Worker;
+
+/// A stress-test scenario: the complete description of one run.
+pub struct Scenario {
+    /// Short name — used for logging and as the S3 test prefix component.
+    pub name: &'static str,
+
+    /// FUSE/Mountpoint session configuration (memory limit, part size, etc.).
+    pub session_config: TestSessionConfig,
+
+    /// The workers to spawn, one thread per entry.
+    pub workers: Vec<Arc<dyn Worker>>,
+
+    /// Maximum allowed p100 latency for each file op, aggregated across all workers.
+    pub max_latency: fn(FileOp) -> Duration,
+}
+
+/// Default per-op latency ceiling: 20s for every op. Scenarios may provide their own
+/// function if they have a different natural profile.
+pub fn default_max_latency(_op: FileOp) -> Duration {
+    Duration::from_secs(20)
+}

--- a/mountpoint-s3-fs/tests/stress/harness/watchdog.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/watchdog.rs
@@ -1,0 +1,56 @@
+//! Stall-detection watchdog. Runs on its own thread, watches per-worker progress counters,
+//! and flags the first worker that goes longer than its per-worker `max_idle` without
+//! advancing.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Watchdog poll interval.
+pub(super) const WATCHDOG_POLL: Duration = Duration::from_secs(1);
+
+/// Sentinel value meaning "no stall detected".
+pub(super) const NO_STALL: usize = usize::MAX;
+
+pub(super) fn spawn_watchdog(
+    scenario_name: String,
+    labels: Vec<String>,
+    max_idle_per_worker: Vec<Duration>,
+    progress: Vec<Arc<AtomicU64>>,
+    stop: Arc<AtomicBool>,
+    stalled_worker: Arc<AtomicUsize>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let start = Instant::now();
+        let mut last_progress: Vec<u64> = progress.iter().map(|p| p.load(Ordering::Relaxed)).collect();
+        let mut last_advance: Vec<Instant> = vec![start; progress.len()];
+        while !stop.load(Ordering::Relaxed) {
+            thread::sleep(WATCHDOG_POLL);
+            let now = Instant::now();
+            for (id, counter) in progress.iter().enumerate() {
+                let current = counter.load(Ordering::Relaxed);
+                if current > last_progress[id] {
+                    last_progress[id] = current;
+                    last_advance[id] = now;
+                } else if now.duration_since(last_advance[id]) >= max_idle_per_worker[id] {
+                    let snapshot: Vec<(&str, u64)> = progress
+                        .iter()
+                        .enumerate()
+                        .map(|(i, p)| (labels[i].as_str(), p.load(Ordering::Relaxed)))
+                        .collect();
+                    tracing::error!(
+                        scenario = %scenario_name,
+                        stalled_worker = %labels[id],
+                        max_idle_secs = max_idle_per_worker[id].as_secs(),
+                        ?snapshot,
+                        "stress: worker stalled — per-worker progress snapshot"
+                    );
+                    stalled_worker.store(id, Ordering::SeqCst);
+                    stop.store(true, Ordering::SeqCst);
+                    return;
+                }
+            }
+        }
+    })
+}

--- a/mountpoint-s3-fs/tests/stress/harness/worker.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/worker.rs
@@ -1,0 +1,41 @@
+//! Worker trait — the unit of composition for stress scenarios.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::time::Duration;
+
+use super::latency::FileOpLatencies;
+
+/// A stress-test worker.
+pub trait Worker: Send + Sync {
+    /// Short human-readable label for this kind of worker.
+    fn kind(&self) -> &'static str;
+
+    /// Shared S3 input objects this worker needs.
+    fn shared_objects(&self) -> Vec<(String, usize)> {
+        Vec::new()
+    }
+
+    /// Maximum time this worker may go without incrementing its progress counter before
+    /// the watchdog declares it stalled. Default 20s.
+    fn max_idle(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+
+    /// The worker body. Must loop until `stop` is set, incrementing `progress` to signal
+    /// liveness. Time file-system operations via `latencies.time(op, || ...)` so the
+    /// harness can aggregate per-op latency histograms and assert p100 ceilings at
+    /// teardown.
+    ///
+    /// `instance` is the 0-based index of this worker *within its kind* (so the first
+    /// `Writer` gets `instance = 0`, the second `Writer` gets `instance = 1`, etc.).
+    /// Writers use it to generate unique per-worker object keys.
+    fn run(
+        &self,
+        instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    );
+}

--- a/mountpoint-s3-fs/tests/stress/mod.rs
+++ b/mountpoint-s3-fs/tests/stress/mod.rs
@@ -1,0 +1,6 @@
+//! Stress-test harness, workers, scenarios, and shared test objects.
+
+pub mod harness;
+pub mod scenarios;
+pub mod test_objects;
+pub mod workers;

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -1,0 +1,6 @@
+//! Stress-test scenarios.
+
+mod idle_and_churn;
+mod mixed_rw;
+mod sustained_reads;
+mod sustained_writes;

--- a/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
@@ -1,0 +1,35 @@
+//! `idle_and_churn`: 8 churn workers + 48 idle workers against a shared-object
+//! pool under the 512 MiB memory limit. The idle workers each read enough of the
+//! object to force the prefetcher to issue a second `GetObject` metarequest and then
+//! hold the handle idle for ~60s. The churn workers concurrently open, drain, and
+//! close handles to verify active readers are not starved by memory pinned behind
+//! idle handles.
+
+use std::iter::{chain, repeat_n};
+use std::sync::Arc;
+
+use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{Churn, Idle, SMALL_OBJECT_POOL};
+
+const NUM_CHURN_WORKERS: usize = 8;
+const NUM_IDLE_WORKERS: usize = 48;
+
+#[test]
+fn idle_and_churn() {
+    let churn: Arc<dyn Worker> = Arc::new(Churn {
+        pool: SMALL_OBJECT_POOL,
+    });
+    let idle: Arc<dyn Worker> = Arc::new(Idle {
+        pool: SMALL_OBJECT_POOL,
+    });
+    let workers = chain(repeat_n(churn, NUM_CHURN_WORKERS), repeat_n(idle, NUM_IDLE_WORKERS)).collect();
+    harness::run(Scenario {
+        name: "idle_and_churn",
+        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
@@ -8,7 +8,7 @@
 use std::iter::{chain, repeat_n};
 use std::sync::Arc;
 
-use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
 
 use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};

--- a/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
@@ -1,0 +1,37 @@
+//! `mixed_rw`: 16 readers + 24 writers sharing the same session under the 512 MiB memory
+//! limit.
+
+use std::iter::{chain, repeat_n};
+use std::sync::Arc;
+
+use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader, Writer};
+
+const NUM_READERS: usize = 16;
+const NUM_WRITERS: usize = 24;
+const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const WRITE_OBJECT_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
+
+#[test]
+fn mixed_rw() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let writer: Arc<dyn Worker> = Arc::new(Writer {
+        scope: "mixed_rw",
+        object_size: WRITE_OBJECT_SIZE,
+        chunk: WRITE_CHUNK,
+    });
+    let workers = chain(repeat_n(reader, NUM_READERS), repeat_n(writer, NUM_WRITERS)).collect();
+    harness::run(Scenario {
+        name: "mixed_rw",
+        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
@@ -4,7 +4,7 @@
 use std::iter::{chain, repeat_n};
 use std::sync::Arc;
 
-use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
 
 use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
@@ -1,0 +1,29 @@
+//! `sustained_reads`: 32 readers concurrently reading a ~100 GiB shared test object
+//! front-to-back under the 512 MiB memory limit.
+
+use std::iter::repeat_n;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
+
+const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const NUM_WORKERS: usize = 32;
+
+#[test]
+fn sustained_reads() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = repeat_n(reader, NUM_WORKERS).collect();
+    harness::run(Scenario {
+        name: "sustained_reads",
+        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
@@ -4,7 +4,7 @@
 use std::iter::repeat_n;
 use std::sync::Arc;
 
-use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
 
 use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
@@ -1,0 +1,31 @@
+//! `sustained_writes`: 48 writers concurrently writing 100 MiB objects under the 512 MiB
+//! memory limit.
+
+use std::iter::repeat_n;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::Writer;
+
+const NUM_WORKERS: usize = 48;
+const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const OBJECT_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
+
+#[test]
+fn sustained_writes() {
+    let writer: Arc<dyn Worker> = Arc::new(Writer {
+        scope: "sustained_writes",
+        object_size: OBJECT_SIZE,
+        chunk: WRITE_CHUNK,
+    });
+    let workers = repeat_n(writer, NUM_WORKERS).collect();
+    harness::run(Scenario {
+        name: "sustained_writes",
+        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
@@ -4,7 +4,7 @@
 use std::iter::repeat_n;
 use std::sync::Arc;
 
-use mountpoint_s3_fs::mem_limiter::MINIMUM_MEM_LIMIT;
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
 
 use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};

--- a/mountpoint-s3-fs/tests/stress/test_objects.rs
+++ b/mountpoint-s3-fs/tests/stress/test_objects.rs
@@ -1,0 +1,166 @@
+//! Shared, reusable stress test objects.
+//!
+//! These objects live at a stable, non-nonced S3 prefix
+//! (`<S3_BUCKET_TEST_PREFIX>shared-stress-test-objects/`) and are uploaded on demand via
+//! Mountpoint's own [`Uploader`] (because of higher performance) if missing or the wrong size.
+//! They are never deleted — multiple stress runs reuse the same objects to avoid paying the upload cost on every run.
+//!
+//! Scenarios mount at the `<S3_BUCKET_TEST_PREFIX>` root and read shared objects via the
+//! `shared-stress-test-objects/<key>` relative path under the mount. Per-worker object
+//! identities (which keys at which sizes) live with the workers that consume them —
+//! e.g. `LARGE_OBJECT_KEY` in `workers/sequential_reader.rs`, the small-object pool in
+//! `workers/common.rs`.
+
+use std::sync::Arc;
+
+use aws_sdk_s3::Client;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
+use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::config::S3ClientConfig;
+use mountpoint_s3_fs::Runtime;
+use mountpoint_s3_fs::mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter};
+use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
+
+use crate::common::s3::{get_test_bucket, get_test_endpoint_config, get_test_region, get_test_sdk_client};
+use crate::common::tokio_block_on;
+
+/// Stable path segment for shared stress test objects.
+pub const SHARED_OBJECTS_PREFIX: &str = "shared-stress-test-objects/";
+
+/// A process-wide, per-run nonce for ephemeral writer keys.
+pub fn ephemeral_run_id() -> &'static str {
+    use std::sync::OnceLock;
+    static RUN_ID: OnceLock<String> = OnceLock::new();
+    RUN_ID.get_or_init(|| {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        format!("{:016x}-{}", now_ns, std::process::id())
+    })
+}
+
+/// Build a flat ephemeral key for writer scenarios to avoid collisions.
+pub fn ephemeral_key(scenario: &str, suffix: &str) -> String {
+    format!("ephemeral_{}_{scenario}_{suffix}", ephemeral_run_id())
+}
+
+/// Return the shared prefix (e.g. `mountpoint-test/shared-stress-test-objects/`).
+fn shared_prefix_string() -> String {
+    let base = std::env::var("S3_BUCKET_TEST_PREFIX").unwrap_or_else(|_| String::from("mountpoint-test/"));
+    assert!(base.ends_with('/'), "S3_BUCKET_TEST_PREFIX should end in '/'");
+    format!("{base}{SHARED_OBJECTS_PREFIX}")
+}
+
+/// Upload the given `(key, size)` shared test objects if they are not already present at the
+/// expected size.
+pub fn ensure_shared_objects(objects: &[(&str, usize)]) {
+    if objects.is_empty() {
+        return;
+    }
+    let max_size = objects.iter().map(|(_, s)| *s).max().unwrap_or(0);
+    let (uploader, bucket, part_size) = build_test_object_uploader(max_size);
+    let region = get_test_region();
+    tokio_block_on(async {
+        let sdk_client: Client = get_test_sdk_client(&region).await;
+        for (key, size) in objects {
+            upload_test_object_with_uploader(&uploader, &sdk_client, &bucket, part_size, key, *size).await;
+        }
+    });
+}
+
+async fn head_object_size(client: &Client, bucket: &str, key: &str) -> Option<usize> {
+    match client.head_object().bucket(bucket).key(key).send().await {
+        Ok(head) => Some(head.content_length().expect("HEAD response missing content_length") as usize),
+        Err(e) => {
+            let service_err = e.into_service_error();
+            if matches!(service_err, HeadObjectError::NotFound(_)) {
+                None
+            } else {
+                panic!("HEAD failed for s3://{bucket}/{key}: {service_err:?}");
+            }
+        }
+    }
+}
+
+const DEFAULT_WRITE_PART_SIZE: usize = 8 * 1024 * 1024;
+const MAX_PARTS: u64 = 10_000;
+const TEST_OBJECT_FILL_BYTE: u8 = 0xA5;
+
+/// Memory budget for the test object uploader: 95% of total system memory, floored at
+/// `MINIMUM_MEM_LIMIT`. Matches the pattern used by Mountpoint.
+fn compute_test_object_mem_budget() -> u64 {
+    use sysinfo::{RefreshKind, System};
+    let sys = System::new_with_specifics(RefreshKind::everything());
+    let ninety_five_pct = ((sys.total_memory() as f64) * 0.95) as u64;
+    ninety_five_pct.max(MINIMUM_MEM_LIMIT)
+}
+
+/// Build an `Uploader<S3CrtClient>` for shared test object uploads.
+///
+/// NOTE: runs in-process, so its `PagedPool` / allocator headroom can inflate the
+/// scenario's peak-memory measurements. TODO: move uploads out-of-process.
+fn build_test_object_uploader(max_object_size: usize) -> (Uploader<S3CrtClient>, String, usize) {
+    let bucket = get_test_bucket();
+    let min_part_size = (max_object_size as u64).div_ceil(MAX_PARTS) as usize;
+    let part_size = DEFAULT_WRITE_PART_SIZE.max(min_part_size);
+
+    let pool = PagedPool::new_with_candidate_sizes([part_size]);
+    let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), compute_test_object_mem_budget()));
+
+    let client_config = S3ClientConfig::default()
+        .part_size(part_size)
+        .endpoint_config(get_test_endpoint_config())
+        .memory_pool(pool.clone());
+    let client = S3CrtClient::new(client_config).expect("failed to build S3CrtClient for test object upload");
+    let runtime = Runtime::new(client.event_loop_group());
+    let uploader = Uploader::new(client, runtime, pool, mem_limiter, UploaderConfig::new(part_size));
+
+    (uploader, bucket, part_size)
+}
+
+/// HEAD-skip-if-size-matches, else stream-upload a shared test object.
+async fn upload_test_object_with_uploader(
+    uploader: &Uploader<S3CrtClient>,
+    sdk_client: &Client,
+    bucket: &str,
+    part_size: usize,
+    key: &str,
+    size: usize,
+) {
+    let full_key = format!("{}{}", shared_prefix_string(), key);
+    if head_object_size(sdk_client, bucket, &full_key).await == Some(size) {
+        tracing::debug!(bucket, key = %full_key, "stress: shared test object already present");
+        return;
+    }
+
+    tracing::info!(
+        bucket,
+        key = %full_key,
+        size,
+        part_size,
+        "stress: uploading shared test object"
+    );
+
+    let mut request = uploader
+        .start_atomic_upload(bucket.to_string(), full_key.clone())
+        .unwrap_or_else(|e| panic!("failed to start MPU for s3://{bucket}/{full_key}: {e:?}"));
+
+    let buf = vec![TEST_OBJECT_FILL_BYTE; part_size];
+    let mut offset = 0u64;
+    while offset < size as u64 {
+        let remaining = size as u64 - offset;
+        let chunk = remaining.min(part_size as u64) as usize;
+        let written = request
+            .write(offset as i64, &buf[..chunk])
+            .await
+            .unwrap_or_else(|e| panic!("write failed at offset {offset} for s3://{bucket}/{full_key}: {e:?}"));
+        offset += written as u64;
+    }
+
+    request
+        .complete()
+        .await
+        .unwrap_or_else(|e| panic!("failed to complete MPU for s3://{bucket}/{full_key}: {e:?}"));
+}

--- a/mountpoint-s3-fs/tests/stress/test_objects.rs
+++ b/mountpoint-s3-fs/tests/stress/test_objects.rs
@@ -11,15 +11,12 @@
 //! e.g. `LARGE_OBJECT_KEY` in `workers/sequential_reader.rs`, the small-object pool in
 //! `workers/common.rs`.
 
-use std::sync::Arc;
-
 use aws_sdk_s3::Client;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_fs::Runtime;
-use mountpoint_s3_fs::mem_limiter::{MINIMUM_MEM_LIMIT, MemoryLimiter};
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, PagedPool};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 
 use crate::common::s3::{get_test_bucket, get_test_endpoint_config, get_test_region, get_test_sdk_client};
@@ -106,8 +103,10 @@ fn build_test_object_uploader(max_object_size: usize) -> (Uploader<S3CrtClient>,
     let min_part_size = (max_object_size as u64).div_ceil(MAX_PARTS) as usize;
     let part_size = DEFAULT_WRITE_PART_SIZE.max(min_part_size);
 
-    let pool = PagedPool::new_with_candidate_sizes([part_size]);
-    let mem_limiter = Arc::new(MemoryLimiter::new(pool.clone(), compute_test_object_mem_budget()));
+    let pool = PagedPool::config()
+        .with_candidate_sizes(vec![part_size])
+        .with_memory_limit(compute_test_object_mem_budget())
+        .build();
 
     let client_config = S3ClientConfig::default()
         .part_size(part_size)
@@ -115,7 +114,7 @@ fn build_test_object_uploader(max_object_size: usize) -> (Uploader<S3CrtClient>,
         .memory_pool(pool.clone());
     let client = S3CrtClient::new(client_config).expect("failed to build S3CrtClient for test object upload");
     let runtime = Runtime::new(client.event_loop_group());
-    let uploader = Uploader::new(client, runtime, pool, mem_limiter, UploaderConfig::new(part_size));
+    let uploader = Uploader::new(client, runtime, pool, UploaderConfig::new(part_size));
 
     (uploader, bucket, part_size)
 }

--- a/mountpoint-s3-fs/tests/stress/workers.rs
+++ b/mountpoint-s3-fs/tests/stress/workers.rs
@@ -1,0 +1,13 @@
+//! Worker implementations composed into stress scenarios.
+
+mod churn;
+mod common;
+mod idle;
+mod sequential_reader;
+mod writer;
+
+pub use churn::Churn;
+pub use common::SMALL_OBJECT_POOL;
+pub use idle::Idle;
+pub use sequential_reader::{LARGE_READ_OBJECT, SequentialReader};
+pub use writer::Writer;

--- a/mountpoint-s3-fs/tests/stress/workers/churn.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/churn.rs
@@ -1,0 +1,45 @@
+//! Churn worker: repeatedly open a random key from a shared object pool, read it fully,
+//! close. Used to exercise high open/close churn under memory pressure.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::stress::harness::{FileOpLatencies, Worker};
+use crate::stress::test_objects::SHARED_OBJECTS_PREFIX;
+
+use super::common::{SharedObjectPool, read_to_eof_once};
+
+/// A worker that, on each iteration, picks a pseudo-random key from `pool` and reads
+/// it to EOF.
+pub struct Churn {
+    pub pool: SharedObjectPool,
+}
+
+impl Worker for Churn {
+    fn kind(&self) -> &'static str {
+        "churn"
+    }
+
+    fn shared_objects(&self) -> Vec<(String, usize)> {
+        self.pool.manifest()
+    }
+
+    fn run(
+        &self,
+        instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    ) {
+        let mut buf = vec![0u8; self.pool.size];
+        let mut iter: u64 = 0;
+        while !stop.load(Ordering::Relaxed) {
+            iter += 1;
+            let path = mount_path
+                .join(SHARED_OBJECTS_PREFIX)
+                .join(self.pool.pick_key(iter, instance));
+            read_to_eof_once("churn", &path, &mut buf, progress, latencies, stop);
+        }
+    }
+}

--- a/mountpoint-s3-fs/tests/stress/workers/common.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/common.rs
@@ -1,0 +1,86 @@
+//! Shared worker-loop helpers and dataset descriptors.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::stress::harness::{FileOp, FileOpLatencies};
+
+/// A single pre-uploaded shared object: the key (relative to `SHARED_OBJECTS_PREFIX`)
+/// and its expected size in bytes.
+#[derive(Clone, Copy, Debug)]
+pub struct SharedObject {
+    pub key: &'static str,
+    pub size: usize,
+}
+
+/// A pool of identically-sized shared objects keyed
+/// `<key_prefix>0000.bin`..`<key_prefix>{count-1:04}.bin`.
+#[derive(Clone, Copy, Debug)]
+pub struct SharedObjectPool {
+    pub key_prefix: &'static str,
+    pub count: usize,
+    pub size: usize,
+}
+
+impl SharedObjectPool {
+    /// Key for pool entry `index` (0-based). Panics if `index >= self.count`.
+    fn key(&self, index: usize) -> String {
+        assert!(
+            index < self.count,
+            "pool index {index} out of range (count={})",
+            self.count
+        );
+        format!("{}{:04}.bin", self.key_prefix, index)
+    }
+
+    /// `(key, size)` entry for every key in the pool.
+    pub fn manifest(&self) -> Vec<(String, usize)> {
+        (0..self.count).map(|i| (self.key(i), self.size)).collect()
+    }
+
+    /// Pseudo-randomly pick a key from the pool, seeded by `iter` and `instance` so
+    /// that concurrent workers pick different keys on the same iteration.
+    pub fn pick_key(&self, iter: u64, instance: usize) -> String {
+        let index = (iter.wrapping_mul(2_654_435_761).wrapping_add(instance as u64) as usize) % self.count;
+        self.key(index)
+    }
+}
+
+/// The canonical small-object pool.
+pub const SMALL_OBJECT_POOL: SharedObjectPool = SharedObjectPool {
+    key_prefix: "small_",
+    count: 100,
+    size: 4 * 1024 * 1024,
+};
+
+/// Open `path`, read it front-to-back into `buf`, close. Increments `progress` on every
+/// successful open and every byte read. Returns on `stop`. Panics (with `scope` in the
+/// message) on any I/O error.
+pub(super) fn read_to_eof_once(
+    scope: &str,
+    path: &Path,
+    buf: &mut [u8],
+    progress: &AtomicU64,
+    latencies: &mut FileOpLatencies,
+    stop: &AtomicBool,
+) {
+    let mut file = latencies
+        .time(FileOp::Open, || File::open(path))
+        .unwrap_or_else(|e| panic!("{scope}: open of {path:?} failed: {e:?}"));
+    progress.fetch_add(1, Ordering::Relaxed);
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+        let n = latencies
+            .time(FileOp::Read, || file.read(buf))
+            .unwrap_or_else(|e| panic!("{scope}: read of {path:?} failed: {e:?}"));
+        if n == 0 {
+            break;
+        }
+        progress.fetch_add(n as u64, Ordering::Relaxed);
+    }
+    latencies.time(FileOp::CloseRead, || drop(file));
+}

--- a/mountpoint-s3-fs/tests/stress/workers/idle.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/idle.rs
@@ -1,0 +1,77 @@
+//! Idle worker.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::stress::harness::{FileOp, FileOpLatencies, Worker};
+use crate::stress::test_objects::SHARED_OBJECTS_PREFIX;
+
+use super::common::SharedObjectPool;
+
+/// How much of each object the idle worker reads before going idle.
+const PREFETCH_PROBE_READ_SIZE: usize = 1024 * 1024;
+
+/// How long each idle-worker iteration holds the handle open without issuing any
+/// further file operations.
+const IDLE_HOLD: Duration = Duration::from_secs(60);
+
+/// A worker that opens a key from `pool`, reads enough of a prefix to force the
+/// prefetcher to issue a second metarequest, then holds the handle idle before
+/// closing and re-opening.
+pub struct Idle {
+    pub pool: SharedObjectPool,
+}
+
+impl Worker for Idle {
+    fn kind(&self) -> &'static str {
+        "idle"
+    }
+
+    fn shared_objects(&self) -> Vec<(String, usize)> {
+        self.pool.manifest()
+    }
+
+    fn run(
+        &self,
+        instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    ) {
+        let mut buf = vec![0u8; PREFETCH_PROBE_READ_SIZE];
+        let mut iter: u64 = 0;
+        while !stop.load(Ordering::Relaxed) {
+            iter += 1;
+            let path = mount_path
+                .join(SHARED_OBJECTS_PREFIX)
+                .join(self.pool.pick_key(iter, instance));
+            idle_cycle(&path, &mut buf, progress, latencies, stop);
+        }
+    }
+}
+
+/// One idle-worker iteration: open, read `buf.len()` bytes, hold idle
+/// for [`IDLE_HOLD`], then close.
+fn idle_cycle(path: &Path, buf: &mut [u8], progress: &AtomicU64, latencies: &mut FileOpLatencies, stop: &AtomicBool) {
+    let mut file = latencies
+        .time(FileOp::Open, || File::open(path))
+        .unwrap_or_else(|e| panic!("idle: open of {path:?} failed: {e:?}"));
+    progress.fetch_add(1, Ordering::Relaxed);
+    let n = latencies
+        .time(FileOp::Read, || file.read(buf))
+        .unwrap_or_else(|e| panic!("idle: read of {path:?} failed: {e:?}"));
+    progress.fetch_add(n as u64, Ordering::Relaxed);
+
+    let deadline = Instant::now() + IDLE_HOLD;
+    while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(500));
+        progress.fetch_add(1, Ordering::Relaxed);
+    }
+
+    latencies.time(FileOp::CloseRead, || drop(file));
+    progress.fetch_add(1, Ordering::Relaxed);
+}

--- a/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
@@ -1,0 +1,47 @@
+//! `SequentialReader`: open a shared object and read it front-to-back in a loop.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::stress::harness::{FileOpLatencies, Worker};
+use crate::stress::test_objects::SHARED_OBJECTS_PREFIX;
+
+use super::common::{SharedObject, read_to_eof_once};
+
+/// The canonical 100 GiB shared object used by the `sustained_reads` and `mixed_rw`
+/// scenarios.
+pub const LARGE_READ_OBJECT: SharedObject = SharedObject {
+    key: "read_100gib.bin",
+    size: 100 * 1024 * 1024 * 1024,
+};
+
+/// A worker that repeatedly opens `target` and reads it front-to-back.
+pub struct SequentialReader {
+    pub target: SharedObject,
+    pub chunk: usize,
+}
+
+impl Worker for SequentialReader {
+    fn kind(&self) -> &'static str {
+        "sequential_reader"
+    }
+
+    fn shared_objects(&self) -> Vec<(String, usize)> {
+        vec![(self.target.key.to_string(), self.target.size)]
+    }
+
+    fn run(
+        &self,
+        _instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    ) {
+        let path = mount_path.join(SHARED_OBJECTS_PREFIX).join(self.target.key);
+        let mut buf = vec![0u8; self.chunk];
+        while !stop.load(Ordering::Relaxed) {
+            read_to_eof_once("sequential_reader", &path, &mut buf, progress, latencies, stop);
+        }
+    }
+}

--- a/mountpoint-s3-fs/tests/stress/workers/writer.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/writer.rs
@@ -1,0 +1,72 @@
+//! Writer worker: repeatedly create a fresh ephemeral object, stream `object_size` bytes
+//! to it, then remove it.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::stress::harness::{FileOp, FileOpLatencies, Worker};
+use crate::stress::test_objects;
+
+/// A worker that streams `object_size` bytes into a fresh ephemeral key every iteration.
+/// `scope` is the scenario label used as the ephemeral-key scenario segment (e.g.
+/// `"sustained_writes"`, `"mixed_rw"`) — it ends up in the S3 key so concurrent scenarios
+/// do not collide.
+pub struct Writer {
+    pub scope: &'static str,
+    pub object_size: usize,
+    pub chunk: usize,
+}
+
+impl Worker for Writer {
+    fn kind(&self) -> &'static str {
+        "writer"
+    }
+
+    fn run(
+        &self,
+        instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    ) {
+        let chunk = vec![0xC3u8; self.chunk];
+        let mut iter: u64 = 0;
+        while !stop.load(Ordering::Relaxed) {
+            iter += 1;
+            let key = test_objects::ephemeral_key(self.scope, &format!("w{instance:03}_i{iter:06}.bin"));
+            let path = mount_path.join(&key);
+
+            let mut file = latencies
+                .time(FileOp::Open, || File::create(&path))
+                .unwrap_or_else(|e| {
+                    panic!("{}: writer {instance}: create failed: {e:?}", self.scope);
+                });
+            progress.fetch_add(1, Ordering::Relaxed);
+
+            let mut written = 0usize;
+            while written < self.object_size && !stop.load(Ordering::Relaxed) {
+                let n = (self.object_size - written).min(self.chunk);
+                latencies
+                    .time(FileOp::Write, || file.write_all(&chunk[..n]))
+                    .unwrap_or_else(|e| {
+                        panic!("{}: writer {instance}: write failed: {e:?}", self.scope);
+                    });
+                written += n;
+                progress.fetch_add(n as u64, Ordering::Relaxed);
+            }
+            // `sync_all` (not implicit `drop`) so MPU-complete errors surface — `Drop for File`
+            // swallows the `close(2)` return value.
+            latencies
+                .time(FileOp::CloseWrite, || file.sync_all())
+                .unwrap_or_else(|e| {
+                    panic!("{}: writer {instance}: sync_all failed: {e:?}", self.scope);
+                });
+            drop(file);
+            progress.fetch_add(1, Ordering::Relaxed);
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}

--- a/mountpoint-s3-fs/tests/stress_tests.rs
+++ b/mountpoint-s3-fs/tests/stress_tests.rs
@@ -1,0 +1,5 @@
+//! Long-running stress tests.
+#![cfg(feature = "stress_tests")]
+
+mod common;
+mod stress;

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806))
 * Add support for automatic content type detection on file uploads. When the `--infer-content-type` flag is specified, Mountpoint will infer the `Content-Type` of new objects based on their file extension instead of using the default `binary/octet-stream`. ([#1790](https://github.com/awslabs/mountpoint-s3/pull/1790))
+* Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718))
 
 ## v1.22.3 (April 28, 2026)
 

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -41,6 +41,10 @@ if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
   optional_args+=" --max-memory-target=${S3_MAX_MEMORY_TARGET_MIB}"
 fi
 
+if [[ -n "${S3_MOUNTPOINT_EXTRA_ARGS}" ]]; then
+  optional_args+=" ${S3_MOUNTPOINT_EXTRA_ARGS}"
+fi
+
 base_dir=$(dirname "$0")
 project_dir="${base_dir}/../.."
 cd ${project_dir}
@@ -207,9 +211,9 @@ run_benchmarks() {
   done
 }
 
-run_benchmarks read
-run_benchmarks write
-run_benchmarks mix
+for category in ${S3_BENCH_CATEGORIES:-read write mix}; do
+  run_benchmarks "$category"
+done
 
 # combine all bench results into one json file
 echo "Throughput:"

--- a/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
+++ b/mountpoint-s3/src/bin/mount-s3-log-analyzer.rs
@@ -54,8 +54,8 @@ struct CliArgs {
 /// JSON field name for the peak (in MiB) and the regex matching lines ending in that
 /// metric's value (bytes). Absent entries are omitted from `_extra_metrics.json` and
 /// rendered as "N/A" in the GH step summary table.
-fn mem_metric_patterns() -> [(&'static str, Regex); 4] {
-    [
+fn mem_metric_patterns() -> Vec<(&'static str, Regex)> {
+    vec![
         (
             "peak_prefetch_reserved_mib",
             Regex::new(r"mem\.bytes_reserved\[area=prefetch\]:\s(\d+)$").unwrap(),
@@ -72,6 +72,10 @@ fn mem_metric_patterns() -> [(&'static str, Regex); 4] {
             "peak_pool_put_object_mib",
             Regex::new(r"pool\.reserved_bytes\[kind=put_object\]:\s(\d+)$").unwrap(),
         ),
+        (
+            "peak_pool_append_mib",
+            Regex::new(r"pool\.reserved_bytes\[kind=append\]:\s(\d+)$").unwrap(),
+        ),
     ]
 }
 
@@ -85,7 +89,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut metric_values: Vec<u64> = Vec::new();
     // Peak value (bytes) per mem-metric field; None until first observation.
-    let mut mem_metric_peaks: [Option<u64>; 4] = [None; 4];
+    let mut mem_metric_peaks: Vec<Option<u64>> = vec![None; mem_metrics.len()];
 
     // collect metrics from all log files in the given directory
     for path in paths {

--- a/mountpoint-s3/tests/metrics/otel_export.sh
+++ b/mountpoint-s3/tests/metrics/otel_export.sh
@@ -5,9 +5,10 @@ set -e
 OTEL_COLLECTOR_CONFIG="otel-config.yaml"
 OTEL_COLLECTOR_METRICS="/tmp/otel-collector-metrics"
 OTLP_ENDPOINT="http://127.0.0.1:4318"
-MOUNT_DIR="/tmp/mount-dir"
-MOUNTPOINT_LOGS="/tmp/mountpoint-logs"
-MOUNTPOINT_CACHE="/tmp/mountpoint-cache"
+TMP_DIR=$(mktemp -d /tmp/mountpoint-XXXXXXXXXXXX)
+MOUNT_DIR="$TMP_DIR/mnt"
+MOUNTPOINT_LOGS="$TMP_DIR/logs"
+MOUNTPOINT_CACHE="$TMP_DIR/cache"
 EXPECTED_METRICS=(
   "experimental.cache.evict_latency"
   "experimental.cache.get_latency"
@@ -48,7 +49,7 @@ fi
 
 cleanup() {
   ! mountpoint -q "${MOUNT_DIR}" || sudo umount "${MOUNT_DIR}"
-  rm -rf "${MOUNT_DIR}" "${MOUNTPOINT_LOGS}" "${MOUNTPOINT_CACHE}"
+  rm -rf "${TMP_DIR}"
 
   if [[ -n "${OTEL_COLLECTOR_PID}" ]]; then
     echo "Stopping OTel Collector with PID ${OTEL_COLLECTOR_PID}"
@@ -93,16 +94,20 @@ trigger_metrics() {
   test_file="${MOUNT_DIR}/test_file.txt"
   dd if=/dev/urandom of="${test_file}" bs=128k count=500 2>/dev/null
   sync
+
+  # Read from the file. Ensure that:
+  # - Some data is cached to disk for the next step
+  # - At least one "skip" is large enough to reset the internal prefetcher
   {
-    for skip in {1..8} {490..500}; do
-      dd bs=128k skip=$skip count=1 iflag=direct 2>/dev/null || true
+    for skip in {0..5} 300; do
+      dd bs=128k skip=$skip count=1 iflag=direct 2>/dev/null
     done
   } < "${test_file}" > /dev/null
 
   # Re-read some data to trigger cache hits
   {
     for skip in {1..5}; do
-      dd bs=128k skip=$skip count=1 2>/dev/null || true
+      dd bs=128k skip=$skip count=1 2>/dev/null
     done
   } < "${test_file}" > /dev/null
 
@@ -124,7 +129,7 @@ setup_mount() {
   local mode=$1
   
   echo "Mount ${S3_BUCKET_NAME}, prefix: ${S3_BUCKET_TEST_PREFIX} ($mode)"
-  mkdir -p "${MOUNT_DIR}" "${MOUNTPOINT_LOGS}"
+  mkdir -p "${MOUNT_DIR}" "${MOUNTPOINT_LOGS}" "${MOUNTPOINT_CACHE}"
 
   local args=(
     "${S3_BUCKET_NAME}" "${MOUNT_DIR}"
@@ -147,15 +152,13 @@ setup_mount() {
       ;;
   esac
 
-  mkdir -p "${MOUNTPOINT_CACHE}"
-
   cargo run --quiet --release -- "${args[@]}"
   if [ $? -ne 0 ]; then
     echo "Failed to mount file system"
     exit 1
   fi
 
-  echo "Mounted ${MOUNT_DIR}."
+  echo "Mounted ${MOUNT_DIR} (logs: ${MOUNTPOINT_LOGS}, cache: ${MOUNTPOINT_CACHE})."
 }
 
 verify_otel_metrics() {


### PR DESCRIPTION
Merges the latest main branch into `feature/memory-limit` to incorporate recent upstream changes. One merge conflict in `mountpoint-s3/tests/metrics/otel_export.sh` was resolved by taking main's version ([PR #1828 fix for skip ranges in metrics tests](https://github.com/awslabs/mountpoint-s3/pull/1828)).

### Does this change impact existing behavior?

No breaking change.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
