### PR TITLE
Add allocation queue depth and wait-time metrics

### DIFF
--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -252,12 +252,10 @@ impl AllocationQueue {
             self.has_pending.store(false, Ordering::SeqCst);
         }
 
-        let waited = entry.as_ref().map(|e| e.queued_at.elapsed());
         drop(inner);
-        if let Some(waited) = waited {
-            metrics::histogram!(ALLOCATION_QUEUE_WAIT).record(waited.as_micros() as f64);
-        }
-        entry
+        entry.inspect(|e| {
+            metrics::histogram!(ALLOCATION_QUEUE_WAIT).record(e.queued_at.elapsed().as_micros() as f64);
+        })
     }
 
     /// Moves all entries for `cursor_id` from the low-priority queue to the back

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -1,17 +1,25 @@
 //! Priority-ordered allocation queue for buffer requests under memory pressure.
 
 use std::collections::VecDeque;
+use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use futures::channel::oneshot;
 use tracing::trace;
 
 use crate::prefetch::CursorId;
-use crate::sync::Mutex;
 use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::sync::{Mutex, MutexGuard};
 
 use super::buffers::PoolBuffer;
 use super::stats::BufferKind;
+
+/// Metric: number of pending entries in the allocation queue.
+const ALLOCATION_QUEUE_DEPTH: &str = "pool.allocation_queue_depth";
+
+/// Metric: time (microseconds) an entry spent waiting in the allocation queue
+/// before being served.
+const ALLOCATION_QUEUE_WAIT: &str = "pool.allocation_queue_wait";
 
 /// Priority for an allocation request.
 ///
@@ -73,6 +81,33 @@ struct AllocationQueueInner {
     low: VecDeque<PendingAllocation>,
 }
 
+/// Guard around the locked [`AllocationQueueInner`] that refreshes the
+/// [`ALLOCATION_QUEUE_DEPTH`] gauge from the queue lengths when it is dropped.
+struct DepthTrackingGuard<'a> {
+    inner: MutexGuard<'a, AllocationQueueInner>,
+}
+
+impl Deref for DepthTrackingGuard<'_> {
+    type Target = AllocationQueueInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for DepthTrackingGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl Drop for DepthTrackingGuard<'_> {
+    fn drop(&mut self) {
+        metrics::gauge!(ALLOCATION_QUEUE_DEPTH, "priority" => "high").set(self.inner.high.len() as f64);
+        metrics::gauge!(ALLOCATION_QUEUE_DEPTH, "priority" => "low").set(self.inner.low.len() as f64);
+    }
+}
+
 impl std::fmt::Debug for AllocationQueue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AllocationQueue")
@@ -96,6 +131,14 @@ impl AllocationQueue {
                 low: VecDeque::new(),
             }),
             has_pending: AtomicBool::new(false),
+        }
+    }
+
+    /// Lock the queue's inner state, returning a [`DepthTrackingGuard`] that refreshes the
+    /// depth gauge when dropped.
+    fn lock_tracked(&self) -> DepthTrackingGuard<'_> {
+        DepthTrackingGuard {
+            inner: self.inner.lock().unwrap(),
         }
     }
 
@@ -135,7 +178,7 @@ impl AllocationQueue {
             sender,
         };
 
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_tracked();
         self.has_pending.store(true, Ordering::SeqCst);
         match priority {
             AllocationPriority::High => inner.high.push_back(entry),
@@ -185,7 +228,7 @@ impl AllocationQueue {
     /// Returns `None` if both queues are empty or the predicate returns `false`.
     /// Sets `has_pending` to `false` if both queues become empty after removal.
     fn pop_front_if(&self, predicate: impl FnOnce(&PendingAllocation) -> bool) -> Option<PendingAllocation> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_tracked();
 
         // Prune cancelled entries from the front of each queue.
         while inner.high.front().is_some_and(|e| e.sender.is_canceled()) {
@@ -208,6 +251,12 @@ impl AllocationQueue {
         if inner.high.is_empty() && inner.low.is_empty() {
             self.has_pending.store(false, Ordering::SeqCst);
         }
+
+        let waited = entry.as_ref().map(|e| e.queued_at.elapsed());
+        drop(inner);
+        if let Some(waited) = waited {
+            metrics::histogram!(ALLOCATION_QUEUE_WAIT).record(waited.as_micros() as f64);
+        }
         entry
     }
 
@@ -217,7 +266,7 @@ impl AllocationQueue {
     /// Called when a FUSE read arrives for a cursor that has pending speculative
     /// allocations — those allocations are now urgent.
     pub fn upgrade(&self, cursor_id: CursorId) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_tracked();
         let n = inner.low.len();
         for _ in 0..n {
             let entry = inner.low.pop_front().unwrap();


### PR DESCRIPTION
Add allocation queue depth and block-time metrics: (will be added to defs.rs and METRICS.md in a separate PR)
- `pool.allocation_queue_depth`
- `pool.allocation_queue_wait`

### Does this change impact existing behavior?

No

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
