### PR TITLE
Bump libgit2-sys to 0.18.7+1.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,9 +2581,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",
@@ -4554,7 +4554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3"
-version = "1.23.0"
+version = "1.23.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-fs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-mountpoint-s3-fs = { version = "0.10.0", path = "./mountpoint-s3-fs" }
-mountpoint-s3-client = { version = "0.21.0", path = "./mountpoint-s3-client" }
+mountpoint-s3-fs = { version = "0.10.1", path = "./mountpoint-s3-fs" }
+mountpoint-s3-client = { version = "0.21.1", path = "./mountpoint-s3-client" }
 mountpoint-s3-crt = { version = "0.15.0", path = "./mountpoint-s3-crt" }
 mountpoint-s3-crt-sys = { version = "0.17.0", path = "./mountpoint-s3-crt-sys" }
 mountpoint-s3-fuser = { version = "0.1.1", path = "./mountpoint-s3-fuser", features = ["abi-7-28", "libfuse"] }

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased (v0.21.0)
+## Unreleased (v0.21.1)
+
+### Other changes
+
+* Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))
 
 ## v0.21.0 (July 20, 2026)
 

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-client"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Unreleased (v0.10.1)
+
+* Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))
 
 ## v0.10.0 (July 20, 2026)
 

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mountpoint-s3-fs"
 # See `/doc/PUBLISHING_CRATES.md` to read how to publish new versions.
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/mountpoint-s3"

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Unreleased (v1.23.1)
 
 ## v1.23.0 (July 20, 2026)
 

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mountpoint-s3"
-version = "1.23.0"
+version = "1.23.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
### Description

Ran `cargo update -p libgit2-sys`.

Noted getrandom went from 0.4.3 to 0.3.4 for tempfile dependency whilst I ran it, but shouldn't be a problem as getrandom 0.3.4 is used by rand_core anyways.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Yes - patch version for affected crates. 



<details>
<summary>See below for `cargo tree --invert -p libgit2-sys` (click to expand)</summary>

```bash
cargo tree --invert -p libgit2-sys

libgit2-sys v0.18.7+1.9.6
└── git2 v0.21.0
    └── built v0.8.1
        [build-dependencies]
        ├── mountpoint-s3 v1.23.1 (/xxx/mountpoint-s3/mountpoint-s3)
        └── mountpoint-s3-client v0.21.1 (/xxx/mountpoint-s3/mountpoint-s3-client)
            ├── mountpoint-s3 v1.23.1 (/xxx/mountpoint-s3/mountpoint-s3)
            └── mountpoint-s3-fs v0.10.1 (/xxx/mountpoint-s3/mountpoint-s3-fs)
                └── mountpoint-s3 v1.23.1 (/xxx/mountpoint-s3/mountpoint-s3)
                [dev-dependencies]
                └── mountpoint-s3-client v0.21.1 (/xxx/mountpoint-s3/mountpoint-s3-client) (*)
            [dev-dependencies]
            ├── mountpoint-s3 v1.23.1 (/xxx/mountpoint-s3/mountpoint-s3)
            ├── mountpoint-s3-client v0.21.1 (/xxx/mountpoint-s3/mountpoint-s3-client) (*)
            └── mountpoint-s3-fs v0.10.1 (/xxx/mountpoint-s3/mountpoint-s3-fs) (*)
```

</details>

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
