### PR TITLE
Avoid pool-buffer aliasing deadlock and stitch multi-part reads in one buffer

### DIFF
--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -196,12 +196,16 @@ impl ChecksummedBytes {
 /// Accumulates several [ChecksummedBytes] into one buffer, copying each piece exactly once and
 /// combining their checksums rather than recomputing one over the result.
 ///
-/// [Self::new] reserves the expected total length up front, so appending that much data allocates
-/// only once. Appending more still succeeds, growing the buffer as [Vec] normally would.
+/// The buffer is only allocated on the first append, reserving the `capacity` given to [Self::new],
+/// so appending up to that much data allocates exactly once and a builder that is never appended to
+/// does not allocate at all. Appending more still succeeds, growing the buffer as [Vec] normally
+/// would.
 #[must_use]
 pub struct ChecksummedBytesBuilder {
-    /// Destination buffer, filled from the front.
+    /// Destination buffer, filled from the front. Empty until the first append.
     buffer: Vec<u8>,
+    /// Bytes to reserve for [Self::buffer] when it is first allocated.
+    capacity: usize,
     /// Combined checksum of [Self::buffer].
     checksum: Crc32c,
 }
@@ -210,7 +214,8 @@ impl ChecksummedBytesBuilder {
     /// Create a builder that can hold `capacity` bytes without reallocating.
     pub fn new(capacity: usize) -> Self {
         Self {
-            buffer: Vec::with_capacity(capacity),
+            buffer: Vec::new(),
+            capacity,
             checksum: Crc32c::new(0),
         }
     }
@@ -238,14 +243,19 @@ impl ChecksummedBytesBuilder {
         // Shrink to fit so `checksum` covers exactly `bytes`, as `combine_checksums` requires.
         let (bytes, checksum) = bytes.into_inner()?;
 
+        if self.buffer.is_empty() {
+            self.buffer.reserve_exact(self.capacity);
+        }
         self.buffer.extend_from_slice(&bytes);
         self.checksum = combine_checksums(self.checksum, checksum, bytes.len());
         Ok(())
     }
 
-    /// Consume the builder and return the accumulated data.
-    pub fn finish(self) -> ChecksummedBytes {
-        ChecksummedBytes::new_from_inner_data(Bytes::from_owner(self.buffer), self.checksum)
+    /// Take the accumulated data, leaving the builder empty and ready to accumulate again.
+    pub fn finish(&mut self) -> ChecksummedBytes {
+        let buffer = std::mem::take(&mut self.buffer);
+        let checksum = std::mem::replace(&mut self.checksum, Crc32c::new(0));
+        ChecksummedBytes::new_from_inner_data(Bytes::from(buffer), checksum)
     }
 }
 

--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -193,53 +193,41 @@ impl ChecksummedBytes {
     }
 }
 
-/// Accumulates several [ChecksummedBytes] into one caller-supplied buffer, copying each piece
-/// exactly once and combining their checksums rather than recomputing one over the result.
+/// Accumulates several [ChecksummedBytes] into one buffer, copying each piece exactly once and
+/// combining their checksums rather than recomputing one over the result.
 ///
-/// The buffer must be exactly the total length of the appended pieces: [Self::finish] requires it
-/// filled, since the checksum is only exact for the whole buffer. Taking the buffer from the caller
-/// lets it come from a memory pool rather than the heap.
+/// [Self::new] reserves the expected total length up front, so appending that much data allocates
+/// only once. Appending more still succeeds, growing the buffer as [Vec] normally would.
 #[must_use]
-pub struct ChecksummedBytesBuilder<Buffer> {
+pub struct ChecksummedBytesBuilder {
     /// Destination buffer, filled from the front.
-    buffer: Buffer,
-    /// Bytes written into [Self::buffer] so far.
-    len: usize,
-    /// Combined checksum of the first [Self::len] bytes.
+    buffer: Vec<u8>,
+    /// Combined checksum of [Self::buffer].
     checksum: Crc32c,
 }
 
-impl<Buffer: AsRef<[u8]> + AsMut<[u8]> + Send + 'static> ChecksummedBytesBuilder<Buffer> {
-    /// Create a builder writing into `buffer`, which must be sized to the exact total length of the
-    /// pieces that will be appended.
-    pub fn new(buffer: Buffer) -> Self {
+impl ChecksummedBytesBuilder {
+    /// Create a builder that can hold `capacity` bytes without reallocating.
+    pub fn new(capacity: usize) -> Self {
         Self {
-            buffer,
-            len: 0,
+            buffer: Vec::with_capacity(capacity),
             checksum: Crc32c::new(0),
         }
     }
 
     /// Number of bytes appended so far.
     pub fn len(&self) -> usize {
-        self.len
+        self.buffer.len()
     }
 
     /// Returns true if nothing has been appended yet.
     pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    /// Total number of bytes this builder can hold.
-    fn capacity(&self) -> usize {
-        self.buffer.as_ref().len()
+        self.buffer.is_empty()
     }
 
     /// Copy `bytes` into the buffer and fold its checksum into the running one.
     ///
     /// Return [IntegrityError] if data corruption is detected in `bytes`.
-    ///
-    /// Panics if `bytes` does not fit in the remaining capacity.
     pub fn append(&mut self, bytes: ChecksummedBytes) -> Result<(), IntegrityError> {
         if bytes.is_empty() {
             // No op, but check that `bytes` was not corrupted.
@@ -250,28 +238,13 @@ impl<Buffer: AsRef<[u8]> + AsMut<[u8]> + Send + 'static> ChecksummedBytesBuilder
         // Shrink to fit so `checksum` covers exactly `bytes`, as `combine_checksums` requires.
         let (bytes, checksum) = bytes.into_inner()?;
 
-        let new_len = self.len + bytes.len();
-        assert!(
-            new_len <= self.capacity(),
-            "appending {} bytes would exceed the builder capacity of {}",
-            bytes.len(),
-            self.capacity(),
-        );
-        self.buffer.as_mut()[self.len..new_len].copy_from_slice(&bytes);
+        self.buffer.extend_from_slice(&bytes);
         self.checksum = combine_checksums(self.checksum, checksum, bytes.len());
-        self.len = new_len;
         Ok(())
     }
 
     /// Consume the builder and return the accumulated data.
-    ///
-    /// Panics if the buffer was not filled to its capacity.
     pub fn finish(self) -> ChecksummedBytes {
-        assert_eq!(
-            self.len,
-            self.capacity(),
-            "builder must be filled to capacity before finishing",
-        );
         ChecksummedBytes::new_from_inner_data(Bytes::from_owner(self.buffer), self.checksum)
     }
 }
@@ -417,7 +390,7 @@ mod tests {
     fn build(pieces: impl IntoIterator<Item = ChecksummedBytes>) -> Result<ChecksummedBytes, IntegrityError> {
         let pieces: Vec<_> = pieces.into_iter().collect();
         let capacity = pieces.iter().map(|p| p.len()).sum();
-        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; capacity]);
+        let mut builder = ChecksummedBytesBuilder::new(capacity);
         for piece in pieces {
             builder.append(piece)?;
         }
@@ -473,20 +446,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "would exceed the builder capacity")]
-    fn builder_append_beyond_capacity_panics() {
-        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; 4]);
-        let _ = builder.append(ChecksummedBytes::new(Bytes::from_static(b"some bytes")));
-    }
+    fn builder_tolerates_a_mis_sized_capacity() {
+        // The capacity is only a hint for how much to reserve, not a limit.
+        let expected = Bytes::from_static(b"some bytes");
+        for capacity in [0, 4, expected.len(), 2 * expected.len()] {
+            let mut builder = ChecksummedBytesBuilder::new(capacity);
+            builder.append(ChecksummedBytes::new(expected.clone())).unwrap();
+            let result = builder.finish();
 
-    #[test]
-    #[should_panic(expected = "must be filled to capacity")]
-    fn builder_finish_underfilled_panics() {
-        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; 10]);
-        builder
-            .append(ChecksummedBytes::new(Bytes::from_static(b"some")))
-            .unwrap();
-        let _ = builder.finish();
+            assert_eq!(crc32c::checksum(&expected), result.checksum);
+            assert_eq!(expected, result.into_bytes().unwrap());
+        }
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -172,9 +172,10 @@ impl ChecksummedBytes {
         }
 
         if self.is_empty() {
-            // Replace with `extend`, but check that `self` was not corrupted
+            // Copy `extend` rather than alias it, so the result never keeps its backing buffer
+            // alive: a pooled buffer pinned here would deadlock allocation under memory pressure.
             self.validate()?;
-            *self = extend;
+            *self = extend.into_detached()?;
             return Ok(());
         }
 
@@ -235,7 +236,7 @@ impl ChecksummedBytes {
 
     /// Copy the bytes into a freshly allocated buffer sharing no storage with the original, e.g. to
     /// release a pooled buffer while this data lives on. Reuses the checksum, so no CRC is recomputed.
-    pub fn into_detached(self) -> Result<Self, IntegrityError> {
+    fn into_detached(self) -> Result<Self, IntegrityError> {
         let (bytes, checksum) = self.into_inner()?;
         Ok(Self::new_from_inner_data(Bytes::copy_from_slice(&bytes), checksum))
     }
@@ -578,6 +579,31 @@ mod tests {
         checksummed_bytes.extend(extend).unwrap();
         let actual = checksummed_bytes.buffer_slice();
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_extend_into_empty_severs_shared_storage() {
+        // Extending an empty accumulator must copy, not alias: the result must not keep the
+        // appended data's backing buffer alive. If it aliased, a pooled buffer accumulated here
+        // would stay pinned across later blocking allocations and deadlock under memory pressure.
+        let mut accumulator = ChecksummedBytes::default();
+        assert!(accumulator.is_empty());
+
+        // A slice of a larger buffer shares its allocation: `tail.buffer` is still the whole `full`.
+        let full = Bytes::from_static(b"some bytes");
+        let mut source = ChecksummedBytes::new(full.clone());
+        let tail = source.split_off(5); // "bytes", still backed by `full`
+        assert_eq!(tail.buffer, full);
+        assert_ne!(tail.buffer.len(), tail.len());
+
+        accumulator.extend(tail).unwrap();
+
+        // Content is preserved, but the accumulator now owns a fresh, full-range allocation that
+        // shares no storage with `full`.
+        assert_eq!(&accumulator.buffer[..], b"bytes");
+        assert_eq!(accumulator.buffer.len(), accumulator.len());
+        assert_eq!(accumulator.range, 0..accumulator.len());
+        assert_ne!(accumulator.buffer, full);
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -276,6 +276,16 @@ impl<Buffer: AsRef<[u8]> + AsMut<[u8]> + Send + 'static> ChecksummedBytesBuilder
         }
     }
 
+    /// Number of bytes appended so far.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if nothing has been appended yet.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Total number of bytes this builder can hold.
     fn capacity(&self) -> usize {
         self.buffer.as_ref().len()

--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Bound, Range, RangeBounds},
 };
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{self, Visitor},
@@ -160,55 +160,6 @@ impl ChecksummedBytes {
         Ok(())
     }
 
-    /// Append the given checksummed bytes to current [ChecksummedBytes]. Will combine the
-    /// existing checksums if possible, or compute a new one and validate data integrity.
-    ///
-    /// Return [IntegrityError] if data corruption is detected.
-    pub fn extend(&mut self, mut extend: ChecksummedBytes) -> Result<(), IntegrityError> {
-        if extend.is_empty() {
-            // No op, but check that `extend` was not corrupted
-            extend.validate()?;
-            return Ok(());
-        }
-
-        if self.is_empty() {
-            // Copy `extend` rather than alias it, so the result never keeps its backing buffer
-            // alive: a pooled buffer pinned here would deadlock allocation under memory pressure.
-            self.validate()?;
-            *self = extend.into_detached()?;
-            return Ok(());
-        }
-
-        // When appending two slices, we can combine their checksums and obtain the new checksum
-        // without having to recompute it from the data.
-        // However, since a `ChecksummedBytes` potentially holds the checksum of some larger buffer,
-        // rather than the exact one for the slice, we need to first invoke `shrink_to_fit` on each
-        // slice and use the resulting exact checksums.
-        self.shrink_to_fit()?;
-        assert_eq!(self.buffer.len(), self.len());
-        extend.shrink_to_fit()?;
-        assert_eq!(extend.buffer.len(), extend.len());
-
-        // Combine the checksums.
-        let new_checksum = combine_checksums(self.checksum, extend.checksum, extend.len());
-
-        // Combine the slices.
-        let new_bytes = {
-            let mut bytes_mut = BytesMut::with_capacity(self.len() + extend.len());
-            bytes_mut.extend_from_slice(&self.buffer);
-            bytes_mut.extend_from_slice(&extend.buffer);
-            bytes_mut.freeze()
-        };
-
-        let new_range = 0..(new_bytes.len());
-        *self = Self {
-            buffer: new_bytes,
-            range: new_range,
-            checksum: new_checksum,
-        };
-        Ok(())
-    }
-
     /// Validate data integrity in this [ChecksummedBytes].
     ///
     /// Return [IntegrityError] on data corruption.
@@ -232,13 +183,6 @@ impl ChecksummedBytes {
     pub fn into_inner(mut self) -> Result<(Bytes, Crc32c), IntegrityError> {
         self.shrink_to_fit()?;
         Ok((self.buffer, self.checksum))
-    }
-
-    /// Copy the bytes into a freshly allocated buffer sharing no storage with the original, e.g. to
-    /// release a pooled buffer while this data lives on. Reuses the checksum, so no CRC is recomputed.
-    fn into_detached(self) -> Result<Self, IntegrityError> {
-        let (bytes, checksum) = self.into_inner()?;
-        Ok(Self::new_from_inner_data(Bytes::copy_from_slice(&bytes), checksum))
     }
 
     /// Return the slice of `buffer` corresponding to `range`.
@@ -688,174 +632,6 @@ mod tests {
         assert_eq!(slice.buffer_slice(), shrunken_bytes);
         assert_ne!(slice.buffer, shrunken_bytes);
         assert_ne!(slice.checksum, shrunken_checksum);
-    }
-
-    #[test]
-    fn test_extend() {
-        let expected = Bytes::from_static(b"some bytes extended");
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-        let extend_bytes = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-        checksummed_bytes.extend(extend_bytes).unwrap();
-        let actual = checksummed_bytes.buffer_slice();
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_extend_after_split() {
-        let expected = Bytes::from_static(b"some bytes extended");
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-        let mut extend = ChecksummedBytes::new(Bytes::from_static(b"bytes extended"));
-        _ = checksummed_bytes.split_off(7);
-        extend = extend.split_off(2);
-        checksummed_bytes.extend(extend).unwrap();
-        let actual = checksummed_bytes.buffer_slice();
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_extend_into_empty_severs_shared_storage() {
-        // Extending an empty accumulator must copy, not alias: the result must not keep the
-        // appended data's backing buffer alive. If it aliased, a pooled buffer accumulated here
-        // would stay pinned across later blocking allocations and deadlock under memory pressure.
-        let mut accumulator = ChecksummedBytes::default();
-        assert!(accumulator.is_empty());
-
-        // A slice of a larger buffer shares its allocation: `tail.buffer` is still the whole `full`.
-        let full = Bytes::from_static(b"some bytes");
-        let mut source = ChecksummedBytes::new(full.clone());
-        let tail = source.split_off(5); // "bytes", still backed by `full`
-        assert_eq!(tail.buffer, full);
-        assert_ne!(tail.buffer.len(), tail.len());
-
-        accumulator.extend(tail).unwrap();
-
-        // Content is preserved, but the accumulator now owns a fresh, full-range allocation that
-        // shares no storage with `full`.
-        assert_eq!(&accumulator.buffer[..], b"bytes");
-        assert_eq!(accumulator.buffer.len(), accumulator.len());
-        assert_eq!(accumulator.range, 0..accumulator.len());
-        assert_ne!(accumulator.buffer, full);
-    }
-
-    #[test]
-    fn test_extend_self_corrupted() {
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-
-        // alter the content
-        checksummed_bytes.buffer = Bytes::from_static(b"otherbytes");
-
-        assert!(matches!(
-            checksummed_bytes.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-
-        let extend = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-        assert!(matches!(extend.validate(), Ok(())));
-
-        checksummed_bytes.extend(extend).unwrap();
-        assert!(matches!(
-            checksummed_bytes.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-    }
-
-    #[test]
-    fn test_extend_after_split_self_corrupted() {
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-
-        // alter the content
-        checksummed_bytes.buffer = Bytes::from_static(b"otherbytes");
-
-        assert!(matches!(
-            checksummed_bytes.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-
-        _ = checksummed_bytes.split_off(4);
-
-        let extend = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-        assert!(matches!(extend.validate(), Ok(())));
-
-        let result = checksummed_bytes.extend(extend);
-        assert!(matches!(result, Err(IntegrityError::ChecksumMismatch(_, _))));
-    }
-
-    #[test]
-    fn test_extend_split_off_self_corrupted() {
-        let mut split_off = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-
-        // alter the content
-        split_off.buffer = Bytes::from_static(b"otherbytes");
-
-        split_off = split_off.split_off(4);
-
-        assert!(matches!(
-            split_off.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-
-        let extend = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-        assert!(matches!(extend.validate(), Ok(())));
-
-        let result = split_off.extend(extend);
-        assert!(matches!(result, Err(IntegrityError::ChecksumMismatch(_, _))));
-    }
-
-    #[test]
-    fn test_extend_other_corrupted() {
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-        assert!(matches!(checksummed_bytes.validate(), Ok(())));
-
-        let mut extend = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-
-        // alter the content
-        extend.buffer = Bytes::from_static(b"corrupted");
-
-        assert!(matches!(extend.validate(), Err(IntegrityError::ChecksumMismatch(_, _))));
-
-        checksummed_bytes.extend(extend).unwrap();
-        assert!(matches!(
-            checksummed_bytes.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-    }
-
-    #[test]
-    fn test_extend_after_split_other_corrupted() {
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-        assert!(matches!(checksummed_bytes.validate(), Ok(())));
-
-        let mut extend = ChecksummedBytes::new(Bytes::from_static(b" extended"));
-
-        // alter the content
-        extend.buffer = Bytes::from_static(b"corrupted");
-
-        assert!(matches!(extend.validate(), Err(IntegrityError::ChecksumMismatch(_, _))));
-
-        _ = extend.split_off(4);
-
-        let result = checksummed_bytes.extend(extend);
-        assert!(matches!(result, Err(IntegrityError::ChecksumMismatch(_, _))));
-    }
-
-    #[test]
-    fn test_extend_split_off_other_corrupted() {
-        let mut checksummed_bytes = ChecksummedBytes::new(Bytes::from_static(b"some bytes"));
-        assert!(matches!(checksummed_bytes.validate(), Ok(())));
-
-        let mut split_off = ChecksummedBytes::new(Bytes::from_static(b"bytes extended"));
-
-        // alter the content
-        split_off.buffer = Bytes::from_static(b"bytescorrupted");
-
-        split_off = split_off.split_off(5);
-        assert!(matches!(
-            split_off.validate(),
-            Err(IntegrityError::ChecksumMismatch(_, _))
-        ));
-
-        let result = checksummed_bytes.extend(split_off);
-        assert!(matches!(result, Err(IntegrityError::ChecksumMismatch(_, _))));
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/checksums.rs
+++ b/mountpoint-s3-fs/src/checksums.rs
@@ -249,6 +249,79 @@ impl ChecksummedBytes {
     }
 }
 
+/// Accumulates several [ChecksummedBytes] into one caller-supplied buffer, copying each piece
+/// exactly once and combining their checksums rather than recomputing one over the result.
+///
+/// The buffer must be exactly the total length of the appended pieces: [Self::finish] requires it
+/// filled, since the checksum is only exact for the whole buffer. Taking the buffer from the caller
+/// lets it come from a memory pool rather than the heap.
+#[must_use]
+pub struct ChecksummedBytesBuilder<Buffer> {
+    /// Destination buffer, filled from the front.
+    buffer: Buffer,
+    /// Bytes written into [Self::buffer] so far.
+    len: usize,
+    /// Combined checksum of the first [Self::len] bytes.
+    checksum: Crc32c,
+}
+
+impl<Buffer: AsRef<[u8]> + AsMut<[u8]> + Send + 'static> ChecksummedBytesBuilder<Buffer> {
+    /// Create a builder writing into `buffer`, which must be sized to the exact total length of the
+    /// pieces that will be appended.
+    pub fn new(buffer: Buffer) -> Self {
+        Self {
+            buffer,
+            len: 0,
+            checksum: Crc32c::new(0),
+        }
+    }
+
+    /// Total number of bytes this builder can hold.
+    fn capacity(&self) -> usize {
+        self.buffer.as_ref().len()
+    }
+
+    /// Copy `bytes` into the buffer and fold its checksum into the running one.
+    ///
+    /// Return [IntegrityError] if data corruption is detected in `bytes`.
+    ///
+    /// Panics if `bytes` does not fit in the remaining capacity.
+    pub fn append(&mut self, bytes: ChecksummedBytes) -> Result<(), IntegrityError> {
+        if bytes.is_empty() {
+            // No op, but check that `bytes` was not corrupted.
+            bytes.validate()?;
+            return Ok(());
+        }
+
+        // Shrink to fit so `checksum` covers exactly `bytes`, as `combine_checksums` requires.
+        let (bytes, checksum) = bytes.into_inner()?;
+
+        let new_len = self.len + bytes.len();
+        assert!(
+            new_len <= self.capacity(),
+            "appending {} bytes would exceed the builder capacity of {}",
+            bytes.len(),
+            self.capacity(),
+        );
+        self.buffer.as_mut()[self.len..new_len].copy_from_slice(&bytes);
+        self.checksum = combine_checksums(self.checksum, checksum, bytes.len());
+        self.len = new_len;
+        Ok(())
+    }
+
+    /// Consume the builder and return the accumulated data.
+    ///
+    /// Panics if the buffer was not filled to its capacity.
+    pub fn finish(self) -> ChecksummedBytes {
+        assert_eq!(
+            self.len,
+            self.capacity(),
+            "builder must be filled to capacity before finishing",
+        );
+        ChecksummedBytes::new_from_inner_data(Bytes::from_owner(self.buffer), self.checksum)
+    }
+}
+
 impl Default for ChecksummedBytes {
     fn default() -> Self {
         Self {
@@ -386,32 +459,80 @@ mod tests {
         assert!(matches!(actual, Err(IntegrityError::ChecksumMismatch(_, _))));
     }
 
-    #[test]
-    fn test_into_detached() {
-        let bytes = Bytes::from_static(b"some bytes");
-        let checksummed_bytes = ChecksummedBytes::new(bytes.clone());
-        let expected_checksum = checksummed_bytes.checksum;
-
-        let detached = checksummed_bytes.into_detached().unwrap();
-
-        // Content and checksum are preserved, and the checksum is reused (not recomputed).
-        assert_eq!(bytes, detached.buffer);
-        assert_eq!(expected_checksum, detached.checksum);
-        assert_eq!(bytes, detached.into_bytes().unwrap());
+    /// Append `pieces` into a builder sized to their total length, and return the result.
+    fn build(pieces: impl IntoIterator<Item = ChecksummedBytes>) -> Result<ChecksummedBytes, IntegrityError> {
+        let pieces: Vec<_> = pieces.into_iter().collect();
+        let capacity = pieces.iter().map(|p| p.len()).sum();
+        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; capacity]);
+        for piece in pieces {
+            builder.append(piece)?;
+        }
+        Ok(builder.finish())
     }
 
     #[test]
-    fn test_into_detached_severs_shared_storage() {
-        // A slice of a larger buffer shares its allocation; `into_detached` must not.
-        let full = Bytes::from_static(b"some bytes");
-        let mut checksummed_bytes = ChecksummedBytes::new(full.clone());
-        let tail = checksummed_bytes.split_off(4); // "bytes", still backed by `full`
+    fn builder_combines_pieces_into_one_buffer() {
+        let expected = Bytes::from_static(b"some bytes and some more bytes");
+        let pieces = [
+            ChecksummedBytes::new(expected.slice(..10)),
+            ChecksummedBytes::new(expected.slice(10..19)),
+            ChecksummedBytes::new(expected.slice(19..)),
+        ];
 
-        let detached = tail.into_detached().unwrap();
-        assert_eq!(&detached.buffer[..], b" bytes");
-        // The detached buffer is a fresh, full-range allocation, not a subslice of `full`.
-        assert_eq!(detached.buffer.len(), detached.len());
-        assert_eq!(detached.range, 0..detached.len());
+        let result = build(pieces).unwrap();
+
+        // The combined checksum must match one computed over the whole result, and must be exact
+        // for the buffer so `validate` (which checksums the entire buffer) passes.
+        assert_eq!(crc32c::checksum(&expected), result.checksum);
+        assert_eq!(result.range, 0..expected.len());
+        assert_eq!(expected, result.into_bytes().unwrap());
+    }
+
+    #[test]
+    fn builder_combines_pieces_whose_checksums_cover_a_larger_buffer() {
+        // `split_off` is zero-copy: each half carries the checksum of the whole parent buffer rather
+        // than its own slice. The builder must reconcile that before combining.
+        let full = Bytes::from_static(b"some bytes and some more bytes");
+        let mut first = ChecksummedBytes::new(full.clone());
+        let second = first.split_off(10);
+        assert_ne!(first.checksum, crc32c::checksum(&full.slice(..10)));
+
+        let result = build([first, second]).unwrap();
+
+        assert_eq!(crc32c::checksum(&full), result.checksum);
+        assert_eq!(full, result.into_bytes().unwrap());
+    }
+
+    #[test]
+    fn builder_skips_empty_pieces() {
+        let expected = Bytes::from_static(b"some bytes");
+        let pieces = [
+            ChecksummedBytes::default(),
+            ChecksummedBytes::new(expected.clone()),
+            ChecksummedBytes::default(),
+        ];
+
+        let result = build(pieces).unwrap();
+
+        assert_eq!(crc32c::checksum(&expected), result.checksum);
+        assert_eq!(expected, result.into_bytes().unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "would exceed the builder capacity")]
+    fn builder_append_beyond_capacity_panics() {
+        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; 4]);
+        let _ = builder.append(ChecksummedBytes::new(Bytes::from_static(b"some bytes")));
+    }
+
+    #[test]
+    #[should_panic(expected = "must be filled to capacity")]
+    fn builder_finish_underfilled_panics() {
+        let mut builder = ChecksummedBytesBuilder::new(vec![0u8; 10]);
+        builder
+            .append(ChecksummedBytes::new(Bytes::from_static(b"some")))
+            .unwrap();
+        let _ = builder.finish();
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -293,7 +293,7 @@ where
         let block_size = self.cache.block_size();
         let object_size = self.original_range.object_size();
 
-        let mut block_builder: Option<ChecksummedBytesBuilder<Vec<u8>>> = None;
+        let mut block_builder: Option<ChecksummedBytesBuilder> = None;
 
         pin_mut!(request_stream);
         while let Some(next) = request_stream.next().await {
@@ -343,8 +343,7 @@ where
                     // This chunk covers the whole block on its own, so cache it as is.
                     chunk
                 } else {
-                    let builder =
-                        block_builder.get_or_insert_with(|| ChecksummedBytesBuilder::new(vec![0u8; block_len]));
+                    let builder = block_builder.get_or_insert_with(|| ChecksummedBytesBuilder::new(block_len));
                     builder
                         .append(chunk)
                         .inspect_err(|e| warn!(key, error=?e, "integrity check for body part failed"))?;

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -293,17 +293,16 @@ where
         let block_size = self.cache.block_size();
         let object_size = self.original_range.object_size();
 
-        let mut block_builder: Option<ChecksummedBytesBuilder> = None;
+        let mut block_builder = ChecksummedBytesBuilder::new(block_size as usize);
 
         pin_mut!(request_stream);
         while let Some(next) = request_stream.next().await {
-            let buffered_len = block_builder.as_ref().map_or(0, |builder| builder.len());
             assert!(
-                buffered_len < block_size as usize,
+                block_builder.len() < block_size as usize,
                 "a full block should have been flushed already"
             );
             let GetBodyPart { offset, data: mut body } = next?;
-            let expected_offset = self.block_offset + buffered_len as u64;
+            let expected_offset = self.block_offset + block_builder.len() as u64;
             if offset != expected_offset {
                 warn!(key, offset, expected_offset, "wrong offset for GetObject body part");
                 return Err(PrefetchReadError::GetRequestReturnedWrongOffset {
@@ -315,10 +314,9 @@ where
             // Split the body into blocks.
             let mut offset = offset;
             while !body.is_empty() {
-                // A full block, except for the object's last one which may be shorter.
-                let block_len = (object_size.saturating_sub(self.block_offset as usize)).min(block_size as usize);
-                let buffered_len = block_builder.as_ref().map_or(0, |builder| builder.len());
-                let chunk_len = block_len.saturating_sub(buffered_len).min(body.len());
+                let chunk_len = (block_size as usize)
+                    .saturating_sub(block_builder.len())
+                    .min(body.len());
                 let chunk: ChecksummedBytes = body.split_to(chunk_len).into();
 
                 // We need to return some bytes to the part queue even before we can fill an entire caching block because
@@ -339,18 +337,19 @@ where
                 }
                 offset += chunk.len() as u64;
 
-                let block = if block_builder.is_none() && chunk.len() == block_len {
+                // A full block, except for the object's last one which may be shorter.
+                let block_len = (object_size.saturating_sub(self.block_offset as usize)).min(block_size as usize);
+                let block = if block_builder.is_empty() && chunk.len() == block_len {
                     // This chunk covers the whole block on its own, so cache it as is.
                     chunk
                 } else {
-                    let builder = block_builder.get_or_insert_with(|| ChecksummedBytesBuilder::new(block_len));
-                    builder
+                    block_builder
                         .append(chunk)
                         .inspect_err(|e| warn!(key, error=?e, "integrity check for body part failed"))?;
-                    if builder.len() < block_size as usize {
+                    if block_builder.len() < block_size as usize {
                         break;
                     }
-                    block_builder.take().expect("builder was just inserted").finish()
+                    block_builder.finish()
                 };
 
                 // We have a full block: write it to the cache and move on to the next one.
@@ -360,7 +359,7 @@ where
             }
         }
 
-        if let Some(block_builder) = block_builder {
+        if !block_builder.is_empty() {
             // If we still have a partial block, this must be the last block for this object,
             // which can be smaller than block_size (and ends at the end of the object).
             assert_eq!(

--- a/mountpoint-s3-fs/src/prefetch/caching_stream.rs
+++ b/mountpoint-s3-fs/src/prefetch/caching_stream.rs
@@ -8,7 +8,7 @@ use mountpoint_s3_client::types::GetBodyPart;
 use tracing::{Instrument, debug_span, trace, warn};
 
 use crate::async_util::Runtime;
-use crate::checksums::ChecksummedBytes;
+use crate::checksums::{ChecksummedBytes, ChecksummedBytesBuilder};
 use crate::data_cache::{BlockIndex, DataCache};
 use crate::memory::PagedPool;
 use crate::object::ObjectId;
@@ -291,16 +291,19 @@ where
     ) -> Result<(), PrefetchReadError<E>> {
         let key = self.cache_key.key();
         let block_size = self.cache.block_size();
-        let mut buffer = ChecksummedBytes::default();
+        let object_size = self.original_range.object_size();
+
+        let mut block_builder: Option<ChecksummedBytesBuilder<Vec<u8>>> = None;
 
         pin_mut!(request_stream);
         while let Some(next) = request_stream.next().await {
+            let buffered_len = block_builder.as_ref().map_or(0, |builder| builder.len());
             assert!(
-                buffer.len() < block_size as usize,
-                "buffer should be flushed when we get a full block"
+                buffered_len < block_size as usize,
+                "a full block should have been flushed already"
             );
             let GetBodyPart { offset, data: mut body } = next?;
-            let expected_offset = self.block_offset + buffer.len() as u64;
+            let expected_offset = self.block_offset + buffered_len as u64;
             if offset != expected_offset {
                 warn!(key, offset, expected_offset, "wrong offset for GetObject body part");
                 return Err(PrefetchReadError::GetRequestReturnedWrongOffset {
@@ -312,8 +315,11 @@ where
             // Split the body into blocks.
             let mut offset = offset;
             while !body.is_empty() {
-                let remaining = (block_size as usize).saturating_sub(buffer.len()).min(body.len());
-                let chunk: ChecksummedBytes = body.split_to(remaining).into();
+                // A full block, except for the object's last one which may be shorter.
+                let block_len = (object_size.saturating_sub(self.block_offset as usize)).min(block_size as usize);
+                let buffered_len = block_builder.as_ref().map_or(0, |builder| builder.len());
+                let chunk_len = block_len.saturating_sub(buffered_len).min(body.len());
+                let chunk: ChecksummedBytes = body.split_to(chunk_len).into();
 
                 // We need to return some bytes to the part queue even before we can fill an entire caching block because
                 // we want to start the feedback loop for the flow-control window.
@@ -332,31 +338,45 @@ where
                     self.part_queue_producer.push(Ok(part));
                 }
                 offset += chunk.len() as u64;
-                buffer
-                    .extend(chunk)
-                    .inspect_err(|e| warn!(key, error=?e, "integrity check for body part failed"))?;
-                if buffer.len() < block_size as usize {
-                    break;
-                }
 
-                // We have a full block: write it to the cache, send it to the queue, and flush the buffer.
-                self.update_cache(buffer, self.block_index, self.block_offset, &self.cache_key, range);
+                let block = if block_builder.is_none() && chunk.len() == block_len {
+                    // This chunk covers the whole block on its own, so cache it as is.
+                    chunk
+                } else {
+                    let builder =
+                        block_builder.get_or_insert_with(|| ChecksummedBytesBuilder::new(vec![0u8; block_len]));
+                    builder
+                        .append(chunk)
+                        .inspect_err(|e| warn!(key, error=?e, "integrity check for body part failed"))?;
+                    if builder.len() < block_size as usize {
+                        break;
+                    }
+                    block_builder.take().expect("builder was just inserted").finish()
+                };
+
+                // We have a full block: write it to the cache and move on to the next one.
+                self.update_cache(block, self.block_index, self.block_offset, &self.cache_key, range);
                 self.block_index += 1;
                 self.block_offset += block_size;
-                buffer = ChecksummedBytes::default();
             }
         }
 
-        if !buffer.is_empty() {
-            // If we still have data in the buffer, this must be the last block for this object,
+        if let Some(block_builder) = block_builder {
+            // If we still have a partial block, this must be the last block for this object,
             // which can be smaller than block_size (and ends at the end of the object).
             assert_eq!(
-                self.block_offset as usize + buffer.len(),
+                self.block_offset as usize + block_builder.len(),
                 self.original_range.object_size(),
                 "a partial block is only allowed at the end of the object"
             );
             // Write the last block to the cache.
-            self.update_cache(buffer, self.block_index, self.block_offset, &self.cache_key, range);
+            self.update_cache(
+                block_builder.finish(),
+                self.block_index,
+                self.block_offset,
+                &self.cache_key,
+                range,
+            );
         }
         Ok(())
     }

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -164,7 +164,7 @@ where
         let total_to_read = (length as u64).min(remaining);
         let mut to_read = total_to_read;
         let mut all_parts_from_cache = true;
-        let mut response: Option<ChecksummedBytesBuilder<Vec<u8>>> = None;
+        let mut response: Option<ChecksummedBytesBuilder> = None;
         while to_read > 0 {
             debug_assert!(self.request_task.remaining() > 0);
 
@@ -182,8 +182,7 @@ where
             }
 
             let part_len = part_bytes.len() as u64;
-            let response =
-                response.get_or_insert_with(|| ChecksummedBytesBuilder::new(vec![0u8; total_to_read as usize]));
+            let response = response.get_or_insert_with(|| ChecksummedBytesBuilder::new(total_to_read as usize));
             response.append(part_bytes)?;
             to_read -= part_len;
         }

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -2,7 +2,7 @@ use metrics::{counter, histogram};
 use mountpoint_s3_client::ObjectClient;
 use tracing::trace;
 
-use crate::checksums::ChecksummedBytes;
+use crate::checksums::{ChecksummedBytes, ChecksummedBytesBuilder};
 use crate::memory::CursorHandle;
 use crate::metrics::defs::PREFETCH_RESET_STATE;
 use crate::object::ObjectId;
@@ -161,9 +161,10 @@ where
             return Ok((ChecksummedBytes::default(), false));
         }
 
-        let mut to_read = (length as u64).min(remaining);
+        let total_to_read = (length as u64).min(remaining);
+        let mut to_read = total_to_read;
         let mut all_parts_from_cache = true;
-        let mut response = ChecksummedBytes::default();
+        let mut response: Option<ChecksummedBytesBuilder<Vec<u8>>> = None;
         while to_read > 0 {
             debug_assert!(self.request_task.remaining() > 0);
 
@@ -176,16 +177,19 @@ where
             // If we can complete the read with just a single buffer, early return to avoid copying
             // into a new buffer. This should be the common case as long as part size is larger than
             // read size, which it almost always is for real S3 clients and FUSE.
-            if response.is_empty() && part_bytes.len() == to_read as usize {
+            if response.is_none() && part_bytes.len() == to_read as usize {
                 return Ok((part_bytes, all_parts_from_cache));
             }
 
             let part_len = part_bytes.len() as u64;
-            response.extend(part_bytes)?;
+            let response =
+                response.get_or_insert_with(|| ChecksummedBytesBuilder::new(vec![0u8; total_to_read as usize]));
+            response.append(part_bytes)?;
             to_read -= part_len;
         }
 
-        Ok((response, all_parts_from_cache))
+        let response = response.expect("multi-part reads build a response, single-part reads return early");
+        Ok((response.finish(), all_parts_from_cache))
     }
 
     /// Try to seek within the current inflight requests without restarting them.

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -164,7 +164,7 @@ where
         let total_to_read = (length as u64).min(remaining);
         let mut to_read = total_to_read;
         let mut all_parts_from_cache = true;
-        let mut response: Option<ChecksummedBytesBuilder> = None;
+        let mut response = ChecksummedBytesBuilder::new(total_to_read as usize);
         while to_read > 0 {
             debug_assert!(self.request_task.remaining() > 0);
 
@@ -177,17 +177,15 @@ where
             // If we can complete the read with just a single buffer, early return to avoid copying
             // into a new buffer. This should be the common case as long as part size is larger than
             // read size, which it almost always is for real S3 clients and FUSE.
-            if response.is_none() && part_bytes.len() == to_read as usize {
+            if response.is_empty() && part_bytes.len() == to_read as usize {
                 return Ok((part_bytes, all_parts_from_cache));
             }
 
             let part_len = part_bytes.len() as u64;
-            let response = response.get_or_insert_with(|| ChecksummedBytesBuilder::new(total_to_read as usize));
             response.append(part_bytes)?;
             to_read -= part_len;
         }
 
-        let response = response.expect("multi-part reads build a response, single-part reads return early");
         Ok((response.finish(), all_parts_from_cache))
     }
 

--- a/mountpoint-s3-fs/src/prefetch/cursor.rs
+++ b/mountpoint-s3-fs/src/prefetch/cursor.rs
@@ -181,14 +181,7 @@ where
             }
 
             let part_len = part_bytes.len() as u64;
-            if response.is_empty() {
-                // Copy off the pool buffer instead of letting `extend` alias it: this read spans
-                // parts, and holding a pool buffer across the next allocation below deadlocks under
-                // memory pressure.
-                response = part_bytes.into_detached()?;
-            } else {
-                response.extend(part_bytes)?;
-            }
+            response.extend(part_bytes)?;
             to_read -= part_len;
         }
 

--- a/mountpoint-s3-fs/src/prefetch/part.rs
+++ b/mountpoint-s3-fs/src/prefetch/part.rs
@@ -32,12 +32,6 @@ impl Part {
         }
     }
 
-    pub fn extend(&mut self, other: &Part) -> Result<(), PartOperationError> {
-        let expected_offset = self.offset + self.checksummed_bytes.len() as u64;
-        other.check(&self.id, expected_offset)?;
-        Ok(self.checksummed_bytes.extend(other.clone().checksummed_bytes)?)
-    }
-
     pub fn into_bytes(self, id: &ObjectId, offset: u64) -> Result<ChecksummedBytes, PartOperationError> {
         self.check(id, offset).map(|_| self.checksummed_bytes)
     }
@@ -110,63 +104,17 @@ mod tests {
     use super::{Part, PartSource};
 
     #[test]
-    fn test_append() {
+    fn into_bytes_rejects_mismatched_object_id() {
         let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let first_offset = 0;
-        let first_part_len = 1024;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(first_offset as u8 as usize)
-            .take(first_part_len)
-            .collect();
+        let offset = 0;
+        let part_len = 1024;
+        let body: Box<[u8]> = (0u8..=255).cycle().skip(offset as u8 as usize).take(part_len).collect();
         let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes, PartSource::S3);
+        let part = Part::new(object_id.clone(), offset, checksummed_bytes, PartSource::S3);
 
-        let second_part_len = 512;
-        let second_offset = first_offset + first_part_len as u64;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(second_offset as u8 as usize)
-            .take(second_part_len)
-            .collect();
-        let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let second = Part::new(object_id.clone(), second_offset, checksummed_bytes, PartSource::S3);
+        let other_object_id = ObjectId::new("other".to_owned(), ETag::for_tests());
 
-        first.extend(&second).expect("should be able to extend");
-        assert_eq!(first_part_len + second_part_len, first.len());
-        first.check(&object_id, first_offset).expect("the part should be valid");
-    }
-
-    #[test]
-    fn test_append_with_mismatch_object_id() {
-        let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let first_offset = 0;
-        let first_part_len = 1024;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(first_offset as u8 as usize)
-            .take(first_part_len)
-            .collect();
-        let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes, PartSource::S3);
-
-        let second_object_id = ObjectId::new("other".to_owned(), ETag::for_tests());
-        let second_part_len = 512;
-        let second_offset = first_offset;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(second_offset as u8 as usize)
-            .take(second_part_len)
-            .collect();
-        let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let second = Part::new(
-            second_object_id.clone(),
-            second_offset,
-            checksummed_bytes,
-            PartSource::S3,
-        );
-
-        let result = first.extend(&second);
+        let result = part.into_bytes(&other_object_id, offset);
         assert!(matches!(
             result,
             Err(PartOperationError::IdMismatch {
@@ -177,29 +125,15 @@ mod tests {
     }
 
     #[test]
-    fn test_append_with_mismatch_offset() {
+    fn into_bytes_rejects_mismatched_offset() {
         let object_id = ObjectId::new("key".to_owned(), ETag::for_tests());
-        let first_offset = 0;
-        let first_part_len = 1024;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(first_offset as u8 as usize)
-            .take(first_part_len)
-            .collect();
+        let offset = 0;
+        let part_len = 1024;
+        let body: Box<[u8]> = (0u8..=255).cycle().skip(offset as u8 as usize).take(part_len).collect();
         let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let mut first = Part::new(object_id.clone(), first_offset, checksummed_bytes, PartSource::S3);
+        let part = Part::new(object_id.clone(), offset, checksummed_bytes, PartSource::S3);
 
-        let second_part_len = 512;
-        let second_offset = first_offset;
-        let body: Box<[u8]> = (0u8..=255)
-            .cycle()
-            .skip(second_offset as u8 as usize)
-            .take(second_part_len)
-            .collect();
-        let checksummed_bytes = ChecksummedBytes::new(body.into());
-        let second = Part::new(object_id.clone(), second_offset, checksummed_bytes, PartSource::S3);
-
-        let result = first.extend(&second);
+        let result = part.into_bytes(&object_id, offset + 1);
         assert!(matches!(
             result,
             Err(PartOperationError::OffsetMismatch {


### PR DESCRIPTION
`ChecksummedBytes::extend` aliased the appended buffer when the accumulator was empty (`*self = extend`). At `CachingPartComposer` and `Cursor::do_read` that buffer is a pooled GetObject buffer, so the accumulator pinned it across the next part's allocation and deadlocked under memory pressure.

Both now stitch their output with a new `ChecksummedBytesBuilder`, which reserves the expected total length on first append and copies each piece exactly once, rather than reallocating and re-copying the accumulated prefix per piece as `extend` did. Nothing aliases a pooled buffer any more, so `ChecksummedBytes::extend` and the already-unused `Part::extend` are removed.

Stress tests: https://github.com/awslabs/mountpoint-s3/actions/runs/31591359789
Benchmarks: https://github.com/awslabs/mountpoint-s3/actions/runs/31591360134

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
