### PR TITLE
stress: Add setup phase and held budget scenarios

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -54,6 +54,8 @@ jobs:
           - held_writes_vs_reads
           - single_reader_budget_part
           - many_readers_budget_part
+          - single_reader_held_budget
+          - many_readers_held_budget
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -17,6 +17,7 @@ mod latency;
 mod memory_monitor;
 mod report;
 mod scenario;
+mod setup;
 mod watchdog;
 mod worker;
 use invariants::{
@@ -26,6 +27,7 @@ pub use latency::{FileOp, FileOpLatencies};
 use memory_monitor::spawn_memory_monitor;
 use report::dump_summary;
 pub use scenario::{Scenario, default_max_latency};
+pub use setup::{SetupGuard, budget_parts, hold_budget_parts};
 use watchdog::{NO_STALL, spawn_watchdog};
 pub use worker::Worker;
 
@@ -48,6 +50,7 @@ pub fn run(scenario: Scenario) {
     let Scenario {
         name: scenario_name,
         mut session_config,
+        setup,
         workers,
         max_latency,
     } = scenario;
@@ -95,6 +98,18 @@ pub fn run(scenario: Scenario) {
         .expect("scenario must declare at least one worker");
 
     let mount_path: std::path::PathBuf = session.mount_path().to_path_buf();
+
+    // Setup phase: run any setup step to completion *before* spawning workers, so whatever it
+    // establishes (pinned memory, a warmed cache, …) is fully in effect and the workers do not race
+    // it. The returned guard is held until just before unmount (see the explicit `drop` after the
+    // workers join).
+    let setup_guard = setup.map(|setup| {
+        tracing::info!(scenario = scenario_name, "stress: setup phase starting");
+        let guard = setup(&mount_path);
+        tracing::info!(scenario = scenario_name, "stress: setup phase complete");
+        guard
+    });
+
     let mut handles: Vec<thread::JoinHandle<FileOpLatencies>> = Vec::with_capacity(num_workers);
     for (worker_id, worker) in workers.iter().enumerate() {
         let worker = Arc::clone(worker);
@@ -144,6 +159,7 @@ pub fn run(scenario: Scenario) {
                 .enumerate()
                 .filter_map(|(id, h)| (!h.is_finished()).then_some(labels[id].as_str()))
                 .collect();
+            drop(setup_guard);
             drop(session);
             panic!("stress: workers {stuck:?} did not finish within {max_join_wait:?} after stop");
         }
@@ -158,6 +174,7 @@ pub fn run(scenario: Scenario) {
         aggregate.merge(&rec);
     }
 
+    drop(setup_guard);
     drop(session);
 
     let stalled = stalled_worker.load(Ordering::SeqCst);

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -3,6 +3,8 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use mountpoint_s3_fs::memory::data_buffer_budget_for;
+
 use crate::common::stress_recorder;
 use crate::common::test_recorder::stress::{HdrMetric, HdrRecorder};
 
@@ -104,7 +106,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         );
         return;
     };
-    let effective_budget = super::setup::data_buffer_budget(mem_limit as usize) as u64;
+    let effective_budget = data_buffer_budget_for(mem_limit as usize) as u64;
 
     let mut reserved_overshoots: Vec<String> = Vec::new();
     for gauge in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {

--- a/mountpoint-s3-fs/tests/stress/harness/invariants.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/invariants.rs
@@ -104,9 +104,7 @@ pub fn assert_peak_reserved_invariant(scenario_name: &str, mem_limit: f64) {
         );
         return;
     };
-    let mem_limit_u64 = mem_limit as u64;
-    let additional_mem_reserved = (mem_limit_u64 / 8).max(128 * 1024 * 1024);
-    let effective_budget = mem_limit_u64.saturating_sub(additional_mem_reserved);
+    let effective_budget = super::setup::data_buffer_budget(mem_limit as usize) as u64;
 
     let mut reserved_overshoots: Vec<String> = Vec::new();
     for gauge in collect_gauges_by_label(recorder, RESERVED_MEMORY_METRIC, "area") {

--- a/mountpoint-s3-fs/tests/stress/harness/scenario.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/scenario.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use crate::common::fuse::TestSessionConfig;
 
 use super::latency::FileOp;
+use super::setup::SetupFn;
 use super::worker::Worker;
 
 /// A stress-test scenario: the complete description of one run.
@@ -15,6 +16,11 @@ pub struct Scenario {
 
     /// FUSE/Mountpoint session configuration (memory limit, part size, etc.).
     pub session_config: TestSessionConfig,
+
+    /// Optional setup step run to completion after mount and before workers start. Its returned
+    /// [`SetupGuard`] is held for the entire run, so anything it establishes (pinned memory, a warmed
+    /// cache, …) stays in effect while the workers execute. `None` for scenarios that need no setup.
+    pub setup: Option<SetupFn>,
 
     /// The workers to spawn, one thread per entry.
     pub workers: Vec<Arc<dyn Worker>>,

--- a/mountpoint-s3-fs/tests/stress/harness/setup.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 mod budget_hold;
 
-pub use budget_hold::{budget_parts, data_buffer_budget, hold_budget_parts};
+pub use budget_hold::{budget_parts, hold_budget_parts};
 
 /// A guard produced by a scenario's [setup phase](super::Scenario::setup). The harness keeps it
 /// alive for the entire run and drops it just before unmount, so whatever a setup step must keep in

--- a/mountpoint-s3-fs/tests/stress/harness/setup.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup.rs
@@ -1,0 +1,16 @@
+//! Setup phase for stress scenarios.
+
+use std::path::Path;
+
+mod budget_hold;
+
+pub use budget_hold::{budget_parts, data_buffer_budget, hold_budget_parts};
+
+/// A guard produced by a scenario's [setup phase](super::Scenario::setup). The harness keeps it
+/// alive for the entire run and drops it just before unmount, so whatever a setup step must keep in
+/// effect during the workload lives here.
+pub trait SetupGuard {}
+
+/// A scenario's setup step: run to completion after mount and before workers, returning a
+/// [`SetupGuard`] held for the whole run.
+pub type SetupFn = fn(&Path) -> Box<dyn SetupGuard>;

--- a/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
@@ -4,21 +4,18 @@ use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use mountpoint_s3_fs::memory::data_buffer_budget_for;
+
 use super::SetupGuard;
 use crate::stress::test_objects;
 
 const STUB_WRITE: usize = 4 * 1024;
 
-// TODO(#1869): replace with `memory::data_buffer_budget_for` once merged.
-pub const fn data_buffer_budget(mem_limit: usize) -> usize {
-    let eighth = mem_limit / 8;
-    let floor = 128 * 1024 * 1024;
-    let additional_mem_reserved = if eighth > floor { eighth } else { floor };
-    mem_limit - additional_mem_reserved
-}
-
-pub const fn budget_parts(mem_limit: usize, part_size: usize) -> usize {
-    data_buffer_budget(mem_limit) / part_size
+/// Number of full write-part buffers that fit in the data-buffer budget at `mem_limit` — i.e. the
+/// concurrent write-handle cap (`WriteHandleLimiter`) and the most parts a [`BudgetHold`] can pin.
+/// Scenarios typically hold `budget_parts(..) - n` to leave `n` parts free.
+pub fn budget_parts(mem_limit: usize, part_size: usize) -> usize {
+    data_buffer_budget_for(mem_limit) / part_size
 }
 
 /// A held slice of the data-buffer budget: a set of open write handles, each pinning one

--- a/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
@@ -1,0 +1,69 @@
+//! `BudgetHold`: a setup-phase hold on part of the data-buffer budget.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::SetupGuard;
+use crate::stress::test_objects;
+
+const STUB_WRITE: usize = 4 * 1024;
+
+// TODO(#1869): replace with `memory::data_buffer_budget_for` once merged.
+pub const fn data_buffer_budget(mem_limit: usize) -> usize {
+    let eighth = mem_limit / 8;
+    let floor = 128 * 1024 * 1024;
+    let additional_mem_reserved = if eighth > floor { eighth } else { floor };
+    mem_limit - additional_mem_reserved
+}
+
+pub const fn budget_parts(mem_limit: usize, part_size: usize) -> usize {
+    data_buffer_budget(mem_limit) / part_size
+}
+
+/// A held slice of the data-buffer budget: a set of open write handles, each pinning one
+/// `write_part_size` buffer. Keep it alive for as long as the memory must stay pinned; dropping it
+/// closes the handles (releasing the buffers) and removes the backing objects best-effort.
+#[must_use = "the budget hold releases its pinned buffers as soon as it is dropped"]
+pub struct BudgetHold {
+    scope: &'static str,
+    held: Vec<(File, PathBuf)>,
+}
+
+impl SetupGuard for BudgetHold {}
+
+impl Drop for BudgetHold {
+    fn drop(&mut self) {
+        let parts = self.held.len();
+        for (file, path) in self.held.drain(..) {
+            if let Err(e) = file.sync_all() {
+                tracing::warn!(scope = self.scope, ?path, error = ?e, "stress: budget hold sync_all failed on release");
+            }
+            drop(file);
+            let _ = std::fs::remove_file(&path);
+        }
+        tracing::info!(scope = self.scope, parts, "stress: budget hold released");
+    }
+}
+
+/// Pin `parts` write-part buffers under `mount_path`, returning a guard that holds them until it is
+/// dropped. Runs synchronously: on return, every buffer is pinned.
+pub fn hold_budget_parts(scope: &'static str, parts: usize, mount_path: &Path) -> BudgetHold {
+    let stub = vec![0xC3u8; STUB_WRITE];
+    let mut held: Vec<(File, PathBuf)> = Vec::with_capacity(parts);
+    for part in 0..parts {
+        let key = test_objects::ephemeral_key(scope, &format!("budget_hold_p{part:04}.bin"));
+        let path = mount_path.join(&key);
+        let mut file = File::create(&path).unwrap_or_else(|e| {
+            panic!(
+                "{scope}: budget hold: create of part {part}/{parts} failed \
+                 (does parts exceed the write-handle cap?): {e:?}",
+            )
+        });
+        file.write_all(&stub)
+            .unwrap_or_else(|e| panic!("{scope}: budget hold: stub write for part {part}/{parts} failed: {e:?}"));
+        held.push((file, path));
+    }
+    tracing::info!(scope, parts, "stress: budget hold pinned");
+    BudgetHold { scope, held }
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -3,7 +3,9 @@
 mod held_writes_vs_reads;
 mod idle_and_churn;
 mod many_readers_budget_part;
+mod many_readers_held_budget;
 mod mixed_rw;
 mod single_reader_budget_part;
+mod single_reader_held_budget;
 mod sustained_reads;
 mod sustained_writes;

--- a/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
@@ -34,6 +34,7 @@ fn held_writes_vs_reads() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
@@ -29,6 +29,7 @@ fn idle_and_churn() {
     harness::run(Scenario {
         name: "idle_and_churn",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
@@ -30,6 +30,7 @@ fn many_readers_budget_part() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(READ_PART_SIZE),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
@@ -16,14 +16,12 @@ use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
 const SCOPE: &str = "many_readers_held_budget";
 const NUM_READERS: usize = 32;
 const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
-/// Hold every part of the budget except one, leaving exactly one read part free. At the 512 MiB
-/// limit this is 48 - 1 = 47 parts (376 MiB) pinned.
-const HELD_PARTS: usize = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
 const READ_CHUNK: usize = PART_SIZE;
 
 /// Setup phase: pin all but one part of the budget before the readers start.
 fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
-    Box::new(hold_budget_parts(SCOPE, HELD_PARTS, mount_path))
+    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+    Box::new(hold_budget_parts(SCOPE, held_parts, mount_path))
 }
 
 #[test]

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
@@ -1,0 +1,45 @@
+//! `many_readers_held_budget`: 32 readers against a default 8 MiB part, with the setup phase
+//! hard-pinning all but one part of the budget so all 32 contend for a single free 8 MiB read part.
+
+use std::iter::repeat_n;
+use std::path::Path;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{
+    self, Scenario, SetupGuard, Worker, budget_parts, default_max_latency, hold_budget_parts,
+};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
+
+const SCOPE: &str = "many_readers_held_budget";
+const NUM_READERS: usize = 32;
+const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
+/// Hold every part of the budget except one, leaving exactly one read part free. At the 512 MiB
+/// limit this is 48 - 1 = 47 parts (376 MiB) pinned.
+const HELD_PARTS: usize = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+const READ_CHUNK: usize = PART_SIZE;
+
+/// Setup phase: pin all but one part of the budget before the readers start.
+fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
+    Box::new(hold_budget_parts(SCOPE, HELD_PARTS, mount_path))
+}
+
+#[test]
+fn many_readers_held_budget() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = repeat_n(reader, NUM_READERS).collect();
+    harness::run(Scenario {
+        name: SCOPE,
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(PART_SIZE),
+        setup: Some(hold),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
@@ -31,6 +31,7 @@ fn mixed_rw() {
     harness::run(Scenario {
         name: "mixed_rw",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
@@ -30,6 +30,7 @@ fn single_reader_budget_part() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(READ_PART_SIZE),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
@@ -16,14 +16,12 @@ use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
 const SCOPE: &str = "single_reader_held_budget";
 const NUM_READERS: usize = 1;
 const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
-/// Hold every part of the budget except one, leaving exactly one read part free. At the 512 MiB
-/// limit this is 48 - 1 = 47 parts (376 MiB) pinned.
-const HELD_PARTS: usize = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
 const READ_CHUNK: usize = PART_SIZE;
 
 /// Setup phase: pin all but one part of the budget before the reader starts.
 fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
-    Box::new(hold_budget_parts(SCOPE, HELD_PARTS, mount_path))
+    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+    Box::new(hold_budget_parts(SCOPE, held_parts, mount_path))
 }
 
 #[test]

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
@@ -1,0 +1,45 @@
+//! `single_reader_held_budget`: a single reader against a default 8 MiB part, with the setup phase
+//! hard-pinning all but one part of the budget so only one 8 MiB read part is free.
+
+use std::iter::repeat_n;
+use std::path::Path;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{
+    self, Scenario, SetupGuard, Worker, budget_parts, default_max_latency, hold_budget_parts,
+};
+use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
+
+const SCOPE: &str = "single_reader_held_budget";
+const NUM_READERS: usize = 1;
+const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
+/// Hold every part of the budget except one, leaving exactly one read part free. At the 512 MiB
+/// limit this is 48 - 1 = 47 parts (376 MiB) pinned.
+const HELD_PARTS: usize = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+const READ_CHUNK: usize = PART_SIZE;
+
+/// Setup phase: pin all but one part of the budget before the reader starts.
+fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
+    Box::new(hold_budget_parts(SCOPE, HELD_PARTS, mount_path))
+}
+
+#[test]
+fn single_reader_held_budget() {
+    let reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: READ_CHUNK,
+    });
+    let workers = repeat_n(reader, NUM_READERS).collect();
+    harness::run(Scenario {
+        name: SCOPE,
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(PART_SIZE),
+        setup: Some(hold),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
@@ -23,6 +23,7 @@ fn sustained_reads() {
     harness::run(Scenario {
         name: "sustained_reads",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
@@ -25,6 +25,7 @@ fn sustained_writes() {
     harness::run(Scenario {
         name: "sustained_writes",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        setup: None,
         workers,
         max_latency: default_max_latency,
     });


### PR DESCRIPTION
Add setup phase and held budget scenarios

Example run: https://github.com/awslabs/mountpoint-s3/actions/runs/29037078205/job/86261526684

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
