### PR TITLE
Add 7-day cooldown to GitHub Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Adds a cooldown to Dependabot, so PRs won't be opened until the version is at least 7 days old. This provides some mitigation to avoid picking up dependencies that may not be suitable due to bug or malicious behavior, as there is time for vetting or bug fixes.

This still respects Dependabot's cadence - for example, it will run weekly still but on that weekly run, the new versions must be at least 7 days old to be considered eligible.

Note, security updates do not respect this config and will open a PR as soon as an update is available. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

Zizmor would report no specification of cooldown (albeit as a pedantic finding): https://docs.zizmor.sh/audits/#dependabot-cooldown

### Does this change impact existing behavior?

This impacts dependencies updates only - dependencies will only be prompted to update if they are at least 7 days old.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
