### PR TITLE
fix: Use FUSE abort to prevent stress tests from hanging indefinitely

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,10 @@
 [profile.ci]
 # Do not cancel the test run on the first failure.
 fail-fast = false
+
+[[profile.default.overrides]]
+# Terminate stress tests that exceed 20 minutes. Stress tests run for 900s (15 min);
+# anything beyond 20 min is hung in cleanup (e.g. FUSE unmount waiting for in-flight requests).
+# grace-period = 0 sends SIGKILL immediately (SIGTERM can't kill processes in uninterruptible state).
+filter = 'test(/stress::scenarios/)'
+slow-timeout = { period = "60s", terminate-after = 20, grace-period = "0s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,8 +3,9 @@
 fail-fast = false
 
 [[profile.default.overrides]]
-# Terminate stress tests that exceed 20 minutes. Stress tests run for 900s (15 min);
-# anything beyond 20 min is hung in cleanup (e.g. FUSE unmount waiting for in-flight requests).
+# Terminate stress tests that exceed 45 minutes. Stress tests run for 900s (15 min, see
+# STRESS_DURATION_SECS in .github/workflows/stress.yml); 45 min timeout allows buffer for
+# setup/cleanup phases that might take longer.
 # grace-period = 0 sends SIGKILL immediately (SIGTERM can't kill processes in uninterruptible state).
 filter = 'test(/stress::scenarios/)'
-slow-timeout = { period = "60s", terminate-after = 20, grace-period = "0s" }
+slow-timeout = { period = "60s", terminate-after = 45, grace-period = "0s" }

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -28,6 +28,7 @@ env:
   S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}
   S3_ENDPOINT_URL: ${{ vars.S3_BENCH_ENDPOINT_URL }}
   S3_REGION: ${{ vars.S3_BENCH_REGION }}
+  # Stress test duration. If changed, also update slow-timeout in .config/nextest.toml
   STRESS_DURATION_SECS: "900"
 
 jobs:

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -1,6 +1,7 @@
 //! Core harness for stress scenarios.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::thread;
@@ -159,18 +160,15 @@ pub fn run(scenario: Scenario) {
                 .enumerate()
                 .filter_map(|(id, h)| (!h.is_finished()).then_some(labels[id].as_str()))
                 .collect();
-            // Workers are wedged (likely in uninterruptible FUSE syscalls). Clean unmount
-            // would hang in fuse_session_unmount waiting for the FUSE session thread, which
-            // is stuck waiting for the workers. Skip cleanup and panic immediately.
-            // TODO: Avoid resource leak
-            tracing::warn!(
-                scenario = scenario_name,
-                "stress: workers wedged after stop; skipping clean unmount to avoid a deadlocked \
-                 teardown. Leaking the mount dir, FUSE mount entry, and setup-guard objects"
+            // Workers are wedged (likely in uninterruptible FUSE syscalls). Abort FUSE connection
+            // to fail in-flight operations with EIO, then terminate immediately.
+            eprintln!(
+                "stress: workers wedged after stop; aborting FUSE connection and exiting. \
+                 Workers {stuck:?} did not finish within {max_join_wait:?} after stop"
             );
-            std::mem::forget(setup_guard);
-            std::mem::forget(session);
-            panic!("stress: workers {stuck:?} did not finish within {max_join_wait:?} after stop");
+            abort_fuse_connections(&mount_path);
+            // _exit() terminates immediately without waiting for threads or running atexit handlers.
+            unsafe { libc::_exit(1) };
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -184,7 +182,31 @@ pub fn run(scenario: Scenario) {
     }
 
     drop(setup_guard);
-    drop(session);
+
+    // Attempt unmount with timeout. If it hangs, abort FUSE connection.
+    let session_thread = thread::spawn(move || drop(session));
+    let unmount_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if session_thread.is_finished() {
+            let _ = session_thread.join();
+            break;
+        }
+        if Instant::now() >= unmount_deadline {
+            eprintln!("stress: unmount hung after 30s, aborting FUSE connection");
+            // Abort FUSE connection - fails all in-flight requests with EIO
+            abort_fuse_connections(&mount_path);
+            thread::sleep(Duration::from_secs(2));
+            if session_thread.is_finished() {
+                let _ = session_thread.join();
+                break;
+            } else {
+                // Thread still stuck even after FUSE abort — terminate immediately.
+                eprintln!("stress: unmount thread still stuck after FUSE abort, terminating");
+                unsafe { libc::_exit(1) };
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 
     let stalled = stalled_worker.load(Ordering::SeqCst);
     if stalled != NO_STALL {
@@ -260,4 +282,22 @@ fn read_duration_env() -> Duration {
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(DEFAULT_DURATION_SECS);
     Duration::from_secs(secs)
+}
+
+/// Abort all FUSE connections by writing to /sys/fs/fuse/connections/*/abort.
+/// This fails all in-flight FUSE operations with EIO, unblocking stuck threads.
+fn abort_fuse_connections(mount_path: &Path) {
+    use std::fs;
+    let connections_dir = Path::new("/sys/fs/fuse/connections");
+    if let Ok(entries) = fs::read_dir(connections_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let abort_file = entry.path().join("abort");
+            if let Err(e) = fs::write(&abort_file, b"1") {
+                eprintln!("stress: failed to abort FUSE connection {:?}: {}", abort_file, e);
+            } else {
+                eprintln!("stress: aborted FUSE connection {:?}", entry.path());
+            }
+        }
+    }
+    let _ = mount_path; // unused but kept for future filtering by mountpoint
 }

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -194,12 +194,9 @@ pub fn run(scenario: Scenario) {
         }
         if Instant::now() >= unmount_deadline {
             eprintln!("stress: unmount hung after 30s, aborting FUSE connection and failing test");
-            // Abort FUSE connection - fails all in-flight requests with EIO
+            // Abort FUSE connection - fails all in-flight requests with EIO, then exit immediately.
             abort_fuse_connections(&mount_path);
-            thread::sleep(Duration::from_secs(2));
-            let _ = session_thread.join();
-            // Unmount hanging for 30s is a test failure even if FUSE abort unblocked it.
-            std::process::exit(1);
+            unsafe { libc::_exit(1) };
         }
         thread::sleep(Duration::from_millis(100));
     }

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -1,6 +1,7 @@
 //! Core harness for stress scenarios.
 
 use std::collections::HashMap;
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -192,18 +193,13 @@ pub fn run(scenario: Scenario) {
             break;
         }
         if Instant::now() >= unmount_deadline {
-            eprintln!("stress: unmount hung after 30s, aborting FUSE connection");
+            eprintln!("stress: unmount hung after 30s, aborting FUSE connection and failing test");
             // Abort FUSE connection - fails all in-flight requests with EIO
             abort_fuse_connections(&mount_path);
             thread::sleep(Duration::from_secs(2));
-            if session_thread.is_finished() {
-                let _ = session_thread.join();
-                break;
-            } else {
-                // Thread still stuck even after FUSE abort — terminate immediately.
-                eprintln!("stress: unmount thread still stuck after FUSE abort, terminating");
-                unsafe { libc::_exit(1) };
-            }
+            let _ = session_thread.join();
+            // Unmount hanging for 30s is a test failure even if FUSE abort unblocked it.
+            std::process::exit(1);
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -284,20 +280,42 @@ fn read_duration_env() -> Duration {
     Duration::from_secs(secs)
 }
 
-/// Abort all FUSE connections by writing to /sys/fs/fuse/connections/*/abort.
-/// This fails all in-flight FUSE operations with EIO, unblocking stuck threads.
+/// Abort the FUSE connection for the given mount path by writing to
+/// /sys/fs/fuse/connections/<minor>/abort. This fails all in-flight FUSE
+/// operations on that mount with EIO, unblocking stuck threads.
 fn abort_fuse_connections(mount_path: &Path) {
-    use std::fs;
-    let connections_dir = Path::new("/sys/fs/fuse/connections");
-    if let Ok(entries) = fs::read_dir(connections_dir) {
-        for entry in entries.filter_map(Result::ok) {
-            let abort_file = entry.path().join("abort");
-            if let Err(e) = fs::write(&abort_file, b"1") {
-                eprintln!("stress: failed to abort FUSE connection {:?}: {}", abort_file, e);
-            } else {
-                eprintln!("stress: aborted FUSE connection {:?}", entry.path());
+    // Find the FUSE minor number for our mount by parsing /proc/self/mountinfo.
+    // Each line has format: "id parent major:minor root mount_point ..."
+    let minor = (|| -> Option<String> {
+        let mountinfo = fs::read_to_string("/proc/self/mountinfo").ok()?;
+        let mount_path_str = mount_path.to_str()?;
+        for line in mountinfo.lines() {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() >= 5 && fields[4] == mount_path_str {
+                // Field 2 is "major:minor"
+                let dev = fields[2];
+                let minor = dev.split(':').nth(1)?;
+                return Some(minor.to_string());
             }
         }
+        None
+    })();
+
+    match minor {
+        Some(minor) => {
+            let abort_file = Path::new("/sys/fs/fuse/connections").join(&minor).join("abort");
+            if let Err(e) = fs::write(&abort_file, b"1") {
+                eprintln!(
+                    "stress: failed to abort FUSE connection {}: {}",
+                    abort_file.display(),
+                    e
+                );
+            } else {
+                eprintln!("stress: aborted FUSE connection (minor={})", minor);
+            }
+        }
+        None => {
+            eprintln!("stress: could not find FUSE minor number for {:?}", mount_path);
+        }
     }
-    let _ = mount_path; // unused but kept for future filtering by mountpoint
 }


### PR DESCRIPTION
Stress tests hang indefinitely on CI when `fuse_session_unmount` waits for in-flight FUSE requests that never complete. Fixed by using the kernel's FUSE abort mechanism (/sys/fs/fuse/connections/*/abort) to fail stuck requests with EIO, followed by `libc::_exit(1)` to terminate immediately, with a nextest per-test timeout (45 min) as a safety net.

[Tested on the CI](https://github.com/awslabs/mountpoint-s3/actions/runs/30545339202/job/90908339229#logs).

### Does this change impact existing behavior?

No breaking change.

### Does this change need a changelog entry? Does it require a version change?

No, this is a test-only change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
