### PR TITLE
Add incremental upload stress test

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -59,6 +59,11 @@ jobs:
           - single_reader_held_budget_direct_io
           - many_readers_held_budget_direct_io
           - single_reader_held_budget_misaligned_part
+          - sustained_writes_incremental_upload
+        include:
+          - scenario: sustained_writes_incremental_upload
+            s3_bucket_name: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_BUCKET_NAME }}
+            s3_endpoint_url: ${{ vars.S3_EXPRESS_ONE_ZONE_BENCH_ENDPOINT_URL }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
@@ -84,6 +89,9 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Run stress scenario
+        env:
+          S3_BUCKET_NAME: ${{ matrix.s3_bucket_name || vars.S3_BENCH_BUCKET_NAME }}
+          S3_ENDPOINT_URL: ${{ matrix.s3_endpoint_url || vars.S3_BENCH_ENDPOINT_URL }}
         run: |
           cargo nextest run \
             --release \

--- a/mountpoint-s3-fs/tests/stress/scenarios.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios.rs
@@ -12,3 +12,4 @@ mod single_reader_held_budget_direct_io;
 mod single_reader_held_budget_misaligned_part;
 mod sustained_reads;
 mod sustained_writes;
+mod sustained_writes_incremental_upload;

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes.rs
@@ -1,4 +1,4 @@
-//! `sustained_writes`: 48 writers concurrently writing 100 MiB objects under the 512 MiB
+//! `sustained_writes`: 47 writers concurrently writing 100 MiB objects under the 512 MiB
 //! memory limit.
 
 use std::iter::repeat_n;
@@ -10,7 +10,7 @@ use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
 use crate::stress::workers::Writer;
 
-const NUM_WORKERS: usize = 48;
+const NUM_WORKERS: usize = 47; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
 const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
 const OBJECT_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
 

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes_incremental_upload.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes_incremental_upload.rs
@@ -1,0 +1,40 @@
+//! `sustained_writes_incremental_upload`: 48 writers concurrently writing 100 MiB objects
+//! using incremental upload mode under the 512 MiB memory limit.
+
+use std::iter::repeat_n;
+use std::sync::Arc;
+
+use mountpoint_s3_fs::S3FilesystemConfig;
+use mountpoint_s3_fs::memory::MINIMUM_MEM_LIMIT;
+
+use crate::common::fuse::TestSessionConfig;
+use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
+use crate::stress::workers::Writer;
+
+const NUM_WORKERS: usize = 47;
+const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
+const OBJECT_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
+
+#[test]
+fn sustained_writes_incremental_upload() {
+    let writer: Arc<dyn Worker> = Arc::new(Writer {
+        scope: "sustained_writes_incremental_upload",
+        object_size: OBJECT_SIZE,
+        chunk: WRITE_CHUNK,
+    });
+    let workers = repeat_n(writer, NUM_WORKERS).collect();
+    harness::run(Scenario {
+        name: "sustained_writes_incremental_upload",
+        session_config: TestSessionConfig {
+            filesystem_config: S3FilesystemConfig {
+                incremental_upload: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .with_mem_limit(MINIMUM_MEM_LIMIT),
+        setup: None,
+        workers,
+        max_latency: default_max_latency,
+    });
+}

--- a/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes_incremental_upload.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/sustained_writes_incremental_upload.rs
@@ -1,4 +1,4 @@
-//! `sustained_writes_incremental_upload`: 48 writers concurrently writing 100 MiB objects
+//! `sustained_writes_incremental_upload`: 47 writers concurrently writing 100 MiB objects
 //! using incremental upload mode under the 512 MiB memory limit.
 
 use std::iter::repeat_n;
@@ -11,7 +11,7 @@ use crate::common::fuse::TestSessionConfig;
 use crate::stress::harness::{self, Scenario, Worker, default_max_latency};
 use crate::stress::workers::Writer;
 
-const NUM_WORKERS: usize = 47;
+const NUM_WORKERS: usize = 47; // Matches WriteHandleLimit for MINIMUM_MEM_LIMIT memory target
 const WRITE_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB — matches default part size
 const OBJECT_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
 


### PR DESCRIPTION
Added a new stress test for incremental uploads. The test has 47 workers that write 100 MiB objects concurrently using incremental upload mode while sharing a 512 MiB memory limit. This mirrors the existing `sustained_writes `scenario but with the incremental upload path enabled. 

Sample run: https://github.com/awslabs/mountpoint-s3/actions/runs/30802403323/job/91649829872

### Does this change impact existing behavior?

No. This only adds a new test

### Does this change need a changelog entry? Does it require a version change?

No. Test-only change

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
