### PR TITLE
Rename to --memory-target and remove feature gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,14 +51,12 @@ jobs:
       matrix:
         include:
           - variant: default
-            features: ""
-            max_memory_target_mib: ""
+            memory_target_mib: ""
             name_suffix: ""
             data_path_suffix: ""
             results_subdir_suffix: ""
           - variant: mem-limited
-            features: "--features mem_limiter"
-            max_memory_target_mib: "512"
+            memory_target_mib: "512"
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
             results_subdir_suffix: "-mem-limited"
@@ -89,10 +87,10 @@ jobs:
         # We need to do this currently because `mountpoint-s3-fuser` contains some warnings and it breaks the build.
         rustflags: ""
     - name: Build
-      run: cargo build --release ${{ matrix.features }}
+      run: cargo build --release
     - name: Run Benchmark
       env:
-        S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_MEMORY_TARGET_MIB: ${{ matrix.memory_target_mib }}
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
@@ -226,14 +224,12 @@ jobs:
       matrix:
         include:
           - variant: default
-            features: ""
-            max_memory_target_mib: ""
+            memory_target_mib: ""
             name_suffix: ""
             data_path_suffix: ""
             results_subdir_suffix: ""
           - variant: mem-limited
-            features: "--features mem_limiter"
-            max_memory_target_mib: "512"
+            memory_target_mib: "512"
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
             results_subdir_suffix: "-mem-limited"
@@ -264,11 +260,11 @@ jobs:
         # We need to do this currently because `mountpoint-s3-fuser` contains some warnings and it breaks the build.
         rustflags: ""
     - name: Build
-      run: cargo build --release ${{ matrix.features }}
+      run: cargo build --release
     - name: Run Benchmark
       env:
         S3_MOUNT_LOCAL_STORAGE: yes
-        S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_MEMORY_TARGET_MIB: ${{ matrix.memory_target_mib }}
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -51,32 +51,28 @@ jobs:
       matrix:
         include:
           - variant: default
-            features: ""
-            max_memory_target_mib: ""
+            memory_target_mib: ""
             extra_args: ""
             bench_categories: ""
             name_suffix: ""
             data_path_suffix: ""
             results_subdir_suffix: ""
           - variant: mem-limited
-            features: "--features mem_limiter"
-            max_memory_target_mib: "512"
+            memory_target_mib: "512"
             extra_args: ""
             bench_categories: ""
             name_suffix: ", Memory-Limited"
             data_path_suffix: "/mem_limited"
             results_subdir_suffix: "-mem-limited"
           - variant: incremental-upload
-            features: ""
-            max_memory_target_mib: ""
+            memory_target_mib: ""
             extra_args: "--incremental-upload"
             bench_categories: "write mix"
             name_suffix: ", Incremental Upload"
             data_path_suffix: "/incremental_upload"
             results_subdir_suffix: "-incremental-upload"
           - variant: incremental-upload-mem-limited
-            features: "--features mem_limiter"
-            max_memory_target_mib: "512"
+            memory_target_mib: "512"
             extra_args: "--incremental-upload"
             bench_categories: "write mix"
             name_suffix: ", Incremental Upload, Memory-Limited"
@@ -109,16 +105,16 @@ jobs:
         # We need to do this currently because `mountpoint-s3-fuser` contains some warnings and it breaks the build.
         rustflags: ""
     - name: Build
-      run: cargo build --release ${{ matrix.features }}
+      run: cargo build --release
     - name: Run Benchmark
       env:
-        S3_MAX_MEMORY_TARGET_MIB: ${{ matrix.max_memory_target_mib }}
+        S3_MEMORY_TARGET_MIB: ${{ matrix.memory_target_mib }}
         S3_MOUNTPOINT_EXTRA_ARGS: ${{ matrix.extra_args }}
         S3_BENCH_CATEGORIES: ${{ matrix.bench_categories }}
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
-      if: matrix.max_memory_target_mib != ''
+      if: matrix.memory_target_mib != ''
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
       if: inputs.s3_bench_results_prefix

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -32,7 +32,7 @@ def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> 
 
     if cfg.mountpoint.mountpoint_binary is None:
         # Compile the binary instead of using cargo run
-        features = ["mock", "mem_limiter"]
+        features = ["mock"]
         build_env = {}
 
         if stub_mode == "s3_client":
@@ -88,8 +88,8 @@ def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> 
     if cfg.mountpoint.upload_checksums is not None:
         subprocess_args.append(f"--upload-checksums={cfg.mountpoint.upload_checksums}")
 
-    if (max_memory_target := cfg.mountpoint.max_memory_target) is not None:
-        subprocess_args.append(f"--max-memory-target={max_memory_target}")
+    if (memory_target := cfg.mountpoint.memory_target) is not None:
+        subprocess_args.append(f"--memory-target={memory_target}")
 
     if (fuse_threads := cfg.mountpoint.fuse_threads) is not None:
         subprocess_args.append(f"--max-threads={fuse_threads}")

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -49,8 +49,8 @@ class PrefetchBenchmark(BaseBenchmark):
         if (max_throughput := self.cfg.network.maximum_throughput_gbps) is not None:
             subprocess_args.extend(["--maximum-throughput-gbps", str(max_throughput)])
 
-        if (max_memory_target := self.cfg.benchmarks.prefetch.max_memory_target) is not None:
-            subprocess_args.extend(["--max-memory-target", str(max_memory_target)])
+        if (memory_target := self.cfg.benchmarks.prefetch.memory_target) is not None:
+            subprocess_args.extend(["--memory-target", str(memory_target)])
 
         if (read_part_size := self.cfg.read_part_size) is not None:
             subprocess_args.extend(["--part-size", str(read_part_size)])

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -45,7 +45,7 @@ mountpoint:
   mountpoint_congestion_threshold: !!null
   mountpoint_binary: !!null
   upload_checksums: !!null
-  max_memory_target: !!null # memory upper-limit in MB
+  memory_target: !!null # memory upper-limit in MB
   stub_mode: "off"  # Options: "off", "fs_handler", "s3_client"
   mountpoint_debug: false
   mountpoint_debug_crt: false
@@ -64,7 +64,7 @@ benchmarks:
     fio_io_engine: "psync"
 
   prefetch:
-    max_memory_target: !!null # memory upper-limit in MB
+    memory_target: !!null # memory upper-limit in MB
 
   crt:
     crt_benchmarks_path: !!null

--- a/benchmark/conf/hydra/sweeper/prefetch.yaml
+++ b/benchmark/conf/hydra/sweeper/prefetch.yaml
@@ -1,3 +1,3 @@
 # @package hydra.sweeper
 params: {}
-  #'benchmarks.prefetch.max_memory_target': null, 1073741824, 2147483648  # null, 1GiB, 2GiB
+  #'benchmarks.prefetch.memory_target': null, 1073741824, 2147483648  # null, 1GiB, 2GiB

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -91,7 +91,6 @@ wiremock = "0.6.5"
 # Unreleased and/or experimental features: not enabled in the release binary and may be dropped in future
 block_size = []
 event_log = []
-mem_limiter = []
 manifest = ["csv", "rusqlite"]
 
 # Features for choosing tests

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -73,7 +73,7 @@ pub struct CliArgs {
         value_name = "MiB",
         value_parser = value_parser!(u64).range(512..),
     )]
-    pub max_memory_target: Option<u64>,
+    pub memory_target: Option<u64>,
 
     #[clap(
         long,
@@ -123,7 +123,7 @@ fn parse_duration(arg: &str) -> Result<Duration, String> {
 
 impl CliArgs {
     fn memory_target_in_bytes(&self) -> usize {
-        if let Some(target) = self.max_memory_target {
+        if let Some(target) = self.memory_target {
             target as usize * 1024 * 1024
         } else {
             // Default to 95% of total system memory (cgroup-aware)

--- a/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
@@ -21,7 +21,7 @@ pub struct GlobalConfig {
     pub region: Option<String>,
     pub endpoint_url: Option<String>,
     pub throughput_target_gbps: Option<f64>,
-    pub max_memory_target: Option<usize>, // MiB
+    pub memory_target: Option<usize>, // MiB
     pub bind: Option<Vec<String>>,
     pub output_file: Option<String>,
     pub read_part_size: Option<usize>,

--- a/mountpoint-s3-fs/examples/s3io_benchmark/examples/example.toml
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/examples/example.toml
@@ -4,7 +4,7 @@ region = "us-east-1"
 output_file = "example_results.json"
 iterations = 3
 throughput_target_gbps = 100.0
-max_memory_target = 4768
+memory_target = 4768
 
 [jobs.read_1]
 workload_type = "read"

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -45,8 +45,8 @@ impl Executor {
         let read_part_size = global.read_part_size.unwrap_or(8 * 1024 * 1024);
         let write_part_size = global.write_part_size.unwrap_or(8 * 1024 * 1024);
 
-        let max_memory_target = global
-            .max_memory_target
+        let memory_target = global
+            .memory_target
             .unwrap_or_else(|| ((effective_total_memory() as f64 * 0.95) / (1024.0 * 1024.0)) as usize);
 
         let bind = global.bind.clone().unwrap_or_default();
@@ -65,7 +65,7 @@ impl Executor {
             ChecksumAlgorithm::Off => None,
         };
 
-        let memory_target_bytes = max_memory_target * 1024 * 1024;
+        let memory_target_bytes = memory_target * 1024 * 1024;
         let pool = PagedPool::config()
             .with_candidate_sizes([read_part_size, write_part_size])
             .with_memory_limit(memory_target_bytes)

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -61,7 +61,7 @@ struct UploadBenchmarkArgs {
         help = "Maximum memory usage target for Mountpoint's memory limiter [default: 95% of total system memory]",
         value_name = "MiB"
     )]
-    pub max_memory_target: Option<usize>,
+    pub memory_target: Option<usize>,
 
     #[clap(long, help = "Write part size for the upload", default_value = "8388608")]
     pub write_part_size: usize,
@@ -96,7 +96,7 @@ fn main() {
         let endpoint_uri = Uri::new_from_str(&Allocator::default(), url).expect("Failed to parse endpoint URL");
         endpoint_config = endpoint_config.endpoint(endpoint_uri);
     }
-    let max_memory_target = if let Some(target) = args.max_memory_target {
+    let memory_target = if let Some(target) = args.memory_target {
         target * 1024 * 1024
     } else {
         // Default to 95% of total system memory (cgroup-aware)
@@ -104,7 +104,7 @@ fn main() {
     };
     let pool = PagedPool::config()
         .with_candidate_sizes([args.write_part_size])
-        .with_memory_limit(max_memory_target)
+        .with_memory_limit(memory_target)
         .build();
     let config = S3ClientConfig::new()
         .endpoint_config(endpoint_config)

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -94,7 +94,7 @@ impl PartConfig {
                 anyhow::bail!(
                     "read part size ({}) exceeds the memory available for data buffers ({}). \
                      The memory target is {}, of which {} is reserved for Mountpoint overhead. \
-                     Increase --max-memory-target or decrease --read-part-size.",
+                     Increase --memory-target or decrease --read-part-size.",
                     format_size(self.read_size_bytes, BINARY),
                     format_size(data_buffer_budget, BINARY),
                     format_size(mem_limit, BINARY),
@@ -178,7 +178,7 @@ impl TargetThroughputSetting {
 pub enum MemoryLimitSetting {
     /// Default memory limit (95% of system memory)
     Default(usize),
-    /// User-specified memory limit via --max-memory-target
+    /// User-specified memory limit via --memory-target
     User(usize),
 }
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -48,7 +48,6 @@ built = { version = "0.8.1", features = ["git2"] }
 # Unreleased feature flags
 block_size = ["mountpoint-s3-fs/block_size"]
 event_log = ["mountpoint-s3-fs/event_log"]
-mem_limiter = ["mountpoint-s3-fs/mem_limiter"]
 # Features for choosing tests
 s3_tests = ["mountpoint-s3-fs/s3_tests"]
 fuse_tests = ["mountpoint-s3-fs/fuse_tests"]

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -30,15 +30,12 @@ if [[ -n "${S3_DEBUG}" ]]; then
   optional_args+=" --debug"
 fi
 
-cargo_feature_args=""
-if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
-  # Memory-limited variant: build with the mem_limiter feature, cap Mountpoint at the
-  # requested MiB, and ask the log analyzer to additionally emit
-  # results/<job>_extra_metrics.json which is consumed only by the GitHub Actions
-  # memory summary table (render-mem-summary.sh). These files are not fed into the
-  # gh-pages benchmark charts.
-  cargo_feature_args="--features mem_limiter"
-  optional_args+=" --max-memory-target=${S3_MAX_MEMORY_TARGET_MIB}"
+if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
+  # Memory-limited variant: cap Mountpoint at the requested MiB, and ask the log
+  # analyzer to additionally emit results/<job>_extra_metrics.json which is consumed
+  # only by the GitHub Actions memory summary table (render-mem-summary.sh). These
+  # files are not fed into the gh-pages benchmark charts.
+  optional_args+=" --memory-target=${S3_MEMORY_TARGET_MIB}"
 fi
 
 if [[ -n "${S3_MOUNTPOINT_EXTRA_ARGS}" ]]; then
@@ -170,7 +167,7 @@ run_benchmarks() {
       unset part_size_option
     fi
     set +e
-    cargo run --quiet --release ${cargo_feature_args} -- \
+    cargo run --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
       --allow-overwrite \
@@ -200,8 +197,8 @@ run_benchmarks() {
 
     # collect resource utilization metrics (peak memory usage)
     log_analyzer_extra_args=""
-    if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
-      log_analyzer_extra_args="--mem-limit-mib=${S3_MAX_MEMORY_TARGET_MIB} --extra-metrics-out=${results_dir}/${job_name}_extra_metrics.json"
+    if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
+      log_analyzer_extra_args="--mem-limit-mib=${S3_MEMORY_TARGET_MIB} --extra-metrics-out=${results_dir}/${job_name}_extra_metrics.json"
     fi
     cargo run --bin mount-s3-log-analyzer ${log_dir} ${results_dir}/${job_name}_peak_mem.json ${job_name} ${log_analyzer_extra_args}
 

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -40,15 +40,12 @@ if [[ -n "${S3_DEBUG}" ]]; then
   optional_args+=" --debug"
 fi
 
-cargo_feature_args=""
-if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
-  # Memory-limited variant: build with the mem_limiter feature, cap Mountpoint at the
-  # requested MiB, and ask the log analyzer to additionally emit
-  # results/<job>_extra_metrics.json which is consumed only by the GitHub Actions
-  # memory summary table (render-mem-summary.sh). These files are not fed into the
-  # gh-pages benchmark charts.
-  cargo_feature_args="--features mem_limiter"
-  optional_args+=" --max-memory-target=${S3_MAX_MEMORY_TARGET_MIB}"
+if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
+  # Memory-limited variant: cap Mountpoint at the requested MiB, and ask the log
+  # analyzer to additionally emit results/<job>_extra_metrics.json which is consumed
+  # only by the GitHub Actions memory summary table (render-mem-summary.sh). These
+  # files are not fed into the gh-pages benchmark charts.
+  optional_args+=" --memory-target=${S3_MEMORY_TARGET_MIB}"
 fi
 
 base_dir=$(dirname "$0")
@@ -177,7 +174,7 @@ cache_benchmark () {
 
     # mount file system
     set +e
-    cargo run --quiet --release ${cargo_feature_args} -- \
+    cargo run --quiet --release -- \
       ${S3_BUCKET_NAME} ${mount_dir} \
       --allow-delete \
       --allow-overwrite \
@@ -214,8 +211,8 @@ cache_benchmark () {
 
     # collect resource utilization metrics (peak memory usage)
     log_analyzer_extra_args=""
-    if [[ -n "${S3_MAX_MEMORY_TARGET_MIB}" ]]; then
-      log_analyzer_extra_args="--mem-limit-mib=${S3_MAX_MEMORY_TARGET_MIB} --extra-metrics-out=${results_dir}/${job_name}_extra_metrics.json"
+    if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
+      log_analyzer_extra_args="--mem-limit-mib=${S3_MEMORY_TARGET_MIB} --extra-metrics-out=${results_dir}/${job_name}_extra_metrics.json"
     fi
     cargo run --bin mount-s3-log-analyzer ${log_dir} ${results_dir}/${job_name}_peak_mem.json ${job_name} ${log_analyzer_extra_args}
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -183,8 +183,6 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
     )]
     pub max_threads: u64,
 
-    // This config is still unstable
-    #[cfg(feature = "mem_limiter")]
     #[clap(
         long,
         help = "Maximum memory usage target [default: 95% of total system memory with a minimum of 512 MiB]",
@@ -192,7 +190,7 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         value_parser = value_parser!(u64).range(512..),
         help_heading = CLIENT_OPTIONS_HEADER
     )]
-    pub max_memory_target: Option<u64>,
+    pub memory_target: Option<u64>,
 
     #[clap(
         long,
@@ -493,9 +491,8 @@ impl CliArgs {
     }
 
     pub fn memory_limit_setting(&self) -> MemoryLimitSetting {
-        #[cfg(feature = "mem_limiter")]
-        if let Some(max_mem_target) = self.max_memory_target {
-            return MemoryLimitSetting::User(max_mem_target as usize * 1024 * 1024);
+        if let Some(memory_target) = self.memory_target {
+            return MemoryLimitSetting::User(memory_target as usize * 1024 * 1024);
         }
 
         let default = (effective_total_memory() as f64 * 0.95) as usize;
@@ -981,13 +978,13 @@ mod tests {
 
     #[test]
     fn memory_limit_setting_default() {
-        // Test that when --max-memory-target is NOT set, we get Default variant
+        // Test that when --memory-target is NOT set, we get Default variant
         let cli_args = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location"]).expect("CLI args should parse");
 
         let memory_limit = cli_args.memory_limit_setting();
         assert!(
             !memory_limit.is_user_specified(),
-            "Should be Default when --max-memory-target not provided"
+            "Should be Default when --memory-target not provided"
         );
         assert!(
             memory_limit.bytes() >= mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT,
@@ -996,16 +993,15 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "mem_limiter")]
     fn memory_limit_setting_user_specified() {
-        // Test that when --max-memory-target IS set, we get User variant
-        let cli_args = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location", "--max-memory-target", "1024"])
+        // Test that when --memory-target IS set, we get User variant
+        let cli_args = CliArgs::try_parse_from(["mount-s3", "bucket", "test/location", "--memory-target", "1024"])
             .expect("CLI args should parse");
 
         let memory_limit = cli_args.memory_limit_setting();
         assert!(
             memory_limit.is_user_specified(),
-            "Should be User when --max-memory-target is provided"
+            "Should be User when --memory-target is provided"
         );
         assert_eq!(
             memory_limit.bytes(),
@@ -1014,7 +1010,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "mem_limiter")]
     #[test_case("--read-part-size", "8388608",   true  ; "read-part within budget ok")]
     #[test_case("--part-size",      "8388608",   true  ; "part-size within budget ok")]
     #[test_case("--read-part-size", "524288000", false ; "read-part over budget fails")]
@@ -1024,7 +1019,7 @@ mod tests {
             "mount-s3",
             "bucket",
             "test/location",
-            "--max-memory-target",
+            "--memory-target",
             "512",
             flag,
             value,


### PR DESCRIPTION
Rename to --memory-target and remove feature gate

Changes:
- Drop the `mem_limiter` feature from `mountpoint-s3` and `mountpoint-s3-fs` Cargo.toml and remove the `#[cfg(feature = "mem_limiter")]` gates in the CLI.
- Rename the `--max-memory-target` flag (and its `max_memory_target` field) to `--memory-target` / `memory_target`, and update the read-part-size validation error message and `MemoryLimitSetting` doc comment.
- Update the benchmark workflows (bench.yml, bench_s3express.yml): drop the now always-empty `features` matrix dimension, and rename the `max_memory_target_mib` matrix key / `S3_MAX_MEMORY_TARGET_MIB` env var to `memory_target_mib` / `S3_MEMORY_TARGET_MIB`.
- Update the fs_bench.sh / fs_cache_bench.sh scripts: drop the `--features mem_limiter` build args and use the renamed flag and env var.
- Rename the matching flag/field/config key in the prefetch_benchmark, upload_benchmark, and s3io_benchmark examples and the Python benchmark harness (mountpoint.py, prefetch_benchmark.py, config.yaml), and stop building mount-s3 with the removed feature.

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
