### PR TITLE
Withhold the prunable reserve from paged allocations

### DIFF
--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -39,7 +39,7 @@ impl PoolBuffer {
         forced: bool,
     ) -> Option<Self> {
         Some(Self(PoolBufferInner::Secondary(
-            limiter.try_allocate(size, kind, true, forced)?,
+            limiter.try_allocate(size, kind, false, forced)?,
         )))
     }
 

--- a/mountpoint-s3-fs/src/memory/buffers.rs
+++ b/mountpoint-s3-fs/src/memory/buffers.rs
@@ -38,9 +38,11 @@ impl PoolBuffer {
         limiter: Arc<MemoryLimiter>,
         forced: bool,
     ) -> Option<Self> {
-        Some(Self(PoolBufferInner::Secondary(
-            limiter.try_allocate(size, kind, false, forced)?,
-        )))
+        Some(Self(PoolBufferInner::Secondary(limiter.try_allocate(
+            size,
+            Some(kind),
+            forced,
+        )?)))
     }
 
     pub fn capacity(&self) -> usize {

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -286,20 +286,36 @@ impl MemoryLimiter {
         metrics::gauge!("mem.bytes_reserved", "area" => BufferArea::Prefetch.as_str()).decrement(decremented as f64);
     }
 
+    /// The memory ceiling [`Self::try_allocate`] enforces.
+    ///
+    /// Every allocation stops `prunable_reserved` bytes short of `mem_limit` — that slice is the
+    /// headroom that lets a read still allocate when writes have taken the rest of the budget — with
+    /// one exception: a prunable ([`BufferKind::is_prunable`]) one-off allocation (`is_paged` false)
+    /// may spend it. Such an allocation is the read the reserve exists for, and it takes the reserve
+    /// in the only shape that gives it back: an exact-size buffer, freed on drop.
+    ///
+    /// Withholding the reserve from paged allocations (`is_paged` true) is what keeps it reachable. A
+    /// page holds up to [`MAX_BUFFERS_PER_PAGE`](super::pages::MAX_BUFFERS_PER_PAGE) buffers and is
+    /// freed only when wholly empty, while any [`BufferKind`] may claim a free buffer inside it. So a
+    /// page carved out of the reserve destroys it: the bytes stay committed to that one size pool,
+    /// where a non-prunable holder can pin them indefinitely.
+    fn allocation_ceiling(&self, kind: BufferKind, is_paged: bool) -> usize {
+        if kind.is_prunable() && !is_paged {
+            self.mem_limit
+        } else {
+            self.mem_limit.saturating_sub(self.prunable_reserved)
+        }
+    }
+
     /// Try to allocate `size` bytes from the pool budget.
     ///
-    /// `kind` selects the ceiling: prunable kinds (see [`BufferKind::is_prunable`]) may use the full
-    /// `mem_limit`, while non-prunable kinds stop `prunable_reserved` bytes short, keeping that slice
-    /// available for prunable allocations.
-    ///
-    /// `track` controls per-kind byte accounting: `true` records the allocation against `kind` (and
-    /// releases it on drop), `false` skips tracking. Page allocations pass `false` because their
-    /// individual buffers are tracked separately as they are acquired.
-    pub fn try_allocate(
+    /// `is_paged` distinguishes a page in a [`SizePool`](super::pool::SizePool) (`true`) from an
+    /// exact-size one-off buffer (`false`).
+    pub(super) fn try_allocate(
         self: &Arc<Self>,
         size: usize,
         kind: BufferKind,
-        track: bool,
+        is_paged: bool,
         forced: bool,
     ) -> Option<ManagedBuffer> {
         if forced {
@@ -307,12 +323,7 @@ impl MemoryLimiter {
             metrics::gauge!("pool.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
-            // Prunable kinds use the full limit; others must leave `prunable_reserved` bytes free.
-            let ceiling = if kind.is_prunable() {
-                self.mem_limit
-            } else {
-                self.mem_limit.saturating_sub(self.prunable_reserved)
-            };
+            let ceiling = self.allocation_ceiling(kind, is_paged);
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
             loop {
                 let new_mem_allocated = mem_allocated.saturating_add(size);
@@ -339,11 +350,11 @@ impl MemoryLimiter {
             }
         }
 
-        if track {
+        if !is_paged {
             self.acquire_bytes(size, kind);
         }
 
-        Some(ManagedBuffer::new(size, track.then_some(kind), self.clone()))
+        Some(ManagedBuffer::new(size, (!is_paged).then_some(kind), self.clone()))
     }
 
     pub fn deallocate(&self, ptr: BufferPtr, kind: Option<BufferKind>) {
@@ -886,6 +897,63 @@ mod tests {
         // Drop the buffer — available goes back up
         drop(buffer);
         assert_eq!(limiter.memory_available_for_reservation(), initial_available);
+    }
+
+    #[test]
+    fn allocation_ceiling_reserves_for_all_but_prunable_one_off() {
+        let mem_limit = 1000;
+        let prunable_buffer_size = 100;
+        let limiter = MemoryLimiter::new(mem_limit, prunable_buffer_size);
+        assert_eq!(limiter.prunable_reserved, prunable_buffer_size);
+        let reserved_ceiling = mem_limit - prunable_buffer_size;
+
+        // Prunable one-off: the read the reserve exists for — it may spend the full limit.
+        assert_eq!(limiter.allocation_ceiling(BufferKind::GetObject, false), mem_limit);
+        assert_eq!(limiter.allocation_ceiling(BufferKind::DiskCache, false), mem_limit);
+
+        // Prunable but paged: a page never gets the reserve.
+        assert_eq!(
+            limiter.allocation_ceiling(BufferKind::GetObject, true),
+            reserved_ceiling
+        );
+        assert_eq!(
+            limiter.allocation_ceiling(BufferKind::DiskCache, true),
+            reserved_ceiling
+        );
+
+        // Non-prunable, paged or one-off: always stops short of the reserve.
+        assert_eq!(
+            limiter.allocation_ceiling(BufferKind::PutObject, false),
+            reserved_ceiling
+        );
+        assert_eq!(
+            limiter.allocation_ceiling(BufferKind::PutObject, true),
+            reserved_ceiling
+        );
+        assert_eq!(limiter.allocation_ceiling(BufferKind::Append, false), reserved_ceiling);
+    }
+
+    #[test]
+    fn allocation_ceiling_without_reserve_is_always_full_limit() {
+        let mem_limit = 1000;
+        let limiter = MemoryLimiter::new(mem_limit, 0);
+        assert_eq!(limiter.prunable_reserved, 0);
+
+        for kind in [
+            BufferKind::GetObject,
+            BufferKind::DiskCache,
+            BufferKind::PutObject,
+            BufferKind::Append,
+            BufferKind::Other,
+        ] {
+            for is_paged in [false, true] {
+                assert_eq!(
+                    limiter.allocation_ceiling(kind, is_paged),
+                    mem_limit,
+                    "kind={kind:?} is_paged={is_paged}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/mountpoint-s3-fs/src/memory/limiter.rs
+++ b/mountpoint-s3-fs/src/memory/limiter.rs
@@ -290,32 +290,32 @@ impl MemoryLimiter {
     ///
     /// Every allocation stops `prunable_reserved` bytes short of `mem_limit` — that slice is the
     /// headroom that lets a read still allocate when writes have taken the rest of the budget — with
-    /// one exception: a prunable ([`BufferKind::is_prunable`]) one-off allocation (`is_paged` false)
-    /// may spend it. Such an allocation is the read the reserve exists for, and it takes the reserve
-    /// in the only shape that gives it back: an exact-size buffer, freed on drop.
+    /// one exception: a prunable ([`BufferKind::is_prunable`]) one-off allocation may spend it. Such
+    /// an allocation is the read the reserve exists for, and it takes the reserve in the only shape
+    /// that gives it back: an exact-size buffer, freed on drop.
     ///
-    /// Withholding the reserve from paged allocations (`is_paged` true) is what keeps it reachable. A
-    /// page holds up to [`MAX_BUFFERS_PER_PAGE`](super::pages::MAX_BUFFERS_PER_PAGE) buffers and is
+    /// Withholding the reserve from paged allocations (`kind` is `None`) is what keeps it reachable.
+    /// A page holds up to [`MAX_BUFFERS_PER_PAGE`](super::pages::MAX_BUFFERS_PER_PAGE) buffers and is
     /// freed only when wholly empty, while any [`BufferKind`] may claim a free buffer inside it. So a
     /// page carved out of the reserve destroys it: the bytes stay committed to that one size pool,
     /// where a non-prunable holder can pin them indefinitely.
-    fn allocation_ceiling(&self, kind: BufferKind, is_paged: bool) -> usize {
-        if kind.is_prunable() && !is_paged {
-            self.mem_limit
-        } else {
-            self.mem_limit.saturating_sub(self.prunable_reserved)
+    fn allocation_ceiling(&self, kind: Option<BufferKind>) -> usize {
+        match kind {
+            Some(kind) if kind.is_prunable() => self.mem_limit,
+            _ => self.mem_limit.saturating_sub(self.prunable_reserved),
         }
     }
 
     /// Try to allocate `size` bytes from the pool budget.
     ///
-    /// `is_paged` distinguishes a page in a [`SizePool`](super::pool::SizePool) (`true`) from an
-    /// exact-size one-off buffer (`false`).
+    /// `kind` is `Some` for an exact-size one-off buffer — the allocation is recorded against that
+    /// [`BufferKind`] and released on drop — and `None` for a page in a
+    /// [`SizePool`](super::pool::SizePool), whose individual buffers are tracked separately as they
+    /// are acquired. It also selects the ceiling; see [`Self::allocation_ceiling`].
     pub(super) fn try_allocate(
         self: &Arc<Self>,
         size: usize,
-        kind: BufferKind,
-        is_paged: bool,
+        kind: Option<BufferKind>,
         forced: bool,
     ) -> Option<ManagedBuffer> {
         if forced {
@@ -323,7 +323,7 @@ impl MemoryLimiter {
             metrics::gauge!("pool.allocated_bytes").increment(size as f64);
         } else {
             let start = Instant::now();
-            let ceiling = self.allocation_ceiling(kind, is_paged);
+            let ceiling = self.allocation_ceiling(kind);
             let mut mem_allocated = self.allocated_bytes.load(Ordering::SeqCst);
             loop {
                 let new_mem_allocated = mem_allocated.saturating_add(size);
@@ -350,11 +350,11 @@ impl MemoryLimiter {
             }
         }
 
-        if !is_paged {
+        if let Some(kind) = kind {
             self.acquire_bytes(size, kind);
         }
 
-        Some(ManagedBuffer::new(size, (!is_paged).then_some(kind), self.clone()))
+        Some(ManagedBuffer::new(size, kind, self.clone()))
     }
 
     pub fn deallocate(&self, ptr: BufferPtr, kind: Option<BufferKind>) {
@@ -908,29 +908,18 @@ mod tests {
         let reserved_ceiling = mem_limit - prunable_buffer_size;
 
         // Prunable one-off: the read the reserve exists for — it may spend the full limit.
-        assert_eq!(limiter.allocation_ceiling(BufferKind::GetObject, false), mem_limit);
-        assert_eq!(limiter.allocation_ceiling(BufferKind::DiskCache, false), mem_limit);
+        assert_eq!(limiter.allocation_ceiling(Some(BufferKind::GetObject)), mem_limit);
+        assert_eq!(limiter.allocation_ceiling(Some(BufferKind::DiskCache)), mem_limit);
 
-        // Prunable but paged: a page never gets the reserve.
-        assert_eq!(
-            limiter.allocation_ceiling(BufferKind::GetObject, true),
-            reserved_ceiling
-        );
-        assert_eq!(
-            limiter.allocation_ceiling(BufferKind::DiskCache, true),
-            reserved_ceiling
-        );
+        // Paged (`None`): a page never gets the reserve, whatever kind fills it.
+        assert_eq!(limiter.allocation_ceiling(None), reserved_ceiling);
 
-        // Non-prunable, paged or one-off: always stops short of the reserve.
+        // Non-prunable one-off: always stops short of the reserve.
         assert_eq!(
-            limiter.allocation_ceiling(BufferKind::PutObject, false),
+            limiter.allocation_ceiling(Some(BufferKind::PutObject)),
             reserved_ceiling
         );
-        assert_eq!(
-            limiter.allocation_ceiling(BufferKind::PutObject, true),
-            reserved_ceiling
-        );
-        assert_eq!(limiter.allocation_ceiling(BufferKind::Append, false), reserved_ceiling);
+        assert_eq!(limiter.allocation_ceiling(Some(BufferKind::Append)), reserved_ceiling);
     }
 
     #[test]
@@ -940,19 +929,14 @@ mod tests {
         assert_eq!(limiter.prunable_reserved, 0);
 
         for kind in [
-            BufferKind::GetObject,
-            BufferKind::DiskCache,
-            BufferKind::PutObject,
-            BufferKind::Append,
-            BufferKind::Other,
+            None,
+            Some(BufferKind::GetObject),
+            Some(BufferKind::DiskCache),
+            Some(BufferKind::PutObject),
+            Some(BufferKind::Append),
+            Some(BufferKind::Other),
         ] {
-            for is_paged in [false, true] {
-                assert_eq!(
-                    limiter.allocation_ceiling(kind, is_paged),
-                    mem_limit,
-                    "kind={kind:?} is_paged={is_paged}"
-                );
-            }
+            assert_eq!(limiter.allocation_ceiling(kind), mem_limit, "kind={kind:?}");
         }
     }
 

--- a/mountpoint-s3-fs/src/memory/pages.rs
+++ b/mountpoint-s3-fs/src/memory/pages.rs
@@ -44,14 +44,14 @@ impl Page {
     /// Create a new page and allocate the required memory.
     ///
     /// Returns `None` if the allocation would hit the memory limit.
-    pub fn try_new(stats: &Arc<SizePoolStats>, buffer_count: usize, kind: BufferKind) -> Option<Self> {
+    pub fn try_new(stats: &Arc<SizePoolStats>, buffer_count: usize) -> Option<Self> {
         assert!(
             buffer_count > 0 && buffer_count <= MAX_BUFFERS_PER_PAGE,
             "buffer_count must be positive and less than {}, but was {}.",
             MAX_BUFFERS_PER_PAGE,
             buffer_count
         );
-        let page_buffer = stats.try_allocate_page(buffer_count, kind)?;
+        let page_buffer = stats.try_allocate_page(buffer_count)?;
 
         // SAFETY: last_buffer is guaranteed to belong to the allocated object.
         let last_buffer = unsafe { page_buffer.as_raw_ptr().add((buffer_count - 1) * stats.buffer_size) };
@@ -143,8 +143,7 @@ impl Page {
     pub(super) fn new_for_tests(buffer_size: usize) -> Page {
         let limiter = super::limiter::MemoryLimiter::new(usize::MAX, 0);
         let stats = SizePoolStats::new(buffer_size, Arc::new(limiter));
-        Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE, BufferKind::Other)
-            .expect("allocation should succeed with usize::MAX limit")
+        Page::try_new(&Arc::new(stats), MAX_BUFFERS_PER_PAGE).expect("allocation should succeed with usize::MAX limit")
     }
 }
 

--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -458,7 +458,7 @@ impl SizePool {
         // memory, keep retrying by halving the count.
         let mut buffer_count = MAX_BUFFERS_PER_PAGE;
         while buffer_count > 0 {
-            let Some(page) = Page::try_new(&self.stats, buffer_count, kind) else {
+            let Some(page) = Page::try_new(&self.stats, buffer_count) else {
                 buffer_count /= 2;
                 continue;
             };

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -53,9 +53,9 @@ impl SizePoolStats {
         self.empty_pages.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn try_allocate_page(&self, buffer_count: usize, kind: BufferKind) -> Option<ManagedBuffer> {
+    pub(super) fn try_allocate_page(&self, buffer_count: usize) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
-        let result = self.limiter.try_allocate(size, kind, true, false)?;
+        let result = self.limiter.try_allocate(size, None, false)?;
         metrics::gauge!(
             "pool.allocated_pages",
             "buffer_size" => format!("{}", self.buffer_size),

--- a/mountpoint-s3-fs/src/memory/stats.rs
+++ b/mountpoint-s3-fs/src/memory/stats.rs
@@ -55,7 +55,7 @@ impl SizePoolStats {
 
     pub(super) fn try_allocate_page(&self, buffer_count: usize, kind: BufferKind) -> Option<ManagedBuffer> {
         let size = self.buffer_size * buffer_count;
-        let result = self.limiter.try_allocate(size, kind, false, false)?;
+        let result = self.limiter.try_allocate(size, kind, true, false)?;
         metrics::gauge!(
             "pool.allocated_pages",
             "buffer_size" => format!("{}", self.buffer_size),


### PR DESCRIPTION
The memory limiter keeps `prunable_reserved` bytes of headroom below `mem_limit` so a read can still allocate after writes have consumed the rest of the budget. `Prunable` kinds (`GetObject`, `DiskCache`) were allowed to spend that reserve. However, the ceiling was chosen purely from `BufferKind`, without regard to whether the allocation was a page in a `SizePool` or an exact-size one-off buffer.
  
The issue: a prunable page allocation could dip into the reserve. A page holds up to `MAX_BUFFERS_PER_PAGE (16)` buffers, is freed only when wholly empty, and any `BufferKind` may claim a free buffer inside it. So a page carved out of the reserve destroys it. I.e. the bytes stay committed to that one size pool, where a non-prunable holder (e.g. a write) can pin them indefinitely. The reserve stops functioning as read headroom.

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
