### PR TITLE
stress: Add cache_hit_vs_miss_held_budget scenario

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -59,6 +59,7 @@ jobs:
           - single_reader_held_budget_direct_io
           - many_readers_held_budget_direct_io
           - single_reader_held_budget_misaligned_part
+          - cache_hit_vs_miss_held_budget
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
@@ -83,6 +84,17 @@ jobs:
           rustflags: ""
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
+      - name: Set up local NVMe cache storage
+        if: contains(matrix.scenario, 'cache')
+        run: |
+          local_storage=/localstorage
+          sudo mkfs -t ext4 /dev/nvme1n1
+          sudo mkdir -p $local_storage
+          sudo mount /dev/nvme1n1 $local_storage
+          sudo chown -R "$(id -u)" $local_storage
+          echo "mounted local file system at $local_storage"
+          df -hT $local_storage
+          echo "S3_STRESS_CACHE_DIR=$local_storage" >> "$GITHUB_ENV"
       - name: Run stress scenario
         run: |
           cargo nextest run \

--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fs::{File, ReadDir};
 use std::os::fd::AsFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fuser::{Mount, MountOption, Session};
@@ -535,12 +535,40 @@ pub mod s3_session {
 
     /// Create a FUSE mount backed by a real S3 client, session will use a test client provided by the caller
     pub fn new_with_test_client(test_config: TestSessionConfig, sdk_client: Client, s3_path: S3Path) -> TestSession {
+        new_with_test_client_inner(test_config, sdk_client, s3_path, None)
+    }
+
+    /// Like [`new_with_test_client`], but mounts with an on-disk data cache rooted at `cache_dir`.
+    pub fn new_with_test_client_and_disk_cache(
+        test_config: TestSessionConfig,
+        sdk_client: Client,
+        s3_path: S3Path,
+        cache_dir: PathBuf,
+    ) -> TestSession {
+        new_with_test_client_inner(test_config, sdk_client, s3_path, Some(cache_dir))
+    }
+
+    /// Shared implementation for [`new_with_test_client`] and
+    /// [`new_with_test_client_and_disk_cache`].
+    fn new_with_test_client_inner(
+        test_config: TestSessionConfig,
+        sdk_client: Client,
+        s3_path: S3Path,
+        cache_dir: Option<PathBuf>,
+    ) -> TestSession {
+        use mountpoint_s3_fs::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
+
         let mount_dir = tempfile::tempdir().unwrap();
 
+        let mut candidate_sizes = vec![CandidateSize::prunable(test_config.part_size)];
+        if cache_dir.is_some() {
+            candidate_sizes.push(CandidateSize::prunable(test_config.cache_block_size));
+        }
         let pool = PagedPool::config()
-            .with_candidate_sizes([CandidateSize::prunable(test_config.part_size)])
+            .with_candidate_sizes(candidate_sizes)
             .with_memory_limit(test_config.mem_limit)
             .build();
+
         let client_config = S3ClientConfig::default()
             .part_size(test_config.part_size)
             .endpoint_config(get_test_endpoint_config())
@@ -550,7 +578,22 @@ pub mod s3_session {
             .memory_pool(pool.clone());
         let client = S3CrtClient::new(client_config).unwrap();
         let runtime = Runtime::new(client.event_loop_group());
-        let prefetcher_builder = Prefetcher::default_builder(client.clone());
+
+        let prefetcher_builder = match cache_dir {
+            Some(cache_dir) => {
+                let cache = DiskDataCache::new(
+                    DiskDataCacheConfig {
+                        cache_directory: cache_dir,
+                        block_size: test_config.cache_block_size as u64,
+                        limit: CacheLimit::default(),
+                    },
+                    pool.clone(),
+                );
+                Prefetcher::caching_builder(cache, client.clone())
+            }
+            None => Prefetcher::default_builder(client.clone()),
+        };
+
         let mounted_session = create_fuse_session(
             client,
             prefetcher_builder,

--- a/mountpoint-s3-fs/tests/stress/README.md
+++ b/mountpoint-s3-fs/tests/stress/README.md
@@ -20,6 +20,7 @@ deadlocks, per-worker stalls, tail-latency regressions, and memory issues.
 | `S3_BUCKET_TEST_PREFIX` | no       | Defaults to `mountpoint-test/`; must end in `/`     |
 | AWS credentials         | yes      | Standard SDK resolution (`AWS_PROFILE`, static keys, instance role, etc.) |
 | `STRESS_DURATION_SECS`  | no       | Per-scenario duration in seconds; default 30        |
+| `S3_STRESS_CACHE_DIR`   | no       | Root dir for cached scenarios' on-disk cache; defaults to system temp |
 
 ## How to run
 

--- a/mountpoint-s3-fs/tests/stress/harness.rs
+++ b/mountpoint-s3-fs/tests/stress/harness.rs
@@ -7,8 +7,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use mountpoint_s3_fs::s3::{Bucket, Prefix, S3Path};
+use tempfile::TempDir;
 
-use crate::common::fuse;
+use crate::common::fuse::{self, TestSession};
 use crate::common::stress_recorder;
 use crate::stress::test_objects::ensure_shared_objects;
 
@@ -27,7 +28,7 @@ pub use latency::{FileOp, FileOpLatencies};
 use memory_monitor::spawn_memory_monitor;
 use report::dump_summary;
 pub use scenario::{Scenario, default_max_latency};
-pub use setup::{SetupGuard, budget_parts, hold_budget_parts};
+pub use setup::{SetupGuard, budget_parts, hold_budget_parts, warm_cache};
 use watchdog::{NO_STALL, spawn_watchdog};
 pub use worker::Worker;
 
@@ -50,6 +51,7 @@ pub fn run(scenario: Scenario) {
     let Scenario {
         name: scenario_name,
         mut session_config,
+        cache,
         setup,
         workers,
         max_latency,
@@ -77,13 +79,24 @@ pub fn run(scenario: Scenario) {
     let shared_refs: Vec<(&str, usize)> = shared_objects.iter().map(|(k, s)| (k.as_str(), *s)).collect();
     ensure_shared_objects(&shared_refs);
 
-    let session = {
+    // The cache directory (if any) must outlive the session — hold it here.
+    let _cache_dir: Option<TempDir>;
+
+    let session: TestSession = {
         session_config.filesystem_config.allow_delete = true;
         session_config.filesystem_config.allow_overwrite = true;
         let s3_path = stress_mount_s3_path();
         let region = crate::common::s3::get_test_region();
         let sdk_client = crate::common::tokio_block_on(async { crate::common::s3::get_test_sdk_client(&region).await });
-        fuse::s3_session::new_with_test_client(session_config, sdk_client, s3_path)
+        if cache {
+            let dir = new_cache_dir();
+            let cache_dir_path = dir.path().to_path_buf();
+            _cache_dir = Some(dir);
+            fuse::s3_session::new_with_test_client_and_disk_cache(session_config, sdk_client, s3_path, cache_dir_path)
+        } else {
+            _cache_dir = None;
+            fuse::s3_session::new_with_test_client(session_config, sdk_client, s3_path)
+        }
     };
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -252,6 +265,18 @@ fn collect_shared_objects(workers: &[Arc<dyn Worker>], scenario_name: &str) -> V
         }
     }
     out
+}
+
+/// Create the temporary directory backing a cached scenario's on-disk data cache.
+///
+/// When `S3_STRESS_CACHE_DIR` is set (in CI it points at a freshly-formatted local NVMe mount, the
+/// same fast disk the cache benchmark uses) the cache is rooted there; otherwise it falls back to
+/// the system temp dir for local runs. The returned [`TempDir`] is deleted on drop.
+fn new_cache_dir() -> TempDir {
+    match std::env::var_os("S3_STRESS_CACHE_DIR") {
+        Some(dir) => tempfile::tempdir_in(dir).expect("failed to create cache dir under S3_STRESS_CACHE_DIR"),
+        None => tempfile::tempdir().expect("failed to create cache dir"),
+    }
 }
 
 fn read_duration_env() -> Duration {

--- a/mountpoint-s3-fs/tests/stress/harness/scenario.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/scenario.rs
@@ -17,6 +17,9 @@ pub struct Scenario {
     /// FUSE/Mountpoint session configuration (memory limit, part size, etc.).
     pub session_config: TestSessionConfig,
 
+    /// When `true`, the harness mounts with local cache.
+    pub cache: bool,
+
     /// Optional setup step run to completion after mount and before workers start. Its returned
     /// [`SetupGuard`] is held for the entire run, so anything it establishes (pinned memory, a warmed
     /// cache, …) stays in effect while the workers execute. `None` for scenarios that need no setup.

--- a/mountpoint-s3-fs/tests/stress/harness/setup.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup.rs
@@ -3,8 +3,10 @@
 use std::path::Path;
 
 mod budget_hold;
+mod cache_warmup;
 
 pub use budget_hold::{budget_parts, hold_budget_parts};
+pub use cache_warmup::warm_cache;
 
 /// A guard produced by a scenario's [setup phase](super::Scenario::setup). The harness keeps it
 /// alive for the entire run and drops it just before unmount, so whatever a setup step must keep in

--- a/mountpoint-s3-fs/tests/stress/harness/setup/cache_warmup.rs
+++ b/mountpoint-s3-fs/tests/stress/harness/setup/cache_warmup.rs
@@ -1,0 +1,36 @@
+//! `CacheWarmup`: a setup-phase step that reads one or more shared objects front-to-back through the
+//! mount to populate the on-disk cache before workers start.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use super::SetupGuard;
+use crate::stress::test_objects::SHARED_OBJECTS_PREFIX;
+
+/// Guard for a completed cache warmup — drop is a no-op.
+pub struct CacheWarmup;
+impl SetupGuard for CacheWarmup {}
+
+/// Read each shared object in `keys` (relative to `SHARED_OBJECTS_PREFIX`) front-to-back through the
+/// FUSE mount, populating the disk cache.
+pub fn warm_cache(keys: &[&str], mount_path: &Path) -> CacheWarmup {
+    const WARMUP_CHUNK: usize = 8 * 1024 * 1024;
+    let mut buf = vec![0u8; WARMUP_CHUNK];
+
+    for &key in keys {
+        let path = mount_path.join(SHARED_OBJECTS_PREFIX).join(key);
+        tracing::info!(key, "stress: cache warmup starting for object");
+        let mut file = File::open(&path).unwrap_or_else(|e| panic!("cache warmup: failed to open {path:?}: {e:?}"));
+        loop {
+            let n = file
+                .read(&mut buf)
+                .unwrap_or_else(|e| panic!("cache warmup: read failed for {path:?}: {e:?}"));
+            if n == 0 {
+                break;
+            }
+        }
+        tracing::info!(key, "stress: cache warmup complete for object");
+    }
+    CacheWarmup
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -1,5 +1,6 @@
 //! Stress-test scenarios.
 
+mod cache_hit_vs_miss_held_budget;
 mod held_writes_vs_reads;
 mod idle_and_churn;
 mod many_readers_budget_part;

--- a/mountpoint-s3-fs/tests/stress/scenarios/cache_hit_vs_miss_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/cache_hit_vs_miss_held_budget.rs
@@ -1,0 +1,59 @@
+//! `cache_hit_vs_miss_held_budget`: Cache-hit sequential readers vs cache-miss sequential readers
+//! under a 512 MiB memory target with the write budget fully pinned (leaving one 8 MiB read-reserve
+//! part free).
+
+use std::iter::{chain, repeat_n};
+use std::path::Path;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{
+    self, Scenario, SetupGuard, Worker, budget_parts, default_max_latency, hold_budget_parts, warm_cache,
+};
+use crate::stress::workers::{LARGE_READ_OBJECT, MEDIUM_READ_OBJECT, SequentialReader};
+
+const SCOPE: &str = "cache_hit_vs_miss_held_budget";
+const PART_SIZE: usize = 8 * 1024 * 1024;
+const NUM_HIT_READERS: usize = 8;
+const NUM_MISS_READERS: usize = 4;
+const WARMUP_KEYS: &[&str] = &[MEDIUM_READ_OBJECT.key];
+
+/// Setup phase: warm the cache-hit object and pin the entire write budget, leaving only the
+/// read reserve (one 8 MiB part) free.
+fn setup(mount_path: &Path) -> Box<dyn SetupGuard> {
+    warm_cache(WARMUP_KEYS, mount_path);
+
+    let held_parts = budget_parts(MINIMUM_MEM_LIMIT, PART_SIZE);
+    Box::new(hold_budget_parts(SCOPE, held_parts, mount_path))
+}
+
+#[test]
+fn cache_hit_vs_miss_held_budget() {
+    let hit_reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: MEDIUM_READ_OBJECT,
+        chunk: PART_SIZE,
+        direct_io: false,
+    });
+    let miss_reader: Arc<dyn Worker> = Arc::new(SequentialReader {
+        target: LARGE_READ_OBJECT,
+        chunk: PART_SIZE,
+        direct_io: false,
+    });
+    let workers = chain(
+        repeat_n(hit_reader, NUM_HIT_READERS),
+        repeat_n(miss_reader, NUM_MISS_READERS),
+    )
+    .collect();
+    harness::run(Scenario {
+        name: SCOPE,
+        session_config: TestSessionConfig::default()
+            .with_mem_limit(MINIMUM_MEM_LIMIT)
+            .with_part_size(PART_SIZE),
+        cache: true,
+        setup: Some(setup),
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/held_writes_vs_reads.rs
@@ -35,6 +35,7 @@ fn held_writes_vs_reads() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/idle_and_churn.rs
@@ -29,6 +29,7 @@ fn idle_and_churn() {
     harness::run(Scenario {
         name: "idle_and_churn",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
@@ -31,6 +31,7 @@ fn many_readers_budget_part() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(READ_PART_SIZE),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget.rs
@@ -38,6 +38,7 @@ fn many_readers_held_budget() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: Some(hold),
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget_direct_io.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_held_budget_direct_io.rs
@@ -39,6 +39,7 @@ fn many_readers_held_budget_direct_io() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: Some(hold),
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/mixed_rw.rs
@@ -32,6 +32,7 @@ fn mixed_rw() {
     harness::run(Scenario {
         name: "mixed_rw",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_budget_part.rs
@@ -31,6 +31,7 @@ fn single_reader_budget_part() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(READ_PART_SIZE),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget.rs
@@ -38,6 +38,7 @@ fn single_reader_held_budget() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: Some(hold),
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget_direct_io.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget_direct_io.rs
@@ -39,6 +39,7 @@ fn single_reader_held_budget_direct_io() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: Some(hold),
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget_misaligned_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/single_reader_held_budget_misaligned_part.rs
@@ -37,6 +37,7 @@ fn single_reader_held_budget_misaligned_part() {
         session_config: TestSessionConfig::default()
             .with_mem_limit(MINIMUM_MEM_LIMIT)
             .with_part_size(PART_SIZE),
+        cache: false,
         setup: Some(hold),
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_reads.rs
@@ -24,6 +24,7 @@ fn sustained_reads() {
     harness::run(Scenario {
         name: "sustained_reads",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
@@ -25,6 +25,7 @@ fn sustained_writes() {
     harness::run(Scenario {
         name: "sustained_writes",
         session_config: TestSessionConfig::default().with_mem_limit(MINIMUM_MEM_LIMIT),
+        cache: false,
         setup: None,
         workers,
         max_latency: default_max_latency,

--- a/mountpoint-s3-fs/tests/stress/workers.rs
+++ b/mountpoint-s3-fs/tests/stress/workers.rs
@@ -11,5 +11,5 @@ pub use churn::Churn;
 pub use common::SMALL_OBJECT_POOL;
 pub use holding_writer::HoldingWriter;
 pub use idle::Idle;
-pub use sequential_reader::{LARGE_READ_OBJECT, SequentialReader};
+pub use sequential_reader::{LARGE_READ_OBJECT, MEDIUM_READ_OBJECT, SequentialReader};
 pub use writer::Writer;

--- a/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
+++ b/mountpoint-s3-fs/tests/stress/workers/sequential_reader.rs
@@ -15,6 +15,12 @@ pub const LARGE_READ_OBJECT: SharedObject = SharedObject {
     size: 100 * 1024 * 1024 * 1024,
 };
 
+/// The canonical 1 GiB shared object used by the `cache_hit_vs_miss_held_budget` scenario.
+pub const MEDIUM_READ_OBJECT: SharedObject = SharedObject {
+    key: "read_1gib.bin",
+    size: 1024 * 1024 * 1024,
+};
+
 /// A worker that repeatedly opens `target` and reads it front-to-back.
 pub struct SequentialReader {
     pub target: SharedObject,


### PR DESCRIPTION
Adding cache hit vs cache miss stress test scenario under single 8MB read part size available.

Sample run: https://github.com/awslabs/mountpoint-s3/actions/runs/30822959093/job/91717290367

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
