### PR TITLE
Keep implicit directories after deleting their last file

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -281,12 +281,14 @@ File deletion (`unlink`) semantics are described in the [Deletes](#deletes) sect
 
 Empty directory removal (`rmdir`) is supported, with the following semantics:
 
-* `rmdir` will only delete empty directories created by `mkdir`.
+* `rmdir` will only delete empty directories created by `mkdir`, or directories left empty because Mountpoint deleted the last file in them.
 * `rmdir` will fail on directories backed on S3 by a directory marker (i.e. zero-byte object with `<directory-name>/` key).
 * As soon as a file is committed to the S3 bucket by Mountpoint,
   the directory will be considered to exist implicitly.
   If Mountpoint later observes that there are no files existing for that directory in S3,
   Mountpoint will implicitly consider the directory to have been deleted.
+  The exception is a directory that Mountpoint itself emptied by deleting the last file in it,
+  which remains visible until it is removed with `rmdir`.
 * On success, the directory will be deleted immediately. Subsequent reads or writes to the directory (e.g. creating a file or subdirectory) will fail.
 
 Synchronization operations (`fsync`) on directories are not supported.

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Keep serving an implicit directory after Mountpoint deletes the last file in it, until it is removed with `rmdir`. ([#PRNUM](https://github.com/awslabs/mountpoint-s3/pull/PRNUM))
+
 ## v0.10.0 (July 20, 2026)
 
 * Add `tls_config` field on `s3::config::ClientConfig` so callers can configure a custom CA trust store through to the underlying S3 client. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834))

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Keep serving an implicit directory after Mountpoint deletes the last file in it, until it is removed with `rmdir`. ([#PRNUM](https://github.com/awslabs/mountpoint-s3/pull/PRNUM))
+* Keep serving an implicit directory after Mountpoint deletes the last file in it, until it is removed with `rmdir`. ([#1898](https://github.com/awslabs/mountpoint-s3/pull/1898))
 
 ## v0.10.0 (July 20, 2026)
 

--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -739,7 +739,15 @@ impl<OC: ObjectClient + Send + Sync + Clone> Metablock for Superblock<OC> {
                 debug_assert!(false, "inodes never change kind");
                 return Err(InodeError::NotADirectory(parent.err()));
             }
-            InodeKindData::Directory { children, .. } => {
+            InodeKindData::Directory {
+                children,
+                unlinked_children,
+                ..
+            } => {
+                // Record that we removed an entry from this directory, so that we keep serving our
+                // local view of it if this turns out to have been the last object under its prefix.
+                *unlinked_children = true;
+
                 // We want to remove the original child.
                 // If there is a mismatch in inode number between the existing inode and the deleted inode, we invalidate the existing inode's stat.
                 // If for some reason the child with the specified name was already removed, we do nothing as this is the desired state.
@@ -1743,6 +1751,29 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
                         stat,
                         path: self.s3_path.clone(),
                         write_status,
+                    })
+                } else if existing_inode.get_inode_state().is_ok_and(|state| {
+                    matches!(&state.kind_data, InodeKindData::Directory { unlinked_children, .. } if *unlinked_children)
+                }) {
+                    // An implicit directory only exists in S3 while there are objects under its
+                    // prefix, so deleting the last of them makes it disappear remotely even though
+                    // the user never asked for the directory itself to be removed. Keep serving our
+                    // local view of it, as a local directory so that `rmdir` is what removes it.
+                    // Directories that went away for any other reason, such as another client
+                    // deleting the objects, are still removed below.
+                    let mut existing_state = existing_inode.get_mut_inode_state()?;
+                    existing_state.write_status = WriteStatus::LocalUnopened;
+                    existing_state.stat.update_validity(self.config.cache_config.dir_ttl);
+                    let stat = existing_state.stat.clone();
+                    drop(existing_state);
+
+                    writing_children.insert(existing_inode.ino());
+
+                    Ok(LookedUpInode {
+                        inode: existing_inode,
+                        stat,
+                        path: self.s3_path.clone(),
+                        write_status: WriteStatus::LocalUnopened,
                     })
                 } else {
                     // This existing inode is local-only (because `remote` is None), but is not
@@ -3291,5 +3322,117 @@ mod tests {
             !cache.should_try_rename(),
             "Success after failure should not modify cache state"
         );
+    }
+
+    /// An implicit directory should remain visible after its last child is deleted, until it is
+    /// explicitly removed with `rmdir`.
+    #[tokio::test]
+    async fn test_lookup_implicit_directory_after_deleting_all_children() {
+        let bucket = Bucket::new("test_bucket").unwrap();
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket.to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
+        let superblock = Superblock::new(
+            client.clone(),
+            S3Path::new(bucket, Default::default()),
+            Default::default(),
+        );
+
+        for key in [
+            "colors/blue/image1.jpg",
+            "colors/blue/image2.jpg",
+            "colors/red/image.jpg",
+            "colors/list.txt",
+        ] {
+            client.add_object(key, MockObject::constant(0xaa, 30, ETag::for_tests()));
+        }
+
+        let colors_ino = superblock
+            .lookup(FUSE_ROOT_INODE, "colors".as_ref())
+            .await
+            .expect("colors should exist")
+            .ino();
+        let blue_ino = superblock
+            .lookup(colors_ino, "blue".as_ref())
+            .await
+            .expect("blue should exist")
+            .ino();
+
+        superblock.unlink(blue_ino, "image1.jpg".as_ref()).await.unwrap();
+        superblock.unlink(blue_ino, "image2.jpg".as_ref()).await.unwrap();
+
+        // The prefix is now empty in S3, but the directory should still be there, and stay there
+        // across repeated lookups.
+        for _ in 0..2 {
+            superblock
+                .lookup(colors_ino, "blue".as_ref())
+                .await
+                .expect("blue should still be visible after its last child is deleted");
+        }
+
+        // ...including in its parent's readdir, alongside the entries that still exist remotely.
+        let entries = collect_dir_entries(&superblock, colors_ino, false, 3).await;
+        assert!(
+            entries.contains(&OsString::from("blue")),
+            "blue should be listed in its parent's readdir, got {entries:?}"
+        );
+
+        // `rmdir` is what actually removes it.
+        superblock
+            .rmdir(colors_ino, "blue".as_ref())
+            .await
+            .expect("rmdir should remove the now-empty directory");
+
+        let err = superblock
+            .lookup(colors_ino, "blue".as_ref())
+            .await
+            .expect_err("blue should be gone after rmdir")
+            .to_errno();
+        assert_eq!(libc::ENOENT, err);
+    }
+
+    /// A directory whose objects were deleted by something other than this Mountpoint process
+    /// should still disappear, rather than being retained as a local directory.
+    #[tokio::test]
+    async fn test_lookup_implicit_directory_emptied_out_of_band() {
+        let bucket = Bucket::new("test_bucket").unwrap();
+        let client = Arc::new(
+            MockClient::config()
+                .bucket(bucket.to_string())
+                .part_size(1024 * 1024)
+                .build(),
+        );
+        let superblock = Superblock::new(
+            client.clone(),
+            S3Path::new(bucket, Default::default()),
+            Default::default(),
+        );
+
+        client.add_object(
+            "colors/blue/image1.jpg",
+            MockObject::constant(0xaa, 30, ETag::for_tests()),
+        );
+
+        let colors_ino = superblock
+            .lookup(FUSE_ROOT_INODE, "colors".as_ref())
+            .await
+            .expect("colors should exist")
+            .ino();
+        superblock
+            .lookup(colors_ino, "blue".as_ref())
+            .await
+            .expect("blue should exist");
+
+        client.remove_object("colors/blue/image1.jpg");
+
+        let err = superblock
+            .lookup(colors_ino, "blue".as_ref())
+            .await
+            .expect_err("blue should not be retained when emptied out of band")
+            .to_errno();
+        assert_eq!(libc::ENOENT, err);
     }
 }

--- a/mountpoint-s3-fs/src/superblock/inode.rs
+++ b/mountpoint-s3-fs/src/superblock/inode.rs
@@ -274,6 +274,14 @@ pub enum InodeKindData {
 
         /// True if this directory has been deleted (`rmdir`) from its parent
         deleted: bool,
+
+        /// True if an entry has been removed from this directory by `unlink`.
+        ///
+        /// An implicit directory only exists in S3 while there are objects under its prefix, so
+        /// deleting the last of them makes the directory disappear remotely. This records that we
+        /// should keep serving our local view of the directory in that case, until it is removed
+        /// with `rmdir`.
+        unlinked_children: bool,
     },
 }
 
@@ -285,6 +293,7 @@ impl InodeKindData {
                 children: Default::default(),
                 writing_children: Default::default(),
                 deleted: false,
+                unlinked_children: false,
             },
         }
     }

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Deleting the last file in a directory no longer makes the directory itself disappear. The directory stays visible until it is removed with `rmdir`, matching how other file systems behave. Directories that are emptied by something other than this Mountpoint process are unaffected. ([#PRNUM](https://github.com/awslabs/mountpoint-s3/pull/PRNUM) by @akhileshvattumilli)
+* Deleting the last file in a directory no longer makes the directory itself disappear. The directory stays visible until it is removed with `rmdir`, matching how other file systems behave. Directories that are emptied by something other than this Mountpoint process are unaffected. ([#1898](https://github.com/awslabs/mountpoint-s3/pull/1898) by @akhileshvattumilli)
 
 ## v1.23.0 (July 20, 2026)
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Deleting the last file in a directory no longer makes the directory itself disappear. The directory stays visible until it is removed with `rmdir`, matching how other file systems behave. Directories that are emptied by something other than this Mountpoint process are unaffected. ([#PRNUM](https://github.com/awslabs/mountpoint-s3/pull/PRNUM) by @akhileshvattumilli)
+
 ## v1.23.0 (July 20, 2026)
 
 * Add `--ca-bundle` flag (and `AWS_CA_BUNDLE` environment variable fallback) for trusting a custom certificate authority when Mountpoint makes HTTPS calls. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834) by @yerzhan7)


### PR DESCRIPTION
An implicit directory only exists in S3 while there are objects under its prefix, so deleting the last file in one makes the directory itself disappear from the mount, even though the user never asked for it to be removed. Using the example from #1055, after deleting `colors/blue/image1.jpg` and `colors/blue/image2.jpg`, a lookup on `colors/blue` fails with `ENOENT`. Other file systems keep the directory until it is explicitly removed, so an application that clears out a directory and then keeps using it sees a surprising failure.

This keeps serving the local view of such a directory instead. `unlink` records on the parent directory that Mountpoint removed an entry from it, and when a later lookup finds the prefix empty in S3, the directory is retained as a local directory rather than dropped. Making it a local directory is what gives the rest of the behavior for free: it shows up in the parent's `readdir` through `writing_children`, and `rmdir` already accepts local directories, so `rmdir` becomes the way to remove it. That matches how directories created by `mkdir` already work.

I scoped the retention to directories this Mountpoint process emptied rather than retaining any directory whose prefix turns up empty. The broader version broke two existing tests that assert a directory disappears when its objects are removed out of band (`test_lookup_with_caching` and `test_finish_writing_convert_parent_local_dirs_to_remote`), and those seem like contracts worth keeping: a directory another client deleted should not linger. Scoping it this way also avoids needing a `ListObjectsV2` on the unlink path to work out whether the prefix is now empty, since the lookup that follows already tells us.

One thing worth flagging for review: the flag is sticky for the lifetime of the inode. If you unlink a file from a directory and another client later removes the remaining objects, the directory is retained even though that last deletion was out of band. Resetting the flag whenever a lookup confirms the directory still exists remotely would tighten this, at the cost of touching both the fast and slow update paths. I left it out to keep the change small, but happy to add it.

Addresses #1055.

### Does this change impact existing behavior?

Yes, and it is the intended change: deleting the last file in a directory now leaves the directory in place until `rmdir`, where previously it disappeared. `rmdir` consequently succeeds on those directories, having previously failed with `CannotRemoveRemoteDirectory`. Directories emptied by anything other than this Mountpoint process behave exactly as before, which `test_lookup_implicit_directory_emptied_out_of_band` covers. I updated the two statements in `doc/SEMANTICS.md` that described the old behavior.

Verified with `make fmt-check`, `make check`, and `make clippy` clean, plus `cargo test` for `mountpoint-s3-crt`, `mountpoint-s3-client`, `mountpoint-s3-fs`, and `mountpoint-s3` (705 unit tests) and the `mountpoint-s3-fs` integration targets, including the 28 reference tests. I develop on macOS, so the `fuse_tests` targets compile here but I could not run them against a real mount; those need CI.

### Does this change need a changelog entry? Does it require a version change?

Yes, entries added under `## Unreleased` in `mountpoint-s3/CHANGELOG.md` and `mountpoint-s3-fs/CHANGELOG.md`. No version change; that is handled at release time.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
