### PR TITLE
Update aws-lc to 5.1.0 and invoke cleanup on exit

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Breaking:** `ObjectClient::put_object_single` now requires `contents: impl AsRef<[u8]> + Send + 'static` (was `+ 'a`), so the body can be held until the request is fully torn down.
 * Update to latest CRT dependencies.
 * Add `TlsConfig` type and `S3ClientConfig::tls_config()` builder for configuring a custom CA trust store. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834))
+* Run cleanup for CRT libraries on process exit. ([#1850](https://github.com/awslabs/mountpoint-s3/pull/1850))
 
 ## v0.20.0 (April 28, 2026)
 

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `MetaRequestOptions::request_body`.
 * Remove the `io::stream` module (`InputStream`) and `Message::set_body_stream`, which are superseded by `MetaRequestOptions::request_body`.
 * `Message` and `MetaRequestOptions` are no longer generic over a lifetime.
+* Run cleanup for CRT libraries on process exit. ([#1850](https://github.com/awslabs/mountpoint-s3/pull/1850))
 
 ## v0.14.0 (April 28, 2026)
 

--- a/mountpoint-s3-crt/src/auth.rs
+++ b/mountpoint-s3-crt/src/auth.rs
@@ -21,5 +21,6 @@ fn auth_library_init(allocator: &Allocator) {
         unsafe {
             aws_auth_library_init(allocator.inner.as_ptr());
         }
+        crate::register_crt_cleanup_at_exit();
     });
 }

--- a/mountpoint-s3-crt/src/common.rs
+++ b/mountpoint-s3-crt/src/common.rs
@@ -25,5 +25,6 @@ fn common_library_init(allocator: &Allocator) {
         unsafe {
             aws_common_library_init(allocator.inner.as_ptr());
         }
+        crate::register_crt_cleanup_at_exit();
     });
 }

--- a/mountpoint-s3-crt/src/http.rs
+++ b/mountpoint-s3-crt/src/http.rs
@@ -17,5 +17,6 @@ fn http_library_init(allocator: &Allocator) {
         unsafe {
             aws_http_library_init(allocator.inner.as_ptr());
         }
+        crate::register_crt_cleanup_at_exit();
     });
 }

--- a/mountpoint-s3-crt/src/io.rs
+++ b/mountpoint-s3-crt/src/io.rs
@@ -22,5 +22,6 @@ pub fn io_library_init(allocator: &Allocator) {
         unsafe {
             aws_io_library_init(allocator.inner.as_ptr());
         }
+        crate::register_crt_cleanup_at_exit();
     });
 }

--- a/mountpoint-s3-crt/src/lib.rs
+++ b/mountpoint-s3-crt/src/lib.rs
@@ -18,9 +18,47 @@ pub mod io;
 pub mod s3;
 
 use std::ptr::NonNull;
+use std::sync::Once;
 use std::{ffi::OsStr, os::unix::prelude::OsStrExt};
 
 use crate::common::error::Error;
+
+static CRT_CLEANUP_REGISTER: Once = Once::new();
+
+/// Register a process-exit handler that cleans up every CRT library.
+///
+/// CRT library init is a demand-driven, boolean-guarded singleton with no automatic cleanup. Cleanup
+/// is what joins the CRT's managed worker threads; without it, a worker thread can still be running
+/// native code when the process runs its C runtime destructors, which aborts the process under the
+/// aws-lc FIPS RNG. Called from every `*_library_init` so we register regardless of entry point.
+fn register_crt_cleanup_at_exit() {
+    CRT_CLEANUP_REGISTER.call_once(|| {
+        // SAFETY: `crt_cleanup_at_exit` is a `'static` `extern "C"` function. Called at most once,
+        // and only from an init path, so the CRT libraries are initialized before it could run.
+        unsafe {
+            libc::atexit(crt_cleanup_at_exit);
+        }
+    });
+}
+
+/// Runs at process exit to tear down every CRT library that was initialized.
+extern "C" fn crt_cleanup_at_exit() {
+    // Each `aws_*_library_clean_up` is self-guarded and idempotent, so the full sequence is safe
+    // regardless of which libraries were initialized; top-down order lets higher layers release
+    // their references before lower layers tear down. The first step of each is
+    // `aws_thread_join_all_managed`, which blocks until CRT worker threads exit — so this must run
+    // on a non-CRT thread, which `atexit` guarantees (it runs on the thread that calls `exit`).
+    //
+    // SAFETY: each cleanup is safe whether or not its library was initialized (see above); they take
+    // no arguments and touch only process-global CRT state.
+    unsafe {
+        aws_s3_library_clean_up();
+        aws_auth_library_clean_up();
+        aws_http_library_clean_up();
+        aws_io_library_clean_up();
+        aws_common_library_clean_up();
+    }
+}
 
 pub(crate) mod private {
     /// Seals a trait to prevent clients from implementing it for their own types, since this trait

--- a/mountpoint-s3-crt/src/s3.rs
+++ b/mountpoint-s3-crt/src/s3.rs
@@ -22,5 +22,6 @@ pub fn s3_library_init(allocator: &Allocator) {
         unsafe {
             aws_s3_library_init(allocator.inner.as_ptr());
         }
+        crate::register_crt_cleanup_at_exit();
     });
 }

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -126,48 +126,22 @@ impl TestSessionConfig {
     }
 }
 
-// Holds resources for the testing session and cleans them on drop.
-pub struct TestSession {
+/// A mounted FUSE session that unmounts and joins its worker threads when dropped.
+pub struct MountedSession {
     mount_dir: TempDir,
-    test_client: Box<dyn TestClient>,
-    prefix: String,
     // Option so we can explicitly unmount
     session: Option<FuseSession>,
     // Only set if `pass_fuse_fd` is true, will unmount the filesystem on drop.
     mount: Option<Mount>,
 }
 
-impl TestSession {
-    pub fn new(
-        mount_dir: TempDir,
-        session: FuseSession,
-        test_client: impl TestClient + 'static,
-        prefix: String,
-        mount: Option<Mount>,
-    ) -> Self {
-        Self {
-            mount_dir,
-            test_client: Box::new(test_client),
-            session: Some(session),
-            mount,
-            prefix,
-        }
-    }
-
-    pub fn mount_path(&self) -> &Path {
+impl MountedSession {
+    pub fn path(&self) -> &Path {
         self.mount_dir.path()
-    }
-
-    pub fn client(&self) -> &dyn TestClient {
-        self.test_client.as_ref()
-    }
-
-    pub fn prefix(&self) -> &str {
-        &self.prefix
     }
 }
 
-impl Drop for TestSession {
+impl Drop for MountedSession {
     fn drop(&mut self) {
         // If the session created with a pre-existing mount (e.g., with `pass_fuse_fd`),
         // this will unmount it explicitly...
@@ -179,6 +153,35 @@ impl Drop for TestSession {
                 tracing::warn!(?error, "error while unmounting");
             }
         }
+    }
+}
+
+/// Holds resources for the testing session and cleans them on drop.
+pub struct TestSession {
+    mounted_session: MountedSession,
+    test_client: Box<dyn TestClient>,
+    prefix: String,
+}
+
+impl TestSession {
+    fn new(mounted_session: MountedSession, test_client: impl TestClient + 'static, prefix: String) -> Self {
+        Self {
+            mounted_session,
+            test_client: Box::new(test_client),
+            prefix,
+        }
+    }
+
+    pub fn mount_path(&self) -> &Path {
+        self.mounted_session.path()
+    }
+
+    pub fn client(&self) -> &dyn TestClient {
+        self.test_client.as_ref()
+    }
+
+    pub fn prefix(&self) -> &str {
+        &self.prefix
     }
 }
 
@@ -238,9 +241,9 @@ pub fn create_fuse_session<Client>(
     pool: PagedPool,
     runtime: Runtime,
     s3_path: S3Path,
-    mount_dir: &Path,
+    mount_dir: TempDir,
     test_config: TestSessionConfig,
-) -> (FuseSession, Option<Mount>)
+) -> MountedSession
 where
     Client: ObjectClient + Clone + Send + Sync + 'static,
 {
@@ -265,17 +268,18 @@ where
     );
     let fs = S3FuseFilesystem::new(fs, test_config.error_logger);
     let (session, mount) = if test_config.pass_fuse_fd {
-        let (fd, mount) = mount_for_passing_fuse_fd(mount_dir, &options);
+        let (fd, mount) = mount_for_passing_fuse_fd(mount_dir.path(), &options);
         let owned_fd = fd.as_fd().try_clone_to_owned().unwrap();
         (Session::from_fd(fs, owned_fd, session_acl), Some(mount))
     } else {
-        (Session::new(fs, mount_dir, &options).unwrap(), None)
+        (Session::new(fs, mount_dir.path(), &options).unwrap(), None)
     };
 
-    (
-        FuseSession::from_session(session, test_config.max_worker_threads, false).unwrap(),
+    MountedSession {
+        mount_dir,
+        session: Some(FuseSession::from_session(session, test_config.max_worker_threads, false).unwrap()),
         mount,
-    )
+    }
 }
 
 /// Open `/dev/fuse` and call `mount` syscall with given `mount_point`.
@@ -331,18 +335,18 @@ pub mod mock_session {
         );
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
-        let (session, mount) = create_fuse_session(
+        let mounted_session = create_fuse_session(
             client.clone(),
             prefetcher_builder,
             pool,
             runtime,
             s3_path,
-            mount_dir.path(),
+            mount_dir,
             test_config,
         );
         let test_client = create_test_client(client, &prefix);
 
-        TestSession::new(mount_dir, session, test_client, prefix, mount)
+        TestSession::new(mounted_session, test_client, prefix)
     }
 
     /// Create a FUSE mount backed by a mock object client, with caching, that does not talk to S3
@@ -373,18 +377,18 @@ pub mod mock_session {
             );
             let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
             let prefetcher_builder = Prefetcher::caching_builder(cache, client.clone());
-            let (session, mount) = create_fuse_session(
+            let mounted_session = create_fuse_session(
                 client.clone(),
                 prefetcher_builder,
                 pool,
                 runtime,
                 s3_path,
-                mount_dir.path(),
+                mount_dir,
                 test_config,
             );
             let test_client = create_test_client(client, &prefix);
 
-            TestSession::new(mount_dir, session, test_client, prefix, mount)
+            TestSession::new(mounted_session, test_client, prefix)
         }
     }
 
@@ -527,13 +531,13 @@ pub mod s3_session {
         let client = S3CrtClient::new(client_config).unwrap();
         let runtime = Runtime::new(client.event_loop_group());
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
-        let (session, mount) = create_fuse_session(
+        let mounted_session = create_fuse_session(
             client,
             prefetcher_builder,
             pool,
             runtime,
             s3_path.clone(),
-            mount_dir.path(),
+            mount_dir,
             test_config,
         );
 
@@ -542,7 +546,7 @@ pub mod s3_session {
             bucket: s3_path.bucket.to_string(),
             sdk_client,
         };
-        TestSession::new(mount_dir, session, test_client, s3_path.prefix.to_string(), mount)
+        TestSession::new(mounted_session, test_client, s3_path.prefix.to_string())
     }
 
     /// Create a FUSE mount backed by a real S3 client, with caching
@@ -567,18 +571,18 @@ pub mod s3_session {
             );
             let runtime = Runtime::new(client.event_loop_group());
             let prefetcher_builder = Prefetcher::caching_builder(cache, client.clone());
-            let (session, mount) = create_fuse_session(
+            let mounted_session = create_fuse_session(
                 client,
                 prefetcher_builder,
                 pool,
                 runtime,
                 s3_path.clone(),
-                mount_dir.path(),
+                mount_dir,
                 test_config,
             );
             let test_client = create_test_client(&region, s3_path.bucket.as_str(), s3_path.prefix.as_str());
 
-            TestSession::new(mount_dir, session, test_client, s3_path.prefix.to_string(), mount)
+            TestSession::new(mounted_session, test_client, s3_path.prefix.to_string())
         }
     }
 

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -1,5 +1,3 @@
-use crate::common::cache::CacheTestWrapper;
-use crate::common::fuse::{self, TestSessionConfig};
 use anyhow::{Context, anyhow};
 use mountpoint_s3_fs::data_cache::{CacheLimit, DEFAULT_CACHE_MIN_AVAILABLE_RATIO, DiskDataCache, DiskDataCacheConfig};
 use rand::rngs::SmallRng;
@@ -10,22 +8,23 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tracing::{debug, info, warn};
 
+use crate::common::cache::CacheTestWrapper;
+use crate::common::fuse::{self, TestSessionConfig};
+
 #[cfg(feature = "s3_tests")]
 use {
-    crate::common::fuse::create_fuse_session,
     crate::common::fuse::s3_session::create_crt_client,
+    crate::common::fuse::{MountedSession, create_fuse_session},
     crate::common::s3::{get_test_prefix, get_test_s3_path},
     mountpoint_s3_client::S3CrtClient,
     mountpoint_s3_fs::Runtime,
     mountpoint_s3_fs::data_cache::DataCache,
-    mountpoint_s3_fs::fuse::session::FuseSession,
     mountpoint_s3_fs::memory::PagedPool,
     mountpoint_s3_fs::object::ObjectId,
     mountpoint_s3_fs::prefetch::Prefetcher,
     mountpoint_s3_fs::s3::S3Path,
     rand::RngExt,
     std::time::Duration,
-    tempfile::TempDir,
     test_case::test_case,
 };
 
@@ -64,7 +63,7 @@ async fn express_invalid_block_read() {
         ExpressDataCacheConfig::new(&cache_bucket, &bucket),
     ));
     let s3_path = S3Path::new(Bucket::new(bucket.clone()).unwrap(), Prefix::new(&prefix).unwrap());
-    let (mount_point, _session) = mount_bucket(client.clone(), cache.clone(), pool, s3_path);
+    let mount = mount_bucket(client.clone(), cache.clone(), pool, s3_path);
 
     // Put an object to the mounted bucket
     let object_key = "key";
@@ -77,7 +76,7 @@ async fn express_invalid_block_read() {
     let object_etag = result.etag.into_inner();
 
     // Read data twice, expect cache hits and no errors
-    let path = mount_point.path().join(object_key);
+    let path = mount.path().join(object_key);
 
     let put_block_count = cache.put_block_count();
     let read = fs::read(&path).expect("read should succeed");
@@ -102,7 +101,7 @@ async fn express_invalid_block_read() {
         .expect("put object must succeed");
 
     // Expect a successful read from the source bucket. We expect cache errors being recorded because of the corrupted block.
-    let path = mount_point.path().join(object_key);
+    let path = mount.path().join(object_key);
     let read = fs::read(&path).expect("read should succeed");
     assert_eq!(read, object_data.as_bytes());
     assert!(
@@ -300,11 +299,11 @@ fn cache_write_read_base<Cache>(
 {
     // Mount a bucket
     let cache = CacheTestWrapper::new(cache);
-    let (mount_point, _session) = mount_bucket(client, cache.clone(), pool, s3_path.clone());
+    let mount = mount_bucket(client, cache.clone(), pool, s3_path.clone());
 
     // Write an object, no caching happens yet
     let key = get_random_key(s3_path.prefix.as_str(), key_suffix, key_size);
-    let path = mount_point.path().join(&key);
+    let path = mount.path().join(&key);
     let written = random_binary_data(object_size);
     fs::write(&path, &written).expect("write should succeed");
     let put_block_count = cache.put_block_count();
@@ -386,11 +385,11 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
 
     let cache = CacheTestWrapper::new(cache);
     let s3_path = S3Path::new(Bucket::new(bucket).unwrap(), Prefix::new(&prefix).unwrap());
-    let (mount_point, _session) = mount_bucket(client, cache.clone(), pool, s3_path);
+    let mount = mount_bucket(client, cache.clone(), pool, s3_path);
 
     // Write an object, no caching happens yet
     let key = get_random_key(&prefix, "key", 100);
-    let path = mount_point.path().join(&key);
+    let path = mount.path().join(&key);
     let written = random_binary_data(CACHE_BLOCK_SIZE as usize);
     fs::write(&path, &written).expect("write should succeed");
 
@@ -433,23 +432,22 @@ fn get_random_key(key_prefix: &str, key_suffix: &str, min_size_in_bytes: usize) 
 }
 
 #[cfg(feature = "s3_tests")]
-fn mount_bucket<Cache>(client: S3CrtClient, cache: Cache, pool: PagedPool, s3_path: S3Path) -> (TempDir, FuseSession)
+fn mount_bucket<Cache>(client: S3CrtClient, cache: Cache, pool: PagedPool, s3_path: S3Path) -> MountedSession
 where
     Cache: DataCache + Send + Sync + 'static,
 {
     let mount_point = tempfile::tempdir().unwrap();
     let runtime = Runtime::new(client.event_loop_group());
     let prefetcher_builder = Prefetcher::caching_builder(cache, client.clone());
-    let (session, _mount) = create_fuse_session(
+    create_fuse_session(
         client,
         prefetcher_builder,
         pool,
         runtime,
         s3_path,
-        mount_point.path(),
+        mount_point,
         Default::default(),
-    );
-    (mount_point, session)
+    )
 }
 
 #[cfg(feature = "s3_tests")]


### PR DESCRIPTION
Update the aws-lc CRT submodule to the latest release: `aws-lc v5.1.0`.

Also added cleanup for the CRT libraries to `mountpoint-s3-crt` in order to address an issue resulting in the address sanitizer test to fail:
- Register a single atexit handler (once, from every `aws_*_library_init`) that runs the full `aws_*_library_clean_up` sequence top-down. Each cleanup is self-guarded and idempotent, so it is safe regardless of which libraries were initialized, and joins all managed threads before aws-lc tears down.
- The init for CRT libraries were not originally paired with a cleanup. However, cleanups join the CRT's managed worker threads, and without them a worker thread could still be running a TLS handshake when the process runs its C runtime destructors, hitting a race condition. With the aws-lc 5.1.0 upgrade, that race hits an abort() call (rand.c:575) in aws-lc's FIPS RNG teardown, taking down `make test-asan` at exit.

<details>
  <summary>Full CRT changelog:</summary>

```
Submodule mountpoint-s3-crt-sys/crt/aws-lc d50ded59..6283365b:
  > Prepare v5.1.0 release (#3321)
  > Concurrency is not generally supported for EVP_AEAD_CTX_foo functions (#3318)
  > Add 'version -fips' to surface FIPS module version in openssl tool (#3315)
  > Bump AWSLC_FIPS_VERSION to 5 for next FIPS branch (#3316)
  > ci: opt in to allow-unsafe-pr-checkout for gated pull_request_target jobs (#3313)
  > ML-DSA: import and enable aarch64 assembly backend from mldsa-native (#3219)
  > Define OPENSSL_INIT_NO_ATEXIT as a no-op (#3311)
  > Bump the github-actions group across 1 directory with 4 updates (#3307)
  > Move TLS 1.3 KDF into the FIPS module and wire up ACVP (#3247)
  > Add WASIp2 build and test support (#3172)
  > Make OPENSSL_memcmp constant time (#3183)
  > Fix SSL_CTX_add_extra_chain_cert slot routing for chains added before the leaf (#3296)
  > Stabilize libgit2 integration test (#3300)
  > CI: Switch integration tests to nightly and raise alarm on failures (#3287)
  > Update MySQL CI integration to mysql-cluster-9.7.1 (#3302)
  > Support SSL_OP_IGNORE_UNEXPECTED_EOF option (#3294)
  > Fix PostgreSQL integration: match upstream revoked-cert alert regex (#3299)
  > ci: fix Windows CI breakage from VS2026 (MSVC 14.51) image bump (#3298)
  > ML-DSA: import and enable x86_64 assembly backend from mldsa-native (#3195)
  > Bump aws-cdk-lib from 2.251.0 to 2.255.0 in /tests/ci in the pip-ci group (#3283)
  > Bump the cargo-ci-lambda group in /tests/ci/lambda with 4 updates (#3284)
  > Bump cross-platform-actions/action from 0.32.0 to 1.2.0 in the github-actions group (#3285)
  > ci: move BSD actions to scheduled (#3276)
  > Add SSL_CTX_set_security_callback and related APIs for OpenSSL compat… (#3275)
  > Quote LIBCRYPTO_PATH for dynamic load test (#3259)
  > Make FIPS compiler wrapper unconditional (#3269)
  > ML-DSA support as a TLS 1.3 signature scheme (#3251)
  > Add inline documentation for API contracts (#3267)
  > use /map: linker flag to avoid running a binary to capture the hash (#3133)
  > Skip MariaDB socket conflict test unable to run as root (#3274)
  > Make rustfmt optional for Rust bindings generation (#3270)
  > Fix python 3.13 patch (#3271)
  > BoringSSL: Harden nc_email name constraint checking (#3266)
  > Gate Linux specific code to fix compilation on AIX (#3265)
  > Fix manylinux1 build: O_CLOEXEC fallback in getauxval shim (#3268)
  > Prefer CRLs with specific IDP match (#3264)
  > Add `getauxval` availability detection with `/proc/self/auxv` fallback for uclibc targets (#3250)
  > Enable Windows 7 compat path on MinGW builds (#3239)
  > Drop obsolete test_pkey_rsa.rb hunk from Ruby 3.4 patch (#3260)
  > Reject undersized buffer in pkey_dsa_sign (#3112)
  > tool-openssl/s_client: default SNI to -connect host to match OpenSSL (#3209)
  > Bump time from 0.3.36 to 0.3.47 in /tests/ci/lambda (#3248)
  > Bump the github-actions group with 2 updates (#3258)
  > Decouple the FIPS version number from the AWS-LC version number (#3211)
  > Document new versioning scheme and bump mainline to v5.0.0 (#3212)
  > Fix correctness findings from penpal testing (#3235)
  > Add SHRT_MAX caps to bound iteration and input lengths (#3240)
  > Tighten OCSP_parse_url URL parsing (#3238)
  > Log versioning and library names druing cmake build step (#3254)
  > Add new review workflow (#3230)
  > ci: declare contents: read on zig compiler workflow (#3249)
  > Release cipher_data on error path too for EVP_CTRL_INIT and EVP_CTRL_COPY (#3243)
  > Free existing responderId union arm in OCSP_RESPID setters (#3234)
  > Check parameters before comparing pqdsa public keys (#3229)
  > Reject negative pass_len in PEM_ASN1_write_bio (#3228)
  > Include trailing NUL in BIO_ADDR_rawaddress AF_UNIX length (#3236)
  > Ensure no trailing data for PKCS8 EVP_parse_private_key (#3242)
  > Free existing union arm by current type in PKCS7_set_type (#3231)
  > Reject len < -1 in ASN1_mbstring_ncopy (#3232)
  > Harden PKCS7 and OCSP error handling (#3237)
  > Fix wherelen handling in BIO_ADDR_rawmake AF_UNIX path (#3233)
  > Fix: Apply COHABITANT_HEADERS logic to location of tool binaries (#3116)
  > Add OPENSSL_cleanse to zero stack secrets before return (#3227)
  > BoringSSL: Test key import in EVPTest a bit more extensively (#3058)
  > Prepare 1.73.0 (#3226)
  > Fix shared library install on Windows: place DLLs in bin directory (#3225)
  > Fix thread-local DRBG cleanup deadlock at process exit (#3220)
  > Reject URIs containing '@' in name constraint checking (#3202)
  > ci: pin zig x86_64-windows job to windows-2022 (#3222)
  > Support non-empty context strings in ML-DSA EVP sign/verify (#3135)
  > Bump the pip-ci group across 1 directory with 4 updates (#3216)
  > Bump the cargo-ci-lambda group across 1 directory with 10 updates (#3217)
  > Bump the github-actions group with 17 updates (#3218)
  > Bump golang.org/x/crypto from 0.31.0 to 0.50.0 in the gomod-root group (#3214)
  > Fixes several issues across X509 and EVP parsing/comparison code (#3213)
  > ci: add Dependabot configuration (#3191)
  > ci: harden zig wrappers against libc++ ABI drift and opaque failures (#3190)
  > Ensure correct bio memory buffer type is assigned (#3204)
  > Rework order for initialisation of digest object. If memory allocation fails, object is now not in a corrupted state. (#3205)
  > Implement EVP_PKEY_get_private_seed to return seed representation of private key (#3200)
  > Align X.509 Limbo local patch with upstream changes (#3206)
  > Dilently drop handshake fragments at the far edge of the seq window (#3203)
  > Add `EVP_PKEY_kem_get_type` public accessor for KEM key NID (#3179)
  > Scope _STL_EXTRA_DISABLED_WARNINGS to C++ to fix Ninja + clang-cl builds (#3199)
  > Fix FIPS build under MSAN by broadening integrity-test guards (#3167)
  > tool/s_client: fix -verify depth and missing CA store (#3189)
  > Handle id-pkix-ocsp-nocheck in OCSP responder verification (#3169)
  > Add WaitForFileAccessible to fix intermittent Windows test failures (#3178)
  > Handle allocation failures in add_string's section strdup and stack push (#3187)
  > Fix grpc CI (#3196)
  > Silence two stringop-overflow false-positives (#3201)
  > Prepare v1.72.1 (#3192)
  > Update NID_rsaesOaep test certificate (#3194)
  > ci: pin cryptography to source builds in pyopenssl integration (#3193)
  > Bump MySQL version to 9.7.0 (#3185)
  > Map rsaesOaep SPKI to RSA in parse_key_type (#3181)
  > docs: update platform support tables (#3176)
  > ci: add gh-pages workflow for API documentation (#3177)
  > BoringSSL: Don't support parameterless DSA keys in SPKIs AND Set an EVP_PKEY's algorithm and data together (#3057)
  > Mitigate intermittent SSL runner timeouts on FreeBSD CI (#3171)
  > Fix intermittent `ImplDispatchTest.AEAD_AES_GCM` failure in gcc-4.8 CI (#3170)
  > Add CI for Zig compiler support (#3142)
  > Improve test portability for OPENSSL_NO_SOCK, OPENSSL_THREADS, and OPENSSL_NO_TTY (#3146)
  > Generalize SSL test runner idle-timeout retry to all tests (#3163)
  > Bump Go version in gcc-4.8 Docker image from 1.18.10 to 1.22.12 (#3168)
  > ssl: invalidate X509 leaf/chain caches in cert_set_chain_and_key and … (#3117)
  > Fix intermittent CA test failure on Windows CI when TEMP is unset (#3161)
  > Bump minimum Go version to 1.20 and update Go dependencies (#3159)
```
</details>


### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
