### PR TITLE
  Clamp read_part_size when exceeds memory budget

### DIFF
--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -129,13 +129,13 @@ impl ConfigOptions {
         Ok(fs_config)
     }
 
-    fn build_client_config(&self) -> Result<ClientConfig> {
+    fn build_client_config(&self, mem_limit: usize) -> Result<ClientConfig> {
         let user_agent_string = match &self.user_agent_prefix {
             Some(prefix) => format!("{prefix}/mp-exmpl"),
             None => "mountpoint-s3-example/mp-exmpl".to_string(),
         };
         let throughput_target = self.determine_throughput()?;
-        Ok(ClientConfig {
+        let mut config = ClientConfig {
             region: Region::new_user_specified(self.region.clone()),
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: AddressingStyle::Automatic,
@@ -148,8 +148,13 @@ impl ConfigOptions {
             bind: None,
             part_config: PartConfig::with_part_size(self.part_size()),
             user_agent: UserAgent::new(Some(user_agent_string)),
-            memory_limit_user_specified: false,
-        })
+        };
+
+        // Validate and clamp read_part_size before returning
+        use mountpoint_s3_fs::s3::config::MemoryLimitSetting;
+        config.validate_and_clamp_read_part_size(MemoryLimitSetting::Default(mem_limit))?;
+
+        Ok(config)
     }
 
     fn build_logging_config(&self) -> LoggingConfig {
@@ -307,13 +312,11 @@ fn mount_filesystem(
         .error_logger(error_logger);
 
     // Create the client and runtime
-    let mut client_config = config.build_client_config()?;
     let mem_limit = config
         .memory_limit_bytes
         .unwrap_or(mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
 
-    // Validate and clamp read_part_size BEFORE creating the memory pool
-    client_config.validate_and_clamp_read_part_size(mem_limit)?;
+    let client_config = config.build_client_config(mem_limit)?;
 
     let pool = PagedPool::config()
         .with_candidate_sizes([client_config.part_config.read_size_bytes])

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -307,10 +307,14 @@ fn mount_filesystem(
         .error_logger(error_logger);
 
     // Create the client and runtime
-    let client_config = config.build_client_config()?;
+    let mut client_config = config.build_client_config()?;
     let mem_limit = config
         .memory_limit_bytes
         .unwrap_or(mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT);
+
+    // Validate and clamp read_part_size BEFORE creating the memory pool
+    client_config.validate_and_clamp_read_part_size(mem_limit)?;
+
     let pool = PagedPool::config()
         .with_candidate_sizes([client_config.part_config.read_size_bytes])
         .with_memory_limit(mem_limit)

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -148,6 +148,7 @@ impl ConfigOptions {
             bind: None,
             part_config: PartConfig::with_part_size(self.part_size()),
             user_agent: UserAgent::new(Some(user_agent_string)),
+            memory_limit_user_specified: false,
         })
     }
 

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -135,7 +135,7 @@ impl ConfigOptions {
             None => "mountpoint-s3-example/mp-exmpl".to_string(),
         };
         let throughput_target = self.determine_throughput()?;
-        let config = ClientConfig {
+        Ok(ClientConfig {
             region: Region::new_user_specified(self.region.clone()),
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: AddressingStyle::Automatic,
@@ -149,9 +149,7 @@ impl ConfigOptions {
             part_config: PartConfig::with_part_size(self.part_size())
                 .validate(MemoryLimitSetting::Default(mem_limit))?,
             user_agent: UserAgent::new(Some(user_agent_string)),
-        };
-
-        Ok(config)
+        })
     }
 
     fn build_logging_config(&self) -> LoggingConfig {

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -16,7 +16,7 @@ use mountpoint_s3_fs::{
     manifest::{ChannelConfig, Manifest, ManifestMetablock, ingest_manifest},
     memory::PagedPool,
     metrics::{self, MetricsSinkHandle},
-    s3::config::{ClientConfig, PartConfig, Region, TargetThroughputSetting},
+    s3::config::{ClientConfig, MemoryLimitSetting, PartConfig, Region, TargetThroughputSetting},
 };
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
@@ -135,7 +135,7 @@ impl ConfigOptions {
             None => "mountpoint-s3-example/mp-exmpl".to_string(),
         };
         let throughput_target = self.determine_throughput()?;
-        let mut config = ClientConfig {
+        let config = ClientConfig {
             region: Region::new_user_specified(self.region.clone()),
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: AddressingStyle::Automatic,
@@ -146,13 +146,10 @@ impl ConfigOptions {
             expected_bucket_owner: self.expected_bucket_owner.clone(),
             throughput_target,
             bind: None,
-            part_config: PartConfig::with_part_size(self.part_size()),
+            part_config: PartConfig::with_part_size(self.part_size())
+                .validate(MemoryLimitSetting::Default(mem_limit))?,
             user_agent: UserAgent::new(Some(user_agent_string)),
         };
-
-        // Validate and clamp read_part_size before returning
-        use mountpoint_s3_fs::s3::config::MemoryLimitSetting;
-        config.validate_and_clamp_read_part_size(MemoryLimitSetting::Default(mem_limit))?;
 
         Ok(config)
     }

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -8,7 +8,10 @@ mod stats;
 mod write_handle_limiter;
 
 pub use buffers::{PoolBuffer, PoolBufferMut};
-pub use limiter::{ActiveReadGuard, BufferArea, CursorHandle, CursorState, MINIMUM_MEM_LIMIT, effective_total_memory};
+pub use limiter::{
+    ActiveReadGuard, BufferArea, CursorHandle, CursorState, MINIMUM_MEM_LIMIT, data_buffer_budget_for,
+    effective_total_memory,
+};
 pub use pool::PagedPool;
 pub use stats::BufferKind;
 pub use write_handle_limiter::{WriteHandleLimitError, WriteHandleLimiter, WriteHandleSlot};

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -16,14 +16,16 @@ use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
 pub const MINIMUM_MEM_LIMIT: usize = 512 * 1024 * 1024;
 
+/// Calculate additional memory reserved for overhead (metadata and internal structures).
+/// Reserves 12.5% of total memory (or 128 MiB minimum) for non-buffer usage.
+fn additional_mem_reserved_for(mem_limit: usize) -> usize {
+    (mem_limit / 8).max(128 * 1024 * 1024)
+}
+
 /// Calculate the data buffer budget for a given memory limit.
-/// This is the memory available for actual data buffers after reserving overhead for metadata and internal structures.
-///
-/// The formula reserves 12.5% of total memory (or 128 MiB minimum) for non-buffer usage.
+/// This is the memory available for actual data buffers after reserving overhead.
 pub fn data_buffer_budget_for(mem_limit: usize) -> usize {
-    let min_reserved = 128 * 1024 * 1024;
-    let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
-    mem_limit.saturating_sub(additional_mem_reserved)
+    mem_limit.saturating_sub(additional_mem_reserved_for(mem_limit))
 }
 
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
@@ -93,7 +95,7 @@ pub struct MemoryLimiter {
 
 impl MemoryLimiter {
     pub fn new(mem_limit: usize) -> Self {
-        let additional_mem_reserved = mem_limit.saturating_sub(data_buffer_budget_for(mem_limit));
+        let additional_mem_reserved = additional_mem_reserved_for(mem_limit);
         let formatter = make_format(humansize::BINARY);
         debug!(
             "target memory usage is {} with {} reserved memory",

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -16,6 +16,16 @@ use super::stats::{BUFFER_KIND_COUNT, BufferKind};
 
 pub const MINIMUM_MEM_LIMIT: usize = 512 * 1024 * 1024;
 
+/// Calculate the data buffer budget for a given memory limit.
+/// This is the memory available for actual data buffers after reserving overhead for metadata and internal structures.
+///
+/// The formula reserves 12.5% of total memory (or 128 MiB minimum) for non-buffer usage.
+pub fn data_buffer_budget_for(mem_limit: usize) -> usize {
+    let min_reserved = 128 * 1024 * 1024;
+    let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
+    mem_limit.saturating_sub(additional_mem_reserved)
+}
+
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
 pub enum BufferArea {
@@ -83,8 +93,7 @@ pub struct MemoryLimiter {
 
 impl MemoryLimiter {
     pub fn new(mem_limit: usize) -> Self {
-        let min_reserved = 128 * 1024 * 1024;
-        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
+        let additional_mem_reserved = mem_limit.saturating_sub(data_buffer_budget_for(mem_limit));
         let formatter = make_format(humansize::BINARY);
         debug!(
             "target memory usage is {} with {} reserved memory",

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -10,7 +10,7 @@ use mountpoint_s3_client::error::ObjectClientError;
 use mountpoint_s3_client::user_agent::UserAgent;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient, S3RequestError};
 
-use crate::memory::PagedPool;
+use crate::memory::{PagedPool, data_buffer_budget_for};
 
 use super::S3Path;
 
@@ -52,9 +52,6 @@ pub struct ClientConfig {
 
     /// Value for the user-agent header
     pub user_agent: UserAgent,
-
-    /// Whether the memory limit was explicitly set by the user via --max-memory-target
-    pub memory_limit_user_specified: bool,
 }
 
 #[derive(Debug)]
@@ -136,33 +133,61 @@ impl TargetThroughputSetting {
     }
 }
 
+/// Memory limit setting.
+#[derive(Debug, Clone, Copy)]
+pub enum MemoryLimitSetting {
+    /// Default memory limit (95% of system memory)
+    Default(usize),
+    /// User-specified memory limit via --max-memory-target
+    User(usize),
+}
+
+impl MemoryLimitSetting {
+    pub fn bytes(&self) -> usize {
+        match self {
+            MemoryLimitSetting::Default(bytes) => *bytes,
+            MemoryLimitSetting::User(bytes) => *bytes,
+        }
+    }
+
+    pub fn is_user_specified(&self) -> bool {
+        matches!(self, MemoryLimitSetting::User(_))
+    }
+}
+
 impl ClientConfig {
     /// Validate and clamp read_part_size against memory budget.
     /// Must be called BEFORE creating the PagedPool.
     ///
     /// - If user explicitly set both memory and part size AND they conflict → FAIL
     /// - If memory is default (auto-detected) and conflict → CLAMP and warn
-    pub fn validate_and_clamp_read_part_size(&mut self, mem_limit: usize) -> anyhow::Result<()> {
-        // Calculate data_buffer_budget (same formula as MemoryLimiter)
-        let min_reserved = 128 * 1024 * 1024;
-        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
-        let data_buffer_budget = mem_limit.saturating_sub(additional_mem_reserved);
+    pub fn validate_and_clamp_read_part_size(&mut self, memory_limit: MemoryLimitSetting) -> anyhow::Result<()> {
+        let mem_limit = memory_limit.bytes();
+        let data_buffer_budget = data_buffer_budget_for(mem_limit);
+        let reserved = mem_limit.saturating_sub(data_buffer_budget);
 
         if self.part_config.read_size_bytes > data_buffer_budget {
-            if self.memory_limit_user_specified {
+            if memory_limit.is_user_specified() {
                 // User explicitly set both → FAIL IMMEDIATELY
                 anyhow::bail!(
-                    "read part size ({}) exceeds memory budget ({}). \
+                    "read part size ({}) exceeds the memory available for data buffers ({}). \
+                     The memory target is {}, of which {} is reserved for Mountpoint overhead. \
                      Increase --max-memory-target or decrease --read-part-size.",
                     format_size(self.part_config.read_size_bytes, BINARY),
-                    format_size(data_buffer_budget, BINARY)
+                    format_size(data_buffer_budget, BINARY),
+                    format_size(mem_limit, BINARY),
+                    format_size(reserved, BINARY)
                 );
             } else {
                 // Memory was auto-detected → CLAMP and warn
                 tracing::warn!(
-                    "read part size ({}) exceeds auto-detected memory budget ({}), clamping to {}",
+                    "read part size ({}) exceeds the memory available for data buffers ({}). \
+                     The auto-detected memory target is {}, of which {} is reserved for Mountpoint overhead. \
+                     Clamping read part size to {}.",
                     format_size(self.part_config.read_size_bytes, BINARY),
                     format_size(data_buffer_budget, BINARY),
+                    format_size(mem_limit, BINARY),
+                    format_size(reserved, BINARY),
                     format_size(data_buffer_budget, BINARY)
                 );
                 self.part_config.read_size_bytes = data_buffer_budget;
@@ -177,7 +202,6 @@ impl ClientConfig {
         memory_pool: PagedPool,
         validate_on_s3_path: Option<&S3Path>,
     ) -> anyhow::Result<S3CrtClient> {
-        // Validation and clamping now happens before pool creation via validate_and_clamp_read_part_size()
         let mut client_config = S3ClientConfig::new()
             .auth_config(self.auth_config)
             .throughput_target_gbps(self.throughput_target.value())
@@ -291,7 +315,7 @@ mod tests {
     #[test]
     fn test_read_part_size_within_budget_no_clamp() {
         // read_part_size < budget → should use requested size, no error
-        let mem_limit = 1024 * 1024 * 1024; // 1 GB
+        let mem_limit = MemoryLimitSetting::Default(1024 * 1024 * 1024); // 1 GB
         let mut config = ClientConfig {
             region: Region::new_inferred("us-east-1".to_string()),
             endpoint_url: None,
@@ -305,7 +329,6 @@ mod tests {
             bind: None,
             part_config: PartConfig::with_part_size(8 * 1024 * 1024), // 8 MB - well within budget
             user_agent: UserAgent::new(None),
-            memory_limit_user_specified: false,
         };
 
         let result = config.validate_and_clamp_read_part_size(mem_limit);
@@ -320,12 +343,10 @@ mod tests {
     #[test]
     fn test_read_part_size_exceeds_budget_user_specified_fails() {
         // User set memory + read_part_size > budget → should fail during validation
-        let mem_limit: usize = 512 * 1024 * 1024; // 512 MB
+        let mem_limit_bytes: usize = 512 * 1024 * 1024; // 512 MB
+        let memory_limit = MemoryLimitSetting::User(mem_limit_bytes);
 
-        // Calculate budget to determine excessive size
-        let min_reserved: usize = 128 * 1024 * 1024;
-        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
-        let budget = mem_limit.saturating_sub(additional_mem_reserved);
+        let budget = data_buffer_budget_for(mem_limit_bytes);
         let excessive_size = budget + 1; // Just over budget
 
         let mut config = ClientConfig {
@@ -341,18 +362,23 @@ mod tests {
             bind: None,
             part_config: PartConfig::with_part_size(excessive_size),
             user_agent: UserAgent::new(None),
-            memory_limit_user_specified: true, // User explicitly set memory
         };
 
-        let result = config.validate_and_clamp_read_part_size(mem_limit);
+        let result = config.validate_and_clamp_read_part_size(memory_limit);
         assert!(
             result.is_err(),
             "Should fail when user set memory and read_part_size > budget"
         );
         let err = result.unwrap_err();
+        let err_msg = err.to_string();
         assert!(
-            err.to_string().contains("exceeds memory budget"),
-            "Error should mention budget exceeded: {}",
+            err_msg.contains("exceeds the memory available for data buffers"),
+            "Error should mention data buffers: {}",
+            err
+        );
+        assert!(
+            err_msg.contains("reserved for Mountpoint overhead"),
+            "Error should explain reserved memory: {}",
             err
         );
     }
@@ -360,12 +386,10 @@ mod tests {
     #[test]
     fn test_read_part_size_exceeds_budget_default_clamps() {
         // Default memory + read_part_size > budget → should clamp and succeed
-        let mem_limit: usize = 512 * 1024 * 1024; // 512 MB
+        let mem_limit_bytes: usize = 512 * 1024 * 1024; // 512 MB
+        let memory_limit = MemoryLimitSetting::Default(mem_limit_bytes);
 
-        // Calculate budget
-        let min_reserved: usize = 128 * 1024 * 1024;
-        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
-        let budget = mem_limit.saturating_sub(additional_mem_reserved);
+        let budget = data_buffer_budget_for(mem_limit_bytes);
         let excessive_size = budget + 100 * 1024 * 1024; // 100 MB over budget
 
         let mut config = ClientConfig {
@@ -381,10 +405,9 @@ mod tests {
             bind: None,
             part_config: PartConfig::with_part_size(excessive_size),
             user_agent: UserAgent::new(None),
-            memory_limit_user_specified: false, // Memory was auto-detected (default)
         };
 
-        let result = config.validate_and_clamp_read_part_size(mem_limit);
+        let result = config.validate_and_clamp_read_part_size(memory_limit);
         assert!(
             result.is_ok(),
             "Should succeed (with clamping) when memory is default and read_part_size > budget"
@@ -396,10 +419,16 @@ mod tests {
             "read_size_bytes should be clamped to budget"
         );
 
+        // Verify write_size_bytes was NOT clamped
+        assert_eq!(
+            config.part_config.write_size_bytes, excessive_size,
+            "write_size_bytes should remain unchanged"
+        );
+
         // Now create pool and client with clamped value to verify end-to-end flow
         let pool = PagedPool::config()
             .with_candidate_sizes([config.part_config.read_size_bytes])
-            .with_memory_limit(mem_limit)
+            .with_memory_limit(mem_limit_bytes)
             .build();
 
         let client = config.create_client(pool, None).unwrap();
@@ -407,6 +436,50 @@ mod tests {
             client.read_part_size(),
             budget,
             "Client should use clamped size equal to budget"
+        );
+    }
+
+    #[test]
+    fn test_read_part_size_with_separate_read_write_sizes() {
+        // Test the --read-part-size override case (separate from --part-size)
+        let mem_limit_bytes: usize = 512 * 1024 * 1024; // 512 MB
+        let memory_limit = MemoryLimitSetting::User(mem_limit_bytes);
+
+        let budget = data_buffer_budget_for(mem_limit_bytes);
+        let excessive_read_size = budget + 1; // Just over budget
+        let normal_write_size = 8 * 1024 * 1024; // 8 MB - within budget
+
+        let mut config = ClientConfig {
+            region: Region::new_inferred("us-east-1".to_string()),
+            endpoint_url: None,
+            addressing_style: AddressingStyle::Automatic,
+            dual_stack: false,
+            transfer_acceleration: false,
+            auth_config: S3ClientAuthConfig::NoSigning,
+            requester_pays: false,
+            expected_bucket_owner: None,
+            throughput_target: TargetThroughputSetting::Default,
+            bind: None,
+            // Use with_read_write_sizes to model --read-part-size override
+            part_config: PartConfig::with_read_write_sizes(excessive_read_size, normal_write_size),
+            user_agent: UserAgent::new(None),
+        };
+
+        // Should fail because read_part_size exceeds budget (even though write is fine)
+        let result = config.validate_and_clamp_read_part_size(memory_limit);
+        assert!(result.is_err(), "Should fail when read_part_size exceeds budget");
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("exceeds the memory available for data buffers"),
+            "Error should mention data buffers: {}",
+            err
+        );
+
+        // Verify write_size_bytes was not affected
+        assert_eq!(
+            config.part_config.write_size_bytes, normal_write_size,
+            "write_size_bytes should remain unchanged"
         );
     }
 }

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -77,6 +77,46 @@ impl PartConfig {
             write_size_bytes,
         }
     }
+
+    /// Validate and clamp read_part_size against the memory budget.
+    /// Must be called BEFORE creating the PagedPool.
+    ///
+    /// - If user explicitly set both memory and part size AND they conflict → FAIL
+    /// - If memory is default (auto-detected) and conflict → CLAMP and warn
+    pub fn validate(mut self, memory_limit: MemoryLimitSetting) -> anyhow::Result<Self> {
+        let mem_limit = memory_limit.bytes();
+        let data_buffer_budget = data_buffer_budget_for(mem_limit);
+        let reserved = mem_limit.saturating_sub(data_buffer_budget);
+
+        if self.read_size_bytes > data_buffer_budget {
+            if memory_limit.is_user_specified() {
+                // User explicitly set both → FAIL IMMEDIATELY
+                anyhow::bail!(
+                    "read part size ({}) exceeds the memory available for data buffers ({}). \
+                     The memory target is {}, of which {} is reserved for Mountpoint overhead. \
+                     Increase --max-memory-target or decrease --read-part-size.",
+                    format_size(self.read_size_bytes, BINARY),
+                    format_size(data_buffer_budget, BINARY),
+                    format_size(mem_limit, BINARY),
+                    format_size(reserved, BINARY)
+                );
+            } else {
+                // Memory was auto-detected → CLAMP and warn
+                tracing::warn!(
+                    "read part size ({}) exceeds the memory available for data buffers ({}). \
+                     The auto-detected memory target is {}, of which {} is reserved for Mountpoint overhead. \
+                     Clamping read part size to {}.",
+                    format_size(self.read_size_bytes, BINARY),
+                    format_size(data_buffer_budget, BINARY),
+                    format_size(mem_limit, BINARY),
+                    format_size(reserved, BINARY),
+                    format_size(data_buffer_budget, BINARY)
+                );
+                self.read_size_bytes = data_buffer_budget;
+            }
+        }
+        Ok(self)
+    }
 }
 
 #[derive(Debug)]
@@ -156,46 +196,6 @@ impl MemoryLimitSetting {
 }
 
 impl ClientConfig {
-    /// Validate and clamp read_part_size against memory budget.
-    /// Must be called BEFORE creating the PagedPool.
-    ///
-    /// - If user explicitly set both memory and part size AND they conflict → FAIL
-    /// - If memory is default (auto-detected) and conflict → CLAMP and warn
-    pub fn validate_and_clamp_read_part_size(&mut self, memory_limit: MemoryLimitSetting) -> anyhow::Result<()> {
-        let mem_limit = memory_limit.bytes();
-        let data_buffer_budget = data_buffer_budget_for(mem_limit);
-        let reserved = mem_limit.saturating_sub(data_buffer_budget);
-
-        if self.part_config.read_size_bytes > data_buffer_budget {
-            if memory_limit.is_user_specified() {
-                // User explicitly set both → FAIL IMMEDIATELY
-                anyhow::bail!(
-                    "read part size ({}) exceeds the memory available for data buffers ({}). \
-                     The memory target is {}, of which {} is reserved for Mountpoint overhead. \
-                     Increase --max-memory-target or decrease --read-part-size.",
-                    format_size(self.part_config.read_size_bytes, BINARY),
-                    format_size(data_buffer_budget, BINARY),
-                    format_size(mem_limit, BINARY),
-                    format_size(reserved, BINARY)
-                );
-            } else {
-                // Memory was auto-detected → CLAMP and warn
-                tracing::warn!(
-                    "read part size ({}) exceeds the memory available for data buffers ({}). \
-                     The auto-detected memory target is {}, of which {} is reserved for Mountpoint overhead. \
-                     Clamping read part size to {}.",
-                    format_size(self.part_config.read_size_bytes, BINARY),
-                    format_size(data_buffer_budget, BINARY),
-                    format_size(mem_limit, BINARY),
-                    format_size(reserved, BINARY),
-                    format_size(data_buffer_budget, BINARY)
-                );
-                self.part_config.read_size_bytes = data_buffer_budget;
-            }
-        }
-        Ok(())
-    }
-
     /// Create an [S3CrtClient]
     pub fn create_client(
         self,
@@ -316,25 +316,11 @@ mod tests {
     fn test_read_part_size_within_budget_no_clamp() {
         // read_part_size < budget → should use requested size, no error
         let mem_limit = MemoryLimitSetting::Default(1024 * 1024 * 1024); // 1 GB
-        let mut config = ClientConfig {
-            region: Region::new_inferred("us-east-1".to_string()),
-            endpoint_url: None,
-            addressing_style: AddressingStyle::Automatic,
-            dual_stack: false,
-            transfer_acceleration: false,
-            auth_config: S3ClientAuthConfig::NoSigning,
-            requester_pays: false,
-            expected_bucket_owner: None,
-            throughput_target: TargetThroughputSetting::Default,
-            bind: None,
-            part_config: PartConfig::with_part_size(8 * 1024 * 1024), // 8 MB - well within budget
-            user_agent: UserAgent::new(None),
-        };
+        let part_config = PartConfig::with_part_size(8 * 1024 * 1024).validate(mem_limit); // 8 MB - well within budget
 
-        let result = config.validate_and_clamp_read_part_size(mem_limit);
-        assert!(result.is_ok(), "Should succeed when read_part_size < budget");
+        assert!(part_config.is_ok(), "Should succeed when read_part_size < budget");
         assert_eq!(
-            config.part_config.read_size_bytes,
+            part_config.unwrap().read_size_bytes,
             8 * 1024 * 1024,
             "read_size_bytes should remain unchanged"
         );
@@ -349,22 +335,7 @@ mod tests {
         let budget = data_buffer_budget_for(mem_limit_bytes);
         let excessive_size = budget + 1; // Just over budget
 
-        let mut config = ClientConfig {
-            region: Region::new_inferred("us-east-1".to_string()),
-            endpoint_url: None,
-            addressing_style: AddressingStyle::Automatic,
-            dual_stack: false,
-            transfer_acceleration: false,
-            auth_config: S3ClientAuthConfig::NoSigning,
-            requester_pays: false,
-            expected_bucket_owner: None,
-            throughput_target: TargetThroughputSetting::Default,
-            bind: None,
-            part_config: PartConfig::with_part_size(excessive_size),
-            user_agent: UserAgent::new(None),
-        };
-
-        let result = config.validate_and_clamp_read_part_size(memory_limit);
+        let result = PartConfig::with_part_size(excessive_size).validate(memory_limit);
         assert!(
             result.is_err(),
             "Should fail when user set memory and read_part_size > budget"
@@ -392,7 +363,33 @@ mod tests {
         let budget = data_buffer_budget_for(mem_limit_bytes);
         let excessive_size = budget + 100 * 1024 * 1024; // 100 MB over budget
 
-        let mut config = ClientConfig {
+        let part_config = PartConfig::with_part_size(excessive_size).validate(memory_limit);
+        assert!(
+            part_config.is_ok(),
+            "Should succeed (with clamping) when memory is default and read_part_size > budget"
+        );
+
+        let part_config = part_config.unwrap();
+
+        // Verify the read_size_bytes was clamped to budget
+        assert_eq!(
+            part_config.read_size_bytes, budget,
+            "read_size_bytes should be clamped to budget"
+        );
+
+        // Verify write_size_bytes was NOT clamped
+        assert_eq!(
+            part_config.write_size_bytes, excessive_size,
+            "write_size_bytes should remain unchanged"
+        );
+
+        // Now create pool and client with clamped value to verify end-to-end flow
+        let pool = PagedPool::config()
+            .with_candidate_sizes([part_config.read_size_bytes])
+            .with_memory_limit(mem_limit_bytes)
+            .build();
+
+        let config = ClientConfig {
             region: Region::new_inferred("us-east-1".to_string()),
             endpoint_url: None,
             addressing_style: AddressingStyle::Automatic,
@@ -403,33 +400,9 @@ mod tests {
             expected_bucket_owner: None,
             throughput_target: TargetThroughputSetting::Default,
             bind: None,
-            part_config: PartConfig::with_part_size(excessive_size),
+            part_config,
             user_agent: UserAgent::new(None),
         };
-
-        let result = config.validate_and_clamp_read_part_size(memory_limit);
-        assert!(
-            result.is_ok(),
-            "Should succeed (with clamping) when memory is default and read_part_size > budget"
-        );
-
-        // Verify the read_size_bytes was clamped to budget
-        assert_eq!(
-            config.part_config.read_size_bytes, budget,
-            "read_size_bytes should be clamped to budget"
-        );
-
-        // Verify write_size_bytes was NOT clamped
-        assert_eq!(
-            config.part_config.write_size_bytes, excessive_size,
-            "write_size_bytes should remain unchanged"
-        );
-
-        // Now create pool and client with clamped value to verify end-to-end flow
-        let pool = PagedPool::config()
-            .with_candidate_sizes([config.part_config.read_size_bytes])
-            .with_memory_limit(mem_limit_bytes)
-            .build();
 
         let client = config.create_client(pool, None).unwrap();
         assert_eq!(
@@ -449,24 +422,8 @@ mod tests {
         let excessive_read_size = budget + 1; // Just over budget
         let normal_write_size = 8 * 1024 * 1024; // 8 MB - within budget
 
-        let mut config = ClientConfig {
-            region: Region::new_inferred("us-east-1".to_string()),
-            endpoint_url: None,
-            addressing_style: AddressingStyle::Automatic,
-            dual_stack: false,
-            transfer_acceleration: false,
-            auth_config: S3ClientAuthConfig::NoSigning,
-            requester_pays: false,
-            expected_bucket_owner: None,
-            throughput_target: TargetThroughputSetting::Default,
-            bind: None,
-            // Use with_read_write_sizes to model --read-part-size override
-            part_config: PartConfig::with_read_write_sizes(excessive_read_size, normal_write_size),
-            user_agent: UserAgent::new(None),
-        };
-
         // Should fail because read_part_size exceeds budget (even though write is fine)
-        let result = config.validate_and_clamp_read_part_size(memory_limit);
+        let result = PartConfig::with_read_write_sizes(excessive_read_size, normal_write_size).validate(memory_limit);
         assert!(result.is_err(), "Should fail when read_part_size exceeds budget");
         let err = result.unwrap_err();
         let err_msg = err.to_string();
@@ -474,12 +431,6 @@ mod tests {
             err_msg.contains("exceeds the memory available for data buffers"),
             "Error should mention data buffers: {}",
             err
-        );
-
-        // Verify write_size_bytes was not affected
-        assert_eq!(
-            config.part_config.write_size_bytes, normal_write_size,
-            "write_size_bytes should remain unchanged"
         );
     }
 }

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -51,6 +51,9 @@ pub struct ClientConfig {
 
     /// Value for the user-agent header
     pub user_agent: UserAgent,
+
+    /// Whether the memory limit was explicitly set by the user via --max-memory-target
+    pub memory_limit_user_specified: bool,
 }
 
 #[derive(Debug)]
@@ -139,13 +142,46 @@ impl ClientConfig {
         memory_pool: PagedPool,
         validate_on_s3_path: Option<&S3Path>,
     ) -> anyhow::Result<S3CrtClient> {
+        // Check if read_part_size exceeds memory budget and apply hybrid approach:
+        // - Fail mount when both memory and part size are explicitly set and conflict
+        // - Clamp when memory is default (auto-detected)
+        const MIB: usize = 1024 * 1024;
+
+        let data_buffer_budget = memory_pool.data_buffer_budget();
+        let mut effective_read_part_size = self.part_config.read_size_bytes;
+
+        if effective_read_part_size > data_buffer_budget {
+            let read_part_size_mib = effective_read_part_size / MIB;
+            let budget_mib = data_buffer_budget / MIB;
+
+            if self.memory_limit_user_specified {
+                // User explicitly set memory target - fail fast with clear error
+                anyhow::bail!(
+                    "read part size ({} MiB) exceeds memory budget ({} MiB). \
+                     Increase --max-memory-target or decrease --read-part-size.",
+                    read_part_size_mib,
+                    budget_mib
+                );
+            } else {
+                // Memory was auto-detected (default) - clamp and warn
+                effective_read_part_size = data_buffer_budget;
+                tracing::warn!(
+                    "read part size ({} MiB) exceeds auto-detected memory budget ({} MiB), \
+                     clamping to {} MiB",
+                    read_part_size_mib,
+                    budget_mib,
+                    budget_mib
+                );
+            }
+        }
+
         let mut client_config = S3ClientConfig::new()
             .auth_config(self.auth_config)
             .throughput_target_gbps(self.throughput_target.value())
-            .read_part_size(self.part_config.read_size_bytes)
+            .read_part_size(effective_read_part_size)
             .write_part_size(self.part_config.write_size_bytes)
             .read_backpressure(true)
-            .initial_read_window(self.part_config.read_size_bytes)
+            .initial_read_window(effective_read_part_size)
             .user_agent(self.user_agent)
             .memory_pool(memory_pool);
         if let Some(interfaces) = self.bind {
@@ -241,5 +277,121 @@ fn validate_client_for_bucket(
                 s3_path.bucket, region
             )
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::PagedPool;
+
+    #[test]
+    fn test_read_part_size_within_budget_no_clamp() {
+        // read_part_size < budget → should use requested size, no error
+        let pool = PagedPool::config()
+            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_memory_limit(1024 * 1024 * 1024) // 1 GB
+            .build();
+
+        let config = ClientConfig {
+            region: Region::new_inferred("us-east-1".to_string()),
+            endpoint_url: None,
+            addressing_style: AddressingStyle::Automatic,
+            dual_stack: false,
+            transfer_acceleration: false,
+            auth_config: S3ClientAuthConfig::NoSigning,
+            requester_pays: false,
+            expected_bucket_owner: None,
+            throughput_target: TargetThroughputSetting::Default,
+            bind: None,
+            part_config: PartConfig::with_part_size(8 * 1024 * 1024), // 8 MB - well within budget
+            user_agent: UserAgent::new(None),
+            memory_limit_user_specified: false,
+        };
+
+        let result = config.create_client(pool, None);
+        assert!(result.is_ok(), "Should succeed when read_part_size < budget");
+    }
+
+    #[test]
+    fn test_read_part_size_exceeds_budget_user_specified_fails() {
+        // User set memory + read_part_size > budget → should fail
+        let pool = PagedPool::config()
+            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_memory_limit(512 * 1024 * 1024) // 512 MB
+            .build();
+
+        let budget = pool.data_buffer_budget();
+        let excessive_size = budget + 1; // Just over budget
+
+        let config = ClientConfig {
+            region: Region::new_inferred("us-east-1".to_string()),
+            endpoint_url: None,
+            addressing_style: AddressingStyle::Automatic,
+            dual_stack: false,
+            transfer_acceleration: false,
+            auth_config: S3ClientAuthConfig::NoSigning,
+            requester_pays: false,
+            expected_bucket_owner: None,
+            throughput_target: TargetThroughputSetting::Default,
+            bind: None,
+            part_config: PartConfig::with_part_size(excessive_size),
+            user_agent: UserAgent::new(None),
+            memory_limit_user_specified: true, // User explicitly set memory
+        };
+
+        let result = config.create_client(pool, None);
+        assert!(
+            result.is_err(),
+            "Should fail when user set memory and read_part_size > budget"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds memory budget"),
+            "Error should mention budget exceeded: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_read_part_size_exceeds_budget_default_clamps() {
+        // Default memory + read_part_size > budget → should clamp and succeed
+        let pool = PagedPool::config()
+            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_memory_limit(512 * 1024 * 1024) // 512 MB
+            .build();
+
+        let budget = pool.data_buffer_budget();
+        let excessive_size = budget + 100 * 1024 * 1024; // 100 MB over budget
+
+        let config = ClientConfig {
+            region: Region::new_inferred("us-east-1".to_string()),
+            endpoint_url: None,
+            addressing_style: AddressingStyle::Automatic,
+            dual_stack: false,
+            transfer_acceleration: false,
+            auth_config: S3ClientAuthConfig::NoSigning,
+            requester_pays: false,
+            expected_bucket_owner: None,
+            throughput_target: TargetThroughputSetting::Default,
+            bind: None,
+            part_config: PartConfig::with_part_size(excessive_size),
+            user_agent: UserAgent::new(None),
+            memory_limit_user_specified: false, // Memory was auto-detected (default)
+        };
+
+        let result = config.create_client(pool, None);
+        assert!(
+            result.is_ok(),
+            "Should succeed (with clamping) when memory is default and read_part_size > budget"
+        );
+
+        // Verify the client was created with clamped size (it should use budget, not excessive_size)
+        let client = result.unwrap();
+        assert_eq!(
+            client.read_part_size(),
+            budget,
+            "Client should use clamped size equal to budget"
+        );
     }
 }

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::num::NonZeroUsize;
 
 use anyhow::Context as _;
+use humansize::{BINARY, format_size};
 use mountpoint_s3_client::config::{
     AddressingStyle, Allocator, EndpointConfig, S3ClientAuthConfig, S3ClientConfig, Uri,
 };
@@ -136,52 +137,54 @@ impl TargetThroughputSetting {
 }
 
 impl ClientConfig {
+    /// Validate and clamp read_part_size against memory budget.
+    /// Must be called BEFORE creating the PagedPool.
+    ///
+    /// - If user explicitly set both memory and part size AND they conflict → FAIL
+    /// - If memory is default (auto-detected) and conflict → CLAMP and warn
+    pub fn validate_and_clamp_read_part_size(&mut self, mem_limit: usize) -> anyhow::Result<()> {
+        // Calculate data_buffer_budget (same formula as MemoryLimiter)
+        let min_reserved = 128 * 1024 * 1024;
+        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
+        let data_buffer_budget = mem_limit.saturating_sub(additional_mem_reserved);
+
+        if self.part_config.read_size_bytes > data_buffer_budget {
+            if self.memory_limit_user_specified {
+                // User explicitly set both → FAIL IMMEDIATELY
+                anyhow::bail!(
+                    "read part size ({}) exceeds memory budget ({}). \
+                     Increase --max-memory-target or decrease --read-part-size.",
+                    format_size(self.part_config.read_size_bytes, BINARY),
+                    format_size(data_buffer_budget, BINARY)
+                );
+            } else {
+                // Memory was auto-detected → CLAMP and warn
+                tracing::warn!(
+                    "read part size ({}) exceeds auto-detected memory budget ({}), clamping to {}",
+                    format_size(self.part_config.read_size_bytes, BINARY),
+                    format_size(data_buffer_budget, BINARY),
+                    format_size(data_buffer_budget, BINARY)
+                );
+                self.part_config.read_size_bytes = data_buffer_budget;
+            }
+        }
+        Ok(())
+    }
+
     /// Create an [S3CrtClient]
     pub fn create_client(
         self,
         memory_pool: PagedPool,
         validate_on_s3_path: Option<&S3Path>,
     ) -> anyhow::Result<S3CrtClient> {
-        // Check if read_part_size exceeds memory budget and apply hybrid approach:
-        // - Fail mount when both memory and part size are explicitly set and conflict
-        // - Clamp when memory is default (auto-detected)
-        const MIB: usize = 1024 * 1024;
-
-        let data_buffer_budget = memory_pool.data_buffer_budget();
-        let mut effective_read_part_size = self.part_config.read_size_bytes;
-
-        if effective_read_part_size > data_buffer_budget {
-            let read_part_size_mib = effective_read_part_size / MIB;
-            let budget_mib = data_buffer_budget / MIB;
-
-            if self.memory_limit_user_specified {
-                // User explicitly set memory target - fail fast with clear error
-                anyhow::bail!(
-                    "read part size ({} MiB) exceeds memory budget ({} MiB). \
-                     Increase --max-memory-target or decrease --read-part-size.",
-                    read_part_size_mib,
-                    budget_mib
-                );
-            } else {
-                // Memory was auto-detected (default) - clamp and warn
-                effective_read_part_size = data_buffer_budget;
-                tracing::warn!(
-                    "read part size ({} MiB) exceeds auto-detected memory budget ({} MiB), \
-                     clamping to {} MiB",
-                    read_part_size_mib,
-                    budget_mib,
-                    budget_mib
-                );
-            }
-        }
-
+        // Validation and clamping now happens before pool creation via validate_and_clamp_read_part_size()
         let mut client_config = S3ClientConfig::new()
             .auth_config(self.auth_config)
             .throughput_target_gbps(self.throughput_target.value())
-            .read_part_size(effective_read_part_size)
+            .read_part_size(self.part_config.read_size_bytes)
             .write_part_size(self.part_config.write_size_bytes)
             .read_backpressure(true)
-            .initial_read_window(effective_read_part_size)
+            .initial_read_window(self.part_config.read_size_bytes)
             .user_agent(self.user_agent)
             .memory_pool(memory_pool);
         if let Some(interfaces) = self.bind {
@@ -288,12 +291,8 @@ mod tests {
     #[test]
     fn test_read_part_size_within_budget_no_clamp() {
         // read_part_size < budget → should use requested size, no error
-        let pool = PagedPool::config()
-            .with_candidate_sizes([8 * 1024 * 1024])
-            .with_memory_limit(1024 * 1024 * 1024) // 1 GB
-            .build();
-
-        let config = ClientConfig {
+        let mem_limit = 1024 * 1024 * 1024; // 1 GB
+        let mut config = ClientConfig {
             region: Region::new_inferred("us-east-1".to_string()),
             endpoint_url: None,
             addressing_style: AddressingStyle::Automatic,
@@ -309,22 +308,27 @@ mod tests {
             memory_limit_user_specified: false,
         };
 
-        let result = config.create_client(pool, None);
+        let result = config.validate_and_clamp_read_part_size(mem_limit);
         assert!(result.is_ok(), "Should succeed when read_part_size < budget");
+        assert_eq!(
+            config.part_config.read_size_bytes,
+            8 * 1024 * 1024,
+            "read_size_bytes should remain unchanged"
+        );
     }
 
     #[test]
     fn test_read_part_size_exceeds_budget_user_specified_fails() {
-        // User set memory + read_part_size > budget → should fail
-        let pool = PagedPool::config()
-            .with_candidate_sizes([8 * 1024 * 1024])
-            .with_memory_limit(512 * 1024 * 1024) // 512 MB
-            .build();
+        // User set memory + read_part_size > budget → should fail during validation
+        let mem_limit: usize = 512 * 1024 * 1024; // 512 MB
 
-        let budget = pool.data_buffer_budget();
+        // Calculate budget to determine excessive size
+        let min_reserved: usize = 128 * 1024 * 1024;
+        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
+        let budget = mem_limit.saturating_sub(additional_mem_reserved);
         let excessive_size = budget + 1; // Just over budget
 
-        let config = ClientConfig {
+        let mut config = ClientConfig {
             region: Region::new_inferred("us-east-1".to_string()),
             endpoint_url: None,
             addressing_style: AddressingStyle::Automatic,
@@ -340,7 +344,7 @@ mod tests {
             memory_limit_user_specified: true, // User explicitly set memory
         };
 
-        let result = config.create_client(pool, None);
+        let result = config.validate_and_clamp_read_part_size(mem_limit);
         assert!(
             result.is_err(),
             "Should fail when user set memory and read_part_size > budget"
@@ -356,15 +360,15 @@ mod tests {
     #[test]
     fn test_read_part_size_exceeds_budget_default_clamps() {
         // Default memory + read_part_size > budget → should clamp and succeed
-        let pool = PagedPool::config()
-            .with_candidate_sizes([8 * 1024 * 1024])
-            .with_memory_limit(512 * 1024 * 1024) // 512 MB
-            .build();
+        let mem_limit: usize = 512 * 1024 * 1024; // 512 MB
 
-        let budget = pool.data_buffer_budget();
+        // Calculate budget
+        let min_reserved: usize = 128 * 1024 * 1024;
+        let additional_mem_reserved = (mem_limit / 8).max(min_reserved);
+        let budget = mem_limit.saturating_sub(additional_mem_reserved);
         let excessive_size = budget + 100 * 1024 * 1024; // 100 MB over budget
 
-        let config = ClientConfig {
+        let mut config = ClientConfig {
             region: Region::new_inferred("us-east-1".to_string()),
             endpoint_url: None,
             addressing_style: AddressingStyle::Automatic,
@@ -380,14 +384,25 @@ mod tests {
             memory_limit_user_specified: false, // Memory was auto-detected (default)
         };
 
-        let result = config.create_client(pool, None);
+        let result = config.validate_and_clamp_read_part_size(mem_limit);
         assert!(
             result.is_ok(),
             "Should succeed (with clamping) when memory is default and read_part_size > budget"
         );
 
-        // Verify the client was created with clamped size (it should use budget, not excessive_size)
-        let client = result.unwrap();
+        // Verify the read_size_bytes was clamped to budget
+        assert_eq!(
+            config.part_config.read_size_bytes, budget,
+            "read_size_bytes should be clamped to budget"
+        );
+
+        // Now create pool and client with clamped value to verify end-to-end flow
+        let pool = PagedPool::config()
+            .with_candidate_sizes([config.part_config.read_size_bytes])
+            .with_memory_limit(mem_limit)
+            .build();
+
+        let client = config.create_client(pool, None).unwrap();
         assert_eq!(
             client.read_part_size(),
             budget,

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -809,6 +809,12 @@ impl CliArgs {
         let throughput_target = self.throughput_target_gbps(&instance_info);
         let region = autoconfigure::get_region(&instance_info, self.region.clone());
 
+        #[cfg(feature = "mem_limiter")]
+        let memory_limit_user_specified = self.max_memory_target.is_some();
+
+        #[cfg(not(feature = "mem_limiter"))]
+        let memory_limit_user_specified = false;
+
         ClientConfig {
             region,
             endpoint_url: self.endpoint_url.clone(),
@@ -822,6 +828,7 @@ impl CliArgs {
             bind: self.bind.clone(),
             part_config: self.part_config(),
             user_agent,
+            memory_limit_user_specified,
         }
     }
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -13,7 +13,7 @@ use mountpoint_s3_fs::fs::{CacheConfig, ServerSideEncryption, TimeToLive, Upload
 use mountpoint_s3_fs::fuse::config::{FuseOptions, FuseSessionConfig, MountPoint};
 use mountpoint_s3_fs::logging::{LoggingConfig, prepare_log_file_name};
 use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, effective_total_memory};
-use mountpoint_s3_fs::s3::config::{ClientConfig, PartConfig, TargetThroughputSetting};
+use mountpoint_s3_fs::s3::config::{ClientConfig, MemoryLimitSetting, PartConfig, TargetThroughputSetting};
 use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path, S3PathError, S3Personality};
 use mountpoint_s3_fs::{S3FilesystemConfig, autoconfigure, metrics};
 
@@ -493,17 +493,17 @@ impl CliArgs {
     }
 
     pub fn mem_limit(&self) -> usize {
-        let mut mem_limit = MINIMUM_MEM_LIMIT;
+        self.memory_limit_setting().bytes()
+    }
 
-        let default_mem_target = (effective_total_memory() as f64 * 0.95) as usize;
-        mem_limit = mem_limit.max(default_mem_target);
-
+    pub fn memory_limit_setting(&self) -> MemoryLimitSetting {
         #[cfg(feature = "mem_limiter")]
         if let Some(max_mem_target) = self.max_memory_target {
-            mem_limit = max_mem_target as usize * 1024 * 1024;
+            return MemoryLimitSetting::User(max_mem_target as usize * 1024 * 1024);
         }
 
-        mem_limit
+        let default = (effective_total_memory() as f64 * 0.95) as usize;
+        MemoryLimitSetting::Default(default.max(MINIMUM_MEM_LIMIT))
     }
 
     fn upload_checksum_algorithm(&self, s3_personality: S3Personality) -> Option<UploadChecksumAlgorithm> {
@@ -809,7 +809,7 @@ impl CliArgs {
         let throughput_target = self.throughput_target_gbps(&instance_info);
         let region = autoconfigure::get_region(&instance_info, self.region.clone());
 
-        let mut config = ClientConfig {
+        let config = ClientConfig {
             region,
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: self.addressing_style(),
@@ -820,26 +820,11 @@ impl CliArgs {
             expected_bucket_owner: self.expected_bucket_owner.clone(),
             throughput_target,
             bind: self.bind.clone(),
-            part_config: self.part_config(),
+            part_config: self.part_config().validate(self.memory_limit_setting())?,
             user_agent,
         };
 
-        // Validate and clamp read_part_size before returning
-        config.validate_and_clamp_read_part_size(self.memory_limit_setting())?;
-
         Ok(config)
-    }
-
-    pub fn memory_limit_setting(&self) -> mountpoint_s3_fs::s3::config::MemoryLimitSetting {
-        use mountpoint_s3_fs::s3::config::MemoryLimitSetting;
-        let mem_limit = self.mem_limit();
-
-        #[cfg(feature = "mem_limiter")]
-        if self.max_memory_target.is_some() {
-            return MemoryLimitSetting::User(mem_limit);
-        }
-
-        MemoryLimitSetting::Default(mem_limit)
     }
 }
 
@@ -882,7 +867,6 @@ fn parse_bucket_name_or_s3_uri(bucket_name_or_uri: &str) -> Result<BucketNameOrS
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::build_info;
     use test_case::test_case;
 
     #[test_case("s3://bucket--eun1-az1--x-s3", true; "s3:// example bucket")]
@@ -1036,99 +1020,28 @@ mod tests {
         );
     }
 
-    #[test]
     #[cfg(feature = "mem_limiter")]
-    fn validate_read_part_size_within_budget() {
-        // Test that validation passes when read_part_size is within budget
-        let cli_args = CliArgs::try_parse_from([
+    #[test_case("--read-part-size", "8388608",   true  ; "read-part within budget ok")]
+    #[test_case("--part-size",      "8388608",   true  ; "part-size within budget ok")]
+    #[test_case("--read-part-size", "524288000", false ; "read-part over budget fails")]
+    #[test_case("--part-size",      "524288000", false ; "part-size over budget fails")]
+    fn validate_read_part_size(flag: &str, value: &str, ok: bool) {
+        let args = CliArgs::try_parse_from([
             "mount-s3",
             "bucket",
             "test/location",
             "--max-memory-target",
-            "1024",
-            "--read-part-size",
-            "8388608", // 8 MiB - well within 1024 MiB budget
+            "512",
+            flag,
+            value,
         ])
-        .expect("CLI args should parse");
-
-        let result = cli_args.client_config(build_info::FULL_VERSION);
-
-        assert!(
-            result.is_ok(),
-            "Validation should succeed when part size is within budget"
-        );
-        let client_config = result.unwrap();
-        assert_eq!(
-            client_config.part_config.read_size_bytes,
-            8 * 1024 * 1024,
-            "Read size should remain unchanged"
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "mem_limiter")]
-    fn validate_read_part_size_exceeds_user_specified_memory() {
-        // Test that validation fails when read_part_size exceeds user-specified memory budget
-        let cli_args = CliArgs::try_parse_from([
-            "mount-s3",
-            "bucket",
-            "test/location",
-            "--max-memory-target",
-            "512", // 512 MiB
-            "--read-part-size",
-            "524288000", // 500 MiB - exceeds budget of ~384 MiB (512 - 128 overhead)
-        ])
-        .expect("CLI args should parse");
-
-        let result = cli_args.client_config(build_info::FULL_VERSION);
-
-        assert!(
-            result.is_err(),
-            "Validation should fail when part size exceeds user-specified budget"
-        );
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("exceeds the memory available for data buffers"),
-            "Error should explain the budget: {}",
-            err_msg
-        );
-        assert!(
-            err_msg.contains("reserved for Mountpoint overhead"),
-            "Error should explain reserved memory: {}",
-            err_msg
-        );
-    }
-
-    #[test]
-    fn validate_read_part_size_exceeds_default_memory_clamps() {
-        // Test that when default memory is used and part size exceeds, it clamps (doesn't fail)
-        // We'll use a small default by not setting --max-memory-target
-        let cli_args = CliArgs::try_parse_from([
-            "mount-s3",
-            "bucket",
-            "test/location",
-            "--read-part-size",
-            "1073741824", // 1 GiB - likely exceeds default budget on small systems
-        ])
-        .expect("CLI args should parse");
-
-        let original_read_size = 1073741824;
-
-        let result = cli_args.client_config(build_info::FULL_VERSION);
-
-        // Should succeed (with clamping) rather than fail
-        assert!(
-            result.is_ok(),
-            "Validation should succeed (with clamping) for default memory"
-        );
-
-        let client_config = result.unwrap();
-
-        // Read size should either be unchanged (if within budget) or clamped (if exceeded)
-        // We can't assert exact value since it depends on system memory, but we can check it's reasonable
-        assert!(
-            client_config.part_config.read_size_bytes <= original_read_size,
-            "Read size should be clamped or unchanged, not increased"
-        );
+        .expect("parse");
+        let result = args.client_config(build_info::FULL_VERSION);
+        assert_eq!(result.is_ok(), ok);
+        if !ok {
+            let msg = result.unwrap_err().to_string();
+            assert!(msg.contains("exceeds the memory available for data buffers"), "{msg}");
+            assert!(msg.contains("reserved for Mountpoint overhead"), "{msg}");
+        }
     }
 }

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -492,10 +492,6 @@ impl CliArgs {
         Ok(s3path)
     }
 
-    pub fn mem_limit(&self) -> usize {
-        self.memory_limit_setting().bytes()
-    }
-
     pub fn memory_limit_setting(&self) -> MemoryLimitSetting {
         #[cfg(feature = "mem_limiter")]
         if let Some(max_mem_target) = self.max_memory_target {
@@ -803,13 +799,13 @@ impl CliArgs {
         }
     }
 
-    pub fn client_config(&self, version: &str) -> anyhow::Result<ClientConfig> {
+    pub fn client_config(&self, version: &str, memory_limit: MemoryLimitSetting) -> anyhow::Result<ClientConfig> {
         let instance_info = InstanceInfo::new();
         let user_agent = self.user_agent(&instance_info, version);
         let throughput_target = self.throughput_target_gbps(&instance_info);
         let region = autoconfigure::get_region(&instance_info, self.region.clone());
 
-        let config = ClientConfig {
+        Ok(ClientConfig {
             region,
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: self.addressing_style(),
@@ -820,11 +816,9 @@ impl CliArgs {
             expected_bucket_owner: self.expected_bucket_owner.clone(),
             throughput_target,
             bind: self.bind.clone(),
-            part_config: self.part_config().validate(self.memory_limit_setting())?,
+            part_config: self.part_config().validate(memory_limit)?,
             user_agent,
-        };
-
-        Ok(config)
+        })
     }
 }
 
@@ -1036,7 +1030,8 @@ mod tests {
             value,
         ])
         .expect("parse");
-        let result = args.client_config(build_info::FULL_VERSION);
+        let memory_limit = args.memory_limit_setting();
+        let result = args.client_config(build_info::FULL_VERSION, memory_limit);
         assert_eq!(result.is_ok(), ok);
         if !ok {
             let msg = result.unwrap_err().to_string();

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -803,19 +803,13 @@ impl CliArgs {
         }
     }
 
-    pub fn client_config(&self, version: &str) -> ClientConfig {
+    pub fn client_config(&self, version: &str) -> anyhow::Result<ClientConfig> {
         let instance_info = InstanceInfo::new();
         let user_agent = self.user_agent(&instance_info, version);
         let throughput_target = self.throughput_target_gbps(&instance_info);
         let region = autoconfigure::get_region(&instance_info, self.region.clone());
 
-        #[cfg(feature = "mem_limiter")]
-        let memory_limit_user_specified = self.max_memory_target.is_some();
-
-        #[cfg(not(feature = "mem_limiter"))]
-        let memory_limit_user_specified = false;
-
-        ClientConfig {
+        let mut config = ClientConfig {
             region,
             endpoint_url: self.endpoint_url.clone(),
             addressing_style: self.addressing_style(),
@@ -828,8 +822,24 @@ impl CliArgs {
             bind: self.bind.clone(),
             part_config: self.part_config(),
             user_agent,
-            memory_limit_user_specified,
+        };
+
+        // Validate and clamp read_part_size before returning
+        config.validate_and_clamp_read_part_size(self.memory_limit_setting())?;
+
+        Ok(config)
+    }
+
+    pub fn memory_limit_setting(&self) -> mountpoint_s3_fs::s3::config::MemoryLimitSetting {
+        use mountpoint_s3_fs::s3::config::MemoryLimitSetting;
+        let mem_limit = self.mem_limit();
+
+        #[cfg(feature = "mem_limiter")]
+        if self.max_memory_target.is_some() {
+            return MemoryLimitSetting::User(mem_limit);
         }
+
+        MemoryLimitSetting::Default(mem_limit)
     }
 }
 
@@ -872,6 +882,7 @@ fn parse_bucket_name_or_s3_uri(bucket_name_or_uri: &str) -> Result<BucketNameOrS
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::build_info;
     use test_case::test_case;
 
     #[test_case("s3://bucket--eun1-az1--x-s3", true; "s3:// example bucket")]
@@ -988,5 +999,136 @@ mod tests {
     fn parse_upload_checksums_rejects_unknown_value() {
         let result = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location", "--upload-checksums", "md5"]);
         assert!(result.is_err(), "unsupported checksum algorithm should be rejected");
+    }
+
+    #[test]
+    fn memory_limit_setting_default() {
+        // Test that when --max-memory-target is NOT set, we get Default variant
+        let cli_args = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location"]).expect("CLI args should parse");
+
+        let memory_limit = cli_args.memory_limit_setting();
+        assert!(
+            !memory_limit.is_user_specified(),
+            "Should be Default when --max-memory-target not provided"
+        );
+        assert!(
+            memory_limit.bytes() >= mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT,
+            "Default memory should be at least MINIMUM_MEM_LIMIT"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "mem_limiter")]
+    fn memory_limit_setting_user_specified() {
+        // Test that when --max-memory-target IS set, we get User variant
+        let cli_args = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location", "--max-memory-target", "1024"])
+            .expect("CLI args should parse");
+
+        let memory_limit = cli_args.memory_limit_setting();
+        assert!(
+            memory_limit.is_user_specified(),
+            "Should be User when --max-memory-target is provided"
+        );
+        assert_eq!(
+            memory_limit.bytes(),
+            1024 * 1024 * 1024,
+            "Should match the specified 1024 MiB"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "mem_limiter")]
+    fn validate_read_part_size_within_budget() {
+        // Test that validation passes when read_part_size is within budget
+        let cli_args = CliArgs::try_parse_from([
+            "mount-s3",
+            "bucket",
+            "test/location",
+            "--max-memory-target",
+            "1024",
+            "--read-part-size",
+            "8388608", // 8 MiB - well within 1024 MiB budget
+        ])
+        .expect("CLI args should parse");
+
+        let result = cli_args.client_config(build_info::FULL_VERSION);
+
+        assert!(
+            result.is_ok(),
+            "Validation should succeed when part size is within budget"
+        );
+        let client_config = result.unwrap();
+        assert_eq!(
+            client_config.part_config.read_size_bytes,
+            8 * 1024 * 1024,
+            "Read size should remain unchanged"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "mem_limiter")]
+    fn validate_read_part_size_exceeds_user_specified_memory() {
+        // Test that validation fails when read_part_size exceeds user-specified memory budget
+        let cli_args = CliArgs::try_parse_from([
+            "mount-s3",
+            "bucket",
+            "test/location",
+            "--max-memory-target",
+            "512", // 512 MiB
+            "--read-part-size",
+            "524288000", // 500 MiB - exceeds budget of ~384 MiB (512 - 128 overhead)
+        ])
+        .expect("CLI args should parse");
+
+        let result = cli_args.client_config(build_info::FULL_VERSION);
+
+        assert!(
+            result.is_err(),
+            "Validation should fail when part size exceeds user-specified budget"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("exceeds the memory available for data buffers"),
+            "Error should explain the budget: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("reserved for Mountpoint overhead"),
+            "Error should explain reserved memory: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn validate_read_part_size_exceeds_default_memory_clamps() {
+        // Test that when default memory is used and part size exceeds, it clamps (doesn't fail)
+        // We'll use a small default by not setting --max-memory-target
+        let cli_args = CliArgs::try_parse_from([
+            "mount-s3",
+            "bucket",
+            "test/location",
+            "--read-part-size",
+            "1073741824", // 1 GiB - likely exceeds default budget on small systems
+        ])
+        .expect("CLI args should parse");
+
+        let original_read_size = 1073741824;
+
+        let result = cli_args.client_config(build_info::FULL_VERSION);
+
+        // Should succeed (with clamping) rather than fail
+        assert!(
+            result.is_ok(),
+            "Validation should succeed (with clamping) for default memory"
+        );
+
+        let client_config = result.unwrap();
+
+        // Read size should either be unchanged (if within budget) or clamped (if exceeded)
+        // We can't assert exact value since it depends on system memory, but we can check it's reasonable
+        assert!(
+            client_config.part_config.read_size_bytes <= original_read_size,
+            "Read size should be clamped or unchanged, not increased"
+        );
     }
 }

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -194,7 +194,8 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let fuse_session_config = args.fuse_session_config()?;
     let sse = args.server_side_encryption()?;
 
-    let client_config = args.client_config(build_info::FULL_VERSION)?;
+    let memory_limit = args.memory_limit_setting();
+    let client_config = args.client_config(build_info::FULL_VERSION, memory_limit)?;
 
     // Set up a paged memory pool with the validated read_size_bytes
     let pool = PagedPool::config()
@@ -203,7 +204,7 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
             client_config.part_config.read_size_bytes,
             client_config.part_config.write_size_bytes,
         ])
-        .with_memory_limit(args.mem_limit())
+        .with_memory_limit(memory_limit.bytes())
         .with_maintenance_interval(Duration::from_secs(60))
         .build();
 

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -194,9 +194,12 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let fuse_session_config = args.fuse_session_config()?;
     let sse = args.server_side_encryption()?;
 
-    let client_config = args.client_config(build_info::FULL_VERSION);
+    let mut client_config = args.client_config(build_info::FULL_VERSION);
 
-    // Set up a paged memory pool
+    // Validate and clamp read_part_size BEFORE creating the memory pool
+    client_config.validate_and_clamp_read_part_size(args.mem_limit())?;
+
+    // Set up a paged memory pool with the validated read_size_bytes
     let pool = PagedPool::config()
         .with_candidate_sizes([
             args.cache_block_size_in_bytes() as usize,

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -194,10 +194,7 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let fuse_session_config = args.fuse_session_config()?;
     let sse = args.server_side_encryption()?;
 
-    let mut client_config = args.client_config(build_info::FULL_VERSION);
-
-    // Validate and clamp read_part_size BEFORE creating the memory pool
-    client_config.validate_and_clamp_read_part_size(args.mem_limit())?;
+    let client_config = args.client_config(build_info::FULL_VERSION)?;
 
     // Set up a paged memory pool with the validated read_size_bytes
     let pool = PagedPool::config()


### PR DESCRIPTION
When read_part_size > data_buffer_budget, the memory pool cannot allocate even a single buffer, causing all read operations to fail.  This PR implements a hybrid validation approach. 

1. When the user explicitly sets both --max-memory-target and --read-part-size and they conflict, the mount fails immediately with an error message that directs the user to either increase the memory target or decrease the part size.
2. When the memory limit is using the default value (not explicitly set by the user), the implementation clamps read_part_size to data_buffer_budget, logs a warning about the clamping, and allows the mount to proceed with the clamped value.

### Does this change impact existing behavior?

Yes, introduces new mount failure when user explicitly sets conflicting values.

### Does this change need a changelog entry? Does it require a version change?

Yes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
