### PR TITLE
Remove unmaintained `smallstr` dependency from `mountpoint-s3-crt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,6 @@ dependencies = [
  "rand 0.10.2",
  "rcgen",
  "serde_json",
- "smallstr",
  "static_assertions",
  "tempfile",
  "test-case",
@@ -4375,15 +4374,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallstr"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "smallvec"

--- a/mountpoint-s3-crt/Cargo.toml
+++ b/mountpoint-s3-crt/Cargo.toml
@@ -13,7 +13,6 @@ mountpoint-s3-crt-sys = { workspace = true }
 futures = "0.3.32"
 libc = "0.2.186"
 log = "0.4.33"
-smallstr = "0.3.1"
 static_assertions = "1.1.0"
 thiserror = "2.0.18"
 

--- a/mountpoint-s3-crt/src/common/rust_log_adapter.rs
+++ b/mountpoint-s3-crt/src/common/rust_log_adapter.rs
@@ -2,8 +2,6 @@
 
 use std::fmt::Write as _;
 
-use smallstr::SmallString;
-
 use crate::common::allocator::Allocator;
 use crate::common::logging::{Level, Logger, LoggerImpl, LoggerInitError, Subject};
 
@@ -31,12 +29,61 @@ impl RustLogAdapter {
 
 impl LoggerImpl for RustLogAdapter {
     fn log(&self, log_level: Level, subject: Subject, message: &str) {
-        let mut target = SmallString::<[u8; 64]>::new();
+        let mut target = LogTarget::new();
         let _ = write!(target, "{}::{}", AWSCRT_LOG_TARGET, subject.name());
         log::log!(target: target.as_str(), log_level.into(), "{message}");
     }
     fn get_log_level(&self, _subject: Subject) -> Level {
         log::max_level().to_level().map(|l| l.into()).unwrap_or(Level::None)
+    }
+}
+
+/// Buffer for building the log target `{AWSCRT_LOG_TARGET}::{subject}`. Holds the common case
+/// inline on the stack; spills to the heap if the target exceeds [`INLINE_CAPACITY`].
+enum LogTarget {
+    Inline { buf: [u8; INLINE_CAPACITY], len: usize },
+    Spilled(String),
+}
+
+const INLINE_CAPACITY: usize = 64;
+
+impl LogTarget {
+    fn new() -> Self {
+        Self::Inline {
+            buf: [0; INLINE_CAPACITY],
+            len: 0,
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            // Only whole `&str`s are ever appended to `buf`, so the populated prefix is valid UTF-8.
+            Self::Inline { buf, len } => std::str::from_utf8(&buf[..*len]).unwrap_or_default(),
+            Self::Spilled(s) => s,
+        }
+    }
+}
+
+impl std::fmt::Write for LogTarget {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        match self {
+            Self::Inline { buf, len } if *len + s.len() <= INLINE_CAPACITY => {
+                buf[*len..*len + s.len()].copy_from_slice(s.as_bytes());
+                *len += s.len();
+                Ok(())
+            }
+            Self::Inline { buf, len } => {
+                let mut spilled = String::with_capacity(*len + s.len());
+                spilled.push_str(std::str::from_utf8(&buf[..*len]).unwrap_or_default());
+                spilled.push_str(s);
+                *self = Self::Spilled(spilled);
+                Ok(())
+            }
+            Self::Spilled(spilled) => {
+                spilled.push_str(s);
+                Ok(())
+            }
+        }
     }
 }
 
@@ -66,5 +113,34 @@ impl From<log::Level> for Level {
             log::Level::Debug => Level::Debug,
             log::Level::Trace => Level::Trace,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_target_boundary() {
+        let mut exact = LogTarget::new();
+        write!(exact, "{}", "a".repeat(INLINE_CAPACITY)).unwrap();
+        assert!(matches!(exact, LogTarget::Inline { .. }));
+        assert_eq!(exact.as_str(), "a".repeat(INLINE_CAPACITY));
+
+        let mut over = LogTarget::new();
+        write!(over, "{}", "a".repeat(INLINE_CAPACITY + 1)).unwrap();
+        assert!(matches!(over, LogTarget::Spilled(_)));
+        assert_eq!(over.as_str(), "a".repeat(INLINE_CAPACITY + 1));
+    }
+
+    #[test]
+    fn log_target_spills_across_multiple_writes() {
+        let mut target = LogTarget::new();
+        let head = "h".repeat(INLINE_CAPACITY - 1);
+        write!(target, "{head}").unwrap();
+        assert!(matches!(target, LogTarget::Inline { .. }));
+        write!(target, "tail").unwrap();
+        assert!(matches!(target, LogTarget::Spilled(_)));
+        assert_eq!(target.as_str(), format!("{head}tail"));
     }
 }


### PR DESCRIPTION
Removes the `smallstr` dependency, which is flagged unmaintained by `RUSTSEC-2026-0215` and fails the `cargo deny` Licenses check ([example run](https://github.com/awslabs/mountpoint-s3/actions/runs/30344994989/job/90229022750?pr=1904#step:4:1754)). Its only use was building the `awscrt::<subject>` log target string; it is replaced with a small internal `LogTarget` that keeps the same small-string optimization (inline on the stack, spilling to the heap only if the target exceeds 64 bytes).

### Does this change impact existing behavior?

No. The log target string is identical, only the backing buffer changes.

### Does this change need a changelog entry? Does it require a version change?

No.