### PR TITLE
Copy first part to heap in `do_read` to avoid pool deadlock

### DIFF
--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -233,6 +233,13 @@ impl ChecksummedBytes {
         Ok((self.buffer, self.checksum))
     }
 
+    /// Copy the bytes into a freshly allocated buffer sharing no storage with the original, e.g. to
+    /// release a pooled buffer while this data lives on. Reuses the checksum, so no CRC is recomputed.
+    pub fn into_detached(self) -> Result<Self, IntegrityError> {
+        let (bytes, checksum) = self.into_inner()?;
+        Ok(Self::new_from_inner_data(Bytes::copy_from_slice(&bytes), checksum))
+    }
+
     /// Return the slice of `buffer` corresponding to `range`.
     ///
     /// Note that no data is copied: the returned `Bytes` still points to a subslice of `buffer`.
@@ -376,6 +383,34 @@ mod tests {
 
         let actual = checksummed_bytes.into_bytes();
         assert!(matches!(actual, Err(IntegrityError::ChecksumMismatch(_, _))));
+    }
+
+    #[test]
+    fn test_into_detached() {
+        let bytes = Bytes::from_static(b"some bytes");
+        let checksummed_bytes = ChecksummedBytes::new(bytes.clone());
+        let expected_checksum = checksummed_bytes.checksum;
+
+        let detached = checksummed_bytes.into_detached().unwrap();
+
+        // Content and checksum are preserved, and the checksum is reused (not recomputed).
+        assert_eq!(bytes, detached.buffer);
+        assert_eq!(expected_checksum, detached.checksum);
+        assert_eq!(bytes, detached.into_bytes().unwrap());
+    }
+
+    #[test]
+    fn test_into_detached_severs_shared_storage() {
+        // A slice of a larger buffer shares its allocation; `into_detached` must not.
+        let full = Bytes::from_static(b"some bytes");
+        let mut checksummed_bytes = ChecksummedBytes::new(full.clone());
+        let tail = checksummed_bytes.split_off(4); // "bytes", still backed by `full`
+
+        let detached = tail.into_detached().unwrap();
+        assert_eq!(&detached.buffer[..], b" bytes");
+        // The detached buffer is a fresh, full-range allocation, not a subslice of `full`.
+        assert_eq!(detached.buffer.len(), detached.len());
+        assert_eq!(detached.range, 0..detached.len());
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -536,6 +536,27 @@ mod tests {
         run_sequential_read_test(prefetcher_type, 256 * 1024 * 1024 + 111, 1024 * 1024, config);
     }
 
+    /// Each read is larger than a part, so `do_read` must stitch multiple parts together (the
+    /// multi-part path that copies the first part off its pool buffer). Guards read correctness
+    /// across that path.
+    #[test_case(PrefetcherType::Default)]
+    #[test_case(PrefetcherType::InMemoryCache(1 * MB))]
+    fn sequential_read_size_larger_than_part(prefetcher_type: PrefetcherType) {
+        let config = TestConfig {
+            initial_request_size: 256 * 1024,
+            max_read_window_size: 64 * 1024 * 1024,
+            sequential_prefetch_multiplier: 8,
+            client_part_size: 1 * 1024 * 1024,
+            max_forward_seek_wait_distance: 16 * 1024 * 1024,
+            max_backward_seek_distance: 2 * 1024 * 1024,
+            cache_block_size: 1 * MB,
+        };
+
+        // read_size (4 MiB + 111) > client_part_size (1 MiB), and the odd tail crosses part
+        // boundaries so reads straddle rather than align.
+        run_sequential_read_test(prefetcher_type, 16 * 1024 * 1024 + 111, 4 * 1024 * 1024 + 111, config);
+    }
+
     fn fail_with_backpressure_precondition_test(
         prefetcher_type: PrefetcherType,
         test_config: TestConfig,

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use metrics::{counter, histogram};
 use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
@@ -181,7 +182,15 @@ where
             }
 
             let part_len = part_bytes.len() as u64;
-            response.extend(part_bytes)?;
+            if response.is_empty() {
+                // Copy off the pool buffer instead of letting `extend` alias it: this read spans
+                // parts, and holding a pool buffer across the next allocation below deadlocks under
+                // memory pressure. Reuse the checksum to avoid recomputing it.
+                let (bytes, checksum) = part_bytes.into_inner()?;
+                response = ChecksummedBytes::new_from_inner_data(Bytes::copy_from_slice(&bytes), checksum);
+            } else {
+                response.extend(part_bytes)?;
+            }
             to_read -= part_len;
         }
 

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use metrics::{counter, histogram};
 use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
@@ -185,9 +184,8 @@ where
             if response.is_empty() {
                 // Copy off the pool buffer instead of letting `extend` alias it: this read spans
                 // parts, and holding a pool buffer across the next allocation below deadlocks under
-                // memory pressure. Reuse the checksum to avoid recomputing it.
-                let (bytes, checksum) = part_bytes.into_inner()?;
-                response = ChecksummedBytes::new_from_inner_data(Bytes::copy_from_slice(&bytes), checksum);
+                // memory pressure.
+                response = part_bytes.into_detached()?;
             } else {
                 response.extend(part_bytes)?;
             }


### PR DESCRIPTION
On a FUSE read spanning two prefetch parts, `Cursor::do_read` accumulated the first part
into `response` via `ChecksummedBytes::extend`, whose empty-self fast path aliases the
part's pool buffer zero-copy, then blocked awaiting the next part's allocation while still
pinning that buffer. Under memory pressure the read reserve holds only one part of headroom,
so the second allocation could never be satisfied and the read wedged (the pruning backstop
clears the seek window, but `response` held the buffer). This copies the first part off its
pool buffer before blocking, leaving the reclaimable seek-window clone as the only pool
reference. The common single-part read is unchanged (early-returns zero-copy).

The copy is untracked heap, bounded to **`max_threads` × 1 MiB (16 MiB at defaults)**:
concurrent `do_read` calls are capped by FUSE worker threads (`max_threads`, default 16),
and each copy is at most one FUSE read (Linux caps a single read at 1 MiB). That fits inside
the `additional_mem_reserved` overhead reserve of `max(mem_limit / 8, 128 MiB)`. Raising
`--max-threads` raises the ceiling proportionally.

Benchmarks: https://github.com/awslabs/mountpoint-s3/actions/runs/30529923080
Stress tests: https://github.com/awslabs/mountpoint-s3/actions/runs/30529922802/job/90829594952

### Does this change impact existing behavior?

No. The single-part read path (common case) is untouched and still zero-copy; only multi-part
straddle reads change.

### Does this change need a changelog entry? Does it require a version change?

No
