### PR TITLE
Fix stress test hanging on cleanup when workers stuck

### DIFF
--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -148,9 +148,9 @@ pub fn run(scenario: Scenario) {
 
     // Bounded join: workers observe `stop` between ops and should finish quickly. If any
     // are wedged in a kernel FUSE syscall they cannot observe `stop` and `JoinHandle` has
-    // no timeout API, so we poll `is_finished()` up to a deadline. On timeout we drop
-    // (unmount) the session to force EIO/EINTR on stuck syscalls, then panic with the
-    // stuck worker labels.
+    // no timeout API, so we poll `is_finished()` up to a deadline. On timeout we skip
+    // clean unmount (which would hang waiting for the stuck workers in a circular
+    // dependency) and let process exit force-unmount the filesystem.
     let join_deadline = Instant::now() + max_join_wait;
     while !handles.iter().all(|h| h.is_finished()) {
         if Instant::now() >= join_deadline {
@@ -159,8 +159,12 @@ pub fn run(scenario: Scenario) {
                 .enumerate()
                 .filter_map(|(id, h)| (!h.is_finished()).then_some(labels[id].as_str()))
                 .collect();
-            drop(setup_guard);
-            drop(session);
+            // Workers are wedged (likely in uninterruptible FUSE syscalls). Clean unmount
+            // would hang in fuse_session_unmount waiting for the FUSE session thread, which
+            // is stuck waiting for the workers. Skip cleanup and panic immediately — process
+            // exit will close /dev/fuse fd and trigger kernel-side unmount.
+            std::mem::forget(setup_guard);
+            std::mem::forget(session);
             panic!("stress: workers {stuck:?} did not finish within {max_join_wait:?} after stop");
         }
         thread::sleep(Duration::from_millis(100));

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -161,8 +161,13 @@ pub fn run(scenario: Scenario) {
                 .collect();
             // Workers are wedged (likely in uninterruptible FUSE syscalls). Clean unmount
             // would hang in fuse_session_unmount waiting for the FUSE session thread, which
-            // is stuck waiting for the workers. Skip cleanup and panic immediately — process
-            // exit will close /dev/fuse fd and trigger kernel-side unmount.
+            // is stuck waiting for the workers. Skip cleanup and panic immediately.
+            // TODO: Avoid resource leak
+            tracing::warn!(
+                scenario = scenario_name,
+                "stress: workers wedged after stop; skipping clean unmount to avoid a deadlocked \
+                 teardown. Leaking the mount dir, FUSE mount entry, and setup-guard objects"
+            );
             std::mem::forget(setup_guard);
             std::mem::forget(session);
             panic!("stress: workers {stuck:?} did not finish within {max_join_wait:?} after stop");


### PR DESCRIPTION
When a stress test worker is stuck in a FUSE syscall (e.g. blocked waiting for a memory allocation that can never be fulfilled), the test harness cleanup would hang indefinitely. The `drop(session)` call triggers `fuse_session_unmount` which waits for all in-flight FUSE requests to drain  but the stuck worker is an in-flight request that will never complete. This creates a circular dependency that causes the test to hang in CI instead of failing.
  
Replaced `drop()` with `std::mem::forget()` in the bounded-join timeout path so the test panics immediately. Process exit handles the unmount cleanup.
  
Confirmed on EC2: test now fails instead of hanging indefinitely.

### Does this change impact existing behavior?

No breaking change.

### Does this change need a changelog entry? Does it require a version change?

No, this is a test-only change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
