### PR TITLE
Allow unlink for LocalUnopened files

### DIFF
--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Allow `unlink` of files in the `LocalUnopened` state (created but never opened, for example when a process is killed between the `mknod` and `open` calls), so they are no longer permanently stuck. ([#1743](https://github.com/awslabs/mountpoint-s3/issues/1743))
+
 ## v0.10.0 (July 20, 2026)
 
 * Add `tls_config` field on `s3::config::ClientConfig` so callers can configure a custom CA trust store through to the underlying S3 client. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834))

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -353,6 +353,10 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
         inode: Inode,
         fh: u64,
     ) -> Result<Option<PendingUploadHook>, InodeError> {
+        if locked_inode.unlinked {
+            debug!(ino = inode.ino(), "cannot read an unlinked inode");
+            return Err(InodeError::InodeDoesNotExist(inode.ino()));
+        }
         match locked_inode.write_status {
             WriteStatus::LocalUnopened => Err(InodeError::InodeNotReadableWhileWriting(inode.err())),
             WriteStatus::LocalOpenForWriting | WriteStatus::PendingRename | WriteStatus::Remote => {
@@ -389,6 +393,10 @@ impl<OC: ObjectClient + Send + Sync> Superblock<OC> {
             locked_inode.write_status = WriteStatus::LocalOpenForWriting;
             Ok(())
         };
+        if locked_inode.unlinked {
+            debug!(ino = inode.ino(), "cannot write to an unlinked inode");
+            return Err(InodeError::InodeDoesNotExist(inode.ino()));
+        }
         match locked_inode.write_status {
             WriteStatus::LocalUnopened => {
                 setup_inode_for_writing(locked_inode)?;
@@ -695,42 +703,54 @@ impl<OC: ObjectClient + Send + Sync + Clone> Metablock for Superblock<OC> {
             return Err(InodeError::IsDirectory(inode.err()));
         }
 
-        let write_status = {
-            let inode_state = inode.get_inode_state()?;
-            inode_state.write_status
+        // Decide what cleanup is needed, and for local files mark the inode `unlinked` while we
+        // still hold the state lock. `LocalUnopened` has no object in S3, so there is no remote
+        // call between reading the write status and recording the unlink, which closes the window
+        // where a concurrent `open` could transition the inode to `LocalOpenForWriting` and later
+        // flush an object we would never clean up.
+        let needs_remote_delete = {
+            let mut inode_state = inode.get_mut_inode_state()?;
+            match inode_state.write_status {
+                WriteStatus::LocalOpenForWriting | WriteStatus::PendingRename => {
+                    // In the future, we may permit `unlink` and cancel any in-flight uploads.
+                    warn!(
+                        parent = parent_ino,
+                        ?name,
+                        write_status = ?inode_state.write_status,
+                        "unlink on local file not allowed until write is complete",
+                    );
+                    return Err(InodeError::UnlinkNotPermittedWhileWriting(inode.err()));
+                }
+                WriteStatus::LocalUnopened => {
+                    // The object was never uploaded to S3, so there is nothing to delete remotely.
+                    debug!(parent=?parent_ino, ?name, "unlink on LocalUnopened file, no S3 cleanup needed");
+                    inode_state.unlinked = true;
+                    false
+                }
+                WriteStatus::Remote => true,
+            }
         };
 
-        match write_status {
-            WriteStatus::LocalUnopened | WriteStatus::LocalOpenForWriting | WriteStatus::PendingRename => {
-                // In the future, we may permit `unlink` and cancel any in-flight uploads.
-                warn!(
-                    parent = parent_ino,
-                    ?name,
-                    "unlink on local file not allowed until write is complete",
-                );
-                return Err(InodeError::UnlinkNotPermittedWhileWriting(inode.err()));
-            }
-            WriteStatus::Remote => {
-                let bucket = &self.inner.s3_path.bucket;
-                let s3_key = self.inner.full_key_for_inode(&inode);
-                debug!(parent=?parent_ino, ?name, "unlink on remote file will delete key {}", s3_key);
-                let delete_obj_result = self.inner.client.delete_object(bucket, &s3_key).await;
+        if needs_remote_delete {
+            let bucket = &self.inner.s3_path.bucket;
+            let s3_key = self.inner.full_key_for_inode(&inode);
+            debug!(parent=?parent_ino, ?name, "unlink on remote file will delete key {}", s3_key);
+            let delete_obj_result = self.inner.client.delete_object(bucket, &s3_key).await;
 
-                match delete_obj_result {
-                    Ok(_res) => (),
-                    Err(e) => {
-                        error!(
-                            inode=%inode.err(),
-                            error=?e,
-                            "DeleteObject failed for unlink",
-                        );
-                        Err(InodeError::client_error(e, "DeleteObject failed", bucket, &s3_key))?;
-                    }
-                };
-            }
+            match delete_obj_result {
+                Ok(_res) => (),
+                Err(e) => {
+                    error!(
+                        inode=%inode.err(),
+                        error=?e,
+                        "DeleteObject failed for unlink",
+                    );
+                    Err(InodeError::client_error(e, "DeleteObject failed", bucket, &s3_key))?;
+                }
+            };
         }
 
-        // Now that the entry was deleted from S3, we need to delete it from the superblock.
+        // Now that any S3 object was deleted, we need to delete the entry from the superblock.
         // The Linux Kernel's VFS should lock both the parent and child (https://www.kernel.org/doc/html/next/filesystems/directory-locking.html).
         // However, the superblock is still subject to concurrent changes as we don't hold this lock over remote calls.
         let mut parent_state = parent.get_mut_inode_state()?;
@@ -3007,6 +3027,140 @@ mod tests {
             .expect_err("lookup should no longer find deleted file")
             .to_errno();
         assert_eq!(libc::ENOENT, err, "lookup should return no existing entry error");
+    }
+
+    #[test_case(""; "unprefixed")]
+    #[test_case("test_prefix/"; "prefixed")]
+    #[tokio::test]
+    async fn test_unlink_local_unopened_file(prefix: &str) {
+        let bucket = Bucket::new("test_bucket").unwrap();
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket.to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
+        let prefix = Prefix::new(prefix).expect("valid prefix");
+        let superblock = Superblock::new(client.clone(), S3Path::new(bucket, prefix.clone()), Default::default());
+
+        let file_name = "file.txt";
+        let parent_ino = FUSE_ROOT_INODE;
+
+        // A file created but never opened is left in `LocalUnopened` state (e.g. a process killed
+        // between `mknod` and `open`). It has no object in S3.
+        let lookup = superblock
+            .create(parent_ino, file_name.as_ref(), InodeKind::File)
+            .await
+            .expect("create should succeed");
+        let ino = lookup.ino();
+        assert_eq!(
+            superblock
+                .inner
+                .get(ino)
+                .unwrap()
+                .get_inode_state()
+                .unwrap()
+                .write_status,
+            WriteStatus::LocalUnopened,
+        );
+
+        // Previously this returned `UnlinkNotPermittedWhileWriting`; now it should succeed and
+        // clean up the local bookkeeping without any S3 call.
+        superblock
+            .unlink(parent_ino, file_name.as_ref())
+            .await
+            .expect("unlink of a LocalUnopened file should succeed");
+
+        let err: i32 = superblock
+            .lookup(parent_ino, file_name.as_ref())
+            .await
+            .expect_err("lookup should no longer find the unlinked file")
+            .to_errno();
+        assert_eq!(libc::ENOENT, err, "lookup should return no existing entry error");
+    }
+
+    #[tokio::test]
+    async fn test_unlink_local_open_for_writing_not_permitted() {
+        let bucket = Bucket::new("test_bucket").unwrap();
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket.to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
+        let superblock = Superblock::new(
+            client.clone(),
+            S3Path::new(bucket, Default::default()),
+            Default::default(),
+        );
+
+        let file_name = "file.txt";
+        let parent_ino = FUSE_ROOT_INODE;
+
+        let lookup = superblock
+            .create(parent_ino, file_name.as_ref(), InodeKind::File)
+            .await
+            .expect("create should succeed");
+        superblock
+            .open_handle(lookup.ino(), 0, &Default::default(), OpenFlags::O_WRONLY)
+            .await
+            .expect("should be able to open for writing");
+
+        // A file that is actively open for writing must still refuse unlink.
+        let err = superblock
+            .unlink(parent_ino, file_name.as_ref())
+            .await
+            .expect_err("unlink of a file open for writing should be rejected");
+        assert!(matches!(err, InodeError::UnlinkNotPermittedWhileWriting(_)));
+        assert_eq!(libc::EPERM, err.to_errno());
+    }
+
+    #[tokio::test]
+    async fn test_open_after_unlink_local_unopened_rejected() {
+        let bucket = Bucket::new("test_bucket").unwrap();
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket.to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
+        let superblock = Superblock::new(
+            client.clone(),
+            S3Path::new(bucket, Default::default()),
+            Default::default(),
+        );
+
+        let file_name = "file.txt";
+        let parent_ino = FUSE_ROOT_INODE;
+
+        let lookup = superblock
+            .create(parent_ino, file_name.as_ref(), InodeKind::File)
+            .await
+            .expect("create should succeed");
+        let ino = lookup.ino();
+
+        superblock
+            .unlink(parent_ino, file_name.as_ref())
+            .await
+            .expect("unlink of a LocalUnopened file should succeed");
+
+        // A lingering kernel reference can still reach the inode by number. Reopening it for
+        // writing must be rejected, otherwise a subsequent flush would create an orphaned object
+        // in S3 that this Mountpoint process would never clean up.
+        let write_err: i32 = superblock
+            .open_handle(ino, 0, &Default::default(), OpenFlags::O_WRONLY)
+            .await
+            .expect_err("opening an unlinked inode for writing should be rejected")
+            .to_errno();
+        assert_eq!(libc::ENOENT, write_err);
+
+        // Reopening for reading is rejected too.
+        let read_err: i32 = superblock
+            .open_handle(ino, 1, &Default::default(), OpenFlags::empty())
+            .await
+            .expect_err("opening an unlinked inode for reading should be rejected")
+            .to_errno();
+        assert_eq!(libc::ENOENT, read_err);
     }
 
     #[tokio::test]

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -160,6 +160,7 @@ impl Inode {
                 write_status: WriteStatus::Remote,
                 kind_data: InodeKindData::default_for(InodeKind::Directory),
                 pending_upload_hook: None,
+                unlinked: false,
             },
         )
     }
@@ -190,6 +191,7 @@ impl Inode {
             write_status: WriteStatus::Remote,
             kind_data: InodeKindData::default_for(InodeKind::File),
             pending_upload_hook: None,
+            unlinked: false,
         };
 
         Ok(Self::new(self.ino(), new_parent, new_key, prefix, new_inode_state))
@@ -245,6 +247,10 @@ pub struct InodeState {
     pub write_status: WriteStatus,
     pub kind_data: InodeKindData,
     pub pending_upload_hook: Option<PendingUploadHook>,
+    /// Set once the inode has been `unlink`-ed. A lingering kernel reference can still reach the
+    /// inode by number (its lookup count may be non-zero even after it's removed from its parent),
+    /// so this flag lets the open path reject any further reads or writes to it.
+    pub unlinked: bool,
 }
 
 impl InodeState {
@@ -254,6 +260,7 @@ impl InodeState {
             kind_data: InodeKindData::default_for(kind),
             write_status,
             pending_upload_hook: None,
+            unlinked: false,
         }
     }
 }
@@ -344,6 +351,7 @@ mod tests {
                 stat: InodeStat::for_file(0, OffsetDateTime::now_utc(), None, None, None, Default::default()),
                 kind_data: InodeKindData::File {},
                 pending_upload_hook: None,
+                unlinked: false,
             },
         );
         superblock.inner.inodes.write().unwrap().insert(ino, inode.clone(), 5);
@@ -487,6 +495,7 @@ mod tests {
                     write_status: WriteStatus::Remote,
                     kind_data: InodeKindData::File {},
                     pending_upload_hook: None,
+                    unlinked: false,
                 }),
             }),
         };
@@ -545,6 +554,7 @@ mod tests {
                     stat: InodeStat::for_file(0, OffsetDateTime::UNIX_EPOCH, None, None, None, Default::default()),
                     kind_data: InodeKindData::File {},
                     pending_upload_hook: None,
+                    unlinked: false,
                 }),
             }),
         };


### PR DESCRIPTION
Previously `unlink` was only permitted for files in `WriteStatus::Remote`; any local state returned `UnlinkNotPermittedWhileWriting`. A file created via `mknod` but never opened (for example when a process is killed between the `mknod` and `open` FUSE calls) is left in `LocalUnopened` state and could never be deleted. Reported in #1743 (and originally in #1735).

Permit `unlink` for `LocalUnopened` files. Such a file has no object in S3, so no `DeleteObject` is issued; only the local superblock bookkeeping is cleaned up. The `LocalUnopened` and `Remote` paths now share that cleanup, while `LocalOpenForWriting` and `PendingRename` remain rejected as before. (The status `match` was restructured to return a `needs_remote_delete` bool rather than adding an `InodeKindData::remove_child` helper, per the review feedback on #1735.)

To avoid orphaning an object in S3, the inode is marked unlinked (a new `InodeState::unlinked` flag) while its state lock is held, and the open path (`start_reading` / `start_writing`) now rejects an inode that has been unlinked. Without this, a lingering kernel reference could reopen the inode by number after it was removed from its parent, write, and flush, creating an object that this Mountpoint process had already stopped tracking. The mark and the write-status read happen under the same lock with no `.await` between them, so `unlink` and a concurrent `open` cannot interleave.

Addresses #1743 

### Does this change impact existing behavior?

Yes: `unlink` of a `LocalUnopened` file now succeeds (previously `EPERM` / `UnlinkNotPermittedWhileWriting`). `LocalOpenForWriting`, `PendingRename`, and `Remote` unlink are unchanged. As a guard tied to the new behavior, reopening a `LocalUnopened` inode that has already been unlinked (reachable only via a stale kernel reference) now returns `ENOENT`. Covered by three new tests in `mountpoint-s3-fs/src/superblock.rs` (using `MockClient`).

### Does this change need a changelog entry? Does it require a version change?

Yes,  a changelog entry was added under `## Unreleased` in `mountpoint-s3-fs/CHANGELOG.md`. No version change is required; that is handled at release time.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).