### PR TITLE
stress: Register cache block pool candidate unconditionally

### DIFF
--- a/mountpoint-s3-fs/tests/common/fuse.rs
+++ b/mountpoint-s3-fs/tests/common/fuse.rs
@@ -560,12 +560,11 @@ pub mod s3_session {
 
         let mount_dir = tempfile::tempdir().unwrap();
 
-        let mut candidate_sizes = vec![CandidateSize::prunable(test_config.part_size)];
-        if cache_dir.is_some() {
-            candidate_sizes.push(CandidateSize::prunable(test_config.cache_block_size));
-        }
         let pool = PagedPool::config()
-            .with_candidate_sizes(candidate_sizes)
+            .with_candidate_sizes([
+                CandidateSize::prunable(test_config.cache_block_size),
+                CandidateSize::prunable(test_config.part_size),
+            ])
             .with_memory_limit(test_config.mem_limit)
             .build();
 


### PR DESCRIPTION
The S3-backed test session builder (`new_with_test_client_inner`, used by the stress harness) only added the cache block size pool candidate when a disk cache directory was configured. The production `mount` path in `mountpoint-s3/src/run.rs` registers it unconditionally, regardless of whether a data cache is enabled. This fix is to match stress test with production binary.

Stress Run: https://github.com/awslabs/mountpoint-s3/actions/runs/31516090475/job/93863218681

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
