### PR TITLE
Return EPERM from setattr for unsupported attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-mountpoint-s3-fs = { version = "0.10.0", path = "./mountpoint-s3-fs" }
+mountpoint-s3-fs = { version = "0.11.0", path = "./mountpoint-s3-fs" }
 mountpoint-s3-client = { version = "0.21.0", path = "./mountpoint-s3-client" }
 mountpoint-s3-crt = { version = "0.15.0", path = "./mountpoint-s3-crt" }
 mountpoint-s3-crt-sys = { version = "0.17.0", path = "./mountpoint-s3-crt-sys" }

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* `setattr` now fails with `EPERM` when asked to change a file's mode, owner, or group, rather than reporting success and ignoring the request. `S3Filesystem::setattr` takes the requested `mode`, `uid`, and `gid` as new arguments to support this. ([#600](https://github.com/awslabs/mountpoint-s3/issues/600))
+
 ## v0.10.0 (July 20, 2026)
 
 * Add `tls_config` field on `s3::config::ClientConfig` so callers can configure a custom CA trust store through to the underlying S3 client. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834))

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* `setattr` now fails with `EPERM` when asked to change a file's mode, owner, or group, rather than reporting success and ignoring the request. `S3Filesystem::setattr` takes the requested `mode`, `uid`, and `gid` as new arguments to support this. ([#600](https://github.com/awslabs/mountpoint-s3/issues/600))
+* `setattr` now fails with `EPERM` when asked to change a file's mode, owner, or group, rather than reporting success and ignoring the request. `S3Filesystem::setattr` takes the requested `mode`, `uid`, and `gid` as new arguments to support this. ([#1897](https://github.com/awslabs/mountpoint-s3/pull/1897))
 
 ## v0.10.0 (July 20, 2026)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-fs"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/src/fs.rs
+++ b/mountpoint-s3-fs/src/fs.rs
@@ -299,22 +299,42 @@ where
         Ok(Attr { ttl, attr })
     }
 
+    #[allow(clippy::too_many_arguments)] // We don't get to choose this interface
     pub async fn setattr(
         &self,
         ino: InodeNo,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
         atime: Option<OffsetDateTime>,
         mtime: Option<OffsetDateTime>,
         size: Option<u64>,
         _flags: Option<u32>,
     ) -> Result<Attr, Error> {
         tracing::debug!(
-            "fs:setattr with ino {:?} flags {:?} atime {:?} mtime {:?} size {:?}",
+            "fs:setattr with ino {:?} flags {:?} mode {:?} uid {:?} gid {:?} atime {:?} mtime {:?} size {:?}",
             ino,
             _flags,
+            mode,
+            uid,
+            gid,
             atime,
             mtime,
             size
         );
+
+        // Mountpoint does not emulate POSIX ownership or permissions, so it can never persist a
+        // change to them. Reject the request rather than reporting a success we won't honor.
+        if mode.is_some() || uid.is_some() || gid.is_some() {
+            return Err(err!(
+                libc::EPERM,
+                "file mode and ownership are not supported, requested mode {:?} uid {:?} gid {:?}",
+                mode,
+                uid,
+                gid
+            ));
+        }
+
         let setattr_result = self.metablock.setattr(ino, atime, mtime).await;
         let lookup = match (setattr_result, size) {
             (Ok(lookup), _) => lookup,

--- a/mountpoint-s3-fs/src/fuse.rs
+++ b/mountpoint-s3-fs/src/fuse.rs
@@ -387,9 +387,9 @@ where
         &self,
         req: &Request<'_>,
         ino: u64,
-        _mode: Option<u32>,
-        _uid: Option<u32>,
-        _gid: Option<u32>,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
         size: Option<u64>,
         atime: Option<TimeOrNow>,
         mtime: Option<TimeOrNow>,
@@ -410,7 +410,11 @@ where
             TimeOrNow::SpecificTime(st) => OffsetDateTime::from(st),
             TimeOrNow::Now => OffsetDateTime::now_utc(),
         });
-        match block_on(self.fs.setattr(ino, atime, mtime, size, flags).in_current_span()) {
+        match block_on(
+            self.fs
+                .setattr(ino, mode, uid, gid, atime, mtime, size, flags)
+                .in_current_span(),
+        ) {
             Ok(attr) => reply.attr(&attr.ttl, &attr.attr),
             Err(e) => fuse_error!("setattr", reply, e, self, req),
         }

--- a/mountpoint-s3-fs/tests/fs.rs
+++ b/mountpoint-s3-fs/tests/fs.rs
@@ -32,6 +32,7 @@ use nix::unistd::{getgid, getuid};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use test_case::test_case;
+use time::OffsetDateTime;
 
 mod common;
 #[cfg(all(feature = "s3_tests", not(feature = "s3express_tests")))]
@@ -436,6 +437,94 @@ async fn test_mknod_cached() {
     assert_eq!(err_no, libc::EEXIST, "expected EEXIST but got {err_no:?}");
     assert_eq!(head_counter.count(), 1);
     assert_eq!(list_counter.count(), 1);
+}
+
+#[test_case(Some(libc::S_IRWXU), None, None; "mode")]
+#[test_case(None, Some(42), None; "uid")]
+#[test_case(None, None, Some(42); "gid")]
+#[test_case(Some(libc::S_IRWXU), Some(42), Some(42); "mode, uid and gid")]
+#[tokio::test]
+async fn test_setattr_unsupported_attributes(mode: Option<u32>, uid: Option<u32>, gid: Option<u32>) {
+    const BUCKET_NAME: &str = "test_setattr_unsupported_attributes";
+
+    let (_client, fs) = make_test_filesystem(BUCKET_NAME, &Default::default(), Default::default());
+
+    let file_mode = libc::S_IFREG | libc::S_IRWXU; // regular file + 0700 permissions
+    let dentry = fs
+        .mknod(FUSE_ROOT_INODE, "file.bin".as_ref(), file_mode, 0, 0)
+        .await
+        .unwrap();
+    let ino = dentry.attr.ino;
+
+    let err_no = fs
+        .setattr(ino, mode, uid, gid, None, None, None, None)
+        .await
+        .expect_err("setattr should not accept ownership or permission changes")
+        .to_errno();
+    assert_eq!(err_no, libc::EPERM, "expected EPERM but got {err_no:?}");
+}
+
+/// A request combining times with an unsupported attribute is rejected as a whole, rather than
+/// applying the part we do support.
+#[tokio::test]
+async fn test_setattr_unsupported_attributes_leave_times_unchanged() {
+    const BUCKET_NAME: &str = "test_setattr_unsupported_attributes_leave_times_unchanged";
+
+    let (_client, fs) = make_test_filesystem(BUCKET_NAME, &Default::default(), Default::default());
+
+    let file_mode = libc::S_IFREG | libc::S_IRWXU; // regular file + 0700 permissions
+    let dentry = fs
+        .mknod(FUSE_ROOT_INODE, "file.bin".as_ref(), file_mode, 0, 0)
+        .await
+        .unwrap();
+    let ino = dentry.attr.ino;
+    let before = fs.getattr(ino).await.unwrap();
+
+    let atime = OffsetDateTime::UNIX_EPOCH + Duration::from_secs(1);
+    let mtime = OffsetDateTime::UNIX_EPOCH + Duration::from_secs(2);
+    let err_no = fs
+        .setattr(
+            ino,
+            Some(libc::S_IRWXU),
+            None,
+            None,
+            Some(atime),
+            Some(mtime),
+            None,
+            None,
+        )
+        .await
+        .expect_err("setattr should not accept ownership or permission changes")
+        .to_errno();
+    assert_eq!(err_no, libc::EPERM, "expected EPERM but got {err_no:?}");
+
+    let after = fs.getattr(ino).await.unwrap();
+    assert_eq!(after.attr.atime, before.attr.atime);
+    assert_eq!(after.attr.mtime, before.attr.mtime);
+}
+
+#[tokio::test]
+async fn test_setattr_times_on_local_file() {
+    const BUCKET_NAME: &str = "test_setattr_times_on_local_file";
+
+    let (_client, fs) = make_test_filesystem(BUCKET_NAME, &Default::default(), Default::default());
+
+    let file_mode = libc::S_IFREG | libc::S_IRWXU; // regular file + 0700 permissions
+    let dentry = fs
+        .mknod(FUSE_ROOT_INODE, "file.bin".as_ref(), file_mode, 0, 0)
+        .await
+        .unwrap();
+    let ino = dentry.attr.ino;
+
+    let atime = OffsetDateTime::UNIX_EPOCH + Duration::from_secs(1);
+    let mtime = OffsetDateTime::UNIX_EPOCH + Duration::from_secs(2);
+    let attr = fs
+        .setattr(ino, None, None, None, Some(atime), Some(mtime), None, None)
+        .await
+        .expect("setattr should still accept times on a local file");
+
+    assert_eq!(attr.attr.atime, SystemTime::from(atime));
+    assert_eq!(attr.attr.mtime, SystemTime::from(mtime));
 }
 
 #[test_case(1024 * 1024; "small")]

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* `chmod`, `chown`, and `chgrp` now consistently fail with `EPERM`. Previously they failed on files already uploaded to S3, but silently reported success on files that had not been uploaded yet, even though Mountpoint never persists the change. ([#600](https://github.com/awslabs/mountpoint-s3/issues/600))
+
 ## v1.23.0 (July 20, 2026)
 
 * Add `--ca-bundle` flag (and `AWS_CA_BUNDLE` environment variable fallback) for trusting a custom certificate authority when Mountpoint makes HTTPS calls. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834) by @yerzhan7)

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* `chmod`, `chown`, and `chgrp` now consistently fail with `EPERM`. Previously they failed on files already uploaded to S3, but silently reported success on files that had not been uploaded yet, even though Mountpoint never persists the change. ([#600](https://github.com/awslabs/mountpoint-s3/issues/600))
+* `chmod`, `chown`, and `chgrp` now consistently fail with `EPERM`. Previously they failed on files already uploaded to S3, but silently reported success on files that had not been uploaded yet, even though Mountpoint never persists the change. ([#1897](https://github.com/awslabs/mountpoint-s3/pull/1897) by @akhileshvattumilli)
 
 ## v1.23.0 (July 20, 2026)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "1.23.0"
+version = "1.24.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Addresses #600.

Mountpoint's `setattr` accepted `mode`, `uid`, and `gid` from FUSE and threw them away — they were bound as `_mode`, `_uid`, and `_gid` in the FUSE handler and never passed on. So a `chmod` or `chown` on a file that hadn't been uploaded yet returned success while Mountpoint quietly kept the mode and owner configured at mount time. The same call on a file already in S3 failed with `EPERM`, because `setattr` on a remote inode is rejected before it reaches that point. The result was that whether `chmod` appeared to work depended on whether the file happened to have been uploaded yet.

This makes the unsupported cases fail consistently. `S3Filesystem::setattr` now takes the requested `mode`, `uid`, and `gid`, and returns `EPERM` when any of them is set. Times are untouched, so `utimensat` on a not-yet-uploaded file still works and `touch` keeps behaving as it does today.

I put the check in `S3Filesystem::setattr` rather than in the FUSE handler for two reasons: it keeps the behavior consistent for anything using `mountpoint-s3-fs` as a library rather than through a mount, and it makes the case testable without mounting a filesystem, which is why the new tests live in `tests/fs.rs`.

`EPERM` is what `setattr` already returns for a remote inode via `InodeError::SetAttrNotPermittedOnRemoteInode`, so after this change `chmod` reports the same error regardless of upload state. This is also the behavior the [tenets](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md#behavior-tenets) describe — failing explicitly rather than accepting an operation that will never be persisted — and `SEMANTICS.md` already documents `chmod`, `chown`, and `chgrp` as unsupported, so this brings the code in line with the documentation rather than changing what's promised.

### Does this change impact existing behavior?

Yes, deliberately — that is the point of the change. `chmod`, `chown`, and `chgrp` on a file that hasn't been uploaded yet now fail with `EPERM` instead of silently reporting success. Applications that create a file and then set its mode (`install`, `cp -p`, `tar -x`, or an `mkstemp` followed by `fchmod`) will now see the error at that call. For files already in S3 there is no change, since those already returned `EPERM`.

One thing worth raising: #976 asks for the opposite, an opt-in flag that turns mode-change errors into no-ops, and this change makes the current behavior slightly more visible by extending the error to the pre-upload case. I kept this PR to what #600 asks for rather than trying to settle that. If you'd rather have the escape hatch land first, or want `setattr` to accept a request whose values already match what Mountpoint reports, I'm happy to follow up.

Nothing else changes: setting times through `setattr`, truncation, and the `--allow-overwrite` hint all behave as before.

### Does this change need a changelog entry? Does it require a version change?

Yes to both, and both are included.

Changelog entries are added to `mountpoint-s3/CHANGELOG.md` for the user-visible `chmod`/`chown` change and to `mountpoint-s3-fs/CHANGELOG.md` for the crate.

For versions: `mountpoint-s3-fs` goes from `0.10.0` to `0.11.0`, since adding arguments to `S3Filesystem::setattr` is a breaking change for the crate and the middle number carries breaking changes for a `0.x` crate. `mountpoint-s3` goes from `1.23.0` to `1.24.0`, treating the behavior change as the "very minor breaking change" case rather than a plain bug fix. The workspace dependency on `mountpoint-s3-fs` and `Cargo.lock` are updated to match. If you read the Mountpoint change as a bug fix warranting `1.23.1` instead, that's an easy change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
