### PR TITLE
Multi-cursor: S3IO benchmarks demonstrating the problematic workload

### DIFF
--- a/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
@@ -63,6 +63,11 @@ pub struct JobConfig {
     /// Whether to generate test objects before running read benchmarks.
     /// Only applies to read workloads. Default: true.
     pub generate_object: Option<bool>,
+    /// Number of interleaved sequential cursors (multi_cursor_sequential only).
+    pub num_cursors: Option<usize>,
+    /// Bytes to read from each cursor before advancing to the next
+    /// (multi_cursor_sequential only).
+    pub bytes_per_cursor_visit: Option<usize>,
 }
 
 /// Configuration for a single job execution
@@ -83,6 +88,8 @@ pub struct ResolvedJobConfig {
     pub max_duration: Option<Duration>,
     pub iteration_duration: Option<Duration>,
     pub generate_object: bool,
+    pub num_cursors: usize,
+    pub bytes_per_cursor_visit: usize,
 }
 
 /// Workload type: read or write
@@ -95,10 +102,17 @@ pub enum WorkloadType {
 
 /// Access pattern for read operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum AccessPattern {
     Sequential,
     Random,
+    /// `num_cursors` sequential cursors, each starting at an evenly-spaced offset, and reading up
+    /// to the start point of the next cursor.
+    MultiCursorSequential,
+    /// `num_cursors` sequential cursors, each starting at an evenly-spaced offset but all reading
+    /// to the *end of the file* (unlike `MultiCursorSequential`, where each cursor is confined to
+    /// its own region).
+    OverlappingCursors,
 }
 
 /// Server-side encryption type
@@ -270,6 +284,27 @@ fn merge_and_resolve(job_name: &str, job: &JobConfig, global: &GlobalConfig) -> 
         .or(global.job_defaults.generate_object)
         .unwrap_or(true);
 
+    // num_cursors: Optional with default of 8
+    let num_cursors = job.num_cursors.or(global.job_defaults.num_cursors).unwrap_or(8);
+    if num_cursors < 1 {
+        return Err(ConfigError::Validation(format!(
+            "Job '{}': Invalid value for 'num_cursors': must be at least 1",
+            job_name
+        )));
+    }
+
+    // bytes_per_cursor_visit: Optional with default of 1 MiB
+    let bytes_per_cursor_visit = job
+        .bytes_per_cursor_visit
+        .or(global.job_defaults.bytes_per_cursor_visit)
+        .unwrap_or(1024 * 1024);
+    if bytes_per_cursor_visit < 1 {
+        return Err(ConfigError::Validation(format!(
+            "Job '{}': Invalid value for 'bytes_per_cursor_visit': must be at least 1",
+            job_name
+        )));
+    }
+
     Ok(ResolvedJobConfig {
         name: job_name.to_string(),
         workload_type,
@@ -285,5 +320,7 @@ fn merge_and_resolve(job_name: &str, job: &JobConfig, global: &GlobalConfig) -> 
         max_duration,
         iteration_duration,
         generate_object,
+        num_cursors,
+        bytes_per_cursor_visit,
     })
 }

--- a/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/config.rs
@@ -68,6 +68,16 @@ pub struct JobConfig {
     /// Bytes to read from each cursor before advancing to the next
     /// (multi_cursor_sequential only).
     pub bytes_per_cursor_visit: Option<usize>,
+    /// Number of dominant sequential reads between distant bursts
+    /// (sequential_with_seeks only). Default: 8.
+    pub seek_interval: Option<usize>,
+    /// Number of random look-aside reads issued in each burst (sequential_with_seeks only).
+    /// Default: 7.
+    pub distant_per_burst: Option<usize>,
+    /// Denominator of the fraction of the object the dominant stream is confined to
+    /// (sequential_with_seeks only): the dominant stream runs over `[0, size/dominant_fraction)`
+    /// and look-aside reads land in the rest. Default: 2 (dominant reads the first half).
+    pub dominant_fraction: Option<usize>,
 }
 
 /// Configuration for a single job execution
@@ -90,6 +100,9 @@ pub struct ResolvedJobConfig {
     pub generate_object: bool,
     pub num_cursors: usize,
     pub bytes_per_cursor_visit: usize,
+    pub seek_interval: usize,
+    pub distant_per_burst: usize,
+    pub dominant_fraction: usize,
 }
 
 /// Workload type: read or write
@@ -113,6 +126,12 @@ pub enum AccessPattern {
     /// to the *end of the file* (unlike `MultiCursorSequential`, where each cursor is confined to
     /// its own region).
     OverlappingCursors,
+    /// A single dominant cursor reading sequentially from offset 0, interrupted every
+    /// `seek_interval` dominant reads by a burst of `distant_per_burst` reads to fresh,
+    /// ever-advancing offsets in the second half of the object. All reads share one prefetch
+    /// request, so each distant offset spawns its own transient cursor while the dominant stream
+    /// keeps advancing.
+    SequentialWithSeeks,
 }
 
 /// Server-side encryption type
@@ -305,6 +324,40 @@ fn merge_and_resolve(job_name: &str, job: &JobConfig, global: &GlobalConfig) -> 
         )));
     }
 
+    // seek_interval: Optional with default of 8
+    let seek_interval = job.seek_interval.or(global.job_defaults.seek_interval).unwrap_or(8);
+    if seek_interval < 1 {
+        return Err(ConfigError::Validation(format!(
+            "Job '{}': Invalid value for 'seek_interval': must be at least 1",
+            job_name
+        )));
+    }
+
+    // distant_per_burst: Optional with default of 7
+    let distant_per_burst = job
+        .distant_per_burst
+        .or(global.job_defaults.distant_per_burst)
+        .unwrap_or(7);
+    if distant_per_burst < 1 {
+        return Err(ConfigError::Validation(format!(
+            "Job '{}': Invalid value for 'distant_per_burst': must be at least 1",
+            job_name
+        )));
+    }
+
+    // dominant_fraction: Optional with default of 2 (dominant stream reads the first half).
+    // Must be at least 2 so the look-aside region is non-empty.
+    let dominant_fraction = job
+        .dominant_fraction
+        .or(global.job_defaults.dominant_fraction)
+        .unwrap_or(2);
+    if dominant_fraction < 2 {
+        return Err(ConfigError::Validation(format!(
+            "Job '{}': Invalid value for 'dominant_fraction': must be at least 2",
+            job_name
+        )));
+    }
+
     Ok(ResolvedJobConfig {
         name: job_name.to_string(),
         workload_type,
@@ -322,5 +375,121 @@ fn merge_and_resolve(job_name: &str, job: &JobConfig, global: &GlobalConfig) -> 
         generate_object,
         num_cursors,
         bytes_per_cursor_visit,
+        seek_interval,
+        distant_per_burst,
+        dominant_fraction,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse a TOML config and resolve the single job named `job`, exercising the same
+    /// merge/default/validation path used at runtime (without the S3 object generation in
+    /// `prepare_jobs`).
+    fn resolve_single_job(toml: &str) -> Result<ResolvedJobConfig, ConfigError> {
+        let config = parse_config_string(toml)?;
+        let job = config
+            .jobs
+            .get("job")
+            .expect("test config must define a job named 'job'");
+        merge_and_resolve("job", job, &config.global)
+    }
+
+    #[test]
+    fn sequential_with_seeks_parses_and_defaults() {
+        let resolved = resolve_single_job(
+            r#"
+            [global]
+            bucket = "test-bucket"
+
+            [jobs.job]
+            workload_type = "read"
+            access_pattern = "sequential_with_seeks"
+            "#,
+        )
+        .expect("config should resolve");
+
+        assert_eq!(resolved.access_pattern, AccessPattern::SequentialWithSeeks);
+        assert_eq!(resolved.seek_interval, 8);
+        assert_eq!(resolved.distant_per_burst, 7);
+        assert_eq!(resolved.dominant_fraction, 2);
+    }
+
+    #[test]
+    fn seek_params_override_defaults() {
+        let resolved = resolve_single_job(
+            r#"
+            [global]
+            bucket = "test-bucket"
+
+            [jobs.job]
+            workload_type = "read"
+            access_pattern = "sequential_with_seeks"
+            seek_interval = 4
+            distant_per_burst = 12
+            "#,
+        )
+        .expect("config should resolve");
+
+        assert_eq!(resolved.seek_interval, 4);
+        assert_eq!(resolved.distant_per_burst, 12);
+    }
+
+    #[test]
+    fn seek_params_inherit_from_global_defaults() {
+        let resolved = resolve_single_job(
+            r#"
+            [global]
+            bucket = "test-bucket"
+            seek_interval = 3
+            distant_per_burst = 5
+
+            [jobs.job]
+            workload_type = "read"
+            access_pattern = "sequential_with_seeks"
+            "#,
+        )
+        .expect("config should resolve");
+
+        assert_eq!(resolved.seek_interval, 3);
+        assert_eq!(resolved.distant_per_burst, 5);
+    }
+
+    #[test]
+    fn zero_seek_interval_is_rejected() {
+        let err = resolve_single_job(
+            r#"
+            [global]
+            bucket = "test-bucket"
+
+            [jobs.job]
+            workload_type = "read"
+            access_pattern = "sequential_with_seeks"
+            seek_interval = 0
+            "#,
+        )
+        .expect_err("seek_interval = 0 should fail validation");
+
+        assert!(matches!(err, ConfigError::Validation(msg) if msg.contains("seek_interval")));
+    }
+
+    #[test]
+    fn zero_distant_per_burst_is_rejected() {
+        let err = resolve_single_job(
+            r#"
+            [global]
+            bucket = "test-bucket"
+
+            [jobs.job]
+            workload_type = "read"
+            access_pattern = "sequential_with_seeks"
+            distant_per_burst = 0
+            "#,
+        )
+        .expect_err("distant_per_burst = 0 should fail validation");
+
+        assert!(matches!(err, ConfigError::Validation(msg) if msg.contains("distant_per_burst")));
+    }
 }

--- a/mountpoint-s3-fs/examples/s3io_benchmark/examples/multi_cursor.toml
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/examples/multi_cursor.toml
@@ -1,0 +1,22 @@
+[global]
+bucket = "amzn-s3-demo-bucket"
+region = "us-east-1"
+read_size = 131072
+iterations = 3
+
+# Sequential baseline for comparison
+[jobs.sequential_baseline]
+workload_type = "read"
+object_key = "benchmark-1GiB.bin"
+object_size = 1073741824  # 1 GiB
+access_pattern = "sequential"
+
+# Multi-cursor: 8 cursors, 1 MiB per visit
+[jobs.multi_cursor]
+workload_type = "read"
+object_key = "benchmark-1GiB.bin"
+object_size = 1073741824  # 1 GiB
+access_pattern = "multi_cursor_sequential"
+num_cursors = 8
+bytes_per_cursor_visit = 1048576  # 1 MiB
+generate_object = false  # already created by sequential_baseline

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Instant;
@@ -128,6 +129,8 @@ impl Executor {
         match config.access_pattern {
             AccessPattern::Sequential => self.execute_sequential_read(config).await,
             AccessPattern::Random => self.execute_random_read(config).await,
+            AccessPattern::MultiCursorSequential => self.execute_multi_cursor_read(config).await,
+            AccessPattern::OverlappingCursors => self.execute_overlapping_cursors_read(config).await,
         }
     }
 
@@ -182,7 +185,7 @@ impl Executor {
                     break;
                 }
 
-                let read_size = std::cmp::min(config.read_size as u64, size - offset);
+                let read_size = min(config.read_size as u64, size - offset);
 
                 match request.read(offset, read_size as usize).await {
                     Ok(bytes) => {
@@ -202,6 +205,160 @@ impl Executor {
             }
 
             if offset >= size {
+                iterations_completed += 1;
+            }
+        }
+
+        let duration = job_start.elapsed();
+
+        Ok(JobResult {
+            job_name: config.name.clone(),
+            workload_type: "read".to_string(),
+            iterations_completed,
+            total_bytes,
+            elapsed_seconds: duration,
+            errors,
+        })
+    }
+
+    /// `num_cursors` interleaved sequential cursors partitioning the object into contiguous,
+    /// non-overlapping regions (the last cursor absorbs any remainder).
+    async fn execute_multi_cursor_read(&self, config: &ResolvedJobConfig) -> Result<JobResult, ExecutionError> {
+        let num_cursors = config.num_cursors;
+        self.run_interleaved_cursors(config, |size| {
+            let region_size = size / num_cursors as u64;
+            (0..num_cursors)
+                .map(|i| {
+                    let start = i as u64 * region_size;
+                    let end = if i == num_cursors - 1 {
+                        size
+                    } else {
+                        start + region_size
+                    };
+                    (start, end)
+                })
+                .collect()
+        })
+        .await
+    }
+
+    /// `num_cursors` interleaved sequential cursors, each starting at an evenly-spaced offset but
+    /// all reading to the end of the file.
+    ///
+    /// Note that total bytes read exceeds the object size (each cursor reads from its start to EOF).
+    async fn execute_overlapping_cursors_read(&self, config: &ResolvedJobConfig) -> Result<JobResult, ExecutionError> {
+        let num_cursors = config.num_cursors;
+        self.run_interleaved_cursors(config, |size| {
+            // Evenly-spaced start offsets; every cursor's end is EOF (this is the overlap).
+            let spacing = size / num_cursors as u64;
+            (0..num_cursors).map(|i| (i as u64 * spacing, size)).collect()
+        })
+        .await
+    }
+
+    /// Shared helper for multi-cursor read patterns. Round-robins through a set of cursors, reading
+    /// up to `bytes_per_cursor_visit` from each before advancing to the next so the cursors stay
+    /// concurrently live. `build_ranges` maps the object size to each cursor's `[start, end)`
+    /// range; ranges may overlap (as in `overlapping_cursors`), in which case `total_bytes` exceeds
+    /// the object size.
+    async fn run_interleaved_cursors(
+        &self,
+        config: &ResolvedJobConfig,
+        build_ranges: impl Fn(u64) -> Vec<(u64, u64)>,
+    ) -> Result<JobResult, ExecutionError> {
+        let client = &self.client;
+        let prefetcher = &self.prefetcher;
+        let bucket = &config.bucket;
+        let object_key = &config.object_key;
+
+        let head_result = client
+            .head_object(bucket, object_key, &HeadObjectParams::new())
+            .await
+            .map_err(|e| ExecutionError::S3Error(format!("HeadObject failed: {}", e)))?;
+
+        let object_id = ObjectId::new(object_key.to_string(), head_result.etag);
+        let size = head_result.size;
+
+        let num_cursors = config.num_cursors;
+        let bytes_per_visit = config.bytes_per_cursor_visit as u64;
+
+        if size < num_cursors as u64 {
+            return Err(ExecutionError::ExecutionFailed(format!(
+                "Object size ({}) is smaller than num_cursors ({})",
+                size, num_cursors
+            )));
+        }
+
+        let ranges = build_ranges(size);
+        let expected_bytes: u64 = ranges.iter().map(|(start, end)| end - start).sum();
+
+        let mut total_bytes = 0u64;
+        let mut errors = Vec::new();
+        let mut iterations_completed = 0usize;
+
+        let job_start = Instant::now();
+        let max_duration = config.max_duration;
+
+        for _iteration in 0..config.iterations {
+            if let Some(max_dur) = max_duration
+                && job_start.elapsed() >= max_dur
+            {
+                break;
+            }
+
+            // Each cursor starts at its range start and runs to its range end.
+            let mut offsets: Vec<u64> = ranges.iter().map(|(start, _)| *start).collect();
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
+            let mut iteration_bytes = 0u64;
+            let mut finished_count = 0;
+            let mut had_error = false;
+
+            'outer: loop {
+                if finished_count >= ranges.len() {
+                    break;
+                }
+
+                for (offset, &(_, end)) in offsets.iter_mut().zip(ranges.iter()) {
+                    if *offset >= end {
+                        continue;
+                    }
+
+                    if let Some(max_dur) = max_duration
+                        && job_start.elapsed() >= max_dur
+                    {
+                        break 'outer;
+                    }
+
+                    // Read up to bytes_per_visit from this cursor, then yield to the next so the
+                    // cursors stay concurrently live and interleaved.
+                    let visit_end = (*offset + bytes_per_visit).min(end);
+                    while *offset < visit_end {
+                        let read_size = min(config.read_size as u64, visit_end - *offset);
+                        match request.read(*offset, read_size as usize).await {
+                            Ok(bytes) => {
+                                let n = bytes.len() as u64;
+                                *offset += n;
+                                iteration_bytes += n;
+                                total_bytes += n;
+                            }
+                            Err(e) => {
+                                errors.push(ErrorInfo {
+                                    error_type: "ReadError".to_string(),
+                                    message: format!("Read failed at offset {}: {}", offset, e),
+                                });
+                                had_error = true;
+                                break 'outer;
+                            }
+                        }
+                    }
+
+                    if *offset >= end {
+                        finished_count += 1;
+                    }
+                }
+            }
+
+            if !had_error && iteration_bytes == expected_bytes {
                 iterations_completed += 1;
             }
         }
@@ -287,7 +444,7 @@ impl Executor {
                 }
 
                 let offset = rng.random_range(0..=max_offset);
-                let read_size = std::cmp::min(config.read_size as u64, size - offset);
+                let read_size = min(config.read_size as u64, size - offset);
 
                 match request.read(offset, read_size as usize).await {
                     Ok(bytes) => {

--- a/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
+++ b/mountpoint-s3-fs/examples/s3io_benchmark/executor.rs
@@ -131,6 +131,7 @@ impl Executor {
             AccessPattern::Random => self.execute_random_read(config).await,
             AccessPattern::MultiCursorSequential => self.execute_multi_cursor_read(config).await,
             AccessPattern::OverlappingCursors => self.execute_overlapping_cursors_read(config).await,
+            AccessPattern::SequentialWithSeeks => self.execute_sequential_with_seeks(config).await,
         }
     }
 
@@ -359,6 +360,149 @@ impl Executor {
             }
 
             if !had_error && iteration_bytes == expected_bytes {
+                iterations_completed += 1;
+            }
+        }
+
+        let duration = job_start.elapsed();
+
+        Ok(JobResult {
+            job_name: config.name.clone(),
+            workload_type: "read".to_string(),
+            iterations_completed,
+            total_bytes,
+            elapsed_seconds: duration,
+            errors,
+        })
+    }
+
+    /// A dominant sequential stream, confined to the first `1/dominant_fraction` of the object,
+    /// sharing one file handle with periodic bursts of random look-aside reads in the remaining
+    /// region. Every `seek_interval` dominant reads, a burst of `distant_per_burst` reads is issued
+    /// at random `read_size`-aligned offsets in the `[size/dominant_fraction, size)` region. All
+    /// reads share one prefetch request, so each random look-aside tends to spawn its own transient
+    /// cursor alongside the dominant stream, exercising the prefetcher's ability to protect the
+    /// dominant stream while occasional distant readers come and go.
+    ///
+    /// The dominant stream is confined to the first region (rather than running to EOF) so it never
+    /// collides with the look-aside region; an iteration completes when it reaches the end of that
+    /// region. Distant-read bytes are added to `total_bytes` but do not affect completion.
+    async fn execute_sequential_with_seeks(&self, config: &ResolvedJobConfig) -> Result<JobResult, ExecutionError> {
+        let client = &self.client;
+        let prefetcher = &self.prefetcher;
+        let bucket = &config.bucket;
+        let object_key = &config.object_key;
+
+        let head_result = client
+            .head_object(bucket, object_key, &HeadObjectParams::new())
+            .await
+            .map_err(|e| ExecutionError::S3Error(format!("HeadObject failed: {}", e)))?;
+
+        let object_id = ObjectId::new(object_key.to_string(), head_result.etag);
+        let size = head_result.size;
+
+        let read_size = config.read_size as u64;
+        let seek_interval = config.seek_interval;
+        let distant_per_burst = config.distant_per_burst;
+
+        // Split the object: the dominant sequential stream runs over the first region
+        // `[0, dominant_end)`; look-aside reads land at random offsets in `[dominant_end, size)`.
+        // Both regions must hold at least one full read.
+        let dominant_end = size / config.dominant_fraction as u64;
+        if dominant_end < read_size || size - dominant_end < read_size {
+            return Err(ExecutionError::ExecutionFailed(format!(
+                "Object size ({}) is too small for sequential_with_seeks with dominant_fraction ({}) and read_size ({}): both the dominant and look-aside regions must hold at least one read",
+                size, config.dominant_fraction, read_size
+            )));
+        }
+        // Random look-aside offsets are chosen from the read_size-aligned slots in the look-aside
+        // region. Deterministic RNG mirrors execute_random_read.
+        let distant_slots = (size - dominant_end) / read_size;
+        let randseed = config.randseed;
+        let mut hasher = DefaultHasher::new();
+        randseed.hash(&mut hasher);
+        object_id.hash(&mut hasher);
+        let mut rng = Pcg64::seed_from_u64(hasher.finish());
+
+        let mut total_bytes = 0u64;
+        let mut errors = Vec::new();
+        let mut iterations_completed = 0usize;
+
+        let job_start = Instant::now();
+        let max_duration = config.max_duration;
+
+        for _iteration in 0..config.iterations {
+            if let Some(max_dur) = max_duration
+                && job_start.elapsed() >= max_dur
+            {
+                break;
+            }
+
+            let mut request = prefetcher.prefetch(bucket.to_string(), object_id.clone(), size);
+            let mut offset = 0u64;
+            let mut dominant_reads = 0usize;
+            let mut had_error = false;
+
+            while offset < dominant_end {
+                if let Some(max_dur) = max_duration
+                    && job_start.elapsed() >= max_dur
+                {
+                    break;
+                }
+
+                // Dominant sequential read from the current frontier.
+                let dominant_len = min(read_size, dominant_end - offset);
+                match request.read(offset, dominant_len as usize).await {
+                    Ok(bytes) => {
+                        let n = bytes.len() as u64;
+                        offset += n;
+                        total_bytes += n;
+                    }
+                    Err(e) => {
+                        errors.push(ErrorInfo {
+                            error_type: "ReadError".to_string(),
+                            message: format!("Dominant read failed at offset {}: {}", offset, e),
+                        });
+                        had_error = true;
+                        break;
+                    }
+                }
+
+                dominant_reads += 1;
+
+                // Every `seek_interval` dominant reads, fire a burst of random look-aside reads.
+                if dominant_reads.is_multiple_of(seek_interval) {
+                    for _ in 0..distant_per_burst {
+                        if let Some(max_dur) = max_duration
+                            && job_start.elapsed() >= max_dur
+                        {
+                            break;
+                        }
+
+                        // A random read at a read_size-aligned offset in the look-aside region.
+                        let distant_offset = dominant_end + rng.random_range(0..distant_slots) * read_size;
+                        match request.read(distant_offset, read_size as usize).await {
+                            Ok(bytes) => {
+                                total_bytes += bytes.len() as u64;
+                            }
+                            Err(e) => {
+                                errors.push(ErrorInfo {
+                                    error_type: "ReadError".to_string(),
+                                    message: format!("Distant read failed at offset {}: {}", distant_offset, e),
+                                });
+                                had_error = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if had_error {
+                        break;
+                    }
+                }
+            }
+
+            if !had_error && offset >= dominant_end {
                 iterations_completed += 1;
             }
         }


### PR DESCRIPTION
> **Note to reviewers/mergers:** please **rebase merge** this PR (not squash) so the
> individual commits are preserved in history.

This is PR 1 of a 5-PR stack adding multi-cursor prefetching (issue #1886). It adds only `s3io_benchmark` access patterns used to exercise and measure the feature in later PRs; it makes no change to the prefetcher or any shipping code path.

Three new access patterns:
- `multi_cursor_sequential` / `overlapping_cursors`: interleaved round-robin reads across N equally-spaced cursors in a single `PrefetchGetObject`. The former stops each cursor at the next cursor's start; the latter runs each to end of object.
- `sequential_with_seeks`: one dominant sequential stream confined to the first `1/dominant_fraction` of the object, interleaved with periodic bursts of random look-aside reads in the remainder, sharing one prefetch request.

New config fields: `seek_interval` (8), `distant_per_burst` (7), `dominant_fraction` (2, validated >= 2).

### Review notes
- Changes are confined to `examples/s3io_benchmark/`; no production code touched.
- `dominant_fraction` is validated `>= 2` to keep the dominant and look-aside regions disjoint.

### Does this change impact existing behavior?

No. It only adds new opt-in access patterns to the `s3io_benchmark` example. Existing patterns and defaults are unchanged.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license and I agree to the terms of the
[Developer Certificate of Origin (DCO)](https://developercertificate.org/).