### PR TITLE
Rename CI runner label AL2 arm to AL2023 arm

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,12 +72,12 @@ jobs:
         runner:
         - name: Ubuntu x86
           tags: [ubuntu-22.04] # GitHub-hosted
-        - name: AL2 arm
+        - name: AL2023 arm
           tags: [self-hosted, linux, arm64]
         exclude:
           # fuse3 is not available on Amazon Linux 2
           - runner:
-              name: AL2 arm
+              name: AL2023 arm
               tags: [self-hosted, linux, arm64]
             fuseVersion: 3
 
@@ -112,7 +112,7 @@ jobs:
     - name: Run tests
       run: cargo nextest run --profile ci ${{ env.packages }} --features '${{ env.features }}'
     - name: Save dump files
-      if: ${{ failure() && matrix.runner.name == 'AL2 arm' }}
+      if: ${{ failure() && matrix.runner.name == 'AL2023 arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
   client-test:
@@ -135,7 +135,7 @@ jobs:
         runner:
         - name: Ubuntu x86
           tags: [ubuntu-22.04] # GitHub-hosted
-        - name: AL2 arm
+        - name: AL2023 arm
           tags: [self-hosted, linux, arm64]
         pool:
         - name: Default Pool
@@ -191,7 +191,7 @@ jobs:
       if: always()
       run: rm -f "${S3_WEB_IDENTITY_TEST_TOKEN_FILE}"
     - name: Save dump files
-      if: ${{ failure() && matrix.runner.name == 'AL2 arm' }}
+      if: ${{ failure() && matrix.runner.name == 'AL2023 arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
   fstab:
@@ -207,7 +207,7 @@ jobs:
         runner:
           - name: Ubuntu x86
             tags: [ubuntu-22.04] # GitHub-hosted
-          - name: AL2 arm
+          - name: AL2023 arm
             tags: [self-hosted, linux, arm64]
 
     steps:
@@ -301,7 +301,7 @@ jobs:
         runner:
         - name: Ubuntu x86
           tags: [ubuntu-22.04]
-        - name: AL2 arm
+        - name: AL2023 arm
           tags: [self-hosted, linux, arm64]
 
     steps:


### PR DESCRIPTION
The `AL2 arm` matrix label in `integration.yml` points at a self-hosted runner pool that runs Amazon Linux 2023, not AL2 - CI logs report `Amazon Linux release 2023.12` and every installed package carries an `.amzn2023` suffix. Renamed the label to `AL2023 arm` so job names match the actual environment.

Run: https://github.com/awslabs/mountpoint-s3/actions/runs/30832697501/job/91750309505

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)