### PR TITLE
Bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"


### PR DESCRIPTION
cargo-deny flagged `anyhow 1.0.102` as unsound under [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190): `Error::downcast_mut` violates borrow rules after `Error::context`, causing undefined behavior. The fix landed in `anyhow 1.0.103`.

This bumps the lockfile entry via `cargo update -p anyhow`. No source changes required.

Failing run: https://github.com/awslabs/mountpoint-s3/actions/runs/28378845507/job/84075625921

### Does this change impact existing behavior?

No. This is a transitive lockfile bump within the `1.x` range.

### Does this change need a changelog entry? Does it require a version change?

No. Lockfile-only update with no user-visible behavior change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)