### PR TITLE
Add `pool.allocated_bytes` and improve `pool.allocated_pages` metrics

### DIFF
--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -254,7 +254,7 @@ impl MemoryLimiter {
     ) -> Option<ManagedBuffer> {
         if forced {
             self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
-            metrics::gauge!("mem.allocated_bytes").increment(size as f64);
+            metrics::gauge!("pool.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
@@ -263,7 +263,7 @@ impl MemoryLimiter {
                 let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved);
                 if new_total_mem_usage > self.mem_limit {
                     trace!(new_total_mem_usage, "not enough memory to allocate");
-                    metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
+                    metrics::histogram!("pool.allocate_latency_us").record(start.elapsed().as_micros() as f64);
                     return None;
                 }
                 // Check that the value we have read is still the same before updating it
@@ -274,8 +274,8 @@ impl MemoryLimiter {
                     Ordering::SeqCst,
                 ) {
                     Ok(_) => {
-                        metrics::gauge!("mem.allocated_bytes").increment(size as f64);
-                        metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
+                        metrics::gauge!("pool.allocated_bytes").increment(size as f64);
+                        metrics::histogram!("pool.allocate_latency_us").record(start.elapsed().as_micros() as f64);
                         break;
                     }
                     Err(current) => mem_allocated = current, // another thread updated the atomic before us, trying again
@@ -294,7 +294,7 @@ impl MemoryLimiter {
         let size = ptr.size();
         drop(ptr);
         self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
-        metrics::gauge!("mem.allocated_bytes").decrement(size as f64);
+        metrics::gauge!("pool.allocated_bytes").decrement(size as f64);
         if let Some(kind) = kind {
             self.release_bytes(size, kind);
         } else {

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -254,6 +254,7 @@ impl MemoryLimiter {
     ) -> Option<ManagedBuffer> {
         if forced {
             self.allocated_bytes.fetch_add(size, Ordering::SeqCst);
+            metrics::gauge!("mem.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
@@ -273,6 +274,7 @@ impl MemoryLimiter {
                     Ordering::SeqCst,
                 ) {
                     Ok(_) => {
+                        metrics::gauge!("mem.allocated_bytes").increment(size as f64);
                         metrics::histogram!("mem.allocate_latency_us").record(start.elapsed().as_micros() as f64);
                         break;
                     }
@@ -292,6 +294,7 @@ impl MemoryLimiter {
         let size = ptr.size();
         drop(ptr);
         self.allocated_bytes.fetch_sub(size, Ordering::SeqCst);
+        metrics::gauge!("mem.allocated_bytes").decrement(size as f64);
         if let Some(kind) = kind {
             self.release_bytes(size, kind);
         } else {

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -73,7 +73,7 @@ impl Page {
         let (index, page_status) = consume(&mut self.inner.acquired_bitmask.lock().unwrap(), self.buffer_count())?;
         let offset = index * self.inner.stats.buffer_size;
         if let PageStatus::Empty = page_status {
-            self.inner.stats.remove_empty_page();
+            self.inner.stats.remove_empty_page(self.buffer_count());
         };
 
         self.inner.stats.acquire_buffer(kind);
@@ -107,7 +107,7 @@ impl Page {
         *bitmask &= mask;
 
         if *bitmask == 0 {
-            self.inner.stats.add_empty_page();
+            self.inner.stats.add_empty_page(self.buffer_count());
         }
         drop(bitmask);
 
@@ -129,7 +129,7 @@ impl Page {
             // arrives before the page is removed from the pool, it will be denied.
             *bitmask = FULL_MASK;
         }
-        self.inner.stats.remove_empty_page();
+        self.inner.stats.remove_empty_page(self.buffer_count());
         true
     }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -372,14 +372,14 @@ impl PagedPoolInner {
                     "free empty memory pool pages"
                 );
                 removed = true;
-                for (buffer_count, &n) in freed_by_count.iter().enumerate() {
-                    if n > 0 {
+                for (buffer_count, &page_count) in freed_by_count.iter().enumerate() {
+                    if page_count > 0 {
                         metrics::gauge!(
                             "pool.allocated_pages",
                             "buffer_size" => format!("{}", pool.stats.buffer_size),
                             "buffer_count" => format!("{}", buffer_count),
                         )
-                        .decrement(n as f64);
+                        .decrement(page_count as f64);
                     }
                 }
             }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -331,7 +331,7 @@ impl PagedPoolInner {
         {
             metrics::histogram!("pool.acquired_bytes", "type" => "primary", "kind" => kind.as_str())
                 .record(size as f64);
-            metrics::histogram!("pool.slack_bytes", "size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
+            metrics::histogram!("pool.slack_bytes", "buffer_size" => format!("{}", pool.buffer_size()), "kind" => kind.as_str())
                     .record((pool.buffer_size() - size) as f64);
 
             PoolBuffer::new_primary(buffer_ptr, size)
@@ -352,20 +352,38 @@ impl PagedPoolInner {
             }
             let mut write = pool.pages.write().unwrap();
             let len = write.len();
-            write.retain(|p| !p.invalidate_if_empty());
+            // Freed pages in a tier can have different buffer counts (small-page fallback), so
+            // tally by count to decrement the matching `pool.allocated_pages` label below.
+            let mut freed_by_count: [usize; MAX_BUFFERS_PER_PAGE + 1] = [0; MAX_BUFFERS_PER_PAGE + 1];
+            write.retain(|p| {
+                if p.invalidate_if_empty() {
+                    freed_by_count[p.buffer_count()] += 1;
+                    false
+                } else {
+                    true
+                }
+            });
 
             let pages_freed = len - write.len();
             if pages_freed > 0 {
                 tracing::trace!(
-                    size = pool.stats.buffer_size,
+                    buffer_size = pool.stats.buffer_size,
                     pages_freed,
                     "free empty memory pool pages"
                 );
                 removed = true;
-                metrics::gauge!("pool.allocated_pages", "size" => format!("{}", pool.stats.buffer_size))
-                    .decrement(pages_freed as f64);
+                for (buffer_count, &n) in freed_by_count.iter().enumerate() {
+                    if n > 0 {
+                        metrics::gauge!(
+                            "pool.allocated_pages",
+                            "buffer_size" => format!("{}", pool.stats.buffer_size),
+                            "buffer_count" => format!("{}", buffer_count),
+                        )
+                        .decrement(n as f64);
+                    }
+                }
             }
-            metrics::histogram!("pool.trim_pages", "size" => format!("{}", pool.stats.buffer_size))
+            metrics::histogram!("pool.trim_pages", "buffer_size" => format!("{}", pool.stats.buffer_size))
                 .record(pages_freed as f64);
         }
 

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -33,13 +33,23 @@ impl SizePoolStats {
         self.empty_pages.load(Ordering::SeqCst)
     }
 
-    pub(super) fn add_empty_page(&self) {
-        metrics::gauge!("pool.empty_pages", "buffer_size" => format!("{}", self.buffer_size)).increment(1.0);
+    pub(super) fn add_empty_page(&self, buffer_count: usize) {
+        metrics::gauge!(
+            "pool.empty_pages",
+            "buffer_size" => format!("{}", self.buffer_size),
+            "buffer_count" => format!("{}", buffer_count),
+        )
+        .increment(1.0);
         self.empty_pages.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub(super) fn remove_empty_page(&self) {
-        metrics::gauge!("pool.empty_pages", "buffer_size" => format!("{}", self.buffer_size)).decrement(1.0);
+    pub(super) fn remove_empty_page(&self, buffer_count: usize) {
+        metrics::gauge!(
+            "pool.empty_pages",
+            "buffer_size" => format!("{}", self.buffer_size),
+            "buffer_count" => format!("{}", buffer_count),
+        )
+        .decrement(1.0);
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
@@ -52,7 +62,7 @@ impl SizePoolStats {
             "buffer_count" => format!("{}", buffer_count),
         )
         .increment(1.0);
-        self.add_empty_page();
+        self.add_empty_page(buffer_count);
         Some(result)
     }
 

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -34,19 +34,24 @@ impl SizePoolStats {
     }
 
     pub(super) fn add_empty_page(&self) {
-        metrics::gauge!("pool.empty_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
+        metrics::gauge!("pool.empty_pages", "buffer_size" => format!("{}", self.buffer_size)).increment(1.0);
         self.empty_pages.fetch_add(1, Ordering::SeqCst);
     }
 
     pub(super) fn remove_empty_page(&self) {
-        metrics::gauge!("pool.empty_pages", "size" => format!("{}", self.buffer_size)).decrement(1.0);
+        metrics::gauge!("pool.empty_pages", "buffer_size" => format!("{}", self.buffer_size)).decrement(1.0);
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
     pub(super) fn try_allocate_page(&self, buffer_count: usize) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
         let result = self.limiter.try_allocate(size, None, false)?;
-        metrics::gauge!("pool.allocated_pages", "size" => format!("{}", self.buffer_size)).increment(1.0);
+        metrics::gauge!(
+            "pool.allocated_pages",
+            "buffer_size" => format!("{}", self.buffer_size),
+            "buffer_count" => format!("{}", buffer_count),
+        )
+        .increment(1.0);
         self.add_empty_page();
         Some(result)
     }

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -35,6 +35,27 @@ impl NamedGauge {
     fn value(&self) -> f64 {
         self.metric.gauge()
     }
+
+    /// Log the gauge's peak against the budget and, iff `peak > effective_budget`, push a
+    /// `{gauge_id} peak ... exceeds effective budget ...` message onto `violations`.
+    fn check_peak_violation(&self, scenario_name: &str, effective_budget: u64, violations: &mut Vec<String>) {
+        let peak = self.metric.gauge_history().max();
+        tracing::info!(
+            scenario = scenario_name,
+            metric = %self.id(),
+            peak = %format_mib(peak),
+            ceiling = %format_mib(effective_budget),
+            "stress: peak memory gauge"
+        );
+        if peak > effective_budget {
+            violations.push(format!(
+                "{} peak {} exceeds effective budget {}",
+                self.id(),
+                format_mib(peak),
+                format_mib(effective_budget),
+            ));
+        }
+    }
 }
 
 /// Collect a [`NamedGauge`] for every registered gauge whose name matches `metric_name` and that
@@ -89,7 +110,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
 
     let mut reserved_overshoots: Vec<String> = Vec::new();
     for gauge in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-        check_peak_violation(scenario_name, &gauge, effective_budget, &mut reserved_overshoots);
+        gauge.check_peak_violation(scenario_name, effective_budget, &mut reserved_overshoots);
     }
     if !reserved_overshoots.is_empty() {
         tracing::warn!(
@@ -110,7 +131,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             label: None,
             metric,
         };
-        check_peak_violation(scenario_name, &gauge, effective_budget, &mut allocated_violations);
+        gauge.check_peak_violation(scenario_name, effective_budget, &mut allocated_violations);
     }
     if allocated_violations.is_empty() {
         tracing::info!(
@@ -138,7 +159,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
 
     let mut in_use_violations: Vec<String> = Vec::new();
     for gauge in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-        check_peak_violation(scenario_name, &gauge, effective_budget, &mut in_use_violations);
+        gauge.check_peak_violation(scenario_name, effective_budget, &mut in_use_violations);
     }
     if in_use_violations.is_empty() {
         tracing::info!(
@@ -163,27 +184,6 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         format_mib(effective_budget),
         in_use_violations.join("\n  "),
     );
-}
-
-/// Log a gauge's peak against the budget and, iff `peak > effective_budget`, push a
-/// `{gauge_id} peak ... exceeds effective budget ...` message onto `violations`.
-fn check_peak_violation(scenario_name: &str, gauge: &NamedGauge, effective_budget: u64, violations: &mut Vec<String>) {
-    let peak = gauge.metric.gauge_history().max();
-    tracing::info!(
-        scenario = scenario_name,
-        metric = %gauge.id(),
-        peak = %format_mib(peak),
-        ceiling = %format_mib(effective_budget),
-        "stress: peak memory gauge"
-    );
-    if peak > effective_budget {
-        violations.push(format!(
-            "{} peak {} exceeds effective budget {}",
-            gauge.id(),
-            format_mib(peak),
-            format_mib(effective_budget),
-        ));
-    }
 }
 
 /// Assert the peak sampled `process.memory_usage` (OS-reported RSS) stayed under

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -13,14 +13,38 @@ const RESERVED_MEMORY_METRIC: &str = "mem.bytes_reserved";
 const ALLOCATED_MEMORY_METRIC: &str = "pool.allocated_bytes";
 const IN_USE_MEMORY_METRIC: &str = "pool.bytes_in_use";
 
-/// Collect `(label_value, Arc<HdrMetric>)` for every registered gauge whose name matches
-/// `metric_name` and that carries a label keyed on `label_key`. Lets invariant checks
-/// auto-discover new `area=` / `kind=` values instead of hardcoding the allowlist.
+/// A gauge handle carrying its identity for logging and violation messages.
+struct NamedGauge {
+    metric_name: &'static str,
+    /// `(label_key, label_value)`, or `None` for an unlabeled gauge.
+    label: Option<(&'static str, String)>,
+    metric: Arc<HdrMetric>,
+}
+
+impl NamedGauge {
+    /// Render the gauge's identity, e.g. `mem.bytes_reserved{area=prefetch}` for a labeled
+    /// gauge or `pool.allocated_bytes` for an unlabeled one.
+    fn id(&self) -> String {
+        match &self.label {
+            Some((key, value)) => format!("{}{{{key}={value}}}", self.metric_name),
+            None => self.metric_name.to_string(),
+        }
+    }
+
+    /// Current gauge value
+    fn value(&self) -> f64 {
+        self.metric.gauge()
+    }
+}
+
+/// Collect a [`NamedGauge`] for every registered gauge whose name matches `metric_name` and that
+/// carries a label keyed on `label_key`. Lets invariant checks auto-discover new `area=` / `kind=`
+/// values instead of hardcoding the allowlist.
 fn collect_gauges_by_label(
     recorder: &HdrRecorder,
-    metric_name: &str,
-    label_key: &str,
-) -> Vec<(String, Arc<HdrMetric>)> {
+    metric_name: &'static str,
+    label_key: &'static str,
+) -> Vec<NamedGauge> {
     let mut out = Vec::new();
     recorder.for_each(|key, metric| {
         if key.name() != metric_name {
@@ -37,9 +61,13 @@ fn collect_gauges_by_label(
         else {
             return;
         };
-        out.push((label_value, Arc::clone(metric)));
+        out.push(NamedGauge {
+            metric_name,
+            label: Some((label_key, label_value)),
+            metric: Arc::clone(metric),
+        });
     });
-    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out.sort_by(|a, b| a.label.cmp(&b.label));
     out
 }
 
@@ -60,22 +88,8 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     let effective_budget = mem_limit_u64.saturating_sub(additional_mem_reserved);
 
     let mut reserved_overshoots: Vec<String> = Vec::new();
-    for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-        let peak = metric.gauge_history().max();
-        tracing::info!(
-            scenario = scenario_name,
-            area = %area,
-            peak = %format_mib(peak),
-            ceiling = %format_mib(effective_budget),
-            "stress: peak mem.bytes_reserved"
-        );
-        check_peak_violation(
-            RESERVED_MEMORY_METRIC,
-            Some(("area", &area)),
-            peak,
-            effective_budget,
-            &mut reserved_overshoots,
-        );
+    for gauge in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
+        check_peak_violation(scenario_name, &gauge, effective_budget, &mut reserved_overshoots);
     }
     if !reserved_overshoots.is_empty() {
         tracing::warn!(
@@ -91,21 +105,12 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     // allocated gauge is a hard bound (unlike reservations, which may transiently overshoot).
     let mut allocated_violations: Vec<String> = Vec::new();
     if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
-        let peak = metric.gauge_history().max();
-        tracing::info!(
-            scenario = scenario_name,
-            peak = %format_mib(peak),
-            ceiling = %format_mib(effective_budget),
-            "stress: peak {}",
-            ALLOCATED_MEMORY_METRIC,
-        );
-        check_peak_violation(
-            ALLOCATED_MEMORY_METRIC,
-            None,
-            peak,
-            effective_budget,
-            &mut allocated_violations,
-        );
+        let gauge = NamedGauge {
+            metric_name: ALLOCATED_MEMORY_METRIC,
+            label: None,
+            metric,
+        };
+        check_peak_violation(scenario_name, &gauge, effective_budget, &mut allocated_violations);
     }
     if allocated_violations.is_empty() {
         tracing::info!(
@@ -132,23 +137,8 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     );
 
     let mut in_use_violations: Vec<String> = Vec::new();
-    for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-        let peak = metric.gauge_history().max();
-        tracing::info!(
-            scenario = scenario_name,
-            kind = %kind,
-            peak = %format_mib(peak),
-            ceiling = %format_mib(effective_budget),
-            "stress: peak {}",
-            IN_USE_MEMORY_METRIC,
-        );
-        check_peak_violation(
-            IN_USE_MEMORY_METRIC,
-            Some(("kind", &kind)),
-            peak,
-            effective_budget,
-            &mut in_use_violations,
-        );
+    for gauge in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
+        check_peak_violation(scenario_name, &gauge, effective_budget, &mut in_use_violations);
     }
     if in_use_violations.is_empty() {
         tracing::info!(
@@ -175,28 +165,21 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     );
 }
 
-/// Render a metric's identity for log messages, e.g. `mem.bytes_reserved{area=prefetch}`
-/// for a labeled gauge or `pool.allocated_bytes` for an unlabeled one.
-fn metric_id(metric_name: &str, label: Option<(&str, &str)>) -> String {
-    match label {
-        Some((key, value)) => format!("{metric_name}{{{key}={value}}}"),
-        None => metric_name.to_string(),
-    }
-}
-
-/// Push a `{metric_id} peak ... exceeds effective budget ...` message onto `violations`
-/// iff `peak > effective_budget`.
-fn check_peak_violation(
-    metric_name: &str,
-    label: Option<(&str, &str)>,
-    peak: u64,
-    effective_budget: u64,
-    violations: &mut Vec<String>,
-) {
+/// Log a gauge's peak against the budget and, iff `peak > effective_budget`, push a
+/// `{gauge_id} peak ... exceeds effective budget ...` message onto `violations`.
+fn check_peak_violation(scenario_name: &str, gauge: &NamedGauge, effective_budget: u64, violations: &mut Vec<String>) {
+    let peak = gauge.metric.gauge_history().max();
+    tracing::info!(
+        scenario = scenario_name,
+        metric = %gauge.id(),
+        peak = %format_mib(peak),
+        ceiling = %format_mib(effective_budget),
+        "stress: peak memory gauge"
+    );
     if peak > effective_budget {
         violations.push(format!(
             "{} peak {} exceeds effective budget {}",
-            metric_id(metric_name, label),
+            gauge.id(),
             format_mib(peak),
             format_mib(effective_budget),
         ));
@@ -260,23 +243,6 @@ pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
 /// zero shortly after `drop(session)` returns. With no deterministic signal to await, we poll.
 const TEARDOWN_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// A gauge handle polled during teardown, retaining its identity for logging.
-struct NamedGauge {
-    metric_name: &'static str,
-    /// `(label_key, label_value)`, or `None` for an unlabeled gauge.
-    label: Option<(&'static str, String)>,
-    metric: Arc<HdrMetric>,
-}
-
-impl NamedGauge {
-    fn id(&self) -> String {
-        metric_id(
-            self.metric_name,
-            self.label.as_ref().map(|(key, value)| (*key, value.as_str())),
-        )
-    }
-}
-
 /// After the session is dropped, every tracked gauge must be back to zero.
 /// Polls until the gauges settle or [`TEARDOWN_SETTLE_TIMEOUT`] elapses.
 pub fn assert_teardown_invariants(scenario_name: &str) {
@@ -289,14 +255,7 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
     };
 
     // Each handle holds a live value that CRT teardown decrements, so we poll them in place.
-    let mut gauges: Vec<NamedGauge> = Vec::new();
-    for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-        gauges.push(NamedGauge {
-            metric_name: RESERVED_MEMORY_METRIC,
-            label: Some(("area", area)),
-            metric,
-        });
-    }
+    let mut gauges = collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area");
     if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
         gauges.push(NamedGauge {
             metric_name: ALLOCATED_MEMORY_METRIC,
@@ -304,25 +263,17 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
             metric,
         });
     }
-    for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-        gauges.push(NamedGauge {
-            metric_name: IN_USE_MEMORY_METRIC,
-            label: Some(("kind", kind)),
-            metric,
-        });
-    }
-
-    let any_leak = |gauges: &[NamedGauge]| gauges.iter().any(|g| g.metric.gauge() != 0.0);
+    gauges.extend(collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind"));
 
     let start = Instant::now();
-    while any_leak(&gauges) && start.elapsed() < TEARDOWN_SETTLE_TIMEOUT {
+    while gauges.iter().any(|g| g.value() != 0.0) && start.elapsed() < TEARDOWN_SETTLE_TIMEOUT {
         std::thread::sleep(Duration::from_millis(50));
     }
 
     // Log each gauge's resting value and record any that did not return to zero.
     let mut leaks: Vec<String> = Vec::new();
     for gauge in &gauges {
-        let value = gauge.metric.gauge();
+        let value = gauge.value();
         tracing::info!(
             scenario = scenario_name,
             metric = %gauge.id(),

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -10,7 +10,7 @@ use super::latency::{FileOp, FileOpLatencies};
 use super::report::{format_mib, us_to_ms_str};
 
 const RESERVED_MEMORY_METRIC: &str = "mem.bytes_reserved";
-const ALLOCATED_MEMORY_METRIC: &str = "mem.allocated_bytes";
+const ALLOCATED_MEMORY_METRIC: &str = "pool.allocated_bytes";
 const IN_USE_MEMORY_METRIC: &str = "pool.bytes_in_use";
 
 /// Collect `(label_value, Arc<HdrMetric>)` for every registered gauge whose name matches
@@ -57,7 +57,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     let additional_mem_reserved = (mem_limit_u64 / 8).max(128 * 1024 * 1024);
     let effective_budget = mem_limit_u64.saturating_sub(additional_mem_reserved);
 
-    let mut mem_overshoots: Vec<String> = Vec::new();
+    let mut reserved_overshoots: Vec<String> = Vec::new();
     for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
         let peak = metric.gauge_history().max();
         tracing::info!(
@@ -69,23 +69,25 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         );
         check_peak_violation(
             RESERVED_MEMORY_METRIC,
-            "area",
-            &area,
+            Some(("area", &area)),
             peak,
             effective_budget,
-            &mut mem_overshoots,
+            &mut reserved_overshoots,
         );
     }
-    if !mem_overshoots.is_empty() {
+    if !reserved_overshoots.is_empty() {
         tracing::warn!(
             scenario = scenario_name,
-            overshoots = ?mem_overshoots,
+            overshoots = ?reserved_overshoots,
             "stress: {} peak exceeded effective budget {} (informational — reservations may transiently exceed the limit)",
             RESERVED_MEMORY_METRIC,
             format_mib(effective_budget),
         );
     }
 
+    // The limiter enforces `allocated_bytes + additional_mem_reserved <= mem_limit`, so the
+    // allocated gauge is a hard bound (unlike reservations, which may transiently overshoot).
+    let mut allocated_violations: Vec<String> = Vec::new();
     if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
         let peak = metric.gauge_history().max();
         tracing::info!(
@@ -95,17 +97,34 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             "stress: peak {}",
             ALLOCATED_MEMORY_METRIC,
         );
-        if peak > effective_budget {
-            mem_overshoots.push(format!(
-                "{} peak {} exceeds effective budget {}",
-                ALLOCATED_MEMORY_METRIC,
-                format_mib(peak),
-                format_mib(effective_budget),
-            ));
-        }
+        check_peak_violation(
+            ALLOCATED_MEMORY_METRIC,
+            None,
+            peak,
+            effective_budget,
+            &mut allocated_violations,
+        );
+    }
+    // TODO: promote from logging error to assert once production accounting is tight
+    // enough that breaches indicate real regressions rather than known-gap overshoot.
+    if !allocated_violations.is_empty() {
+        tracing::error!(
+            scenario = scenario_name,
+            violations = ?allocated_violations,
+            "stress: assertion FAILED — peak {} invariant (ceiling {})",
+            ALLOCATED_MEMORY_METRIC,
+            format_mib(effective_budget),
+        );
+    } else {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — peak {} invariant (ceiling {})",
+            ALLOCATED_MEMORY_METRIC,
+            format_mib(effective_budget),
+        );
     }
 
-    let mut pool_violations: Vec<String> = Vec::new();
+    let mut in_use_violations: Vec<String> = Vec::new();
     for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
         let peak = metric.gauge_history().max();
         tracing::info!(
@@ -118,19 +137,18 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         );
         check_peak_violation(
             IN_USE_MEMORY_METRIC,
-            "kind",
-            &kind,
+            Some(("kind", &kind)),
             peak,
             effective_budget,
-            &mut pool_violations,
+            &mut in_use_violations,
         );
     }
     // TODO: promote from logging error to assert once production accounting is tight
     // enough that breaches indicate real regressions rather than known-gap overshoot.
-    if !pool_violations.is_empty() {
+    if !in_use_violations.is_empty() {
         tracing::error!(
             scenario = scenario_name,
-            violations = ?pool_violations,
+            violations = ?in_use_violations,
             "stress: assertion FAILED — peak {} invariant (ceiling {})",
             IN_USE_MEMORY_METRIC,
             format_mib(effective_budget),
@@ -145,19 +163,28 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     }
 }
 
-/// Push a `{metric}{{{label_key}={label_value}}} peak ... exceeds effective budget ...`
-/// message onto `violations` iff `peak > effective_budget`.
+/// Render a metric's identity for log messages, e.g. `mem.bytes_reserved{area=prefetch}`
+/// for a labeled gauge or `pool.allocated_bytes` for an unlabeled one.
+fn metric_id(metric_name: &str, label: Option<(&str, &str)>) -> String {
+    match label {
+        Some((key, value)) => format!("{metric_name}{{{key}={value}}}"),
+        None => metric_name.to_string(),
+    }
+}
+
+/// Push a `{metric_id} peak ... exceeds effective budget ...` message onto `violations`
+/// iff `peak > effective_budget`.
 fn check_peak_violation(
     metric_name: &str,
-    label_key: &str,
-    label_value: &str,
+    label: Option<(&str, &str)>,
     peak: u64,
     effective_budget: u64,
     violations: &mut Vec<String>,
 ) {
     if peak > effective_budget {
         violations.push(format!(
-            "{metric_name}{{{label_key}={label_value}}} peak {} exceeds effective budget {}",
+            "{} peak {} exceeds effective budget {}",
+            metric_id(metric_name, label),
             format_mib(peak),
             format_mib(effective_budget),
         ));
@@ -215,11 +242,30 @@ pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
     }
 }
 
-/// How long to wait for reservation gauges to settle to zero after the session is dropped.
-/// Freeing pool pages lags `drop(session)` by however long CRT teardown takes.
+/// How long to wait for the tracked gauges to settle to zero after the session is dropped.
+///
+/// The CRT releases its pool references asynchronously on its own threads, so the gauges reach
+/// zero shortly after `drop(session)` returns. With no deterministic signal to await, we poll.
 const TEARDOWN_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// After the session is dropped, every reservation-tracking gauge must be back to zero.
+/// A gauge handle polled during teardown, retaining its identity for logging.
+struct NamedGauge {
+    metric_name: &'static str,
+    /// `(label_key, label_value)`, or `None` for an unlabeled gauge.
+    label: Option<(&'static str, String)>,
+    metric: Arc<HdrMetric>,
+}
+
+impl NamedGauge {
+    fn id(&self) -> String {
+        metric_id(
+            self.metric_name,
+            self.label.as_ref().map(|(key, value)| (*key, value.as_str())),
+        )
+    }
+}
+
+/// After the session is dropped, every tracked gauge must be back to zero.
 /// Polls until the gauges settle or [`TEARDOWN_SETTLE_TIMEOUT`] elapses.
 pub fn assert_teardown_invariants(scenario_name: &str) {
     let Some(recorder) = stress_recorder::recorder() else {
@@ -230,51 +276,56 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
         return;
     };
 
-    // Collect any reservation gauge not back to zero.
-    let collect_leaks = || {
-        let mut leaks: Vec<String> = Vec::new();
-        for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-            check_teardown_leak(RESERVED_MEMORY_METRIC, "area", &area, metric.gauge(), &mut leaks);
-        }
-        if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
-            let v = metric.gauge();
-            if v != 0.0 {
-                leaks.push(format!("{ALLOCATED_MEMORY_METRIC} = {v}"));
-            }
-        }
-        for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-            check_teardown_leak(IN_USE_MEMORY_METRIC, "kind", &kind, metric.gauge(), &mut leaks);
-        }
-        leaks
-    };
-
-    let start = Instant::now();
-    let mut leaks = collect_leaks();
-    while !leaks.is_empty() && start.elapsed() < TEARDOWN_SETTLE_TIMEOUT {
-        std::thread::sleep(Duration::from_millis(50));
-        leaks = collect_leaks();
-    }
-
-    // Log each gauge's resting value.
+    // Each handle holds a live value that CRT teardown decrements, so we poll them in place.
+    let mut gauges: Vec<NamedGauge> = Vec::new();
     for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-        tracing::info!(scenario = scenario_name, area = %area, value = metric.gauge(), "stress: teardown {}", RESERVED_MEMORY_METRIC);
+        gauges.push(NamedGauge {
+            metric_name: RESERVED_MEMORY_METRIC,
+            label: Some(("area", area)),
+            metric,
+        });
     }
     if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
-        tracing::info!(
-            scenario = scenario_name,
-            value = metric.gauge(),
-            "stress: teardown {}",
-            ALLOCATED_MEMORY_METRIC
-        );
+        gauges.push(NamedGauge {
+            metric_name: ALLOCATED_MEMORY_METRIC,
+            label: None,
+            metric,
+        });
     }
     for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-        tracing::info!(scenario = scenario_name, kind = %kind, value = metric.gauge(), "stress: teardown {}", IN_USE_MEMORY_METRIC);
+        gauges.push(NamedGauge {
+            metric_name: IN_USE_MEMORY_METRIC,
+            label: Some(("kind", kind)),
+            metric,
+        });
+    }
+
+    let any_leak = |gauges: &[NamedGauge]| gauges.iter().any(|g| g.metric.gauge() != 0.0);
+
+    let start = Instant::now();
+    while any_leak(&gauges) && start.elapsed() < TEARDOWN_SETTLE_TIMEOUT {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Log each gauge's resting value and record any that did not return to zero.
+    let mut leaks: Vec<String> = Vec::new();
+    for gauge in &gauges {
+        let value = gauge.metric.gauge();
+        tracing::info!(
+            scenario = scenario_name,
+            metric = %gauge.id(),
+            value,
+            "stress: teardown gauge"
+        );
+        if value != 0.0 {
+            leaks.push(format!("{} = {value}", gauge.id()));
+        }
     }
 
     if leaks.is_empty() {
         tracing::info!(
             scenario = scenario_name,
-            "stress: assertion PASSED — teardown invariants (all reservation gauges back to zero)"
+            "stress: assertion PASSED — teardown invariants (all tracked gauges back to zero)"
         );
     } else {
         tracing::error!(
@@ -288,13 +339,6 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
         "teardown invariant violated:\n  {}",
         leaks.join("\n  ")
     );
-}
-
-/// Push a `{metric}{{{label_key}={label_value}}} = {v}` message onto `leaks` iff `v != 0`.
-fn check_teardown_leak(metric_name: &str, label_key: &str, label_value: &str, v: f64, leaks: &mut Vec<String>) {
-    if v != 0.0 {
-        leaks.push(format!("{metric_name}{{{label_key}={label_value}}} = {v}"));
-    }
 }
 
 /// Assert that the merged per-op p100 latency is within `max_latency(op)`.

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -10,6 +10,7 @@ use super::latency::{FileOp, FileOpLatencies};
 use super::report::{format_mib, us_to_ms_str};
 
 const RESERVED_MEMORY_METRIC: &str = "mem.bytes_reserved";
+const ALLOCATED_MEMORY_METRIC: &str = "mem.allocated_bytes";
 const IN_USE_MEMORY_METRIC: &str = "pool.bytes_in_use";
 
 /// Collect `(label_value, Arc<HdrMetric>)` for every registered gauge whose name matches
@@ -83,6 +84,25 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             RESERVED_MEMORY_METRIC,
             format_mib(effective_budget),
         );
+    }
+
+    if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
+        let peak = metric.gauge_history().max();
+        tracing::info!(
+            scenario = scenario_name,
+            peak = %format_mib(peak),
+            ceiling = %format_mib(effective_budget),
+            "stress: peak {}",
+            ALLOCATED_MEMORY_METRIC,
+        );
+        if peak > effective_budget {
+            mem_overshoots.push(format!(
+                "{} peak {} exceeds effective budget {}",
+                ALLOCATED_MEMORY_METRIC,
+                format_mib(peak),
+                format_mib(effective_budget),
+            ));
+        }
     }
 
     let mut pool_violations: Vec<String> = Vec::new();
@@ -209,6 +229,18 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
         let v = metric.gauge();
         tracing::info!(scenario = scenario_name, area = %area, value = v, "stress: teardown {}", RESERVED_MEMORY_METRIC);
         check_teardown_leak(RESERVED_MEMORY_METRIC, "area", &area, v, &mut leaks);
+    }
+    if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
+        let v = metric.gauge();
+        tracing::info!(
+            scenario = scenario_name,
+            value = v,
+            "stress: teardown {}",
+            ALLOCATED_MEMORY_METRIC
+        );
+        if v != 0.0 {
+            leaks.push(format!("{ALLOCATED_MEMORY_METRIC} = {v}"));
+        }
     }
     for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
         let v = metric.gauge();

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -43,8 +43,10 @@ fn collect_gauges_by_label(
     out
 }
 
-/// Assert each individual reserved-memory gauge stayed below the effective budget the
-/// limiter enforces against (`mem_limit - additional_mem_reserved`)
+/// Assert each memory gauge's peak stayed within the effective budget the limiter enforces
+/// against (`mem_limit - additional_mem_reserved`). Reservations may transiently overshoot, so
+/// `mem.bytes_reserved` is only logged; the pool's committed memory is a hard bound, so
+/// `pool.allocated_bytes` and `pool.bytes_in_use` breaches fail the assertion.
 pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     let Some(recorder) = stress_recorder::recorder() else {
         tracing::warn!(
@@ -105,9 +107,14 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             &mut allocated_violations,
         );
     }
-    // TODO: promote from logging error to assert once production accounting is tight
-    // enough that breaches indicate real regressions rather than known-gap overshoot.
-    if !allocated_violations.is_empty() {
+    if allocated_violations.is_empty() {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — peak {} invariant (ceiling {})",
+            ALLOCATED_MEMORY_METRIC,
+            format_mib(effective_budget),
+        );
+    } else {
         tracing::error!(
             scenario = scenario_name,
             violations = ?allocated_violations,
@@ -115,14 +122,14 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             ALLOCATED_MEMORY_METRIC,
             format_mib(effective_budget),
         );
-    } else {
-        tracing::info!(
-            scenario = scenario_name,
-            "stress: assertion PASSED — peak {} invariant (ceiling {})",
-            ALLOCATED_MEMORY_METRIC,
-            format_mib(effective_budget),
-        );
     }
+    assert!(
+        allocated_violations.is_empty(),
+        "peak {} invariant violated (ceiling {}):\n  {}",
+        ALLOCATED_MEMORY_METRIC,
+        format_mib(effective_budget),
+        allocated_violations.join("\n  "),
+    );
 
     let mut in_use_violations: Vec<String> = Vec::new();
     for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
@@ -143,9 +150,14 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             &mut in_use_violations,
         );
     }
-    // TODO: promote from logging error to assert once production accounting is tight
-    // enough that breaches indicate real regressions rather than known-gap overshoot.
-    if !in_use_violations.is_empty() {
+    if in_use_violations.is_empty() {
+        tracing::info!(
+            scenario = scenario_name,
+            "stress: assertion PASSED — peak {} invariant (ceiling {})",
+            IN_USE_MEMORY_METRIC,
+            format_mib(effective_budget),
+        );
+    } else {
         tracing::error!(
             scenario = scenario_name,
             violations = ?in_use_violations,
@@ -153,14 +165,14 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
             IN_USE_MEMORY_METRIC,
             format_mib(effective_budget),
         );
-    } else {
-        tracing::info!(
-            scenario = scenario_name,
-            "stress: assertion PASSED — peak {} invariant (ceiling {})",
-            IN_USE_MEMORY_METRIC,
-            format_mib(effective_budget),
-        );
     }
+    assert!(
+        in_use_violations.is_empty(),
+        "peak {} invariant violated (ceiling {}):\n  {}",
+        IN_USE_MEMORY_METRIC,
+        format_mib(effective_budget),
+        in_use_violations.join("\n  "),
+    );
 }
 
 /// Render a metric's identity for log messages, e.g. `mem.bytes_reserved{area=prefetch}`

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -1,7 +1,7 @@
 //! Teardown-time invariant assertions for stress scenarios.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::common::stress_recorder;
 use crate::common::test_recorder::stress::{HdrMetric, HdrRecorder};
@@ -215,7 +215,12 @@ pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
     }
 }
 
+/// How long to wait for reservation gauges to settle to zero after the session is dropped.
+/// Freeing pool pages lags `drop(session)` by however long CRT teardown takes.
+const TEARDOWN_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// After the session is dropped, every reservation-tracking gauge must be back to zero.
+/// Polls until the gauges settle or [`TEARDOWN_SETTLE_TIMEOUT`] elapses.
 pub fn assert_teardown_invariants(scenario_name: &str) {
     let Some(recorder) = stress_recorder::recorder() else {
         tracing::warn!(
@@ -224,29 +229,48 @@ pub fn assert_teardown_invariants(scenario_name: &str) {
         );
         return;
     };
-    let mut leaks: Vec<String> = Vec::new();
+
+    // Collect any reservation gauge not back to zero.
+    let collect_leaks = || {
+        let mut leaks: Vec<String> = Vec::new();
+        for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
+            check_teardown_leak(RESERVED_MEMORY_METRIC, "area", &area, metric.gauge(), &mut leaks);
+        }
+        if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
+            let v = metric.gauge();
+            if v != 0.0 {
+                leaks.push(format!("{ALLOCATED_MEMORY_METRIC} = {v}"));
+            }
+        }
+        for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
+            check_teardown_leak(IN_USE_MEMORY_METRIC, "kind", &kind, metric.gauge(), &mut leaks);
+        }
+        leaks
+    };
+
+    let start = Instant::now();
+    let mut leaks = collect_leaks();
+    while !leaks.is_empty() && start.elapsed() < TEARDOWN_SETTLE_TIMEOUT {
+        std::thread::sleep(Duration::from_millis(50));
+        leaks = collect_leaks();
+    }
+
+    // Log each gauge's resting value.
     for (area, metric) in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {
-        let v = metric.gauge();
-        tracing::info!(scenario = scenario_name, area = %area, value = v, "stress: teardown {}", RESERVED_MEMORY_METRIC);
-        check_teardown_leak(RESERVED_MEMORY_METRIC, "area", &area, v, &mut leaks);
+        tracing::info!(scenario = scenario_name, area = %area, value = metric.gauge(), "stress: teardown {}", RESERVED_MEMORY_METRIC);
     }
     if let Some(metric) = recorder.get(ALLOCATED_MEMORY_METRIC, &[]) {
-        let v = metric.gauge();
         tracing::info!(
             scenario = scenario_name,
-            value = v,
+            value = metric.gauge(),
             "stress: teardown {}",
             ALLOCATED_MEMORY_METRIC
         );
-        if v != 0.0 {
-            leaks.push(format!("{ALLOCATED_MEMORY_METRIC} = {v}"));
-        }
     }
     for (kind, metric) in collect_gauges_by_label(recorder, IN_USE_MEMORY_METRIC, "kind") {
-        let v = metric.gauge();
-        tracing::info!(scenario = scenario_name, kind = %kind, value = v, "stress: teardown {}", IN_USE_MEMORY_METRIC);
-        check_teardown_leak(IN_USE_MEMORY_METRIC, "kind", &kind, v, &mut leaks);
+        tracing::info!(scenario = scenario_name, kind = %kind, value = metric.gauge(), "stress: teardown {}", IN_USE_MEMORY_METRIC);
     }
+
     if leaks.is_empty() {
         tracing::info!(
             scenario = scenario_name,


### PR DESCRIPTION
Adds observability for the memory the pool has actually committed, which no existing metric exposed. The limiter checks allocated_bytes + additional_mem_reserved <= mem_limit
  on every allocation, but allocated_bytes itself was never emitted — so you couldn't see how close the pool was to its ceiling, or the gap between committed and in-use memory
  (idle pages).

  Changes:

  1. Add the `pool.allocated_bytes` gauge, emitted wherever `allocated_bytes` changes (both `try_allocate` paths and `deallocate`). Stress invariants assert it stays within budget at peak and returns to zero at teardown.
  2. Label `pool.allocated_pages` and `pool.empty_pages` by `buffer_size` and `buffer_count`. With the small-page fallback, a size tier can hold pages of differing buffer counts, so a bare page count no longer maps to committed memory. The `buffer_count` dimension restores it as `sum(buffer_size * buffer_count * page_count)` and surfaces fallback activity. The size label is renamed to `buffer_size` across the affected pool metrics for clarity.
  3. Poll for the teardown gauges to settle before asserting. Freeing pool pages (which decrements `pool.allocated_bytes`) lags `drop(session)` by however long asynchronous CRT teardown takes to release its pool reference, so the teardown assertion now polls until the gauges settle rather than reading once.
  4. Promote the peak memory invariants to hard assertions. `pool.allocated_bytes` and `pool.bytes_in_use` peak breaches now fail the stress test rather than only logging, so the memory limit is enforced ahead of the feature release. Reservations may transiently overshoot, so `mem.bytes_reserved` remains informational.

### Does this change impact existing behavior?

No behavioral change — allocation and trim logic are untouched; only metric emission
is added or relabeled. Log-schema change for consumers: `size` becomes `buffer_size`
on the pool metrics, and `pool.allocated_pages` gains `buffer_count`.

### Does this change need a changelog entry? Does it require a version change?

No, internal.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
