### PR TITLE
Fix Python lint errors in benchmark and packaging scripts

### DIFF
--- a/benchmark/analysis-scripts/autogroup.py
+++ b/benchmark/analysis-scripts/autogroup.py
@@ -6,21 +6,21 @@
 # ]
 # ///
 
-import os
-import json
 import argparse
-import glob
 import csv
-import warnings
+import glob
+import json
+import os
 import statistics
-
-from tabulate import tabulate
+import warnings
 from collections import defaultdict
-from typing import Dict, Any, Optional, Tuple, List, Set, Union
+from typing import Any
+
 from omegaconf import OmegaConf
+from tabulate import tabulate
 
 
-def parse_hydra_config(iteration_dir: str) -> Dict[str, Any]:
+def parse_hydra_config(iteration_dir: str) -> dict[str, Any]:
     """Parse Hydra config and overrides for an iteration using OmegaConf and flattens the result"""
     hydra_dir = os.path.join(iteration_dir, '.hydra')
 
@@ -50,8 +50,8 @@ def parse_hydra_config(iteration_dir: str) -> Dict[str, Any]:
 
 
 def to_gigabits_per_second(
-    bytes: Union[int, float],
-    seconds: Union[int, float],
+    bytes: float,
+    seconds: float,
 ) -> float:
     """
     Converts bytes to gigabits per second
@@ -61,7 +61,7 @@ def to_gigabits_per_second(
     return gigabits / float(seconds)
 
 
-def flatten_config(config: Dict[str, Any], parent_key: str = '', sep: str = '.') -> Dict[str, Any]:
+def flatten_config(config: dict[str, Any], parent_key: str = '', sep: str = '.') -> dict[str, Any]:
     """Flatten nested configuration dictionary."""
     result = {}
     for k, v in config.items():
@@ -73,7 +73,7 @@ def flatten_config(config: Dict[str, Any], parent_key: str = '', sep: str = '.')
     return result
 
 
-def parse_benchmark_file(file_path: str) -> Optional[float]:
+def parse_benchmark_file(file_path: str) -> float | None:
     """Parse benchmark output file and return throughput."""
     try:
         with open(file_path, 'r') as f:
@@ -108,7 +108,7 @@ def parse_benchmark_file(file_path: str) -> Optional[float]:
         return None
 
 
-def process_iteration(iteration_dir: str) -> Tuple[Dict[str, Any], Optional[float]]:
+def process_iteration(iteration_dir: str) -> tuple[dict[str, Any], float | None]:
     """Process a single iteration directory."""
     config = parse_hydra_config(iteration_dir)
 
@@ -127,7 +127,7 @@ def process_iteration(iteration_dir: str) -> Tuple[Dict[str, Any], Optional[floa
     return config, throughput
 
 
-def find_varying_parameters(all_configs: List[Dict[str, Any]]) -> Set[str]:
+def find_varying_parameters(all_configs: list[dict[str, Any]]) -> set[str]:
     """Identify parameters that vary across configurations, ignoring run-specific parameters."""
     if not all_configs:
         return set()
@@ -152,7 +152,7 @@ def find_varying_parameters(all_configs: List[Dict[str, Any]]) -> Set[str]:
     return varying
 
 
-def combine_raw_values(all_results: List[Tuple[Dict[str, Any], float, str]]) -> List[Dict[str, Any]]:
+def combine_raw_values(all_results: list[tuple[dict[str, Any], float, str]]) -> list[dict[str, Any]]:
     varying_params = sorted(find_varying_parameters([config for config, _, _ in all_results]))
 
     grouped_results = defaultdict(list)
@@ -237,7 +237,7 @@ def main() -> None:
         return benchmark_order.get(value, 999)  # Unknown types go to end
 
     # Sort rows by all columns
-    def sort_key(row: List[str]) -> List[Union[int, float, str]]:
+    def sort_key(row: list[str]) -> list[int | float | str]:
         key_parts = []
         for value, header in zip(row, aggregated_headers):
             if header == 'benchmark_type':

--- a/benchmark/analysis-scripts/autogroup.py
+++ b/benchmark/analysis-scripts/autogroup.py
@@ -103,7 +103,7 @@ def parse_benchmark_file(file_path: str) -> float | None:
                 warnings.warn(f"Unknown format in {file_path}")
                 return None
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         warnings.warn(f"Warning: Error parsing {file_path}: {e}")
         return None
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,24 +2,22 @@ import json
 import logging
 import os
 import subprocess
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 import hydra
-from hydra.core.hydra_config import HydraConfig
-from hydra.types import RunMode
-from omegaconf import DictConfig, OmegaConf
-import urllib.request
-
 from benchmarks.client_benchmark import ClientBenchmark
 from benchmarks.command import CommandResult
 from benchmarks.crt_benchmark import CrtBenchmark
 from benchmarks.fio_benchmark import FioBenchmark
 from benchmarks.prefetch_benchmark import PrefetchBenchmark
-
+from hydra.core.hydra_config import HydraConfig
+from hydra.types import RunMode
 from monitoring import ResourceMonitoring
-from monitoring.tools import MonitoringTool, MpstatTool, BwmNgTool, PerfStatTool, FlamegraphTool
+from monitoring.tools import BwmNgTool, FlamegraphTool, MonitoringTool, MpstatTool, PerfStatTool
+from omegaconf import DictConfig, OmegaConf
 
 logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
 
@@ -31,7 +29,7 @@ OmegaConf.register_new_resolver(
 )
 
 
-def get_ec2_instance_id() -> Optional[str]:
+def get_ec2_instance_id() -> str | None:
     """Get the EC2 instance ID if running on EC2."""
     if os.getenv("AWS_EC2_METADATA_DISABLED") == "true":
         return None
@@ -54,7 +52,7 @@ def get_ec2_instance_id() -> Optional[str]:
         return None
 
 
-def write_metadata(metadata: Dict[str, Any]) -> None:
+def write_metadata(metadata: dict[str, Any]) -> None:
     """Write metadata to a file."""
     try:
         with open("metadata.json", "w") as f:
@@ -146,7 +144,7 @@ def run_experiment(cfg: DictConfig) -> None:
         metadata["target_pid"] = target_pid
 
         # Construct monitoring tools
-        tools: List[MonitoringTool] = [MpstatTool()]
+        tools: list[MonitoringTool] = [MpstatTool()]
         if cfg.monitoring.with_bwm:
             tools.append(BwmNgTool())
         if cfg.monitoring.with_perf_stat:

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -59,7 +59,7 @@ def write_metadata(metadata: dict[str, Any]) -> None:
             json.dump(metadata, f, default=str)
         log.debug("Metadata written to metadata.json")
     except Exception:
-        log.error("Failed to write metadata", exc_info=True)
+        log.error("Failed to write metadata", exc_info=True)  # noqa: G201
 
 
 def upload_results_to_s3(bucket_name: str, region: str) -> None:
@@ -87,7 +87,7 @@ def upload_results_to_s3(bucket_name: str, region: str) -> None:
             "--region",
             region,
         ]
-        result = subprocess.run(aws_cmd, capture_output=True, text=True)
+        result = subprocess.run(aws_cmd, capture_output=True, text=True)  # noqa: PLW1510
         if result.returncode == 0:
             log.info("Successfully uploaded benchmark results to S3")
         else:
@@ -165,14 +165,14 @@ def run_experiment(cfg: DictConfig) -> None:
         metadata["success"] = True
 
     except Exception:
-        log.error("Benchmark execution failed:", exc_info=True)
+        log.error("Benchmark execution failed:", exc_info=True)  # noqa: G201
         raise
     finally:
         try:
             if result is not None:
                 benchmark.post_process(result)
         except Exception:
-            log.error("Post-processing failed:", exc_info=True)
+            log.error("Post-processing failed:", exc_info=True)  # noqa: G201
         finally:
             result_bucket_name = cfg.s3_result_bucket
             region = cfg.region

--- a/benchmark/benchmarks/base_benchmark.py
+++ b/benchmark/benchmarks/base_benchmark.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any
 
 from .command import Command, CommandResult
 
@@ -13,7 +13,7 @@ class BaseBenchmark(ABC):
     """
 
     @abstractmethod
-    def setup(self, with_flamegraph: bool = False) -> Dict[str, Any]:
+    def setup(self, with_flamegraph: bool = False) -> dict[str, Any]:
         """
         Set up the environment for the benchmark.
 
@@ -23,7 +23,6 @@ class BaseBenchmark(ABC):
         Returns:
             Dict containing setup metadata
         """
-        pass
 
     @abstractmethod
     def get_command(self) -> Command:
@@ -33,10 +32,9 @@ class BaseBenchmark(ABC):
         Returns:
             Command object containing the subprocess arguments and environment.
         """
-        pass
 
     @abstractmethod
-    def post_process(self, result: CommandResult) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> dict[str, Any]:
         """
         Process results and output, collect logs, and clean up resources.
 
@@ -46,4 +44,3 @@ class BaseBenchmark(ABC):
         Returns:
             Dict containing post-processing metadata
         """
-        pass

--- a/benchmark/benchmarks/cargo_helper.py
+++ b/benchmark/benchmarks/cargo_helper.py
@@ -1,16 +1,15 @@
 import json
 import logging
-import subprocess
-from typing import List, Optional, Dict
 import os
+import subprocess
 
 log = logging.getLogger(__name__)
 
 
 def build_example(
     name: str,
-    features: Optional[List[str]] = None,
-    build_env: Optional[Dict[str, str]] = None,
+    features: list[str] | None = None,
+    build_env: dict[str, str] | None = None,
     with_flamegraph: bool = False,
 ) -> str:
     """
@@ -32,8 +31,8 @@ def build_example(
 
 def build_binary(
     name: str,
-    features: Optional[List[str]] = None,
-    build_env: Optional[Dict[str, str]] = None,
+    features: list[str] | None = None,
+    build_env: dict[str, str] | None = None,
     with_flamegraph: bool = False,
 ) -> str:
     """
@@ -54,10 +53,10 @@ def build_binary(
 
 
 def _build_and_get_executable(
-    binary_name: Optional[str] = None,
-    example_name: Optional[str] = None,
-    features: Optional[List[str]] = None,
-    build_env: Optional[Dict[str, str]] = None,
+    binary_name: str | None = None,
+    example_name: str | None = None,
+    features: list[str] | None = None,
+    build_env: dict[str, str] | None = None,
     with_flamegraph: bool = False,
 ) -> str:
     """Build and get executable path."""

--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -1,10 +1,10 @@
 import logging
 import subprocess
-from typing import Dict, Any
+from typing import Any
 
 from benchmarks.base_benchmark import BaseBenchmark
-from benchmarks.command import Command, CommandResult
 from benchmarks.cargo_helper import build_example
+from benchmarks.command import Command, CommandResult
 from benchmarks.config_utils import get_s3_keys
 from omegaconf import DictConfig
 
@@ -12,12 +12,12 @@ log = logging.getLogger(__name__)
 
 
 class ClientBenchmark(BaseBenchmark):
-    def __init__(self, cfg: DictConfig, metadata: Dict[str, Any], backpressure=False):
+    def __init__(self, cfg: DictConfig, metadata: dict[str, Any], backpressure=False):
         self.cfg = cfg
         self.metadata = metadata
         self.backpressure = backpressure
 
-    def setup(self, with_flamegraph: bool = False) -> Dict[str, Any]:
+    def setup(self, with_flamegraph: bool = False) -> dict[str, Any]:
         # Compile the client_benchmark example
         features = None
         if self.backpressure:
@@ -74,7 +74,7 @@ class ClientBenchmark(BaseBenchmark):
 
         return Command(args=subprocess_args, env=client_env)
 
-    def post_process(self, result: CommandResult) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> dict[str, Any]:
         if result.returncode != 0:
             log.error(f"Client benchmark failed with exit code {result.returncode}")
             if result.stderr:

--- a/benchmark/benchmarks/client_benchmark.py
+++ b/benchmark/benchmarks/client_benchmark.py
@@ -33,7 +33,7 @@ class ClientBenchmark(BaseBenchmark):
     def get_command(self) -> Command:
         subprocess_args = [self.executable_path]
 
-        if self.backpressure:
+        if self.backpressure:  # noqa: SIM102
             if (backpressure_window_size := self.cfg.benchmarks.client_bp.backpressure_window_size) is not None:
                 subprocess_args.extend(["--backpressure-window-size", str(backpressure_window_size)])
 
@@ -60,7 +60,7 @@ class ClientBenchmark(BaseBenchmark):
 
         if len(objects) >= self.cfg.application_workers:
             for obj in objects:
-                subprocess_args.append(obj)
+                subprocess_args.append(obj)  # noqa: PERF402
         else:
             raise ValueError("Seeing fewer objects than app workers. So cannot proceed with the run.")
 

--- a/benchmark/benchmarks/command.py
+++ b/benchmark/benchmarks/command.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass, field
-from typing import List, Dict, Optional
 import os
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -8,16 +7,16 @@ class CommandResult:
     """Result of command execution."""
 
     returncode: int
-    stdout: Optional[str] = None
-    stderr: Optional[str] = None
+    stdout: str | None = None
+    stderr: str | None = None
 
 
 @dataclass
 class Command:
     """Represents a command to be executed with its environment."""
 
-    args: List[str]
-    env: Dict[str, str] = field(default_factory=dict)
+    args: list[str]
+    env: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
         """Merge command environment with current environment."""

--- a/benchmark/benchmarks/crt_benchmark.py
+++ b/benchmark/benchmarks/crt_benchmark.py
@@ -4,7 +4,7 @@ import os
 import re
 import subprocess
 import tempfile
-from typing import Dict, Any
+from typing import Any
 
 from benchmarks.base_benchmark import BaseBenchmark
 from benchmarks.command import Command, CommandResult
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 class CrtBenchmark(BaseBenchmark):
-    def __init__(self, cfg: DictConfig, metadata: Dict[str, Any]):
+    def __init__(self, cfg: DictConfig, metadata: dict[str, Any]):
         self.cfg = cfg
         self.metadata = metadata
 
@@ -47,7 +47,7 @@ class CrtBenchmark(BaseBenchmark):
 
         return config
 
-    def setup(self, with_flamegraph: bool = False) -> Dict[str, Any]:
+    def setup(self, with_flamegraph: bool = False) -> dict[str, Any]:
         # Setup the benchmark configuration files
         object_size_in_gib = self.cfg.object_size_in_gib
         app_workers = self.cfg.application_workers
@@ -114,7 +114,7 @@ class CrtBenchmark(BaseBenchmark):
             return metrics
         return {}
 
-    def post_process(self, result: CommandResult) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> dict[str, Any]:
         if result.returncode != 0:
             log.error(f"CRT benchmark failed with exit code {result.returncode}")
             if result.stderr:

--- a/benchmark/benchmarks/crt_benchmark.py
+++ b/benchmark/benchmarks/crt_benchmark.py
@@ -135,6 +135,6 @@ class CrtBenchmark(BaseBenchmark):
             if self.crt_cfg_file and os.path.exists(self.crt_cfg_file):
                 log.info(f"Remove CRT benchmark configuration: {self.crt_cfg_file}")
                 os.remove(self.crt_cfg_file)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             log.warning(f"Failed to clean up CRT config file: {e}")
         return self.metadata

--- a/benchmark/benchmarks/fio_benchmark.py
+++ b/benchmark/benchmarks/fio_benchmark.py
@@ -1,21 +1,20 @@
 import logging
 import subprocess
 import tempfile
-from typing import Dict, Any
 from datetime import datetime, timezone
+from typing import Any
 
+import hydra
 from benchmarks.base_benchmark import BaseBenchmark
 from benchmarks.command import Command, CommandResult
-import hydra
+from benchmarks.mountpoint import cleanup_mp, mount_mp
 from omegaconf import DictConfig
-
-from benchmarks.mountpoint import mount_mp, cleanup_mp
 
 log = logging.getLogger(__name__)
 
 
 class FioBenchmark(BaseBenchmark):
-    def __init__(self, cfg: DictConfig, metadata: Dict[str, Any]):
+    def __init__(self, cfg: DictConfig, metadata: dict[str, Any]):
         self.cfg = cfg
         self.metadata = metadata  # Use the metadata passed from benchmark.py
         self.mount_dir = None
@@ -39,7 +38,7 @@ class FioBenchmark(BaseBenchmark):
         subprocess.run(['sudo', 'sh', '-c', cmd], check=True, capture_output=True)
         log.info(f"Set read_ahead_kb to {bytes} for device {dev_id}")
 
-    def setup(self, with_flamegraph: bool = False) -> Dict[str, Any]:
+    def setup(self, with_flamegraph: bool = False) -> dict[str, Any]:
         self.mount_dir = tempfile.mkdtemp(suffix=".mountpoint-s3")
         mount_metadata = mount_mp(self.cfg, self.mount_dir, with_flamegraph)
         self.metadata.update(mount_metadata)
@@ -78,7 +77,7 @@ class FioBenchmark(BaseBenchmark):
 
         return Command(args=subprocess_args, env=fio_env)
 
-    def post_process(self, result: CommandResult) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> dict[str, Any]:
         cleanup_mp(self.mount_dir)
         if result.returncode != 0:
             log.error(f"FIO process failed with exit code {result.returncode}")

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -1,11 +1,10 @@
 import logging
 import os
 import subprocess
-from typing import Dict, Any
-
-from omegaconf import DictConfig
+from typing import Any
 
 from benchmarks.cargo_helper import build_binary
+from omegaconf import DictConfig
 
 logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
 log = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ def cleanup_mp(mount_dir):
         os.remove(f"{mount_dir}.pid")
 
 
-def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> Dict[str, Any]:
+def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> dict[str, Any]:
     """
     Mount an S3 bucket using Mountpoint,
     using the configuration to apply Mountpoint arguments.

--- a/benchmark/benchmarks/mountpoint.py
+++ b/benchmark/benchmarks/mountpoint.py
@@ -36,7 +36,7 @@ def mount_mp(cfg: DictConfig, mount_dir: str, with_flamegraph: bool = False) -> 
 
         if stub_mode == "s3_client":
             # `mock-mount-s3` requires bucket to be prefixed with `sthree-` to verify we're not actually reaching S3
-            logging.debug("using mock-mount-s3 due to `stub_mode`, bucket will be prefixed with \"sthree-\"")
+            logging.debug("using mock-mount-s3 due to `stub_mode`, bucket will be prefixed with \"sthree-\"")  # noqa: LOG015
             bucket = f"sthree-{bucket}"
             binary_name = "mock-mount-s3"
         elif stub_mode == "fs_handler":

--- a/benchmark/benchmarks/prefetch_benchmark.py
+++ b/benchmark/benchmarks/prefetch_benchmark.py
@@ -1,10 +1,10 @@
 import logging
 import subprocess
-from typing import Dict, Any
+from typing import Any
 
 from benchmarks.base_benchmark import BaseBenchmark
-from benchmarks.command import Command, CommandResult
 from benchmarks.cargo_helper import build_example
+from benchmarks.command import Command, CommandResult
 from benchmarks.config_utils import get_s3_keys
 from omegaconf import DictConfig
 
@@ -12,11 +12,11 @@ log = logging.getLogger(__name__)
 
 
 class PrefetchBenchmark(BaseBenchmark):
-    def __init__(self, cfg: DictConfig, metadata: Dict[str, Any]):
+    def __init__(self, cfg: DictConfig, metadata: dict[str, Any]):
         self.cfg = cfg
         self.metadata = metadata
 
-    def setup(self, with_flamegraph: bool = False) -> Dict[str, Any]:
+    def setup(self, with_flamegraph: bool = False) -> dict[str, Any]:
         log.info("Compiling prefetch_benchmark example...")
         self.executable_path = build_example("prefetch_benchmark", with_flamegraph=with_flamegraph)
         log.info(f"Prefetch benchmark executable ready at: {self.executable_path}")
@@ -77,7 +77,7 @@ class PrefetchBenchmark(BaseBenchmark):
 
         return Command(args=subprocess_args, env=prefetch_env)
 
-    def post_process(self, result: CommandResult) -> Dict[str, Any]:
+    def post_process(self, result: CommandResult) -> dict[str, Any]:
         if result.returncode != 0:
             log.error(f"Prefetch benchmark failed with exit code {result.returncode}")
             if result.stderr:

--- a/benchmark/hydra_plugins/smart_sweeper/smart_benchmark_sweeper.py
+++ b/benchmark/hydra_plugins/smart_sweeper/smart_benchmark_sweeper.py
@@ -49,7 +49,7 @@ class SmartBenchmarkSweeper(Sweeper):
                 params = benchmark_config.get("params", {})
                 return [f"{key}={value}" for key, value in params.items()]
             return []
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             log.error(f"Failed to load config for {benchmark_type}: {e}")
             return []
 

--- a/benchmark/hydra_plugins/smart_sweeper/smart_benchmark_sweeper.py
+++ b/benchmark/hydra_plugins/smart_sweeper/smart_benchmark_sweeper.py
@@ -1,16 +1,16 @@
-from dataclasses import dataclass
 import itertools
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
-from hydra.types import HydraContext
+from typing import Any
+
 from hydra.core.config_store import ConfigStore
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.override_parser.types import Override
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.plugins.sweeper import Sweeper
-from hydra.types import TaskFunction
+from hydra.types import HydraContext, TaskFunction
 from omegaconf import DictConfig, OmegaConf
 
 log = logging.getLogger(__name__)
@@ -19,20 +19,20 @@ log = logging.getLogger(__name__)
 @dataclass
 class SmartBenchmarkSweeperConf:
     _target_: str = "hydra_plugins.smart_sweeper.smart_benchmark_sweeper.SmartBenchmarkSweeper"
-    max_batch_size: Optional[int] = None
-    params: Optional[Dict[str, str]] = None
+    max_batch_size: int | None = None
+    params: dict[str, str] | None = None
 
 
 ConfigStore.instance().store(group="hydra/sweeper", name="smart_benchmark", node=SmartBenchmarkSweeperConf)
 
 
 class SmartBenchmarkSweeper(Sweeper):
-    def __init__(self, max_batch_size: Optional[int] = None, params: Optional[Dict[str, str]] = None):
+    def __init__(self, max_batch_size: int | None = None, params: dict[str, str] | None = None):
         self.max_batch_size = max_batch_size
         self.params = params or {}
-        self.config: Optional[DictConfig] = None
-        self.launcher: Optional[Launcher] = None
-        self.hydra_context: Optional[HydraContext] = None
+        self.config: DictConfig | None = None
+        self.launcher: Launcher | None = None
+        self.hydra_context: HydraContext | None = None
 
     def setup(self, *, hydra_context: HydraContext, task_function: TaskFunction, config: DictConfig) -> None:
         self.config = config
@@ -41,7 +41,7 @@ class SmartBenchmarkSweeper(Sweeper):
         )
         self.hydra_context = hydra_context
 
-    def _load_benchmark_params(self, benchmark_type: str) -> List[str]:
+    def _load_benchmark_params(self, benchmark_type: str) -> list[str]:
         try:
             config_path = Path("conf") / "hydra" / "sweeper" / f"{benchmark_type}.yaml"
             if config_path.exists():
@@ -53,7 +53,7 @@ class SmartBenchmarkSweeper(Sweeper):
             log.error(f"Failed to load config for {benchmark_type}: {e}")
             return []
 
-    def sweep(self, arguments: List[str]) -> Any:
+    def sweep(self, arguments: list[str]) -> Any:
         benchmark_types = self._extract_benchmark_types(arguments)
         log.info(f"Running benchmark types: {benchmark_types}")
 
@@ -91,14 +91,14 @@ class SmartBenchmarkSweeper(Sweeper):
 
         return returns
 
-    def _extract_benchmark_types(self, arguments: List[str]) -> List[str]:
+    def _extract_benchmark_types(self, arguments: list[str]) -> list[str]:
         for arg in arguments:
             if arg.startswith("benchmark_type="):
                 benchmark_type_str = arg.split("=", 1)[1]
                 return [bt.strip() for bt in benchmark_type_str.split(",")]
         return ["fio"]
 
-    def _generate_combinations_for_type(self, benchmark_type: str, parsed_overrides: List[Override]) -> List[List[str]]:
+    def _generate_combinations_for_type(self, benchmark_type: str, parsed_overrides: list[Override]) -> list[list[str]]:
         param_lists = [[f"benchmark_type={benchmark_type}"]]
 
         for param_override in parsed_overrides:

--- a/benchmark/monitoring/__init__.py
+++ b/benchmark/monitoring/__init__.py
@@ -1,6 +1,5 @@
 import logging
 from contextlib import contextmanager
-from typing import List
 
 from .base import MonitoringTool
 

--- a/benchmark/monitoring/__init__.py
+++ b/benchmark/monitoring/__init__.py
@@ -1,5 +1,5 @@
-from contextlib import contextmanager
 import logging
+from contextlib import contextmanager
 from typing import List
 
 from .base import MonitoringTool
@@ -21,7 +21,7 @@ class ResourceMonitoring:
             pass
     """
 
-    def __init__(self, tools: List[MonitoringTool]):
+    def __init__(self, tools: list[MonitoringTool]):
         """Resource monitoring setup.
 
         tools: List of MonitoringTool instances to manage
@@ -40,7 +40,7 @@ class ResourceMonitoring:
 
     @staticmethod
     @contextmanager
-    def managed(tools: List[MonitoringTool]):
+    def managed(tools: list[MonitoringTool]):
         resource = ResourceMonitoring(tools)
         try:
             resource._start()

--- a/benchmark/monitoring/tools.py
+++ b/benchmark/monitoring/tools.py
@@ -2,7 +2,6 @@ import logging
 import os
 import signal
 import subprocess
-from typing import Optional
 
 import psutil
 
@@ -100,7 +99,7 @@ class PerfStatTool(MonitoringTool):
 
 
 class FlamegraphTool(MonitoringTool):
-    def __init__(self, target_pid: int, flamegraph_scripts_path: Optional[str] = None):
+    def __init__(self, target_pid: int, flamegraph_scripts_path: str | None = None):
         self.target_pid = target_pid
         self.flamegraph_scripts_path = flamegraph_scripts_path
         self.process = None
@@ -148,7 +147,7 @@ class FlamegraphTool(MonitoringTool):
                 )
             else:
                 log.info("verified that kernel.kptr_restrict=0 (for flamegraphing)")
-        except (OSError, IOError) as e:
+        except OSError as e:
             log.warning(f"Could not check kernel.kptr_restrict: {e}")
 
         try:
@@ -161,7 +160,7 @@ class FlamegraphTool(MonitoringTool):
                 )
             else:
                 log.info(f"verified that kernel.perf_event_paranoid={paranoid_value} for flamegraphing")
-        except (OSError, IOError) as e:
+        except OSError as e:
             log.warning(f"Could not check kernel.perf_event_paranoid: {e}")
 
     def _generate_inverted_flamegraph(self):

--- a/benchmark/monitoring/tools.py
+++ b/benchmark/monitoring/tools.py
@@ -16,7 +16,7 @@ class MpstatTool(MonitoringTool):
         self.output_file = None
 
     def start(self) -> None:
-        self.output_file = open('mpstat.json', 'w')
+        self.output_file = open('mpstat.json', 'w')  # noqa: SIM115
         log.info("Starting mpstat monitoring")
         # fmt: off
         self.process = subprocess.Popen([
@@ -33,12 +33,12 @@ class MpstatTool(MonitoringTool):
                 self.process.send_signal(signal.SIGINT)
                 self.process.wait()
             except Exception:
-                log.error("Error shutting down mpstat:", exc_info=True)
+                log.error("Error shutting down mpstat:", exc_info=True)  # noqa: G201
         if self.output_file:
             try:
                 self.output_file.close()
             except Exception:
-                log.error("Error closing mpstat output file:", exc_info=True)
+                log.error("Error closing mpstat output file:", exc_info=True)  # noqa: G201
 
 
 class BwmNgTool(MonitoringTool):
@@ -47,7 +47,7 @@ class BwmNgTool(MonitoringTool):
         self.output_file = None
 
     def start(self) -> None:
-        self.output_file = open('bwm-ng.csv', 'w')
+        self.output_file = open('bwm-ng.csv', 'w')  # noqa: SIM115
         log.info("Starting bwm-ng monitoring")
         # fmt: off
         self.process = subprocess.Popen([
@@ -61,12 +61,12 @@ class BwmNgTool(MonitoringTool):
                 self.process.send_signal(signal.SIGINT)
                 self.process.wait()
             except Exception:
-                log.error("Error shutting down bwm-ng:", exc_info=True)
+                log.error("Error shutting down bwm-ng:", exc_info=True)  # noqa: G201
         if self.output_file:
             try:
                 self.output_file.close()
             except Exception:
-                log.error("Error closing bwm-ng output file:", exc_info=True)
+                log.error("Error closing bwm-ng output file:", exc_info=True)  # noqa: G201
 
 
 class PerfStatTool(MonitoringTool):
@@ -95,7 +95,7 @@ class PerfStatTool(MonitoringTool):
                 self.process.send_signal(signal.SIGINT)
                 self.process.wait()
             except Exception:
-                log.error("Error shutting down perf stat:", exc_info=True)
+                log.error("Error shutting down perf stat:", exc_info=True)  # noqa: G201
 
 
 class FlamegraphTool(MonitoringTool):
@@ -124,7 +124,7 @@ class FlamegraphTool(MonitoringTool):
             except psutil.NoSuchProcess:
                 log.warning(f"Process {self.process.pid} no longer exists")
             except Exception:
-                log.error("Error shutting down flamegraph:", exc_info=True)
+                log.error("Error shutting down flamegraph:", exc_info=True)  # noqa: G201
 
             if self.flamegraph_scripts_path and os.path.exists("perf.data"):
                 self._generate_inverted_flamegraph()
@@ -176,7 +176,7 @@ class FlamegraphTool(MonitoringTool):
             log.info("Generating inverted flamegraph...")
 
             with open("perf.txt", "w") as perf_txt:
-                result = subprocess.run(
+                result = subprocess.run(  # noqa: PLW1510
                     ["perf", "script", "-i", "perf.data"], stdout=perf_txt, stderr=subprocess.PIPE, text=True
                 )
                 if result.returncode != 0:
@@ -184,7 +184,7 @@ class FlamegraphTool(MonitoringTool):
                     return
 
             with open("perf.txt", "r") as perf_txt, open("stacks.txt", "w") as stacks_txt:
-                result = subprocess.run(
+                result = subprocess.run(  # noqa: PLW1510
                     [stackcollapse_script], stdin=perf_txt, stdout=stacks_txt, stderr=subprocess.PIPE, text=True
                 )
                 if result.returncode != 0:
@@ -192,7 +192,7 @@ class FlamegraphTool(MonitoringTool):
                     return
 
             with open("stacks.txt", "r") as stacks_txt, open("inverted-flamegraph.svg", "w") as flamegraph_svg:
-                result = subprocess.run(
+                result = subprocess.run(  # noqa: PLW1510
                     [flamegraph_script, "--inverted", "--reverse", "--colors", "blue"],
                     stdin=stacks_txt,
                     stdout=flamegraph_svg,
@@ -209,8 +209,8 @@ class FlamegraphTool(MonitoringTool):
                 try:
                     if os.path.exists(temp_file):
                         os.remove(temp_file)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     log.debug(f"Failed to remove temporary file {temp_file}: {e}")
 
         except Exception:
-            log.error("Error generating inverted flamegraph:", exc_info=True)
+            log.error("Error generating inverted flamegraph:", exc_info=True)  # noqa: G201

--- a/benchmark/test_monitoring_tools.py
+++ b/benchmark/test_monitoring_tools.py
@@ -1,8 +1,8 @@
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 from monitoring import ResourceMonitoring
 from monitoring.base import MonitoringTool
-from monitoring.tools import MpstatTool, BwmNgTool, PerfStatTool, FlamegraphTool
+from monitoring.tools import BwmNgTool, FlamegraphTool, MpstatTool, PerfStatTool
 
 
 class TestMpstatTool:

--- a/package/package.py
+++ b/package/package.py
@@ -56,22 +56,22 @@ def check_dependencies(args: argparse.Namespace):
     log("Checking dependencies")
 
     deps = ["cargo", "cargo-about", "tar", "whereis"]
-    if any(map(lambda ext: ext.endswith("rpm"), args.pkg_extensions)):
+    if any(map(lambda ext: ext.endswith("rpm"), args.pkg_extensions)):  # noqa: C417
         deps.extend(["rpm", "rpmbuild"])
-    if any(map(lambda ext: ext.endswith("deb"), args.pkg_extensions)):
+    if any(map(lambda ext: ext.endswith("deb"), args.pkg_extensions)):  # noqa: C417
         deps.extend(["fakeroot", "dpkg-deb"])
 
     for dep in deps:
         if shutil.which(dep) is None:
-            raise Exception(f"`{dep}` must be installed")
+            raise Exception(f"`{dep}` must be installed")  # noqa: TRY002
 
     output = run(["whereis", "libfuse"])
     if b"libfuse.so" not in output:
-        raise Exception(f"libfuse not found (whereis output: {output})")
+        raise Exception(f"libfuse not found (whereis output: {output})")  # noqa: TRY002
 
     output = run(["whereis", "libfuse3"])
     if b"libfuse3.so" in output:
-        raise Exception(f"libfuse3 should not be installed (whereis output: {output})")
+        raise Exception(f"libfuse3 should not be installed (whereis output: {output})")  # noqa: TRY002
 
 
 def get_build_metadata(args: argparse.Namespace) -> BuildMetadata:
@@ -89,10 +89,10 @@ def get_build_metadata(args: argparse.Namespace) -> BuildMetadata:
             version = package["version"]
             break
     if version is None:
-        raise Exception(f"couldn't find mountpoint-s3 in Cargo metadata in {root_dir}")
-    if args.expected_version is not None:
+        raise Exception(f"couldn't find mountpoint-s3 in Cargo metadata in {root_dir}")  # noqa: TRY002
+    if args.expected_version is not None:  # noqa: SIM102
         if args.expected_version != version:
-            raise Exception(f"version mismatch: expected {args.expected_version} but found {version} in Cargo metadata")
+            raise Exception(f"version mismatch: expected {args.expected_version} but found {version} in Cargo metadata")  # noqa: TRY002
     version_string = version
     if not args.official:
         version_string += "+unofficial"
@@ -147,7 +147,7 @@ def build_mountpoint_binary(metadata: BuildMetadata, args: argparse.Namespace) -
     run(cmd, cwd=metadata.cargoroot, env=env)
     binary_path = os.path.join(target_dir, "release/mount-s3")
     if not os.path.exists(binary_path):
-        raise Exception(f"binary wasn't found at path {binary_path}")
+        raise Exception(f"binary wasn't found at path {binary_path}")  # noqa: TRY002
 
     # Validate the binary runs and is the right version
     log(f"Validating binary at {binary_path}")
@@ -155,11 +155,11 @@ def build_mountpoint_binary(metadata: BuildMetadata, args: argparse.Namespace) -
     output = output.decode("ascii").strip()
     if args.official:
         if output != f"mount-s3 {metadata.version}":
-            raise Exception(f"unexpected compiled version {output}")
+            raise Exception(f"unexpected compiled version {output}")  # noqa: TRY002
     else:
         # Might not have a known Git hash available, so just check for the 'unofficial' part
         if not output.startswith(f"mount-s3 {metadata.version}-unofficial"):
-            raise Exception(f"unexpected compiled version {output}")
+            raise Exception(f"unexpected compiled version {output}")  # noqa: TRY002
 
     log(f"Built binary for {output} at {binary_path}")
 
@@ -280,7 +280,7 @@ def build_deb(metadata: BuildMetadata, package_dir: str) -> str:
     elif metadata.arch == "aarch64":
         deb_arch = "arm64"
     else:
-        raise Exception(f"unknown architecture {metadata.args} for DEB package")
+        raise Exception(f"unknown architecture {metadata.args} for DEB package")  # noqa: TRY002
     control_file = control_file.replace("__ARCH__", deb_arch)
     control_file_path = os.path.join(deb_DEBIAN_dir, "control")
     with open(control_file_path, "w") as f:
@@ -349,7 +349,7 @@ def build(args: argparse.Namespace) -> str:
         elif ext.endswith("tar.gz"):
             artifacts.append(build_package_archive(metadata, package_dir))
         else:
-            raise Exception(f"unable to infer package type from extension {ext}")
+            raise Exception(f"unable to infer package type from extension {ext}")  # noqa: TRY002
 
     for path in artifacts:
         os.chmod(path, 0o755)

--- a/package/package.py
+++ b/package/package.py
@@ -8,13 +8,13 @@ directory in the root of the Mountpoint repository.
 """
 
 import argparse
-from dataclasses import dataclass
 import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 
 
 def log(msg: str):

--- a/package/spec/generate_spec.py
+++ b/package/spec/generate_spec.py
@@ -8,10 +8,11 @@ and outputs a complete RPM spec file ready for rpmbuild.
 
 import argparse
 import subprocess
-from pathlib import Path
 from datetime import datetime
-from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
 import tomllib
+from jinja2 import Environment, FileSystemLoader
 
 script_dir = Path(__file__).parent
 project_root = script_dir.parent.parent

--- a/package/spec/generate_spec.py
+++ b/package/spec/generate_spec.py
@@ -34,7 +34,7 @@ def get_rust_version() -> str:
 
 
 def get_submodule_versions() -> dict[str, str]:
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: PLW1510
         'git submodule foreach -q \'echo $name `git describe --tags`\'', capture_output=True, text=True, shell=True
     )
     versions = {}
@@ -69,7 +69,7 @@ def main() -> None:
     version = get_version()
     rust_version = get_rust_version()
     submodule_versions = get_submodule_versions()
-    current_date = datetime.now().strftime("%a %b %d %Y")
+    current_date = datetime.now().strftime("%a %b %d %Y")  # noqa: DTZ005
 
     env = Environment(loader=FileSystemLoader(templates_dir), trim_blocks=True, lstrip_blocks=True)
 

--- a/package/validate/validate.py
+++ b/package/validate/validate.py
@@ -24,7 +24,7 @@ def validate(args: argparse.Namespace) -> str:
     elif package == "rpm-centos8":
         image = "public.ecr.aws/docker/library/centos:8"
     else:
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"unsupported OS {args.os} for {args.artifact}. Supported combinations are: deb-ubuntu, rpm-al2, gzip-al2, rpm-suse"
         )
 
@@ -39,8 +39,8 @@ def validate(args: argparse.Namespace) -> str:
     validate_script = f"validate-{package}.sh"
     scripts_dir = os.path.dirname(os.path.realpath(__file__))
 
-    subprocess.run(["docker", "pull", image])
-    subprocess.run(
+    subprocess.run(["docker", "pull", image])  # noqa: PLW1510
+    subprocess.run(  # noqa: PLW1510
         [
             "docker",
             "run",


### PR DESCRIPTION
CI runs uvx ruff check . which picks up the latest ruff version. Ruff 0.16.0 expanded default rules from 59 to 413, which flagged existing code in `benchmark/ `and `package/`.
  
Commit 1: Ran` ruff check --fix `and `ruff format` - these are all mechanical, tool-applied changes (import sorting, type annotation modernization, etc.) with no behavioral impact.
  
Commit 2: Added `# noqa` suppressions for remaining rules where fixing them would change code behavior, which is not worth the risk for a lint-only PR. Also removed an unused import and fixed file permissions.
  
Tested uvx ruff check locally and passes clean in both directories.

 ### Does this change impact existing behavior?

No - commit 1 is tool-applied safe fixes, commit 2 only adds lint suppressions.

### Does this change need a changelog entry? Does it require a version change?

No - CI fix only, no user-facing changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
