### PR TITLE
  Reduce NUM_WORKERS in many_readers_budget_part stress test

### DIFF
--- a/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
+++ b/mountpoint-s3-fs/tests/stress/scenarios/many_readers_budget_part.rs
@@ -1,4 +1,4 @@
-//! `many_readers_budget_part`: 32 readers competing under a read part size that equals the entire
+//! `many_readers_budget_part`: 4 readers competing under a read part size that equals the entire
 //! data-buffer budget (384 MiB at the 512 MiB memory limit).
 
 use std::iter::repeat_n;
@@ -16,7 +16,7 @@ use crate::stress::workers::{LARGE_READ_OBJECT, SequentialReader};
 /// data buffers. One part therefore fills the whole budget.
 const READ_PART_SIZE: usize = MINIMUM_MEM_LIMIT - 128 * 1024 * 1024; // 384 MiB
 const READ_CHUNK: usize = 8 * 1024 * 1024; // 8 MiB
-const NUM_WORKERS: usize = 32;
+const NUM_WORKERS: usize = 4;
 
 #[test]
 fn many_readers_budget_part() {


### PR DESCRIPTION
With a 384 MiB part size and a 384 MiB data buffer budget (512 MiB memory limit minus 128 MiB overhead), only one reader can hold a part-sized buffer at a time. With 32 workers, each reader must wait its turn to get the single available buffer, and the time for all workers to make progress exceeds the 20-second watchdog timeout, causing the test to fail intermittently.
Reduce to 4 workers so all readers cycle through the buffer within the watchdog window.
Stress test run: https://github.com/awslabs/mountpoint-s3/actions/runs/31476369019/job/93730922523

### Does this change impact existing behavior?

No breaking change.

### Does this change need a changelog entry? Does it require a version change?

No. Test-only change, no user-facing impact.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
