### PR TITLE
Remove AL2 from various pieces of documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -46,7 +46,7 @@ body:
         * How do you provide [AWS credentials](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#aws-credentials) to Mountpoint?
         * What operating system are you using?
         * Any other details about your environment?
-      placeholder: Running in EC2 on Amazon Linux 2 using instance profile credentials against an S3 Bucket in the same account.
+      placeholder: Running in EC2 on Amazon Linux 2023 using instance profile credentials against an S3 Bucket in the same account.
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On Amazon Linux 2023, you can install Mountpoint for Amazon S3 directly from the
 
     sudo dnf install mount-s3
 
-On other RPM-based distributions (Amazon Linux 2, Fedora, CentOS, RHEL; excluding SUSE), run these two commands to install Mountpoint for Amazon S3 on your EC2 instance (for Graviton instances, replace `x86_64` with `arm64` in the URL):
+On other RPM-based distributions (Fedora, CentOS, RHEL; excluding SUSE), run these two commands to install Mountpoint for Amazon S3 on your EC2 instance (for Graviton instances, replace `x86_64` with `arm64` in the URL):
 
     wget https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.rpm
     sudo yum install -y ./mount-s3.rpm

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -27,7 +27,7 @@ Mountpoint is available directly in the Amazon Linux 2023 repository since AL202
    mount-s3 1.21.0+1.amzn2023
    ```
 
-### Other RPM-based distributions (Amazon Linux 2, Fedora, CentOS, RHEL; excluding SUSE)
+### Other RPM-based distributions (Fedora, CentOS, RHEL; excluding SUSE)
 
 To download and install Mountpoint for Amazon S3 on RPM-based distributions, including Amazon Linux, follow these steps:
 

--- a/package/README.md
+++ b/package/README.md
@@ -21,33 +21,6 @@ You should pass the `--expected-version` to the build script to verify that the 
 
 The container will create an `out` folder in the root of the Git repository containing the build artifacts.
 
-## Building locally
-
-If building outside Docker, your host needs the appropriate dependencies installed.
-On Amazon Linux 2, some dependencies come from EPEL, so you'll need to set that up first if you want to install a DEB:
-
-    sudo amazon-linux-extras install epel
-
-Then install the dependencies:
-
-    sudo yum install fuse fuse-devel make cmake3 clang git pkg-config dpkg fakeroot rpmdevtools tar python3
-
-You can skip `dpkg` and `fakeroot` if you don't want to compile a DEB, and `rpmdevtools` if you don't want to compile an RPM. Use the `--pkg-extensions` flag on the build script to specify which package to build.
-
-You'll also need Rust, and the [cargo-about] tool to generate third-party attribution documents:
-
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-    source "$HOME/.cargo/env"
-    cargo install --locked cargo-about
-
-Now run the build script:
-
-    python3 package.py --expected-version 0.3.0
-
-By default, the script will discover the Cargo workspace by walking up the directory hierarchy starting from the current working directory. You can manually specify the workspace root with the `--root-dir` argument.
-
-The script will create an `out` folder in the root of the Git repository containing the build artifacts.
-
 ## Building Amazon Linux 2023 SRPM
 
 For Amazon Linux 2023 specifically, you can build an SRPM (Source RPM) package using the dedicated build script. **The script must be run from the repository root directory:**


### PR DESCRIPTION
Replace AL2 with AL2023 in various pieces of documentation. Removing because AL2 is now end of life

Remove instructions for building the packaging script without docker, as AL2023 already comes with a native release, and `dpkg` cannot be installed on it. Users who want to build custom releases can use docker.

### Does this change impact existing behavior?

Only documentation is changed. 

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
