### PR TITLE
Fix false-positive stress test memory invariant failures

### DIFF
--- a/mountpoint-s3-fs/tests/common/test_recorder.rs
+++ b/mountpoint-s3-fs/tests/common/test_recorder.rs
@@ -236,13 +236,14 @@ pub mod stress {
         }
     }
 
-    /// State behind a [`HdrMetric::Gauge`]. Holds both the latest point-in-time value and
-    /// a history of every value the gauge has taken on since installation. The history lets
-    /// tests assert true peak/percentiles of the gauge; the current
-    /// value is still needed for teardown invariants assertions.
+    /// State behind a [`HdrMetric::Gauge`]. Holds the latest point-in-time value, the exact
+    /// running peak, and a history of every value the gauge has taken on since installation.
+    /// `current` is needed for teardown invariants; `peak` is the exact maximum used for peak
+    /// invariants; `history` backs the percentile report (`p50`/`p90`/`p99`).
     #[derive(Debug)]
     pub struct GaugeState {
         pub current: f64,
+        pub peak: f64,
         pub history: HdrHistogram<u64>,
     }
 
@@ -250,6 +251,7 @@ pub mod stress {
         fn new(metric_name: &str) -> Self {
             Self {
                 current: 0.0,
+                peak: 0.0,
                 history: new_hdr(metric_name),
             }
         }
@@ -270,8 +272,27 @@ pub mod stress {
             }
         }
 
+        /// Current value if this metric is a gauge, otherwise `None`. Unlike [`Self::gauge`],
+        /// this never panics on counters/histograms, so callers iterating every registered
+        /// metric (e.g. the time-series snapshotter) can filter to gauges safely.
+        pub fn try_gauge(&self) -> Option<f64> {
+            match self {
+                HdrMetric::Gauge(g) => Some(g.lock().unwrap().current),
+                _ => None,
+            }
+        }
+
+        /// Exact largest value the gauge has held, in bytes. Unlike [`Self::gauge_history`]'s
+        /// `max()`, it is not quantized by the histogram, so it is exact for invariant checks.
+        pub fn gauge_peak(&self) -> u64 {
+            match self {
+                HdrMetric::Gauge(g) => g.lock().unwrap().peak.max(0.0) as u64,
+                _ => panic!("expected gauge"),
+            }
+        }
+
         /// Clone of the full history of values this gauge has been set to since installation.
-        /// Use `.max()` on the returned histogram to get the true peak without sampling races.
+        /// Backs the percentile report; use [`Self::gauge_peak`] for the exact maximum.
         pub fn gauge_history(&self) -> HdrHistogram<u64> {
             match self {
                 HdrMetric::Gauge(g) => g.lock().unwrap().history.clone(),
@@ -349,8 +370,7 @@ pub mod stress {
             };
             let mut g = g.lock().unwrap();
             g.current += value;
-            let current = g.current;
-            record_gauge_sample(&mut g.history, current);
+            record_gauge_sample(&mut g);
         }
         fn decrement(&self, value: f64) {
             let HdrMetric::Gauge(g) = self else {
@@ -358,8 +378,7 @@ pub mod stress {
             };
             let mut g = g.lock().unwrap();
             g.current -= value;
-            let current = g.current;
-            record_gauge_sample(&mut g.history, current);
+            record_gauge_sample(&mut g);
         }
         fn set(&self, value: f64) {
             let HdrMetric::Gauge(g) = self else {
@@ -367,15 +386,16 @@ pub mod stress {
             };
             let mut g = g.lock().unwrap();
             g.current = value;
-            let current = g.current;
-            record_gauge_sample(&mut g.history, current);
+            record_gauge_sample(&mut g);
         }
     }
 
-    /// Record a gauge's post-mutation value into its history histogram.
-    fn record_gauge_sample(history: &mut HdrHistogram<u64>, value: f64) {
-        let clamped = clamp(value, history);
-        history.record(clamped).ok();
+    /// Fold a gauge's just-updated `current` value into its exact `peak` and its history
+    /// histogram. Callers must have already set `current`.
+    fn record_gauge_sample(g: &mut GaugeState) {
+        g.peak = g.peak.max(g.current);
+        let clamped = clamp(g.current, &g.history);
+        g.history.record(clamped).ok();
     }
 
     impl HistogramFn for HdrMetric {
@@ -411,6 +431,24 @@ pub mod stress {
             assert!(
                 peak.abs_diff(rss) <= tolerance,
                 "gauge peak {peak} should be within {tolerance} of {rss}",
+            );
+        }
+
+        /// `gauge_peak` is the exact maximum the gauge ever held, unlike the quantized
+        /// `gauge_history().max()`. It tracks the running peak across increments and is not
+        /// pulled down by later decrements.
+        #[test]
+        fn gauge_peak_is_exact_and_tracks_the_running_maximum() {
+            let metric = HdrMetric::Gauge(Mutex::new(GaugeState::new(PROCESS_MEMORY_USAGE)));
+            // A value that sits exactly on a bucket boundary, so history.max() would round up.
+            let high: u64 = 402_653_184; // 384 MiB
+            GaugeFn::increment(&metric, high as f64);
+            GaugeFn::decrement(&metric, (high / 2) as f64); // fall back down; peak stays at `high`
+
+            assert_eq!(metric.gauge_peak(), high, "peak must be the exact running maximum");
+            assert!(
+                metric.gauge_history().max() > high,
+                "precondition: history.max() rounds the boundary value up, so gauge_peak is the exact source",
             );
         }
     }

--- a/mountpoint-s3-fs/tests/common/test_recorder.rs
+++ b/mountpoint-s3-fs/tests/common/test_recorder.rs
@@ -272,16 +272,6 @@ pub mod stress {
             }
         }
 
-        /// Current value if this metric is a gauge, otherwise `None`. Unlike [`Self::gauge`],
-        /// this never panics on counters/histograms, so callers iterating every registered
-        /// metric (e.g. the time-series snapshotter) can filter to gauges safely.
-        pub fn try_gauge(&self) -> Option<f64> {
-            match self {
-                HdrMetric::Gauge(g) => Some(g.lock().unwrap().current),
-                _ => None,
-            }
-        }
-
         /// Exact largest value the gauge has held, in bytes. Unlike [`Self::gauge_history`]'s
         /// `max()`, it is not quantized by the histogram, so it is exact for invariant checks.
         pub fn gauge_peak(&self) -> u64 {

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -170,10 +170,14 @@ pub fn run(scenario: Scenario) {
 
     dump_summary(scenario_name, &aggregate);
 
+    // Workers run in this process, so their I/O buffers count toward RSS; sum them so the
+    // peak-RSS invariant can exclude memory a real out-of-process application would own.
+    let worker_io_buffer_bytes: usize = workers.iter().map(|w| w.io_buffer_bytes()).sum();
+
     tracing::info!("");
     tracing::info!("=== STRESS [{}] INVARIANT ASSERTIONS ===", scenario_name);
     assert_peak_reserved_invariant(scenario_name, mem_limit);
-    assert_peak_rss_invariant(scenario_name, mem_limit);
+    assert_peak_rss_invariant(scenario_name, mem_limit, worker_io_buffer_bytes);
     assert_teardown_invariants(scenario_name);
     assert_p100_latency(scenario_name, &aggregate, max_latency);
     tracing::info!("");

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -39,7 +39,7 @@ impl NamedGauge {
     /// Log the gauge's peak against the budget and, iff `peak > effective_budget`, push a
     /// `{gauge_id} peak ... exceeds effective budget ...` message onto `violations`.
     fn check_peak_violation(&self, scenario_name: &str, effective_budget: u64, violations: &mut Vec<String>) {
-        let peak = self.metric.gauge_history().max();
+        let peak = self.metric.gauge_peak();
         tracing::info!(
             scenario = scenario_name,
             metric = %self.id(),
@@ -203,7 +203,7 @@ pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
         );
         return;
     };
-    let peak = metric.gauge_history().max();
+    let peak = metric.gauge_peak();
     let ceiling = ceiling_bytes as u64;
     tracing::info!(
         scenario = scenario_name,

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -186,9 +186,9 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
     );
 }
 
-/// Assert the peak sampled `process.memory_usage` (OS-reported RSS) stayed under
-/// `ceiling_bytes`.
-pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
+/// Assert the peak sampled `process.memory_usage` (OS-reported RSS), minus
+/// `worker_io_buffer_bytes` of in-process worker I/O buffers, stayed under `ceiling_bytes`.
+pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64, worker_io_buffer_bytes: usize) {
     let Some(recorder) = stress_recorder::recorder() else {
         tracing::warn!(
             scenario = scenario_name,
@@ -203,13 +203,13 @@ pub fn assert_peak_rss_invariant(scenario_name: &str, ceiling_bytes: f64) {
         );
         return;
     };
-    let peak = metric.gauge_peak();
+    let peak = metric.gauge_peak().saturating_sub(worker_io_buffer_bytes as u64);
     let ceiling = ceiling_bytes as u64;
     tracing::info!(
         scenario = scenario_name,
         peak = %format_mib(peak),
         ceiling = %format_mib(ceiling),
-        "stress: peak process.memory_usage"
+        "stress: peak process.memory_usage (worker buffers subtracted)"
     );
     let mut violations: Vec<String> = Vec::new();
     if peak > ceiling {

--- a/mountpoint-s3-fs/tests/stress/harness/worker.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/worker.rs
@@ -22,6 +22,11 @@ pub trait Worker: Send + Sync {
         Duration::from_secs(20)
     }
 
+    /// Bytes of I/O buffer this worker allocates for its reads or writes. Default 0.
+    fn io_buffer_bytes(&self) -> usize {
+        0
+    }
+
     /// The worker body. Must loop until `stop` is set, incrementing `progress` to signal
     /// liveness. Time file-system operations via `latencies.time(op, || ...)` so the
     /// harness can aggregate per-op latency histograms and assert p100 ceilings at

--- a/mountpoint-s3-fs/tests/stress/workers/churn.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/churn.rs
@@ -24,6 +24,10 @@ impl Worker for Churn {
         self.pool.manifest()
     }
 
+    fn io_buffer_bytes(&self) -> usize {
+        self.pool.size
+    }
+
     fn run(
         &self,
         instance: usize,

--- a/mountpoint-s3-fs/tests/stress/workers/holding_writer.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/holding_writer.rs
@@ -25,6 +25,10 @@ impl Worker for HoldingWriter {
         "holding_writer"
     }
 
+    fn io_buffer_bytes(&self) -> usize {
+        WRITE_CHUNK
+    }
+
     fn run(
         &self,
         instance: usize,

--- a/mountpoint-s3-fs/tests/stress/workers/idle.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/idle.rs
@@ -34,6 +34,10 @@ impl Worker for Idle {
         self.pool.manifest()
     }
 
+    fn io_buffer_bytes(&self) -> usize {
+        PREFETCH_PROBE_READ_SIZE
+    }
+
     fn run(
         &self,
         instance: usize,

--- a/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
@@ -30,6 +30,10 @@ impl Worker for SequentialReader {
         vec![(self.target.key.to_string(), self.target.size)]
     }
 
+    fn io_buffer_bytes(&self) -> usize {
+        self.chunk
+    }
+
     fn run(
         &self,
         _instance: usize,

--- a/mountpoint-s3-fs/tests/stress/workers/writer.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/writer.rs
@@ -24,6 +24,10 @@ impl Worker for Writer {
         "writer"
     }
 
+    fn io_buffer_bytes(&self) -> usize {
+        self.chunk
+    }
+
     fn run(
         &self,
         instance: usize,


### PR DESCRIPTION
These are fixes to the invariants in the stress tests. following up the metrics changes in #1852.

1. **Track the exact gauge peak.** Peak invariants read gauge_history().max(), but HDR bucketing could round a peak sitting on the ceiling up into a spurious breach. `GaugeState` now records an exact peak and the invariants read that; the histogram still backs the percentile report.

2. **Exclude worker I/O buffers from the peak-RSS invariant.** Stress workers allocate I/O buffers outside the pool, inflating RSS with memory the limiter doesn't govern. The invariant now subtracts `worker_io_buffer_bytes` before checking the ceiling.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)