### PR TITLE
Reserve buffer budget so writers don't starve reads

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -311,13 +311,13 @@ At mount time, Mountpoint automatically selects appropriate defaults to provide 
 
 ### Maximum number of files open for writing
 
-Mountpoint enforces a cap on the number of files that may be open for writing at the same time, to control memory usage. The cap is computed at startup from the configured memory target, the write part size, and a small reserve kept for reads:
+Mountpoint enforces a cap on the number of files that may be open for writing at the same time, to control memory usage. The cap is computed at startup from the configured memory target, the write part size, and one read part kept available for reads:
 
 ```
-max_concurrent_writes = (memory_target − additional_mem_reserved − read_reserve) / write_part_size
+max_concurrent_writes = (memory_target − additional_mem_reserved − read_part_size) / write_part_size
 ```
 
-`memory_target` is set with `--memory-target` and defaults to 95% of total system memory with a minimum of 512 MiB. `write_part_size` is set with `--write-part-size` (or with `--part-size`) and defaults to 8 MiB. `additional_mem_reserved` is `max(128 MiB, memory_target / 8)` and is held back from data buffers for Mountpoint's own overhead. `read_reserve` is one `read_part_size` (defaulting to 8 MiB) held back so that concurrent writers cannot consume the entire data-buffer budget and starve active reads. With the minimum supported `memory_target` of 512 MiB and the default 8 MiB read and write part sizes, the cap is 47 concurrent writers.
+`memory_target` is set with `--memory-target` and defaults to 95% of total system memory with a minimum of 512 MiB. `additional_mem_reserved` is `max(128 MiB, memory_target / 8)` and is held back from data buffers for Mountpoint's own overhead. `read_part_size` and `write_part_size` are set with `--read-part-size` and `--write-part-size` (or both with `--part-size`) and each default to 8 MiB; one read part is kept available for reads. With the minimum `memory_target` of 512 MiB and the default 8 MiB part sizes, the cap is 47 concurrent writers.
 
 Once the cap is reached, `open()` calls for write return `ENOMEM` ("Cannot allocate memory") until an existing write handle is closed. To raise the cap, increase `--memory-target` or decrease `--write-part-size`.
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -311,13 +311,13 @@ At mount time, Mountpoint automatically selects appropriate defaults to provide 
 
 ### Maximum number of files open for writing
 
-Mountpoint enforces a cap on the number of files that may be open for writing at the same time, to control memory usage. The cap is computed at startup from the configured memory target and write part size:
+Mountpoint enforces a cap on the number of files that may be open for writing at the same time, to control memory usage. The cap is computed at startup from the configured memory target, the write part size, and a small reserve kept for reads:
 
 ```
-max_concurrent_writes = (memory_target − additional_mem_reserved) / write_part_size
+max_concurrent_writes = (memory_target − additional_mem_reserved − read_reserve) / write_part_size
 ```
 
-`memory_target` is set with `--memory-target` and defaults to 95% of total system memory with a minimum of 512 MiB. `write_part_size` is set with `--write-part-size` (or with `--part-size`) and defaults to 8 MiB. `additional_mem_reserved` is `max(128 MiB, memory_target / 8)` and is held back from data buffers for Mountpoint's own overhead. With the minimum supported `memory_target` of 512 MiB and the default 8 MiB write part size, the cap is 48 concurrent writers.
+`memory_target` is set with `--memory-target` and defaults to 95% of total system memory with a minimum of 512 MiB. `write_part_size` is set with `--write-part-size` (or with `--part-size`) and defaults to 8 MiB. `additional_mem_reserved` is `max(128 MiB, memory_target / 8)` and is held back from data buffers for Mountpoint's own overhead. `read_reserve` is one `read_part_size` (defaulting to 8 MiB) held back so that concurrent writers cannot consume the entire data-buffer budget and starve active reads. With the minimum supported `memory_target` of 512 MiB and the default 8 MiB read and write part sizes, the cap is 47 concurrent writers.
 
 Once the cap is reached, `open()` calls for write return `ENOMEM` ("Cannot allocate memory") until an existing write handle is closed. To raise the cap, increase `--memory-target` or decrease `--write-part-size`.
 

--- a/mountpoint-s3-client/examples/client_benchmark.rs
+++ b/mountpoint-s3-client/examples/client_benchmark.rs
@@ -13,7 +13,7 @@ use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::types::{ClientBackpressureHandle, ETag, GetObjectParams, GetObjectResponse};
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use serde_json::{json, to_writer};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::Subscriber;
@@ -223,7 +223,7 @@ struct CliArgs {
 
 fn create_s3_client_config(region: &str, args: &CliArgs, nics: Vec<String>) -> S3ClientConfig {
     let pool = PagedPool::config()
-        .with_candidate_sizes([args.part_size])
+        .with_candidate_sizes([CandidateSize::new(args.part_size)])
         .with_no_memory_limit()
         .build();
     let mut config = S3ClientConfig::new()

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -81,7 +81,7 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
     #[cfg(feature = "fs_pool_tests")]
     let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
         mountpoint_s3_fs::memory::PagedPool::config()
-            .with_candidate_sizes([options.part_size()])
+            .with_candidate_sizes([mountpoint_s3_fs::memory::CandidateSize::new(options.part_size())])
             .with_no_memory_limit()
             .build()
     });

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -7,7 +7,7 @@ use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_fs::data_cache::{ChecksummedBytes, DataCache, DiskDataCache, DiskDataCacheConfig};
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::object::ObjectId;
 use rand::Rng;
 use tempfile::TempDir;
@@ -40,7 +40,7 @@ fn cache_read_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Pat
         limit: mountpoint_s3_fs::data_cache::CacheLimit::Unbounded,
     };
     let pool = PagedPool::config()
-        .with_candidate_sizes([BLOCK_SIZE as usize])
+        .with_candidate_sizes([CandidateSize::new(BLOCK_SIZE as usize)])
         .with_no_memory_limit()
         .build();
     let cache = DiskDataCache::new(config, pool);

--- a/mountpoint-s3-fs/examples/fs_benchmark.rs
+++ b/mountpoint-s3-fs/examples/fs_benchmark.rs
@@ -9,7 +9,7 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_fs::fuse::S3FuseFilesystem;
 use mountpoint_s3_fs::fuse::config::{FuseOptions, FuseSessionConfig, MountPoint};
 use mountpoint_s3_fs::fuse::session::FuseSession;
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::s3::{Bucket, S3Path};
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig, Superblock, SuperblockConfig};
@@ -144,7 +144,7 @@ fn mount_file_system(
 ) -> FuseSession {
     let part_size = 8 * 1024 * 1024;
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let mut config = S3ClientConfig::new().endpoint_config(EndpointConfig::new(region));

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -14,7 +14,7 @@ use mountpoint_s3_fs::{
     },
     logging::{LoggingConfig, LoggingHandle, error_logger::FileErrorLogger, init_logging},
     manifest::{ChannelConfig, Manifest, ManifestMetablock, ingest_manifest},
-    memory::PagedPool,
+    memory::{CandidateSize, PagedPool},
     metrics::{self, MetricsSinkHandle},
     s3::config::{ClientConfig, MemoryLimitSetting, PartConfig, Region, TargetThroughputSetting},
 };
@@ -314,7 +314,7 @@ fn mount_filesystem(
     let client_config = config.build_client_config(mem_limit)?;
 
     let pool = PagedPool::config()
-        .with_candidate_sizes([client_config.part_config.read_size_bytes])
+        .with_candidate_sizes([CandidateSize::new(client_config.part_config.read_size_bytes)])
         .with_memory_limit(mem_limit)
         .build();
     let client = client_config

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -12,8 +12,8 @@ use mountpoint_s3_client::config::{EndpointConfig, RustLogAdapter, S3ClientConfi
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::Runtime;
-use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::memory::effective_total_memory;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{PrefetchGetObject, Prefetcher, PrefetcherConfig};
 use serde_json::{json, to_writer};
@@ -168,7 +168,7 @@ fn main() -> anyhow::Result<()> {
 
     let bucket = args.bucket.as_str();
     let pool = PagedPool::config()
-        .with_candidate_sizes([args.part_size.unwrap_or(8 * 1024 * 1024) as usize])
+        .with_candidate_sizes([CandidateSize::new(args.part_size.unwrap_or(8 * 1024 * 1024) as usize)])
         .with_memory_limit(args.memory_target_in_bytes())
         .build();
     let client_config = args.s3_client_config().memory_pool(pool.clone());

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -5,8 +5,8 @@ use std::time::Instant;
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::HeadObjectParams;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::memory::effective_total_memory;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::object::ObjectId;
 use mountpoint_s3_fs::prefetch::{Prefetcher, PrefetcherConfig};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
@@ -67,7 +67,7 @@ impl Executor {
 
         let memory_target_bytes = memory_target * 1024 * 1024;
         let pool = PagedPool::config()
-            .with_candidate_sizes([read_part_size, write_part_size])
+            .with_candidate_sizes([CandidateSize::new(read_part_size), CandidateSize::new(write_part_size)])
             .with_memory_limit(memory_target_bytes)
             .build();
 

--- a/mountpoint-s3-fs/examples/upload_benchmark.rs
+++ b/mountpoint-s3-fs/examples/upload_benchmark.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use mountpoint_s3_client::config::{Allocator, EndpointConfig, RustLogAdapter, S3ClientConfig, Uri};
 use mountpoint_s3_client::types::ChecksumAlgorithm;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::memory::effective_total_memory;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 use mountpoint_s3_fs::{Runtime, ServerSideEncryption};
 use tracing_subscriber::EnvFilter;
@@ -103,7 +103,7 @@ fn main() {
         (effective_total_memory() as f64 * 0.95) as usize
     };
     let pool = PagedPool::config()
-        .with_candidate_sizes([args.write_part_size])
+        .with_candidate_sizes([CandidateSize::new(args.write_part_size)])
         .with_memory_limit(memory_target)
         .build();
     let config = S3ClientConfig::new()

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -650,6 +650,7 @@ mod tests {
 
     use super::*;
 
+    use crate::memory::CandidateSize;
     use futures::StreamExt as _;
     use futures::executor::{ThreadPool, block_on};
     use futures::task::SpawnExt;
@@ -692,7 +693,7 @@ mod tests {
     fn get_path_for_block_key() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_no_memory_limit()
             .build();
         let data_cache = DiskDataCache::new(
@@ -727,7 +728,7 @@ mod tests {
     fn get_path_for_block_key_huge_block_index() {
         let cache_dir = PathBuf::from("mountpoint-cache/");
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_no_memory_limit()
             .build();
         let data_cache = DiskDataCache::new(
@@ -772,7 +773,7 @@ mod tests {
 
         let cache_directory = tempfile::tempdir().unwrap();
         let pool = PagedPool::config()
-            .with_candidate_sizes([pool_buffer_size])
+            .with_candidate_sizes([CandidateSize::new(pool_buffer_size)])
             .with_no_memory_limit()
             .build();
         let cache = DiskDataCache::new(
@@ -862,7 +863,7 @@ mod tests {
 
         let cache_directory = tempfile::tempdir().unwrap();
         let pool = PagedPool::config()
-            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_candidate_sizes([CandidateSize::new(8 * 1024 * 1024)])
             .with_no_memory_limit()
             .build();
         let cache = DiskDataCache::new(
@@ -947,7 +948,7 @@ mod tests {
 
         let cache_directory = tempfile::tempdir().unwrap();
         let pool = PagedPool::config()
-            .with_candidate_sizes([BLOCK_SIZE])
+            .with_candidate_sizes([CandidateSize::new(BLOCK_SIZE)])
             .with_no_memory_limit()
             .build();
         let cache = DiskDataCache::new(
@@ -1133,7 +1134,7 @@ mod tests {
         replace_u64_at(&mut buf, offset, u64::MAX);
 
         let pool = PagedPool::config()
-            .with_candidate_sizes([MAX_LENGTH as usize])
+            .with_candidate_sizes([CandidateSize::new(MAX_LENGTH as usize)])
             .with_no_memory_limit()
             .build();
         let err = block_on(DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None))
@@ -1153,7 +1154,7 @@ mod tests {
         let block_size = 1024 * 1024;
         let cache_directory = tempfile::tempdir().unwrap();
         let pool = PagedPool::config()
-            .with_candidate_sizes([block_size])
+            .with_candidate_sizes([CandidateSize::new(block_size)])
             .with_no_memory_limit()
             .build();
         let data_cache = DiskDataCache::new(

--- a/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/multilevel_cache.rs
@@ -118,7 +118,7 @@ mod tests {
     use super::*;
     use crate::checksums::ChecksummedBytes;
     use crate::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig, ExpressDataCache, ExpressDataCacheConfig};
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
 
     use futures::executor::ThreadPool;
     use mountpoint_s3_client::mock_client::MockClient;
@@ -132,7 +132,7 @@ mod tests {
     fn create_disk_cache() -> (TempDir, Arc<DiskDataCache>) {
         let cache_directory = tempfile::tempdir().unwrap();
         let pool = PagedPool::config()
-            .with_candidate_sizes([BLOCK_SIZE as usize, PART_SIZE])
+            .with_candidate_sizes([CandidateSize::new(BLOCK_SIZE as usize), CandidateSize::new(PART_SIZE)])
             .with_no_memory_limit()
             .build();
         let cache = DiskDataCache::new(

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -153,8 +153,13 @@ where
         trace!(?config, "new filesystem");
 
         let pool = pool.clone();
-        let write_handle_limiter = (!config.read_only)
-            .then(|| WriteHandleLimiter::new(pool.mem_limit(), pool.data_buffer_budget(), client.write_part_size()));
+        let write_handle_limiter = (!config.read_only).then(|| {
+            WriteHandleLimiter::new(
+                pool.mem_limit(),
+                pool.non_prunable_data_buffer_budget(),
+                client.write_part_size(),
+            )
+        });
         let prefetcher = prefetch_builder.build(runtime.clone(), pool.clone(), config.prefetcher_config);
         let uploader = Uploader::new(
             client.clone(),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -153,13 +153,8 @@ where
         trace!(?config, "new filesystem");
 
         let pool = pool.clone();
-        let write_handle_limiter = (!config.read_only).then(|| {
-            WriteHandleLimiter::new(
-                pool.mem_limit(),
-                pool.non_prunable_data_buffer_budget(),
-                client.write_part_size(),
-            )
-        });
+        let write_handle_limiter = (!config.read_only)
+            .then(|| WriteHandleLimiter::new(pool.mem_limit(), pool.write_buffer_budget(), client.write_part_size()));
         let prefetcher = prefetch_builder.build(runtime.clone(), pool.clone(), config.prefetcher_config);
         let uploader = Uploader::new(
             client.clone(),

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -798,6 +798,7 @@ where
 mod tests {
     use super::*;
 
+    use crate::memory::CandidateSize;
     use crate::prefetch::Prefetcher;
     use crate::s3::{Bucket, S3Path};
     use crate::{Superblock, SuperblockConfig};
@@ -823,7 +824,7 @@ mod tests {
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
         let pool = PagedPool::config()
-            .with_candidate_sizes([32])
+            .with_candidate_sizes([CandidateSize::new(32)])
             .with_minimum_memory_limit()
             .build();
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
@@ -1090,7 +1091,7 @@ mod tests {
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(10).create().unwrap());
         let pool = PagedPool::config()
-            .with_candidate_sizes([32])
+            .with_candidate_sizes([CandidateSize::new(32)])
             .with_minimum_memory_limit()
             .build();
         let prefetcher_builder = Prefetcher::default_builder(client.clone());
@@ -1138,7 +1139,7 @@ mod tests {
 
         let runtime = Runtime::new(ThreadPool::builder().pool_size(2).create().unwrap());
         let pool = PagedPool::config()
-            .with_candidate_sizes([PART_SIZE])
+            .with_candidate_sizes([CandidateSize::new(PART_SIZE)])
             .with_memory_limit(MEM_LIMIT)
             .build();
         let prefetcher_builder = Prefetcher::default_builder(client.clone());

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -10,7 +10,7 @@ mod write_handle_limiter;
 pub use buffers::{PoolBuffer, PoolBufferMut};
 pub use limiter::{
     ActiveReadGuard, BufferArea, CursorHandle, CursorState, MINIMUM_MEM_LIMIT, data_buffer_budget_for,
-    effective_total_memory,
+    effective_total_memory, write_buffer_budget_for,
 };
 pub use pool::{CandidateSize, PagedPool};
 pub use stats::BufferKind;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -12,6 +12,6 @@ pub use limiter::{
     ActiveReadGuard, BufferArea, CursorHandle, CursorState, MINIMUM_MEM_LIMIT, data_buffer_budget_for,
     effective_total_memory,
 };
-pub use pool::PagedPool;
+pub use pool::{CandidateSize, PagedPool};
 pub use stats::BufferKind;
 pub use write_handle_limiter::{WriteHandleLimitError, WriteHandleLimiter, WriteHandleSlot};

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -38,11 +38,9 @@ impl PoolBuffer {
         limiter: Arc<MemoryLimiter>,
         forced: bool,
     ) -> Option<Self> {
-        Some(Self(PoolBufferInner::Secondary(limiter.try_allocate(
-            size,
-            Some(kind),
-            forced,
-        )?)))
+        Some(Self(PoolBufferInner::Secondary(
+            limiter.try_allocate(size, kind, true, forced)?,
+        )))
     }
 
     pub fn capacity(&self) -> usize {
@@ -302,7 +300,7 @@ mod tests {
         PoolBuffer::try_new_secondary(
             buffer_size,
             BufferKind::Other,
-            Arc::new(MemoryLimiter::new(usize::MAX)),
+            Arc::new(MemoryLimiter::new(usize::MAX, 0)),
             true,
         )
         .unwrap()

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -32,6 +32,17 @@ pub fn data_buffer_budget_for(mem_limit: usize) -> usize {
 /// prunable kind today) holds one part while it prefetches the next.
 const PRUNABLE_RESERVED_PARTS: usize = 1;
 
+/// The budget reserved for prunable allocations (0 if none is configured).
+fn prunable_reserved_for(prunable_buffer_size: usize) -> usize {
+    prunable_buffer_size * PRUNABLE_RESERVED_PARTS
+}
+
+/// The buffer budget available to writes: `data_buffer_budget_for(mem_limit)` minus the prunable
+/// reserve. Source of truth for the write-handle cap (see [`MemoryLimiter::write_buffer_budget`]).
+pub fn write_buffer_budget_for(mem_limit: usize, prunable_buffer_size: usize) -> usize {
+    data_buffer_budget_for(mem_limit).saturating_sub(prunable_reserved_for(prunable_buffer_size))
+}
+
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
 pub enum BufferArea {
@@ -104,7 +115,7 @@ pub struct MemoryLimiter {
 impl MemoryLimiter {
     pub fn new(mem_limit: usize, prunable_buffer_size: usize) -> Self {
         let additional_mem_reserved = additional_mem_reserved_for(mem_limit);
-        let prunable_reserved = prunable_buffer_size * PRUNABLE_RESERVED_PARTS;
+        let prunable_reserved = prunable_reserved_for(prunable_buffer_size);
         let formatter = make_format(humansize::BINARY);
         debug!(
             "target memory usage is {} with {} reserved memory and {} reserved for prunable buffers",
@@ -139,11 +150,11 @@ impl MemoryLimiter {
         self.mem_limit.saturating_sub(self.additional_mem_reserved)
     }
 
-    /// The buffer budget available to non-evictable allocations, i.e. `data_buffer_budget - prunable_reserved`.
+    /// The buffer budget available to writes, i.e. `data_buffer_budget - prunable_reserved`.
     /// This is the ceiling writes actually see (reads may use the full `data_buffer_budget`), so
     /// [`crate::memory::WriteHandleLimiter`] derives its cap from it: an admitted writer is then
     /// always backed by budget and never waits on memory reserved for reads.
-    pub fn non_prunable_data_buffer_budget(&self) -> usize {
+    pub fn write_buffer_budget(&self) -> usize {
         self.data_buffer_budget().saturating_sub(self.prunable_reserved)
     }
 

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -633,12 +633,12 @@ mod tests {
     // TODO: Consider which tests are specific to the MemoryLimiter and which are testing the whole PagedPool.
 
     use super::*;
-    use crate::memory::{BufferKind, PagedPool};
+    use crate::memory::{BufferKind, CandidateSize, PagedPool};
     use crate::sync::atomic::Ordering;
 
     fn new_pool() -> PagedPool {
         PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_minimum_memory_limit()
             .build()
     }
@@ -737,7 +737,7 @@ mod tests {
         // Simulates the cancellation race: on_reserve fires after release_cursor
         // removed the entry. The callback should be a no-op.
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();
@@ -760,7 +760,7 @@ mod tests {
     #[test]
     fn test_on_pool_acquire_saturates_on_over_decrement() {
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();
@@ -786,7 +786,7 @@ mod tests {
         let buffer_size = 1024;
 
         let pool = PagedPool::config()
-            .with_candidate_sizes([buffer_size])
+            .with_candidate_sizes([CandidateSize::new(buffer_size)])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();
@@ -822,7 +822,7 @@ mod tests {
         let buffer_size = 1024;
 
         let pool = PagedPool::config()
-            .with_candidate_sizes([buffer_size])
+            .with_candidate_sizes([CandidateSize::new(buffer_size)])
             .with_minimum_memory_limit()
             .build();
         let limiter = pool.limiter();

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -75,8 +75,9 @@ pub struct MemoryLimiter {
     mem_limit: usize,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: usize,
-    /// Bytes reserved for reads: non-read allocations stop this many bytes short of `mem_limit`, so they can't starve active reads.
-    /// Derived in [`Self::new`] from the prunable buffer size; zero when none is configured.
+    /// Bytes reserved for reads: non-read allocations stop this many bytes short of `mem_limit`, so
+    /// they can't starve active reads. Derived in [`Self::new`] from the prunable buffer size; zero
+    /// when none is configured.
     prunable_reserved: usize,
     /// Memory allocated by the pool.
     allocated_bytes: AtomicUsize,
@@ -133,10 +134,17 @@ impl MemoryLimiter {
     }
 
     /// The static memory budget available for data buffers, i.e. `mem_limit - additional_mem_reserved`.
-    /// This is the upper bound on buffer-backed allocations and is used by
-    /// [`crate::memory::WriteHandleLimiter`] to derive its cap.
+    /// This is the upper bound on buffer-backed allocations across all kinds.
     pub fn data_buffer_budget(&self) -> usize {
         self.mem_limit.saturating_sub(self.additional_mem_reserved)
+    }
+
+    /// The buffer budget available to non-evictable allocations, i.e. `data_buffer_budget - prunable_reserved`.
+    /// This is the ceiling writes actually see (reads may use the full `data_buffer_budget`), so
+    /// [`crate::memory::WriteHandleLimiter`] derives its cap from it: an admitted writer is then
+    /// always backed by budget and never waits on memory reserved for reads.
+    pub fn non_prunable_data_buffer_budget(&self) -> usize {
+        self.data_buffer_budget().saturating_sub(self.prunable_reserved)
     }
 
     /// Reserve the memory for future uses. Always succeeds, even if it means going beyond

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -28,6 +28,10 @@ pub fn data_buffer_budget_for(mem_limit: usize) -> usize {
     mem_limit.saturating_sub(additional_mem_reserved_for(mem_limit))
 }
 
+/// Prunable-sized buffers reserved so prunable allocations aren't starved. A sequential read (the
+/// prunable kind today) holds one part while it prefetches the next.
+const PRUNABLE_RESERVED_PARTS: usize = 1;
+
 /// Buffer areas that can be managed by the memory limiter. This is used for updating metrics.
 #[derive(Debug)]
 pub enum BufferArea {
@@ -71,6 +75,9 @@ pub struct MemoryLimiter {
     mem_limit: usize,
     /// Additional reserved memory for other non-buffer usage like storing metadata
     additional_mem_reserved: usize,
+    /// Bytes reserved for reads: non-read allocations stop this many bytes short of `mem_limit`, so they can't starve active reads.
+    /// Derived in [`Self::new`] from the prunable buffer size; zero when none is configured.
+    prunable_reserved: usize,
     /// Memory allocated by the pool.
     allocated_bytes: AtomicUsize,
     /// Memory in use by [`BufferKind`].
@@ -94,17 +101,20 @@ pub struct MemoryLimiter {
 }
 
 impl MemoryLimiter {
-    pub fn new(mem_limit: usize) -> Self {
+    pub fn new(mem_limit: usize, prunable_buffer_size: usize) -> Self {
         let additional_mem_reserved = additional_mem_reserved_for(mem_limit);
+        let prunable_reserved = prunable_buffer_size * PRUNABLE_RESERVED_PARTS;
         let formatter = make_format(humansize::BINARY);
         debug!(
-            "target memory usage is {} with {} reserved memory",
+            "target memory usage is {} with {} reserved memory and {} reserved for prunable buffers",
             formatter(mem_limit),
-            formatter(additional_mem_reserved)
+            formatter(additional_mem_reserved),
+            formatter(prunable_reserved)
         );
         Self {
             mem_limit,
             additional_mem_reserved,
+            prunable_reserved,
             allocated_bytes: Default::default(),
             acquired_bytes: Default::default(),
             mem_reserved: Default::default(),
@@ -257,10 +267,20 @@ impl MemoryLimiter {
         metrics::gauge!("mem.bytes_reserved", "area" => BufferArea::Prefetch.as_str()).decrement(decremented as f64);
     }
 
+    /// Try to allocate `size` bytes from the pool budget.
+    ///
+    /// `kind` selects the ceiling: reads ([`BufferKind::GetObject`]) may use the full `mem_limit`,
+    /// while every other kind stops `prunable_reserved` bytes short, keeping a read-part-sized slice
+    /// exclusively for reads.
+    ///
+    /// `track` controls per-kind byte accounting: `true` records the allocation against `kind` (and
+    /// releases it on drop), `false` skips tracking. Page allocations pass `false` because their
+    /// individual buffers are tracked separately as they are acquired.
     pub fn try_allocate(
         self: &Arc<Self>,
         size: usize,
-        kind: Option<BufferKind>,
+        kind: BufferKind,
+        track: bool,
         forced: bool,
     ) -> Option<ManagedBuffer> {
         if forced {
@@ -268,11 +288,17 @@ impl MemoryLimiter {
             metrics::gauge!("pool.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
+            // Reads use the full limit; other kinds must leave `prunable_reserved` bytes free.
+            let ceiling = if matches!(kind, BufferKind::GetObject) {
+                self.mem_limit
+            } else {
+                self.mem_limit.saturating_sub(self.prunable_reserved)
+            };
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
             loop {
                 let new_mem_allocated = mem_allocated.saturating_add(size);
                 let new_total_mem_usage = new_mem_allocated.saturating_add(self.additional_mem_reserved);
-                if new_total_mem_usage > self.mem_limit {
+                if new_total_mem_usage > ceiling {
                     trace!(new_total_mem_usage, "not enough memory to allocate");
                     metrics::histogram!("pool.allocate_latency_us").record(start.elapsed().as_micros() as f64);
                     return None;
@@ -294,11 +320,11 @@ impl MemoryLimiter {
             }
         }
 
-        if let Some(kind) = kind {
+        if track {
             self.acquire_bytes(size, kind);
         }
 
-        Some(ManagedBuffer::new(size, kind, self.clone()))
+        Some(ManagedBuffer::new(size, track.then_some(kind), self.clone()))
     }
 
     pub fn deallocate(&self, ptr: BufferPtr, kind: Option<BufferKind>) {

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -277,9 +277,9 @@ impl MemoryLimiter {
 
     /// Try to allocate `size` bytes from the pool budget.
     ///
-    /// `kind` selects the ceiling: reads ([`BufferKind::GetObject`]) may use the full `mem_limit`,
-    /// while every other kind stops `prunable_reserved` bytes short, keeping a read-part-sized slice
-    /// exclusively for reads.
+    /// `kind` selects the ceiling: prunable kinds (see [`BufferKind::is_prunable`]) may use the full
+    /// `mem_limit`, while non-prunable kinds stop `prunable_reserved` bytes short, keeping that slice
+    /// available for prunable allocations.
     ///
     /// `track` controls per-kind byte accounting: `true` records the allocation against `kind` (and
     /// releases it on drop), `false` skips tracking. Page allocations pass `false` because their
@@ -296,8 +296,8 @@ impl MemoryLimiter {
             metrics::gauge!("pool.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
-            // Reads use the full limit; other kinds must leave `prunable_reserved` bytes free.
-            let ceiling = if matches!(kind, BufferKind::GetObject) {
+            // Prunable kinds use the full limit; others must leave `prunable_reserved` bytes free.
+            let ceiling = if kind.is_prunable() {
                 self.mem_limit
             } else {
                 self.mem_limit.saturating_sub(self.prunable_reserved)

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -174,8 +174,8 @@ mod tests {
         let additional_reserved = (BUF * 16).max(128 * 1024 * 1024);
         let mem_limit = BUF * 16 + additional_reserved;
 
-        let limiter = MemoryLimiter::new(mem_limit);
-        let inner_pool = PagedPoolInner::new(&[BUF], Arc::new(limiter));
+        let limiter = MemoryLimiter::new(mem_limit, 0);
+        let inner_pool = PagedPoolInner::new(&[BUF.into()], Arc::new(limiter));
         PagedPool {
             inner: Arc::new(inner_pool),
         }

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -156,7 +156,7 @@ mod tests {
 
     use crate::memory::limiter::MemoryLimiter;
     use crate::memory::pool::PagedPoolInner;
-    use crate::memory::{BufferKind, PagedPool};
+    use crate::memory::{BufferKind, CandidateSize, PagedPool};
 
     use super::{PRUNING_STARVATION_THRESHOLD, PruningOutcome, run_pruning_round, spawn_pool_maintenance_thread};
 
@@ -175,7 +175,7 @@ mod tests {
         let mem_limit = BUF * 16 + additional_reserved;
 
         let limiter = MemoryLimiter::new(mem_limit, 0);
-        let inner_pool = PagedPoolInner::new(&[BUF.into()], Arc::new(limiter));
+        let inner_pool = PagedPoolInner::new(&[CandidateSize::new(BUF)], Arc::new(limiter));
         PagedPool {
             inner: Arc::new(inner_pool),
         }
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     fn run_pruning_round_returns_idle_on_empty_queue() {
         let pool = PagedPool::config()
-            .with_candidate_sizes([1024])
+            .with_candidate_sizes([CandidateSize::new(1024)])
             .with_minimum_memory_limit()
             .build();
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -44,14 +44,14 @@ impl Page {
     /// Create a new page and allocate the required memory.
     ///
     /// Returns `None` if the allocation would hit the memory limit.
-    pub fn try_new(stats: &Arc<SizePoolStats>, buffer_count: usize) -> Option<Self> {
+    pub fn try_new(stats: &Arc<SizePoolStats>, buffer_count: usize, kind: BufferKind) -> Option<Self> {
         assert!(
             buffer_count > 0 && buffer_count <= MAX_BUFFERS_PER_PAGE,
             "buffer_count must be positive and less than {}, but was {}.",
             MAX_BUFFERS_PER_PAGE,
             buffer_count
         );
-        let page_buffer = stats.try_allocate_page(buffer_count)?;
+        let page_buffer = stats.try_allocate_page(buffer_count, kind)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
         let last_buffer = unsafe { page_buffer.as_raw_ptr().add((buffer_count - 1) * stats.buffer_size) };
@@ -141,9 +141,10 @@ impl Page {
 
     #[cfg(test)]
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
-        let limiter = super::limiter::MemoryLimiter::new(usize::MAX);
+        let limiter = super::limiter::MemoryLimiter::new(usize::MAX, 0);
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
-        Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE).expect("allocation should succeed with usize::MAX limit")
+        Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE, BufferKind::Other)
+            .expect("allocation should succeed with usize::MAX limit")
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -170,6 +170,11 @@ impl PagedPool {
         self.inner.limiter.data_buffer_budget()
     }
 
+    /// The buffer budget available to non-evictable allocations, i.e. `data_buffer_budget - prunable_reserved`.
+    pub fn non_prunable_data_buffer_budget(&self) -> usize {
+        self.inner.limiter.non_prunable_data_buffer_budget()
+    }
+
     /// Create a new cursor and return the shared state handle.
     pub fn create_cursor(&self) -> CursorHandle {
         self.inner.limiter.create_cursor(self)

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -69,14 +69,7 @@ impl PagedPool {
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
         let ordered_sizes: &[CandidateSize] = config.ordered_sizes();
-        // The largest prunable candidate size drives the limiter's reserve.
-        let prunable_size = ordered_sizes
-            .iter()
-            .filter(|s| s.is_prunable())
-            .map(|s| s.bytes())
-            .max()
-            .unwrap_or(0);
-        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), prunable_size));
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), config.largest_prunable_size));
 
         let inner = Arc::new(PagedPoolInner::new(ordered_sizes, limiter));
 
@@ -165,14 +158,9 @@ impl PagedPool {
         self.inner.limiter.mem_limit()
     }
 
-    /// The static memory budget available for data buffers, i.e. `mem_limit - additional_mem_reserved`.
-    pub fn data_buffer_budget(&self) -> usize {
-        self.inner.limiter.data_buffer_budget()
-    }
-
-    /// The buffer budget available to non-evictable allocations, i.e. `data_buffer_budget - prunable_reserved`.
-    pub fn non_prunable_data_buffer_budget(&self) -> usize {
-        self.inner.limiter.non_prunable_data_buffer_budget()
+    /// The buffer budget available to writes, i.e. `data_buffer_budget - prunable_reserved`.
+    pub fn write_buffer_budget(&self) -> usize {
+        self.inner.limiter.write_buffer_budget()
     }
 
     /// Create a new cursor and return the shared state handle.
@@ -552,6 +540,7 @@ impl From<&usize> for CandidateSize {
 #[derive(Debug, Clone)]
 pub struct PagedPoolConfig {
     ordered_sizes: Vec<CandidateSize>,
+    largest_prunable_size: usize,
     mem_limit: usize,
     maintenance_interval: Duration,
 }
@@ -560,6 +549,7 @@ impl Default for PagedPoolConfig {
     fn default() -> Self {
         Self {
             ordered_sizes: Default::default(),
+            largest_prunable_size: 0,
             mem_limit: MINIMUM_MEM_LIMIT,
             maintenance_interval: Duration::from_secs(60),
         }
@@ -578,6 +568,12 @@ impl PagedPoolConfig {
         I::Item: Into<CandidateSize>,
     {
         let mut sizes: Vec<CandidateSize> = buffer_sizes.into_iter().map(Into::into).collect();
+        self.largest_prunable_size = sizes
+            .iter()
+            .filter(|s| s.prunable && s.bytes > 0)
+            .map(|s| s.bytes)
+            .max()
+            .unwrap_or(0);
         sizes.retain(|s| s.bytes > 0 && s.bytes <= MAX_BUFFER_SIZE);
         // Sort by size; keep a prunable candidate ahead of a non-prunable one of the same size so
         // dedup (which keeps the first) preserves prunability when sizes coincide.
@@ -768,6 +764,40 @@ mod tests {
         assert!(ordered_bytes.iter().is_sorted(), "Sizes should be sorted");
         let unique: HashSet<_> = ordered_bytes.iter().collect();
         assert_eq!(ordered_bytes.len(), unique.len(), "Sizes should be unique");
+    }
+
+    /// The reserve is sized from the *largest prunable* candidate, ignoring non-prunable sizes.
+    #[test]
+    fn largest_prunable_candidate_sizes_the_reserve() {
+        const READ: usize = 256 * 1024;
+        const CACHE: usize = 1024 * 1024;
+        const WRITE: usize = 8 * 1024 * 1024;
+        const MEM_LIMIT: usize = 512 * 1024 * 1024;
+        let data_budget = MEM_LIMIT - 128 * 1024 * 1024; // additional_mem_reserved floors at 128 MiB
+        let pool = PagedPool::config()
+            .with_candidate_sizes([
+                CandidateSize::prunable(READ),
+                CandidateSize::prunable(CACHE),
+                CandidateSize::new(WRITE),
+            ])
+            .with_memory_limit(MEM_LIMIT)
+            .build();
+        // Reserve is the max prunable size (CACHE), not the max overall size (WRITE) nor the read.
+        assert_eq!(pool.write_buffer_budget(), data_budget - CACHE);
+    }
+
+    /// A prunable candidate larger than [MAX_BUFFER_SIZE] is dropped from `ordered_sizes` (served
+    /// from secondary memory instead), but the reserve must still account for its full size.
+    #[test]
+    fn prunable_reserve_honours_sizes_above_max_buffer_size() {
+        const BIG_READ: usize = MAX_BUFFER_SIZE * 2;
+        const MEM_LIMIT: usize = 4 * 1024 * 1024 * 1024;
+        let data_budget = MEM_LIMIT - MEM_LIMIT / 8; // additional_mem_reserved == mem_limit / 8 here
+        let pool = PagedPool::config()
+            .with_candidate_sizes([CandidateSize::prunable(BIG_READ), CandidateSize::new(8 * 1024 * 1024)])
+            .with_memory_limit(MEM_LIMIT)
+            .build();
+        assert_eq!(pool.write_buffer_budget(), data_budget - BIG_READ);
     }
 
     mod allocation_queue_tests {

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -526,17 +526,18 @@ impl CandidateSize {
     }
 }
 
-// TODO: Consider removing these and updating calls.
-
+// Let callers pass bare sizes (owned or borrowed, e.g. from a `&[usize]` slice); these default to
+// non-prunable. Prunable sizes must be constructed explicitly via `CandidateSize::prunable`.
+//
+// TODO: remove these conversions and make every call site pass an explicit `CandidateSize`, so
+// prunability is always stated rather than silently defaulted (follow-up PR).
 impl From<usize> for CandidateSize {
-    /// Bare sizes default to non-prunable.
     fn from(bytes: usize) -> Self {
         Self::new(bytes)
     }
 }
 
 impl From<&usize> for CandidateSize {
-    /// Convenience for callers passing `&[usize]` slices.
     fn from(bytes: &usize) -> Self {
         Self::new(*bytes)
     }
@@ -1068,12 +1069,18 @@ mod tests {
                 "non-read allocation must not consume the read-reserved slice"
             );
 
-            // But a read can still claim the reserved slice.
+            // But prunable allocations (reads and disk-cache read-backs) can still claim the slice.
             assert!(
                 pool.inner
                     .try_get_buffer(BUF, BufferKind::GetObject, None, false)
                     .is_some(),
                 "read allocation must succeed into the reserved slice"
+            );
+            assert!(
+                pool.inner
+                    .try_get_buffer(BUF, BufferKind::DiskCache, None, false)
+                    .is_some(),
+                "disk-cache allocation must succeed into the reserved slice"
             );
         }
     }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -68,9 +68,17 @@ impl PagedPool {
 
     /// Create a new [PagedPool] with the given configuration.
     pub fn new(config: &PagedPoolConfig) -> Self {
-        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit()));
+        let ordered_sizes: &[CandidateSize] = config.ordered_sizes();
+        // The largest prunable candidate size drives the limiter's reserve.
+        let prunable_size = ordered_sizes
+            .iter()
+            .filter(|s| s.is_prunable())
+            .map(|s| s.bytes())
+            .max()
+            .unwrap_or(0);
+        let limiter = Arc::new(MemoryLimiter::new(config.memory_limit(), prunable_size));
 
-        let inner = Arc::new(PagedPoolInner::new(config.ordered_sizes(), limiter));
+        let inner = Arc::new(PagedPoolInner::new(ordered_sizes, limiter));
 
         // Spawn a background thread to process pending allocation requests.
         inner.spawn_process_pending_thread();
@@ -220,12 +228,12 @@ pub(super) struct PagedPoolInner {
 }
 
 impl PagedPoolInner {
-    pub(super) fn new(ordered_sizes: &[usize], limiter: Arc<MemoryLimiter>) -> Self {
+    pub(super) fn new(ordered_sizes: &[CandidateSize], limiter: Arc<MemoryLimiter>) -> Self {
         let ordered_size_pools = ordered_sizes
             .iter()
-            .map(|&buffer_size| SizePool {
+            .map(|candidate| SizePool {
                 pages: Default::default(),
-                stats: Arc::new(SizePoolStats::new(buffer_size, limiter.clone())),
+                stats: Arc::new(SizePoolStats::new(candidate.bytes(), limiter.clone())),
             })
             .collect();
 
@@ -457,7 +465,7 @@ impl SizePool {
         // memory, keep retrying by halving the count.
         let mut buffer_count = MAX_BUFFERS_PER_PAGE;
         while buffer_count > 0 {
-            let Some(page) = Page::try_new(&self.stats, buffer_count) else {
+            let Some(page) = Page::try_new(&self.stats, buffer_count, kind) else {
                 buffer_count /= 2;
                 continue;
             };
@@ -482,6 +490,53 @@ impl SizePool {
     }
 }
 
+/// A buffer size the pool maintains a [SizePool] for, and whether allocations of that size are
+/// prunable (reclaimable on demand, e.g. prefetch reads).
+///
+/// The limiter keeps a budget reserve for prunable sizes so non-prunable allocations can't consume
+/// the whole budget and starve them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CandidateSize {
+    bytes: usize,
+    prunable: bool,
+}
+
+impl CandidateSize {
+    /// A non-prunable candidate size (the default).
+    pub fn new(bytes: usize) -> Self {
+        Self { bytes, prunable: false }
+    }
+
+    /// A prunable candidate size: the limiter keeps a reserve for it so it is not starved.
+    pub fn prunable(bytes: usize) -> Self {
+        Self { bytes, prunable: true }
+    }
+
+    pub fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    pub fn is_prunable(&self) -> bool {
+        self.prunable
+    }
+}
+
+// TODO: Consider removing these and updating calls.
+
+impl From<usize> for CandidateSize {
+    /// Bare sizes default to non-prunable.
+    fn from(bytes: usize) -> Self {
+        Self::new(bytes)
+    }
+}
+
+impl From<&usize> for CandidateSize {
+    /// Convenience for callers passing `&[usize]` slices.
+    fn from(bytes: &usize) -> Self {
+        Self::new(*bytes)
+    }
+}
+
 /// Configuration for a [PagedPool].
 ///
 /// Defaults:
@@ -490,7 +545,7 @@ impl SizePool {
 /// - maintenance interval: 60s.
 #[derive(Debug, Clone)]
 pub struct PagedPoolConfig {
-    ordered_sizes: Vec<usize>,
+    ordered_sizes: Vec<CandidateSize>,
     mem_limit: usize,
     maintenance_interval: Duration,
 }
@@ -506,16 +561,23 @@ impl Default for PagedPoolConfig {
 }
 
 impl PagedPoolConfig {
-    /// Configure primary memory with the given set of buffer sizes, if valid.
+    /// Configure primary memory with the given candidate buffer sizes, if valid. Accepts bare
+    /// `usize` sizes (non-prunable) or explicit [CandidateSize] values.
     ///
-    /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE])
-    /// or duplicate values for buffer sizes. If no valid value is provided,
-    /// uses [DEFAULT_BUFFER_SIZE].
-    pub fn with_candidate_sizes(&mut self, buffer_sizes: impl Into<Vec<usize>>) -> &mut Self {
-        self.ordered_sizes = buffer_sizes.into();
-        self.ordered_sizes.retain(|&size| size > 0 && size <= MAX_BUFFER_SIZE);
-        self.ordered_sizes.sort();
-        self.ordered_sizes.dedup();
+    /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE]) or duplicate sizes; falls back to
+    /// [DEFAULT_BUFFER_SIZE] if none are valid. On a size collision the prunable candidate wins.
+    pub fn with_candidate_sizes<I>(&mut self, buffer_sizes: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: Into<CandidateSize>,
+    {
+        let mut sizes: Vec<CandidateSize> = buffer_sizes.into_iter().map(Into::into).collect();
+        sizes.retain(|s| s.bytes > 0 && s.bytes <= MAX_BUFFER_SIZE);
+        // Sort by size; keep a prunable candidate ahead of a non-prunable one of the same size so
+        // dedup (which keeps the first) preserves prunability when sizes coincide.
+        sizes.sort_by(|a, b| a.bytes.cmp(&b.bytes).then(b.prunable.cmp(&a.prunable)));
+        sizes.dedup_by_key(|s| s.bytes);
+        self.ordered_sizes = sizes;
         self
     }
 
@@ -549,9 +611,13 @@ impl PagedPoolConfig {
         PagedPool::new(self)
     }
 
-    fn ordered_sizes(&self) -> &[usize] {
+    fn ordered_sizes(&self) -> &[CandidateSize] {
         if self.ordered_sizes.is_empty() {
-            &[DEFAULT_BUFFER_SIZE]
+            const DEFAULT: &[CandidateSize] = &[CandidateSize {
+                bytes: DEFAULT_BUFFER_SIZE,
+                prunable: false,
+            }];
+            DEFAULT
         } else {
             &self.ordered_sizes
         }
@@ -692,10 +758,10 @@ mod tests {
         let mut config = PagedPool::config();
         config.with_candidate_sizes(buffer_sizes);
 
-        let ordered_sizes = config.ordered_sizes();
-        assert!(ordered_sizes.iter().is_sorted(), "Sizes should be sorted");
-        let unique: HashSet<_> = ordered_sizes.iter().collect();
-        assert_eq!(ordered_sizes.len(), unique.len(), "Sizes should be unique");
+        let ordered_bytes: Vec<usize> = config.ordered_sizes().iter().map(|s| s.bytes()).collect();
+        assert!(ordered_bytes.iter().is_sorted(), "Sizes should be sorted");
+        let unique: HashSet<_> = ordered_bytes.iter().collect();
+        assert_eq!(ordered_bytes.len(), unique.len(), "Sizes should be unique");
     }
 
     mod allocation_queue_tests {
@@ -967,6 +1033,43 @@ mod tests {
                 );
                 drop(granted);
             }
+        }
+
+        /// With a read reserve configured, non-read allocations must stop one read-part
+        /// short of the budget, leaving that slice allocatable only by reads. This is the
+        /// pool-level guarantee behind the `held_writes_vs_reads` starvation fix.
+        #[test]
+        fn read_reserve_keeps_last_slice_for_reads() {
+            const BUF: usize = 1024;
+            let additional_reserved = (BUF * 16).max(128 * 1024 * 1024);
+            let mem_limit = BUF * 16 + additional_reserved;
+            let pool = PagedPool::config()
+                .with_candidate_sizes([CandidateSize::prunable(BUF)])
+                .with_memory_limit(mem_limit)
+                .build();
+
+            // Fill the budget with non-read (upload) buffers. The reduced ceiling
+            // (mem_limit - BUF) stops them one buffer short of the full budget.
+            let mut writes = Vec::new();
+            while let Some(buffer) = pool.inner.try_get_buffer(BUF, BufferKind::Append, None, false) {
+                writes.push(buffer);
+            }
+
+            // A further non-read allocation is denied — the last slice is off-limits to writes.
+            assert!(
+                pool.inner
+                    .try_get_buffer(BUF, BufferKind::PutObject, None, false)
+                    .is_none(),
+                "non-read allocation must not consume the read-reserved slice"
+            );
+
+            // But a read can still claim the reserved slice.
+            assert!(
+                pool.inner
+                    .try_get_buffer(BUF, BufferKind::GetObject, None, false)
+                    .is_some(),
+                "read allocation must succeed into the reserved slice"
+            );
         }
     }
 }

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -514,23 +514,6 @@ impl CandidateSize {
     }
 }
 
-// Let callers pass bare sizes (owned or borrowed, e.g. from a `&[usize]` slice); these default to
-// non-prunable. Prunable sizes must be constructed explicitly via `CandidateSize::prunable`.
-//
-// TODO: remove these conversions and make every call site pass an explicit `CandidateSize`, so
-// prunability is always stated rather than silently defaulted (follow-up PR).
-impl From<usize> for CandidateSize {
-    fn from(bytes: usize) -> Self {
-        Self::new(bytes)
-    }
-}
-
-impl From<&usize> for CandidateSize {
-    fn from(bytes: &usize) -> Self {
-        Self::new(*bytes)
-    }
-}
-
 /// Configuration for a [PagedPool].
 ///
 /// Defaults:
@@ -557,17 +540,15 @@ impl Default for PagedPoolConfig {
 }
 
 impl PagedPoolConfig {
-    /// Configure primary memory with the given candidate buffer sizes, if valid. Accepts bare
-    /// `usize` sizes (non-prunable) or explicit [CandidateSize] values.
+    /// Configure primary memory with the given [CandidateSize] buffer sizes, if valid.
     ///
     /// Ignores invalid (0 or greater than [MAX_BUFFER_SIZE]) or duplicate sizes; falls back to
     /// [DEFAULT_BUFFER_SIZE] if none are valid. On a size collision the prunable candidate wins.
     pub fn with_candidate_sizes<I>(&mut self, buffer_sizes: I) -> &mut Self
     where
-        I: IntoIterator,
-        I::Item: Into<CandidateSize>,
+        I: IntoIterator<Item = CandidateSize>,
     {
-        let mut sizes: Vec<CandidateSize> = buffer_sizes.into_iter().map(Into::into).collect();
+        let mut sizes: Vec<CandidateSize> = buffer_sizes.into_iter().collect();
         self.largest_prunable_size = sizes
             .iter()
             .filter(|s| s.prunable && s.bytes > 0)
@@ -653,7 +634,7 @@ mod tests {
     #[test_case(&vec![42u8; 1000], &[128, 1024])]
     fn test_from_slice(original: &[u8], buffer_sizes: &[usize]) {
         let pool = PagedPool::config()
-            .with_candidate_sizes(buffer_sizes)
+            .with_candidate_sizes(buffer_sizes.iter().map(|&b| CandidateSize::new(b)))
             .with_no_memory_limit()
             .build();
         let bytes = copy_from_slice(&pool, original);
@@ -663,7 +644,7 @@ mod tests {
     #[test_case(&[5, 10, 1024])]
     fn test_pages(buffer_sizes: &[usize]) {
         let pool = PagedPool::config()
-            .with_candidate_sizes(buffer_sizes)
+            .with_candidate_sizes(buffer_sizes.iter().map(|&b| CandidateSize::new(b)))
             .with_no_memory_limit()
             .build();
 
@@ -702,7 +683,7 @@ mod tests {
     #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [Duration::MAX, Duration::from_millis(10)])]
     fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Duration) {
         let pool = PagedPool::config()
-            .with_candidate_sizes(buffer_sizes)
+            .with_candidate_sizes(buffer_sizes.iter().map(|&b| CandidateSize::new(b)))
             .with_no_memory_limit()
             .with_maintenance_interval(schedule)
             .build();
@@ -737,7 +718,7 @@ mod tests {
         let buffer_size = 1024;
         let reservations = HashMap::from([(BufferKind::GetObject, 10), (BufferKind::Other, 20)]);
         let pool = PagedPool::config()
-            .with_candidate_sizes([buffer_size])
+            .with_candidate_sizes([CandidateSize::new(buffer_size)])
             .with_no_memory_limit()
             .build();
         let mut buffers = Vec::new();
@@ -758,7 +739,7 @@ mod tests {
     #[test_case(&[8, 8, 10])]
     fn test_ordered_pool_sizes(buffer_sizes: &[usize]) {
         let mut config = PagedPool::config();
-        config.with_candidate_sizes(buffer_sizes);
+        config.with_candidate_sizes(buffer_sizes.iter().map(|&b| CandidateSize::new(b)));
 
         let ordered_bytes: Vec<usize> = config.ordered_sizes().iter().map(|s| s.bytes()).collect();
         assert!(ordered_bytes.iter().is_sorted(), "Sizes should be sorted");
@@ -811,7 +792,7 @@ mod tests {
             let additional_reserved = (buffer_size * 16).max(128 * 1024 * 1024);
             let mem_limit = buffer_size * 16 + additional_reserved;
             PagedPool::config()
-                .with_candidate_sizes([buffer_size])
+                .with_candidate_sizes([CandidateSize::new(buffer_size)])
                 .with_memory_limit(mem_limit)
                 .build()
         }

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -101,6 +101,14 @@ impl<T> Index<BufferKind> for [T; BUFFER_KIND_COUNT] {
 }
 
 impl BufferKind {
+    /// Whether allocations of this kind are prunable: reclaimable/re-fetchable so the memory
+    /// limiter reserves budget for them and lets them use the full memory limit. Reads
+    /// ([`GetObject`](Self::GetObject)) and disk-cache read-backs ([`DiskCache`](Self::DiskCache))
+    /// both serve in-flight reads; writes hold the only copy of their data and are not prunable.
+    pub fn is_prunable(&self) -> bool {
+        matches!(self, BufferKind::GetObject | BufferKind::DiskCache)
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             BufferKind::GetObject => "get_object",

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -53,9 +53,9 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn try_allocate_page(&self, buffer_count: usize) -> Option<ManagedBuffer> {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize, kind: BufferKind) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
-        let result = self.limiter.try_allocate(size, None, false)?;
+        let result = self.limiter.try_allocate(size, kind, false, false)?;
         metrics::gauge!(
             "pool.allocated_pages",
             "buffer_size" => format!("{}", self.buffer_size),

--- a/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
+++ b/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
@@ -3,15 +3,15 @@
 //! Each open write handle should have at least one part-sized buffer's worth of memory budget for
 //! forward progress — S3 multipart uploads require non-final parts to be at least 5 MiB, so this
 //! is a hard floor we cannot reduce by flushing more often. This module enforces a hard cap on
-//! the number of concurrently open write handles, derived from the available data-buffer budget
-//! and write part size:
+//! the number of concurrently open write handles, derived from the buffer budget available to
+//! writes and the write part size:
 //!
 //! ```text
-//! max_concurrent_writes = data_buffer_budget / write_part_size
+//! max_concurrent_writes = non_prunable_data_buffer_budget / write_part_size
 //! ```
 //!
-//! `data_buffer_budget` is `mem_limit - additional_mem_reserved`, exposed by
-//! `PagedPool::data_buffer_budget`.
+//! `non_prunable_data_buffer_budget` (from [`crate::memory::PagedPool`]) subtracts the read reserve
+//! from the data-buffer budget, so writes can't open into the slice kept for reads.
 //!
 //! Acquisition is attempted at `open()` time via [`WriteHandleLimiter::try_acquire`]; on
 //! rejection the operation returns `ENOMEM`. The slot is released when the returned
@@ -67,11 +67,13 @@ pub struct WriteHandleLimiter {
 
 impl WriteHandleLimiter {
     /// Construct a limiter with the cap derived from the configured memory parameters.
-    /// `data_buffer_budget` is the static memory budget available for data buffers, i.e.
-    /// `mem_limit - additional_mem_reserved`. `mem_limit` is retained for diagnostics so that
-    /// rejection errors quote the same value as the user-facing `--memory-target` flag.
-    pub fn new(mem_limit: usize, data_buffer_budget: usize, write_part_size: usize) -> Self {
-        let max_concurrent_writes = data_buffer_budget / write_part_size;
+    /// `non_prunable_data_buffer_budget` is the budget available to non-read allocations, i.e.
+    /// `mem_limit - additional_mem_reserved - prunable_reserved`. Deriving the cap from this (rather than
+    /// the full data-buffer budget) guarantees an admitted writer never has to wait on memory that is
+    /// reserved for reads. `mem_limit` is retained for diagnostics so that rejection errors quote the
+    /// same value as the user-facing `--memory-target` flag.
+    pub fn new(mem_limit: usize, non_prunable_data_buffer_budget: usize, write_part_size: usize) -> Self {
+        let max_concurrent_writes = non_prunable_data_buffer_budget / write_part_size;
         let mem_limit_mib = mem_limit / (1024 * 1024);
         let write_part_size_mib = write_part_size / (1024 * 1024);
         if max_concurrent_writes == 0 {
@@ -215,5 +217,37 @@ mod tests {
         let successes: Vec<_> = threads.into_iter().filter_map(|t| t.join().unwrap()).collect();
         assert_eq!(successes.len(), max, "exactly `max` threads should succeed");
         assert!(limiter.try_acquire().is_err());
+    }
+
+    /// A prunable (read) reserve lowers the write cap, so every admitted writer gets a buffer and a
+    /// read can still allocate — the fix for the `held_writes_vs_reads` stall.
+    #[test]
+    fn read_reserve_lowers_the_write_cap() {
+        use crate::memory::{BufferKind, CandidateSize, PagedPool};
+
+        let pool = PagedPool::config()
+            .with_candidate_sizes([CandidateSize::prunable(PART_SIZE_8MIB)])
+            .with_memory_limit(MIN_LIMIT)
+            .build();
+
+        // The reserve drops the cap: (384 - 8) MiB / 8 MiB = 47, versus 48 without it.
+        let write_limiter = WriteHandleLimiter::new(MIN_LIMIT, pool.non_prunable_data_buffer_budget(), PART_SIZE_8MIB);
+        assert_eq!(write_limiter.max_concurrent_writes(), 47);
+
+        // Every admitted writer pins a part-sized buffer; all fit.
+        let mut slots = Vec::new();
+        let mut pinned_buffers = Vec::new();
+        for _ in 0..write_limiter.max_concurrent_writes() {
+            slots.push(write_limiter.try_acquire().expect("acquire should succeed within cap"));
+            pinned_buffers.push(pool.get_buffer_mut(PART_SIZE_8MIB, BufferKind::Append, None));
+        }
+
+        // A read can still allocate while all admitted writers hold their buffers.
+        assert!(
+            pool.inner
+                .try_get_buffer(PART_SIZE_8MIB, BufferKind::GetObject, None, false)
+                .is_some(),
+            "a read must still allocate its buffer while all admitted writers hold theirs"
+        );
     }
 }

--- a/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
+++ b/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
@@ -7,11 +7,11 @@
 //! writes and the write part size:
 //!
 //! ```text
-//! max_concurrent_writes = non_prunable_data_buffer_budget / write_part_size
+//! max_concurrent_writes = write_buffer_budget / write_part_size
 //! ```
 //!
-//! `non_prunable_data_buffer_budget` (from [`crate::memory::PagedPool`]) subtracts the read reserve
-//! from the data-buffer budget, so writes can't open into the slice kept for reads.
+//! `write_buffer_budget` (from [`crate::memory::PagedPool`]) subtracts the read reserve from the
+//! data-buffer budget, so writes can't open into the slice kept for reads.
 //!
 //! Acquisition is attempted at `open()` time via [`WriteHandleLimiter::try_acquire`]; on
 //! rejection the operation returns `ENOMEM`. The slot is released when the returned
@@ -67,13 +67,13 @@ pub struct WriteHandleLimiter {
 
 impl WriteHandleLimiter {
     /// Construct a limiter with the cap derived from the configured memory parameters.
-    /// `non_prunable_data_buffer_budget` is the budget available to non-read allocations, i.e.
+    /// `write_buffer_budget` is the budget available to writes, i.e.
     /// `mem_limit - additional_mem_reserved - prunable_reserved`. Deriving the cap from this (rather than
     /// the full data-buffer budget) guarantees an admitted writer never has to wait on memory that is
     /// reserved for reads. `mem_limit` is retained for diagnostics so that rejection errors quote the
     /// same value as the user-facing `--memory-target` flag.
-    pub fn new(mem_limit: usize, non_prunable_data_buffer_budget: usize, write_part_size: usize) -> Self {
-        let max_concurrent_writes = non_prunable_data_buffer_budget / write_part_size;
+    pub fn new(mem_limit: usize, write_buffer_budget: usize, write_part_size: usize) -> Self {
+        let max_concurrent_writes = write_buffer_budget / write_part_size;
         let mem_limit_mib = mem_limit / (1024 * 1024);
         let write_part_size_mib = write_part_size / (1024 * 1024);
         if max_concurrent_writes == 0 {
@@ -153,22 +153,22 @@ mod tests {
     use super::*;
 
     const MIN_LIMIT: usize = 512 * 1024 * 1024;
-    const MIN_BUDGET: usize = MIN_LIMIT - 128 * 1024 * 1024;
+    const MIN_WRITE_BUDGET: usize = MIN_LIMIT - 128 * 1024 * 1024;
     const LARGE_LIMIT: usize = 4 * 1024 * 1024 * 1024;
-    const LARGE_BUDGET: usize = LARGE_LIMIT - 512 * 1024 * 1024;
+    const LARGE_WRITE_BUDGET: usize = LARGE_LIMIT - 512 * 1024 * 1024;
     const PART_SIZE_8MIB: usize = 8 * 1024 * 1024;
     const PART_SIZE_1GIB: usize = 1024 * 1024 * 1024;
 
-    #[test_case(MIN_LIMIT, MIN_BUDGET, PART_SIZE_8MIB, 48; "512MiB_limit_8MiB_part")]
-    #[test_case(LARGE_LIMIT, LARGE_BUDGET, PART_SIZE_8MIB, 448; "4GiB_limit_8MiB_part")]
-    #[test_case(MIN_LIMIT, MIN_BUDGET, PART_SIZE_1GIB, 0; "part_larger_than_budget_saturates_to_zero")]
+    #[test_case(MIN_LIMIT, MIN_WRITE_BUDGET, PART_SIZE_8MIB, 48; "512MiB_limit_8MiB_part")]
+    #[test_case(LARGE_LIMIT, LARGE_WRITE_BUDGET, PART_SIZE_8MIB, 448; "4GiB_limit_8MiB_part")]
+    #[test_case(MIN_LIMIT, MIN_WRITE_BUDGET, PART_SIZE_1GIB, 0; "part_larger_than_budget_saturates_to_zero")]
     fn test_max_concurrent_writes(
         mem_limit: usize,
-        data_buffer_budget: usize,
+        write_buffer_budget: usize,
         write_part_size: usize,
         expected: usize,
     ) {
-        let limiter = WriteHandleLimiter::new(mem_limit, data_buffer_budget, write_part_size);
+        let limiter = WriteHandleLimiter::new(mem_limit, write_buffer_budget, write_part_size);
         assert_eq!(limiter.max_concurrent_writes(), expected);
         if expected == 0 {
             assert!(limiter.try_acquire().is_err());
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_try_acquire_caps_at_max() {
-        let limiter = WriteHandleLimiter::new(MIN_LIMIT, MIN_BUDGET, PART_SIZE_8MIB);
+        let limiter = WriteHandleLimiter::new(MIN_LIMIT, MIN_WRITE_BUDGET, PART_SIZE_8MIB);
         let max = limiter.max_concurrent_writes();
 
         let mut slots = Vec::new();
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_release_allows_reacquire() {
-        let limiter = WriteHandleLimiter::new(MIN_LIMIT, MIN_BUDGET, PART_SIZE_8MIB);
+        let limiter = WriteHandleLimiter::new(MIN_LIMIT, MIN_WRITE_BUDGET, PART_SIZE_8MIB);
         let max = limiter.max_concurrent_writes();
 
         let mut slots: Vec<WriteHandleSlot> = (0..max)
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_try_acquire_concurrent_no_overshoot() {
-        let limiter = Arc::new(WriteHandleLimiter::new(MIN_LIMIT, MIN_BUDGET, PART_SIZE_8MIB));
+        let limiter = Arc::new(WriteHandleLimiter::new(MIN_LIMIT, MIN_WRITE_BUDGET, PART_SIZE_8MIB));
         let max = limiter.max_concurrent_writes();
 
         let threads: Vec<_> = (0..max * 4)
@@ -226,12 +226,15 @@ mod tests {
         use crate::memory::{BufferKind, CandidateSize, PagedPool};
 
         let pool = PagedPool::config()
-            .with_candidate_sizes([CandidateSize::prunable(PART_SIZE_8MIB)])
+            .with_candidate_sizes([
+                CandidateSize::prunable(PART_SIZE_8MIB),
+                CandidateSize::new(PART_SIZE_8MIB),
+            ])
             .with_memory_limit(MIN_LIMIT)
             .build();
 
         // The reserve drops the cap: (384 - 8) MiB / 8 MiB = 47, versus 48 without it.
-        let write_limiter = WriteHandleLimiter::new(MIN_LIMIT, pool.non_prunable_data_buffer_budget(), PART_SIZE_8MIB);
+        let write_limiter = WriteHandleLimiter::new(MIN_LIMIT, pool.write_buffer_budget(), PART_SIZE_8MIB);
         assert_eq!(write_limiter.max_concurrent_writes(), 47);
 
         // Every admitted writer pins a part-sized buffer; all fit.

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -393,7 +393,7 @@ mod tests {
 
     use crate::Runtime;
     use crate::data_cache::InMemoryDataCache;
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
     use crate::sync::Arc;
 
     use super::*;
@@ -433,7 +433,10 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let pool = PagedPool::config()
-            .with_candidate_sizes([client.read_part_size(), client.write_part_size()])
+            .with_candidate_sizes([
+                CandidateSize::new(client.read_part_size()),
+                CandidateSize::new(client.write_part_size()),
+            ])
             .with_minimum_memory_limit()
             .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
@@ -1234,7 +1237,7 @@ mod tests {
                     .build(),
             );
             let pool = PagedPool::config()
-                .with_candidate_sizes([part_size])
+                .with_candidate_sizes([CandidateSize::new(part_size)])
                 .with_minimum_memory_limit()
                 .build();
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());
@@ -1305,7 +1308,7 @@ mod tests {
                     .build(),
             );
             let pool = PagedPool::config()
-                .with_candidate_sizes([part_size])
+                .with_candidate_sizes([CandidateSize::new(part_size)])
                 .with_minimum_memory_limit()
                 .build();
             let object = MockObject::ramp(0xaa, object_size as usize, ETag::for_tests());

--- a/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
+++ b/mountpoint-s3-fs/src/prefetch/backpressure_controller.rs
@@ -381,6 +381,7 @@ impl ReadWindowIncrementQueue {
 mod tests {
     use super::*;
 
+    use crate::memory::CandidateSize;
     use futures::executor::block_on;
     use mountpoint_s3_client::mock_client::MockClientError;
     use test_case::test_case;
@@ -507,7 +508,7 @@ mod tests {
         backpressure_config: BackpressureConfig,
     ) -> (BackpressureController, BackpressureLimiter) {
         let pool = PagedPool::config()
-            .with_candidate_sizes([8 * 1024 * 1024])
+            .with_candidate_sizes([CandidateSize::new(8 * 1024 * 1024)])
             .with_memory_limit(backpressure_config.max_read_window_size)
             .build();
         let cursor_state = pool.create_cursor().state();

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -423,7 +423,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::data_cache::InMemoryDataCache;
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
     use crate::object::ObjectId;
 
     use super::*;
@@ -467,7 +467,7 @@ mod tests {
                 .build(),
         );
         let pool = PagedPool::config()
-            .with_candidate_sizes([block_size, client_part_size])
+            .with_candidate_sizes([CandidateSize::new(block_size), CandidateSize::new(client_part_size)])
             .with_minimum_memory_limit()
             .build();
         mock_client.add_object(key, object.clone());
@@ -554,7 +554,7 @@ mod tests {
                 .build(),
         );
         let pool = PagedPool::config()
-            .with_candidate_sizes([block_size, client_part_size])
+            .with_candidate_sizes([CandidateSize::new(block_size), CandidateSize::new(client_part_size)])
             .with_minimum_memory_limit()
             .build();
         mock_client.add_object(key, object.clone());

--- a/mountpoint-s3-fs/src/s3/config.rs
+++ b/mountpoint-s3-fs/src/s3/config.rs
@@ -310,7 +310,7 @@ fn validate_client_for_bucket(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
 
     #[test]
     fn test_read_part_size_within_budget_no_clamp() {
@@ -385,7 +385,7 @@ mod tests {
 
         // Now create pool and client with clamped value to verify end-to-end flow
         let pool = PagedPool::config()
-            .with_candidate_sizes([part_config.read_size_bytes])
+            .with_candidate_sizes([CandidateSize::new(part_config.read_size_bytes)])
             .with_memory_limit(mem_limit_bytes)
             .build();
 

--- a/mountpoint-s3-fs/src/upload/atomic.rs
+++ b/mountpoint-s3-fs/src/upload/atomic.rs
@@ -276,7 +276,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::fs::SseCorruptedError;
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
     use crate::sync::Arc;
     use crate::upload::{Uploader, UploaderConfig};
 
@@ -299,7 +299,7 @@ mod tests {
     {
         let buffer_size = client.write_part_size();
         let pool = PagedPool::config()
-            .with_candidate_sizes([buffer_size])
+            .with_candidate_sizes([CandidateSize::new(buffer_size)])
             .with_minimum_memory_limit()
             .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -445,7 +445,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use crate::memory::PagedPool;
+    use crate::memory::{CandidateSize, PagedPool};
     use crate::sync::Arc;
 
     use super::super::{Uploader, UploaderConfig};
@@ -469,7 +469,10 @@ mod tests {
         Client: ObjectClient + Clone + Send + Sync + 'static,
     {
         let pool = PagedPool::config()
-            .with_candidate_sizes([client.read_part_size(), client.write_part_size()])
+            .with_candidate_sizes([
+                CandidateSize::new(client.read_part_size()),
+                CandidateSize::new(client.write_part_size()),
+            ])
             .with_minimum_memory_limit()
             .build();
         let runtime = Runtime::new(ThreadPool::builder().pool_size(1).create().unwrap());
@@ -1141,7 +1144,7 @@ mod tests {
         // path on every part.
         const NON_BUFFER_FLOOR: usize = 128 * 1024 * 1024;
         let pool = PagedPool::config()
-            .with_candidate_sizes([part_size])
+            .with_candidate_sizes([CandidateSize::new(part_size)])
             .with_memory_limit(NON_BUFFER_FLOOR + part_size)
             .build();
 
@@ -1197,7 +1200,7 @@ mod tests {
         // so set `mem_limit` just above that floor to leave room for exactly one part.
         const LIMITER_MIN_RESERVED: usize = 128 * 1024 * 1024;
         let pool = PagedPool::config()
-            .with_candidate_sizes([part_size])
+            .with_candidate_sizes([CandidateSize::new(part_size)])
             .with_memory_limit(LIMITER_MIN_RESERVED + part_size)
             .build();
         assert_eq!(pool.memory_available_for_reservation(), part_size);

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -14,7 +14,9 @@ use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::fuse::{ErrorLogger, S3FuseFilesystem};
 #[cfg(feature = "manifest")]
 use mountpoint_s3_fs::manifest::{Manifest, ManifestMetablock};
-use mountpoint_s3_fs::memory::{CandidateSize, MINIMUM_MEM_LIMIT, PagedPool};
+#[cfg(feature = "s3_tests")]
+use mountpoint_s3_fs::memory::CandidateSize;
+use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, PagedPool};
 use mountpoint_s3_fs::prefetch::PrefetcherBuilder;
 use mountpoint_s3_fs::s3::{Prefix, S3Path};
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig, Superblock, SuperblockConfig};

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -14,9 +14,7 @@ use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::fuse::{ErrorLogger, S3FuseFilesystem};
 #[cfg(feature = "manifest")]
 use mountpoint_s3_fs::manifest::{Manifest, ManifestMetablock};
-#[cfg(feature = "s3_tests")]
-use mountpoint_s3_fs::memory::CandidateSize;
-use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, PagedPool};
+use mountpoint_s3_fs::memory::{CandidateSize, MINIMUM_MEM_LIMIT, PagedPool};
 use mountpoint_s3_fs::prefetch::PrefetcherBuilder;
 use mountpoint_s3_fs::s3::{Prefix, S3Path};
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig, Superblock, SuperblockConfig};
@@ -329,7 +327,7 @@ pub mod mock_session {
 
         let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
         let pool = PagedPool::config()
-            .with_candidate_sizes([test_config.part_size])
+            .with_candidate_sizes([CandidateSize::new(test_config.part_size)])
             .with_memory_limit(test_config.mem_limit)
             .build();
         let client = Arc::new(
@@ -374,7 +372,10 @@ pub mod mock_session {
 
             let s3_path = S3Path::new(Bucket::new(BUCKET_NAME).unwrap(), Prefix::new(&prefix).unwrap());
             let pool = PagedPool::config()
-                .with_candidate_sizes([test_config.cache_block_size, test_config.part_size])
+                .with_candidate_sizes([
+                    CandidateSize::new(test_config.cache_block_size),
+                    CandidateSize::new(test_config.part_size),
+                ])
                 .with_memory_limit(test_config.mem_limit)
                 .build();
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());
@@ -573,7 +574,10 @@ pub mod s3_session {
             let region = get_test_region();
 
             let pool = PagedPool::config()
-                .with_candidate_sizes([test_config.cache_block_size, test_config.part_size])
+                .with_candidate_sizes([
+                    CandidateSize::new(test_config.cache_block_size),
+                    CandidateSize::new(test_config.part_size),
+                ])
                 .with_memory_limit(test_config.mem_limit)
                 .build();
             let cache = cache_factory(test_config.cache_block_size as u64, pool.clone());

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -14,7 +14,7 @@ use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::fuse::{ErrorLogger, S3FuseFilesystem};
 #[cfg(feature = "manifest")]
 use mountpoint_s3_fs::manifest::{Manifest, ManifestMetablock};
-use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, PagedPool};
+use mountpoint_s3_fs::memory::{CandidateSize, MINIMUM_MEM_LIMIT, PagedPool};
 use mountpoint_s3_fs::prefetch::PrefetcherBuilder;
 use mountpoint_s3_fs::s3::{Prefix, S3Path};
 use mountpoint_s3_fs::{Runtime, S3Filesystem, S3FilesystemConfig, Superblock, SuperblockConfig};
@@ -528,7 +528,7 @@ pub mod s3_session {
         let mount_dir = tempfile::tempdir().unwrap();
 
         let pool = PagedPool::config()
-            .with_candidate_sizes([test_config.part_size])
+            .with_candidate_sizes([CandidateSize::prunable(test_config.part_size)])
             .with_memory_limit(test_config.mem_limit)
             .build();
         let client_config = S3ClientConfig::default()

--- a/mountpoint-s3-fs/tests/common/mod.rs
+++ b/mountpoint-s3-fs/tests/common/mod.rs
@@ -26,7 +26,7 @@ use mountpoint_s3_client::config::{
 };
 use mountpoint_s3_client::mock_client::MockClient;
 use mountpoint_s3_fs::fs::{DirectoryEntry, DirectoryReplier};
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::metrics::metrics_tracing_span_layer;
 use mountpoint_s3_fs::prefetch::Prefetcher;
 use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path};
@@ -53,7 +53,7 @@ pub fn make_test_filesystem(
             .build(),
     );
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let fs = make_test_filesystem_with_client(client.clone(), pool, bucket, prefix, config);

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -25,7 +25,7 @@ use mountpoint_s3_fs::fs::error_metadata::MOUNTPOINT_ERROR_LOOKUP_NONEXISTENT;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
 use mountpoint_s3_fs::fs::error_metadata::{ErrorMetadata, MOUNTPOINT_ERROR_CLIENT};
 use mountpoint_s3_fs::fs::{CacheConfig, FUSE_ROOT_INODE, OpenFlags, RenameFlags, TimeToLive, ToErrno};
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::s3::{Prefix, S3Personality};
 use mountpoint_s3_fs::{S3Filesystem, S3FilesystemConfig};
 use nix::unistd::{getgid, getuid};
@@ -731,7 +731,7 @@ async fn test_upload_aborted_on_write_failure() {
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
         PagedPool::config()
-            .with_candidate_sizes([part_size])
+            .with_candidate_sizes([CandidateSize::new(part_size)])
             .with_minimum_memory_limit()
             .build(),
         BUCKET_NAME,
@@ -810,7 +810,7 @@ async fn test_upload_aborted_on_fsync_failure() {
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
         PagedPool::config()
-            .with_candidate_sizes([part_size])
+            .with_candidate_sizes([CandidateSize::new(part_size)])
             .with_minimum_memory_limit()
             .build(),
         BUCKET_NAME,
@@ -874,7 +874,7 @@ async fn test_upload_aborted_on_release_failure() {
     let fs = make_test_filesystem_with_client(
         Arc::new(failure_client),
         PagedPool::config()
-            .with_candidate_sizes([part_size])
+            .with_candidate_sizes([CandidateSize::new(part_size)])
             .with_minimum_memory_limit()
             .build(),
         BUCKET_NAME,
@@ -1541,7 +1541,7 @@ async fn test_lookup_404_not_an_error() {
     let (bucket, prefix) = get_test_bucket_and_prefix(name);
     let part_size = 1024 * 1024;
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let client_config = S3ClientConfig::default()
@@ -1581,7 +1581,7 @@ async fn test_lookup_forbidden() {
 
     let part_size = 1024 * 1024;
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let auth_config = get_crt_client_auth_config(get_scoped_down_credentials(&policy).await);
@@ -1667,7 +1667,7 @@ async fn test_rename_support_is_cached() {
 
     let part_size = 1024 * 1024;
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let client = Arc::new(

--- a/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/cache_test.rs
@@ -19,7 +19,7 @@ use {
     mountpoint_s3_fs::Runtime,
     mountpoint_s3_fs::data_cache::DataCache,
     mountpoint_s3_fs::fuse::session::FuseSession,
-    mountpoint_s3_fs::memory::PagedPool,
+    mountpoint_s3_fs::memory::{CandidateSize, PagedPool},
     mountpoint_s3_fs::object::ObjectId,
     mountpoint_s3_fs::prefetch::Prefetcher,
     mountpoint_s3_fs::s3::S3Path,
@@ -58,7 +58,10 @@ async fn express_invalid_block_read() {
 
     // Mount the bucket
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -123,7 +126,10 @@ fn express_cache_write_read(key_suffix: &str, key_size: usize, object_size: usiz
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -152,7 +158,10 @@ fn disk_cache_write_read(key_suffix: &str, key_size: usize, object_size: usize) 
         limit: Default::default(),
     };
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let cache = DiskDataCache::new(cache_config, pool.clone());
@@ -176,7 +185,10 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
     use mountpoint_s3_fs::s3::{Bucket, Prefix};
 
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool.clone());
@@ -194,7 +206,10 @@ fn express_cache_write_read_sse(sse_type: Option<String>, kms_key_id: Option<Str
 #[cfg(feature = "s3express_tests")]
 async fn express_cache_read_empty() {
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
@@ -215,7 +230,7 @@ async fn disk_cache_read_empty() {
         limit: Default::default(),
     };
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize])
+        .with_candidate_sizes([CandidateSize::new(CACHE_BLOCK_SIZE as usize)])
         .with_no_memory_limit()
         .build();
     let cache = DiskDataCache::new(cache_config, pool);
@@ -229,7 +244,10 @@ async fn express_cache_verify_fail_non_express() {
     use mountpoint_s3_fs::data_cache::DataCacheError;
 
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(CLIENT_PART_SIZE, CLIENT_PART_SIZE, Default::default(), pool);
@@ -259,7 +277,10 @@ async fn express_cache_verify_fail_forbidden() {
     use mountpoint_s3_client::config::{
         Allocator, CredentialsProvider, CredentialsProviderStaticOptions, S3ClientAuthConfig,
     };
-    use mountpoint_s3_fs::{data_cache::DataCacheError, memory::PagedPool};
+    use mountpoint_s3_fs::{
+        data_cache::DataCacheError,
+        memory::{CandidateSize, PagedPool},
+    };
 
     let bucket_name = get_standard_bucket();
     let cache_bucket_name = get_express_bucket();
@@ -281,7 +302,10 @@ async fn express_cache_verify_fail_forbidden() {
     let provider = CredentialsProvider::new_static(&Allocator::default(), config).unwrap();
 
     let pool = PagedPool::config()
-        .with_candidate_sizes([CACHE_BLOCK_SIZE as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(CACHE_BLOCK_SIZE as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let client = create_crt_client(
@@ -394,7 +418,10 @@ fn express_cache_expected_bucket_owner(cache_bucket: String, owner_checked: bool
     let prefix = get_test_prefix("express_expected_bucket_owner");
     let cache_config = ExpressDataCacheConfig::new(&cache_bucket, &bucket);
     let pool = PagedPool::config()
-        .with_candidate_sizes([cache_config.block_size as usize, CLIENT_PART_SIZE])
+        .with_candidate_sizes([
+            CandidateSize::new(cache_config.block_size as usize),
+            CandidateSize::new(CLIENT_PART_SIZE),
+        ])
         .with_no_memory_limit()
         .build();
     let cache = ExpressDataCache::new(client.clone(), cache_config);

--- a/mountpoint-s3-fs/tests/fuse_tests/write_test.rs
+++ b/mountpoint-s3-fs/tests/fuse_tests/write_test.rs
@@ -18,6 +18,8 @@ use mountpoint_s3_fs::ServerSideEncryption;
 #[cfg(feature = "s3_tests")]
 use mountpoint_s3_fs::content_type::ContentTypeDetection;
 use mountpoint_s3_fs::fs::{CacheConfig, UploadChecksumAlgorithm};
+#[cfg(feature = "s3_tests")]
+use mountpoint_s3_fs::memory::write_buffer_budget_for;
 
 use crate::common::fuse::{self, TestSessionConfig, TestSessionCreator, read_dir_to_entry_names};
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
@@ -1380,19 +1382,20 @@ fn write_with_sse_settings_test(policy: &str, sse: ServerSideEncryption, should_
 }
 
 #[cfg(feature = "s3_tests")]
-// `additional_mem_reserved = max(mem_limit/8, 128 MiB)` and `write_part_size = 8 MiB`, so the
-// write-handle cap is `(mem_limit - additional_mem_reserved) / 8 MiB`:
-// - `mem_limit = 512 MiB` → reserved 128 MiB, budget 384 MiB, cap 48 (boundary case at the
-//   minimum supported memory target).
-// - `mem_limit = 2 GiB` → reserved 256 MiB, budget 1792 MiB, cap 224 (high-fan-out case
-//   exercising the concurrent-write path without bumping into the cap).
-#[test_case(512 * 1024 * 1024, 48; "minimum_mem_limit_48_writers")]
-#[test_case(2 * 1024 * 1024 * 1024, 224; "2gib_mem_limit_224_writers")]
-fn concurrent_open_for_write_test(mem_limit: usize, max_files: usize) {
+// The write-handle cap is `write_buffer_budget(mem_limit, write_part_size) / write_part_size`, where
+// the write budget is `mem_limit - additional_mem_reserved - one prunable read part`. With the
+// default 8 MiB part size: `mem_limit = 512 MiB` → cap 47 (boundary at the minimum memory target),
+// `mem_limit = 2 GiB` → cap 223 (high-fan-out). Derived here so the expectation can't drift from the
+// limiter.
+#[test_case(512 * 1024 * 1024; "minimum_mem_limit")]
+#[test_case(2 * 1024 * 1024 * 1024; "2gib_mem_limit")]
+fn concurrent_open_for_write_test(mem_limit: usize) {
     let test_config = TestSessionConfig {
         mem_limit,
         ..Default::default()
     };
+    let part_size = test_config.part_size;
+    let max_files = write_buffer_budget_for(mem_limit, part_size) / part_size;
     let test_session = fuse::s3_session::new("concurrent_open_for_write_test", test_config);
 
     let file_names: Vec<_> = (0..max_files).map(|i| format!("file-{i}")).collect();
@@ -1431,20 +1434,22 @@ fn concurrent_open_for_write_test(mem_limit: usize, max_files: usize) {
 #[cfg(feature = "s3_tests")]
 #[test]
 fn open_for_write_returns_enomem_when_cap_exhausted() {
-    // With `mem_limit = 512 MiB`, `additional_mem_reserved = max(mem_limit/8, 128 MiB) = 128 MiB`,
-    // and the default `write_part_size = 8 MiB`, the cap is `(512 - 128) / 8 = 48` writers.
+    // With `mem_limit = 512 MiB`, `additional_mem_reserved = 128 MiB`, a one-part (8 MiB) read
+    // reserve, and the default 8 MiB write part size, the cap is `(512 - 128 - 8) / 8 = 47` writers.
+    // Derived from `write_buffer_budget_for` so it can't drift from the limiter.
     const MEM_LIMIT: usize = 512 * 1024 * 1024;
-    const CAP: usize = 48;
 
     let test_config = TestSessionConfig {
         mem_limit: MEM_LIMIT,
         ..Default::default()
     };
+    let part_size = test_config.part_size;
+    let cap = write_buffer_budget_for(MEM_LIMIT, part_size) / part_size;
     let test_session = fuse::s3_session::new("open_for_write_returns_enomem_when_cap_exhausted", test_config);
 
-    // Open `CAP` files for write — all should succeed.
-    let mut open_files = Vec::with_capacity(CAP);
-    for i in 0..CAP {
+    // Open `cap` files for write — all should succeed.
+    let mut open_files = Vec::with_capacity(cap);
+    for i in 0..cap {
         let path = test_session.mount_path().join(format!("file-{i}"));
         let f = File::options()
             .append(true)
@@ -1455,7 +1460,7 @@ fn open_for_write_returns_enomem_when_cap_exhausted() {
     }
 
     // The next open exceeds the cap → ENOMEM at the syscall boundary.
-    let extra_path = test_session.mount_path().join(format!("file-{CAP}"));
+    let extra_path = test_session.mount_path().join(format!("file-{cap}"));
     let err = File::options()
         .append(true)
         .create(true)

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -12,7 +12,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use mountpoint_s3_fs::S3Filesystem;
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use test_case::test_case;
 
 mod common;
@@ -216,7 +216,7 @@ async fn create_fs_with_mock_s3(bucket: &str) -> (S3Filesystem<S3CrtClient>, Moc
         .endpoint(endpoint);
     let part_size = 1024 * 1024;
     let pool = PagedPool::config()
-        .with_candidate_sizes([part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_minimum_memory_limit()
         .build();
     let client_config = S3ClientConfig::default()

--- a/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup/budget_hold.rs
@@ -4,18 +4,18 @@ use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use mountpoint_s3_fs::memory::data_buffer_budget_for;
+use mountpoint_s3_fs::memory::write_buffer_budget_for;
 
 use super::SetupGuard;
 use crate::stress::test_objects;
 
 const STUB_WRITE: usize = 4 * 1024;
 
-/// Number of full write-part buffers that fit in the data-buffer budget at `mem_limit` — i.e. the
+/// Number of full write-part buffers that fit in the write budget at `mem_limit` — i.e. the
 /// concurrent write-handle cap (`WriteHandleLimiter`) and the most parts a [`BudgetHold`] can pin.
 /// Scenarios typically hold `budget_parts(..) - n` to leave `n` parts free.
 pub fn budget_parts(mem_limit: usize, part_size: usize) -> usize {
-    data_buffer_budget_for(mem_limit) / part_size
+    write_buffer_budget_for(mem_limit, part_size) / part_size
 }
 
 /// A held slice of the data-buffer budget: a set of open write handles, each pinning one

--- a/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
@@ -8,7 +8,7 @@ use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
 use crate::stress::workers::{HoldingWriter, LARGE_READ_OBJECT, SequentialReader};
 
-const NUM_WRITERS: usize = 48; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
+const NUM_WRITERS: usize = 47; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
 const NUM_READERS: usize = 16;
 const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
 const WRITE_BEFORE_HOLD: usize = PART_SIZE + 4 * 1024;

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
@@ -1,5 +1,5 @@
 //! `many_readers_held_budget`: 32 readers against a default 8 MiB part, with the setup phase
-//! hard-pinning all but one part of the budget so all 32 contend for a single free 8 MiB read part.
+//! hard-pinning the entire write budget so all 32 contend for the single free read-reserve part.
 
 use std::iter::repeat_n;
 use std::path::Path;
@@ -18,9 +18,10 @@ const NUM_READERS: usize = 32;
 const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
 const READ_CHUNK: usize = PART_SIZE;
 
-/// Setup phase: pin all but one part of the budget before the readers start.
+/// Setup phase: pin the entire write budget before the readers start, leaving only the read
+/// reserve (one 8 MiB part) free — so all 32 readers contend for it.
 fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
-    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE);
     Box::new(hold_budget_parts(SCOPE, held_parts, mount_path))
 }
 

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
@@ -1,5 +1,5 @@
 //! `single_reader_held_budget`: a single reader against a default 8 MiB part, with the setup phase
-//! hard-pinning all but one part of the budget so only one 8 MiB read part is free.
+//! hard-pinning the entire write budget so only the read reserve (one 8 MiB part) is free.
 
 use std::iter::repeat_n;
 use std::path::Path;
@@ -18,9 +18,10 @@ const NUM_READERS: usize = 1;
 const PART_SIZE: usize = 8 * 1024 * 1024; // 8 MiB — the default, realistic part size
 const READ_CHUNK: usize = PART_SIZE;
 
-/// Setup phase: pin all but one part of the budget before the reader starts.
+/// Setup phase: pin the entire write budget before the reader starts, leaving only the read
+/// reserve (one 8 MiB part) free.
 fn hold(mount_path: &Path) -> Box<dyn SetupGuard> {
-    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE) - 1;
+    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE);
     Box::new(hold_budget_parts(SCOPE, held_parts, mount_path))
 }
 

--- a/mountpoint-s3-fs/tests/stress/test_objects.rs
+++ b/mountpoint-s3-fs/tests/stress/test_objects.rs
@@ -16,7 +16,7 @@ use aws_sdk_s3::operation::head_object::HeadObjectError;
 use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_fs::Runtime;
-use mountpoint_s3_fs::memory::{MINIMUM_MEM_LIMIT, PagedPool, effective_total_memory};
+use mountpoint_s3_fs::memory::{CandidateSize, MINIMUM_MEM_LIMIT, PagedPool, effective_total_memory};
 use mountpoint_s3_fs::upload::{Uploader, UploaderConfig};
 
 use crate::common::s3::{get_test_bucket, get_test_endpoint_config, get_test_region, get_test_sdk_client};
@@ -102,7 +102,7 @@ fn build_test_object_uploader(max_object_size: usize) -> (Uploader<S3CrtClient>,
     let part_size = DEFAULT_WRITE_PART_SIZE.max(min_part_size);
 
     let pool = PagedPool::config()
-        .with_candidate_sizes(vec![part_size])
+        .with_candidate_sizes([CandidateSize::new(part_size)])
         .with_memory_limit(compute_test_object_mem_budget())
         .build();
 

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -10,7 +10,7 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::data_cache::{DataCacheConfig, ManagedCacheDir};
 use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::logging::init_logging;
-use mountpoint_s3_fs::memory::PagedPool;
+use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
 use mountpoint_s3_fs::metrics::MetricsConfig;
 use mountpoint_s3_fs::s3::config::ClientConfig;
 use mountpoint_s3_fs::s3::{S3Path, S3Personality};
@@ -200,9 +200,9 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     // Set up a paged memory pool with the validated read_size_bytes
     let pool = PagedPool::config()
         .with_candidate_sizes([
-            args.cache_block_size_in_bytes() as usize,
-            client_config.part_config.read_size_bytes,
-            client_config.part_config.write_size_bytes,
+            CandidateSize::prunable(args.cache_block_size_in_bytes() as usize),
+            CandidateSize::prunable(client_config.part_config.read_size_bytes),
+            CandidateSize::new(client_config.part_config.write_size_bytes),
         ])
         .with_memory_limit(memory_limit.bytes())
         .with_maintenance_interval(Duration::from_secs(60))


### PR DESCRIPTION
Under memory pressure, concurrent writers could consume the entire data-buffer budget and starve active reads (the `held_writes_vs_reads` stress scenario stall). This reserves a slice of the pool budget for "prunable" allocations (reads and disk-cache read-backs, which are reclaimable/re-fetchable) that non-prunable allocations (writes) cannot take:

- `MemoryLimiter` reserves budget sized from the prunable candidate buffer sizes, and non-prunable allocations stop that many bytes short of the limit.
- The `WriteHandleLimiter` open-time cap is derived from the non-prunable budget, so an admitted writer is always backed by budget and never parks on memory reserved for reads.
- Buffer sizes are now configured as `CandidateSize` values carrying a `prunable` flag; reads and the disk cache block are marked prunable.

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No