### PR TITLE
Add single_reader_budget_part and many_readers_budget_part stress tests

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -52,6 +52,8 @@ jobs:
           - mixed_rw
           - idle_and_churn
           - held_writes_vs_reads
+          - single_reader_budget_part
+          - many_readers_budget_part
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -2,6 +2,8 @@
 
 mod held_writes_vs_reads;
 mod idle_and_churn;
+mod many_readers_budget_part;
 mod mixed_rw;
+mod single_reader_budget_part;
 mod sustained_reads;
 mod sustained_writes;

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
@@ -1,0 +1,36 @@
+//! `many_readers_budget_part`: 32 readers competing under a read part size that equals the entire
+//! data-buffer budget (384 MiB at the 512 MiB memory limit).
+
+use std::iter::repeat_n;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
+
+/// The read part size under test: the memory limiter's entire data-buffer budget. At
+/// `MINIMUM_MEM_LIMIT` (512 MiB) the limiter reserves `max(mem_limit / 8, 128 MiB)` = 128 MiB for
+/// non-buffer overhead (see `MemoryLimiter::data_buffer_budget`), leaving 512 - 128 = 384 MiB for
+/// data buffers. One part therefore fills the whole budget.
+const READ_PART_SIZE: usize = MINIMUM_MEM_LIMIT - 128 * 1024 * 1024; // 384 MiB
+const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB
+const NUM_WORKERS: usize = 32;
+
+#[test]
+fn many_readers_budget_part() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = repeat_n(reader, NUM_WORKERS).collect();
+    harness::run(Scenario {
+        name: "many_readers_budget_part",
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(READ_PART_SIZE),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
@@ -1,0 +1,36 @@
+//! `single_reader_budget_part`: a single reader whose read part size equals the entire
+//! data-buffer budget (384 MiB at the 512 MiB memory limit).
+
+use std::iter::repeat_n;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
+
+/// The read part size under test: the memory limiter's entire data-buffer budget. At
+/// `MINIMUM_MEM_LIMIT` (512 MiB) the limiter reserves `max(mem_limit / 8, 128 MiB)` = 128 MiB for
+/// non-buffer overhead (see `MemoryLimiter::data_buffer_budget`), leaving 512 - 128 = 384 MiB for
+/// data buffers. One part therefore fills the whole budget.
+const READ_PART_SIZE: usize = MINIMUM_MEM_LIMIT - 128 * 1024 * 1024; // 384 MiB
+const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB
+const NUM_WORKERS: usize = 1;
+
+#[test]
+fn single_reader_budget_part() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = repeat_n(reader, NUM_WORKERS).collect();
+    harness::run(Scenario {
+        name: "single_reader_budget_part",
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(READ_PART_SIZE),
+        workers,
+        max_latency: default_max_latency,
+    });
+}


### PR DESCRIPTION
Add single_reader_budget_part and many_readers_budget_part stress tests

Test run: https://github.com/awslabs/mountpoint-s3/actions/runs/28879670445

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
