### PR TITLE
stress: Add held_writes_vs_reads scenario

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
   push:
-    branches: [main]
+    branches: [main, feature/memory-limit]
   workflow_dispatch:
 
 permissions:
@@ -51,6 +51,7 @@ jobs:
           - sustained_writes
           - mixed_rw
           - idle_and_churn
+          - held_writes_vs_reads
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
   push:
-    branches: [main, feature/memory-limit]
+    branches: [main, feature/memory-limit, "wf-changes/**"]
   workflow_dispatch:
 
 permissions:

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -126,6 +126,12 @@ impl TestSessionConfig {
         self.mem_limit = mem_limit;
         self
     }
+
+    /// Override the part size for this test session.
+    pub fn with_part_size(mut self, part_size: usize) -> Self {
+        self.part_size = part_size;
+        self
+    }
 }
 
 // Holds resources for the testing session and cleans them on drop.

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -1,5 +1,6 @@
 //! Stress-test scenarios.
 
+mod held_writes_vs_reads;
 mod idle_and_churn;
 mod mixed_rw;
 mod sustained_reads;

--- a/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
@@ -10,11 +10,12 @@ use crate::stress::workers::{HoldingWriter, LARGE_READ_OBJECT, SequentialReader}
 
 const NUM_WRITERS: usize = 48; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
 const NUM_READERS: usize = 16;
-const WRITE_BEFORE_HOLD: usize = 8 * 1024 * 1024 + 4 * 1024; // 8 MiB + 4 KiB
+const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
+const WRITE_BEFORE_HOLD: usize = PART_SIZE + 4 * 1024;
 /// How long each writer holds its handle open. Longer than the 20s per-worker watchdog so that, if
 /// holding writers do starve reads, a reader will visibly stall rather than just run slow.
 const HOLD: Duration = Duration::from_secs(60);
-const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const READ_CHUNK: usize = PART_SIZE;
 
 #[test]
 fn held_writes_vs_reads() {
@@ -30,7 +31,9 @@ fn held_writes_vs_reads() {
     let workers = chain(repeat_n(writer, NUM_WRITERS), repeat_n(reader, NUM_READERS)).collect();
     harness::run(Scenario {
         name: "held_writes_vs_reads",
-        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(PART_SIZE),
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
@@ -1,0 +1,37 @@
+use std::iter::{chain, repeat_n};
+use std::sync::Arc;
+use std::time::Duration;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{HoldingWriter, LARGE_READ_OBJECT, SequentialReader};
+
+const NUM_WRITERS: usize = 48; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
+const NUM_READERS: usize = 16;
+const WRITE_BEFORE_HOLD: usize = 8 * 1024 * 1024 + 4 * 1024; // 8 MiB + 4 KiB
+/// How long each writer holds its handle open. Longer than the 20s per-worker watchdog so that, if
+/// holding writers do starve reads, a reader will visibly stall rather than just run slow.
+const HOLD: Duration = Duration::from_secs(60);
+const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+
+#[test]
+fn held_writes_vs_reads() {
+    let writer: Arc<dyn Worker> = Arc::new(HoldingWriter {
+        scope: "held_writes_vs_reads",
+        write_before_hold: WRITE_BEFORE_HOLD,
+        hold: HOLD,
+    });
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = chain(repeat_n(writer, NUM_WRITERS), repeat_n(reader, NUM_READERS)).collect();
+    harness::run(Scenario {
+        name: "held_writes_vs_reads",
+        session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/workers.rs
+++ b/mountpoint-s3-fs/tests/stress/workers.rs
@@ -2,12 +2,14 @@
 
 mod churn;
 mod common;
+mod holding_writer;
 mod idle;
 mod sequential_reader;
 mod writer;
 
 pub use churn::Churn;
 pub use common::SMALL_OBJECT_POOL;
+pub use holding_writer::HoldingWriter;
 pub use idle::Idle;
 pub use sequential_reader::{LARGE_READ_OBJECT, SequentialReader};
 pub use writer::Writer;

--- a/mountpoint-s3-fs/tests/stress/workers/holding_writer.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/holding_writer.rs
@@ -1,0 +1,74 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::stress::harness::{FileOp, FileOpLatencies, Worker};
+use crate::stress::test_objects;
+
+const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+
+/// A worker that creates a fresh object, writes `write_before_hold` bytes, then holds the handle
+/// open for `hold` before closing and starting over.
+pub struct HoldingWriter {
+    /// Scenario label used as the ephemeral-key scenario segment.
+    pub scope: &'static str,
+    /// Total bytes to write before holding.
+    pub write_before_hold: usize,
+    /// How long to hold the handle open before closing.
+    pub hold: Duration,
+}
+
+impl Worker for HoldingWriter {
+    fn kind(&self) -> &'static str {
+        "holding_writer"
+    }
+
+    fn run(
+        &self,
+        instance: usize,
+        mount_path: &Path,
+        progress: &AtomicU64,
+        latencies: &mut FileOpLatencies,
+        stop: &AtomicBool,
+    ) {
+        let chunk = vec![0xC3u8; WRITE_CHUNK];
+        let mut iter: u64 = 0;
+        while !stop.load(Ordering::Relaxed) {
+            iter += 1;
+            let key = test_objects::ephemeral_key(self.scope, &format!("h{instance:03}_i{iter:06}.bin"));
+            let path = mount_path.join(&key);
+
+            let mut file = latencies
+                .time(FileOp::Open, || File::create(&path))
+                .unwrap_or_else(|e| panic!("{}: holding_writer {instance}: create failed: {e:?}", self.scope));
+            progress.fetch_add(1, Ordering::Relaxed);
+
+            let mut written = 0usize;
+            while written < self.write_before_hold && !stop.load(Ordering::Relaxed) {
+                let n = (self.write_before_hold - written).min(chunk.len());
+                latencies
+                    .time(FileOp::Write, || file.write_all(&chunk[..n]))
+                    .unwrap_or_else(|e| panic!("{}: holding_writer {instance}: write failed: {e:?}", self.scope));
+                written += n;
+                progress.fetch_add(n as u64, Ordering::Relaxed);
+            }
+
+            // Hold the handle (and its pinned trailing part buffer) open, ticking progress so the
+            // watchdog does not flag us. Only a starved reader should stall.
+            let deadline = Instant::now() + self.hold;
+            while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(500));
+                progress.fetch_add(1, Ordering::Relaxed);
+            }
+
+            latencies
+                .time(FileOp::CloseWrite, || file.sync_all())
+                .unwrap_or_else(|e| panic!("{}: holding_writer {instance}: sync_all failed: {e:?}", self.scope));
+            drop(file);
+            progress.fetch_add(1, Ordering::Relaxed);
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}


### PR DESCRIPTION
**What changed and why?** Need to test scenario when many writers hold unevictable buffers and do not stall buffers needed for active reads.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
