### PR TITLE
Add Experimental metrics and rename `seek_window_clears` to `seek_window_resets`

### DIFF
--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -100,6 +100,11 @@ Mountpoint emits the following metrics:
 | `experimental.fuse.cache_hit` | Counter | | Number of FUSE requests fully served from [data cache](CONFIGURATION.md#data-cache)<br> (Prefetched data served from memory or partial cache hits are not included in this metric) |
 | `experimental.fuse.idle_threads` | Histogram | | FUSE worker threads waiting for new requests |
 | `experimental.fuse.total_threads` | Gauge | | Total number of FUSE worker threads spawned |
+| `experimental.fs.write_handle_limit_exceeded` | Counter | | Number of times an open-for-write request was rejected due to reaching the concurrent write handle limit |
+| `experimental.mem.cursor_resets` | Counter | | Number of times an idle read cursor was reset to reclaim memory under pressure |
+| `experimental.mem.seek_window_resets` | Counter | | Number of times an active cursor's backward seek window was cleared to reclaim memory under pressure |
+| `experimental.pool.allocation_queue_depth` | Gauge | `priority` (high, low) | Number of pending buffer allocation requests in the queue |
+| `experimental.pool.allocation_queue_wait` | Histogram | | Time (microseconds) a buffer allocation request spent waiting in the queue |
 | `experimental.prefetch.reset_state` | Counter | | Times Mountpoint discarded prefetched data due to access patterns |
 
 > [!NOTE]

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -97,10 +97,10 @@ Mountpoint emits the following metrics:
 | `experimental.cache.evict_latency` | Histogram | `cache` | Time to evict data from [data cache](CONFIGURATION.md#data-cache) |
 | `experimental.cache.get_latency` | Histogram | `cache` | Time to retrieve from [data cache](CONFIGURATION.md#data-cache) |
 | `experimental.cache.put_latency` | Histogram | `cache` | Time to store in [date cache](CONFIGURATION.md#data-cache) |
+| `experimental.fs.write_handle_limit_exceeded` | Counter | | Number of times an open-for-write request was rejected due to reaching the concurrent write handle limit |
 | `experimental.fuse.cache_hit` | Counter | | Number of FUSE requests fully served from [data cache](CONFIGURATION.md#data-cache)<br> (Prefetched data served from memory or partial cache hits are not included in this metric) |
 | `experimental.fuse.idle_threads` | Histogram | | FUSE worker threads waiting for new requests |
 | `experimental.fuse.total_threads` | Gauge | | Total number of FUSE worker threads spawned |
-| `experimental.fs.write_handle_limit_exceeded` | Counter | | Number of times an open-for-write request was rejected due to reaching the concurrent write handle limit |
 | `experimental.mem.cursor_resets` | Counter | | Number of times an idle read cursor was reset to reclaim memory under pressure |
 | `experimental.mem.seek_window_resets` | Counter | | Number of times an active cursor's backward seek window was cleared to reclaim memory under pressure |
 | `experimental.pool.allocation_queue_depth` | Gauge | `priority` (high, low) | Number of pending buffer allocation requests in the queue |

--- a/mountpoint-s3-fs/src/memory/allocation_queue.rs
+++ b/mountpoint-s3-fs/src/memory/allocation_queue.rs
@@ -7,19 +7,13 @@ use std::time::Instant;
 use futures::channel::oneshot;
 use tracing::trace;
 
+use crate::metrics::defs::{POOL_ALLOCATION_QUEUE_DEPTH, POOL_ALLOCATION_QUEUE_WAIT};
 use crate::prefetch::CursorId;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::{Mutex, MutexGuard};
 
 use super::buffers::PoolBuffer;
 use super::stats::BufferKind;
-
-/// Metric: number of pending entries in the allocation queue.
-const ALLOCATION_QUEUE_DEPTH: &str = "pool.allocation_queue_depth";
-
-/// Metric: time (microseconds) an entry spent waiting in the allocation queue
-/// before being served.
-const ALLOCATION_QUEUE_WAIT: &str = "pool.allocation_queue_wait";
 
 /// Priority for an allocation request.
 ///
@@ -82,7 +76,7 @@ struct AllocationQueueInner {
 }
 
 /// Guard around the locked [`AllocationQueueInner`] that refreshes the
-/// [`ALLOCATION_QUEUE_DEPTH`] gauge from the queue lengths when it is dropped.
+/// [`POOL_ALLOCATION_QUEUE_DEPTH`] gauge from the queue lengths when it is dropped.
 struct DepthTrackingGuard<'a> {
     inner: MutexGuard<'a, AllocationQueueInner>,
 }
@@ -103,8 +97,8 @@ impl DerefMut for DepthTrackingGuard<'_> {
 
 impl Drop for DepthTrackingGuard<'_> {
     fn drop(&mut self) {
-        metrics::gauge!(ALLOCATION_QUEUE_DEPTH, "priority" => "high").set(self.inner.high.len() as f64);
-        metrics::gauge!(ALLOCATION_QUEUE_DEPTH, "priority" => "low").set(self.inner.low.len() as f64);
+        metrics::gauge!(POOL_ALLOCATION_QUEUE_DEPTH, "priority" => "high").set(self.inner.high.len() as f64);
+        metrics::gauge!(POOL_ALLOCATION_QUEUE_DEPTH, "priority" => "low").set(self.inner.low.len() as f64);
     }
 }
 
@@ -254,7 +248,7 @@ impl AllocationQueue {
 
         drop(inner);
         entry.inspect(|e| {
-            metrics::histogram!(ALLOCATION_QUEUE_WAIT).record(e.queued_at.elapsed().as_micros() as f64);
+            metrics::histogram!(POOL_ALLOCATION_QUEUE_WAIT).record(e.queued_at.elapsed().as_micros() as f64);
         })
     }
 

--- a/mountpoint-s3-fs/src/memory/maintenance.rs
+++ b/mountpoint-s3-fs/src/memory/maintenance.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use tracing::{debug, trace};
 
+use crate::metrics::defs::{MEM_CURSOR_RESETS, MEM_SEEK_WINDOW_RESETS};
 use crate::sync::{Arc, Weak, thread};
 use crate::util::wake_signal::WakeSignal;
 
@@ -129,13 +130,13 @@ fn run_pruning_round(pool_inner: &Arc<PagedPoolInner>, starvation_threshold: Dur
 
     // 4. Disruptive: reset one idle cursor.
     if reset_one_idle_cursor(limiter, &cursors) {
-        metrics::counter!("mem.cursor_resets").increment(1);
+        metrics::counter!(MEM_CURSOR_RESETS).increment(1);
         return PruningOutcome::ResetIdleCursor;
     }
 
     // 5. No idle cursor was eligible. Clear one active cursor's seek window to release the buffer.
     if starving && clear_one_seek_window(&cursors) {
-        metrics::counter!("mem.seek_window_clears").increment(1);
+        metrics::counter!(MEM_SEEK_WINDOW_RESETS).increment(1);
         return PruningOutcome::ClearedSeekWindow;
     }
 

--- a/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
+++ b/mountpoint-s3-fs/src/memory/write_handle_limiter.rs
@@ -36,6 +36,7 @@
 use thiserror::Error;
 use tracing::{info, warn};
 
+use crate::metrics::defs::FS_WRITE_HANDLE_LIMIT_EXCEEDED;
 use crate::sync::Arc;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
@@ -115,7 +116,7 @@ impl WriteHandleLimiter {
                 active: Arc::clone(&self.active),
             }),
             Err(_) => {
-                metrics::counter!("fs.write_handle_limit_exceeded").increment(1);
+                metrics::counter!(FS_WRITE_HANDLE_LIMIT_EXCEEDED).increment(1);
                 Err(WriteHandleLimitError {
                     max: self.max_concurrent_writes,
                     mem_limit_mib: self.mem_limit_mib,

--- a/mountpoint-s3-fs/src/metrics/defs.rs
+++ b/mountpoint-s3-fs/src/metrics/defs.rs
@@ -40,6 +40,14 @@ pub const CACHE_PUT_ERRORS: &str = "cache.put_errors";
 pub const CACHE_TOTAL_SIZE: &str = "cache.total_size";
 pub const CACHE_OVERSIZED_OBJECTS: &str = "cache.oversized_objects";
 
+pub const FS_WRITE_HANDLE_LIMIT_EXCEEDED: &str = "fs.write_handle_limit_exceeded";
+
+pub const MEM_CURSOR_RESETS: &str = "mem.cursor_resets";
+pub const MEM_SEEK_WINDOW_RESETS: &str = "mem.seek_window_resets";
+
+pub const POOL_ALLOCATION_QUEUE_DEPTH: &str = "pool.allocation_queue_depth";
+pub const POOL_ALLOCATION_QUEUE_WAIT: &str = "pool.allocation_queue_wait";
+
 // Attribute constants
 pub const ATTR_FUSE_REQUEST: &str = "fuse_request";
 pub const ATTR_CACHE: &str = "cache";
@@ -138,6 +146,31 @@ pub fn lookup_config(name: &str) -> MetricConfig {
         CACHE_TOTAL_SIZE => MetricConfig {
             unit: Unit::Bytes,
             stability: MetricStability::Internal,
+            otlp_attributes: &[],
+        },
+        FS_WRITE_HANDLE_LIMIT_EXCEEDED => MetricConfig {
+            unit: Unit::Count,
+            stability: MetricStability::Experimental,
+            otlp_attributes: &[],
+        },
+        MEM_CURSOR_RESETS => MetricConfig {
+            unit: Unit::Count,
+            stability: MetricStability::Experimental,
+            otlp_attributes: &[],
+        },
+        MEM_SEEK_WINDOW_RESETS => MetricConfig {
+            unit: Unit::Count,
+            stability: MetricStability::Experimental,
+            otlp_attributes: &[],
+        },
+        POOL_ALLOCATION_QUEUE_DEPTH => MetricConfig {
+            unit: Unit::Count,
+            stability: MetricStability::Experimental,
+            otlp_attributes: &["priority"],
+        },
+        POOL_ALLOCATION_QUEUE_WAIT => MetricConfig {
+            unit: Unit::Microseconds,
+            stability: MetricStability::Experimental,
             otlp_attributes: &[],
         },
         // Treat everything else as count metrics


### PR DESCRIPTION
Added new Experimental metric definitions to `defs.rs` and documented them in `METRICS.md`:
  - `fs.write_handle_limit_exceeded`
  - `mem.cursor_resets`
  - `mem.seek_window_resets` (renamed from `seek_window_clears`)
  - `pool.allocation_queue_depth`
  - `pool.allocation_queue_wait`
  
### Does this change impact existing behavior?

No breaking change. The only observable difference is the rename of the emitted metric name `mem.seek_window_clears` to `mem.seek_window_resets`.

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
