### PR TITLE
Fix cgroup memory limit detection for inherited limits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -431,8 +431,6 @@ jobs:
         cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "not found"
         echo "=== Process cgroup location ==="
         cat /proc/self/cgroup
-        echo "=== Check if we can write to cgroups ==="
-        mkdir -p /sys/fs/cgroup/test-write 2>&1 || echo "Cannot create cgroups"
     - name: Run cgroup-aware memory detection test
       env:
         TEST_CGROUP_MEM_LIMIT_MB: "2048"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -393,6 +393,7 @@ jobs:
       options: >-
         --memory=2g
         --memory-swap=2g
+        --privileged
 
     steps:
     - name: Install prerequisites for container
@@ -428,10 +429,49 @@ jobs:
         cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "not found"
         echo "=== cgroup v1 ==="
         cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "not found"
+        echo "=== Process cgroup location ==="
+        cat /proc/self/cgroup
+        echo "=== Check if we can write to cgroups ==="
+        mkdir -p /sys/fs/cgroup/test-write 2>&1 || echo "Cannot create cgroups"
     - name: Run cgroup-aware memory detection test
       env:
         TEST_CGROUP_MEM_LIMIT_MB: "2048"
       run: cargo test -p mountpoint-s3-fs --lib mem_limiter::tests::test_effective_total_memory_respects_cgroup
+    - name: Test inherited cgroup memory limit detection
+      run: |
+        set -e
+
+        readonly LIMIT_BYTES=$((1 * 1024 * 1024 * 1024))
+        readonly SLICE=/sys/fs/cgroup/mp-test.slice
+        readonly LEAF="$SLICE/mp-test.scope"
+
+        # Move all processes out of root so we can enable subtree_control
+        mkdir -p /sys/fs/cgroup/init.scope
+        for pid in $(cat /sys/fs/cgroup/cgroup.procs); do
+          echo "$pid" > /sys/fs/cgroup/init.scope/cgroup.procs 2>/dev/null || true
+        done
+        echo '+memory' > /sys/fs/cgroup/cgroup.subtree_control
+
+        # Create nested hierarchy with limit only on parent slice
+        mkdir -p "$SLICE"
+        echo '+memory' > "$SLICE/cgroup.subtree_control"
+        mkdir -p "$LEAF"
+
+        echo "$LIMIT_BYTES" > "$SLICE/memory.max"
+        echo max > "$LEAF/memory.max"
+
+        echo "Parent slice memory.max: $(cat "$SLICE/memory.max")"
+        echo "Child scope memory.max: $(cat "$LEAF/memory.max")"
+
+        # Run test from inside the child cgroup
+        bash -c "
+          echo \$\$ > '$LEAF/cgroup.procs'
+          cat /proc/self/cgroup
+          TEST_CGROUP_MEM_LIMIT_MB=1024 cargo test -p mountpoint-s3-fs --lib mem_limiter::tests::test_effective_total_memory_respects_cgroup
+        "
+
+        # Cleanup
+        rmdir "$LEAF" "$SLICE" /sys/fs/cgroup/init.scope 2>/dev/null || true
 
   workflow-complete:
     name: "Tests Workflow Complete"

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased (v0.10.1)
 
+* Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
 * Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))
 * Update EC2 instance network throughput table. ([#1895](https://github.com/awslabs/mountpoint-s3/pull/1895))
 

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -2,7 +2,7 @@ use std::{sync::atomic::Ordering, time::Instant};
 
 use humansize::make_format;
 use metrics::atomics::AtomicU64;
-use sysinfo::{Pid, System};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
@@ -173,9 +173,9 @@ pub fn effective_total_memory() -> u64 {
     // walks the ancestor cgroup tree to find inherited limits.
     let pid = Pid::from_u32(std::process::id());
     sys.refresh_processes_specifics(
-        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        ProcessesToUpdate::Some(&[pid]),
         false, // don't remove dead processes
-        sysinfo::ProcessRefreshKind::nothing(),
+        ProcessRefreshKind::nothing(),
     );
     if let Some(cg) = sys.process(pid).and_then(|p| p.cgroup_limits()) {
         return cg.total_memory;
@@ -223,11 +223,7 @@ mod tests {
         sys.refresh_memory();
 
         let pid = Pid::from_u32(std::process::id());
-        sys.refresh_processes_specifics(
-            sysinfo::ProcessesToUpdate::Some(&[pid]),
-            false,
-            sysinfo::ProcessRefreshKind::nothing(),
-        );
+        sys.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), false, ProcessRefreshKind::nothing());
         if sys.process(pid).and_then(|p| p.cgroup_limits()).is_some() {
             // A cgroup limit is active on this machine — the fallback path
             // won't be exercised, so there's nothing to assert here.

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -2,7 +2,7 @@ use std::{sync::atomic::Ordering, time::Instant};
 
 use humansize::make_format;
 use metrics::atomics::AtomicU64;
-use sysinfo::System;
+use sysinfo::{Pid, System};
 use tracing::{debug, trace};
 
 use crate::memory::{BufferKind, PagedPool};
@@ -160,14 +160,31 @@ impl MemoryLimiter {
 
 /// Returns the effective total memory available to this process in bytes.
 ///
-/// On Linux, this respects cgroup memory limits when set.
+/// On Linux, this respects cgroup memory limits when set, including limits
+/// inherited from ancestor cgroups (e.g., when running in a nested scope
+/// under a parent slice with memory constraints).
+///
 /// On other platforms, returns the total physical memory.
 pub fn effective_total_memory() -> u64 {
     let mut sys = System::new();
     sys.refresh_memory();
-    sys.cgroup_limits()
-        .map(|cg| cg.total_memory)
-        .unwrap_or_else(|| sys.total_memory())
+
+    // Try to get cgroup limits for this specific process. Process::cgroup_limits()
+    // walks the ancestor cgroup tree to find inherited limits.
+    let pid = Pid::from_u32(std::process::id());
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        false, // don't remove dead processes
+        sysinfo::ProcessRefreshKind::nothing()
+    );
+    if let Some(process) = sys.process(pid) {
+        if let Some(cg) = process.cgroup_limits() {
+            return cg.total_memory;
+        }
+    }
+
+    // Fallback to total system memory
+    sys.total_memory()
 }
 
 #[cfg(test)]
@@ -202,11 +219,19 @@ mod tests {
     fn test_effective_total_memory_falls_back_to_system_memory() {
         let mut sys = System::new();
         sys.refresh_memory();
-        if sys.cgroup_limits().is_some() {
+
+        let pid = Pid::from_u32(std::process::id());
+        sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            false,
+            sysinfo::ProcessRefreshKind::nothing()
+        );
+        if sys.process(pid).and_then(|p| p.cgroup_limits()).is_some() {
             // A cgroup limit is active on this machine — the fallback path
             // won't be exercised, so there's nothing to assert here.
             return;
         }
+
         assert_eq!(
             effective_total_memory(),
             sys.total_memory(),

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -175,12 +175,10 @@ pub fn effective_total_memory() -> u64 {
     sys.refresh_processes_specifics(
         sysinfo::ProcessesToUpdate::Some(&[pid]),
         false, // don't remove dead processes
-        sysinfo::ProcessRefreshKind::nothing()
+        sysinfo::ProcessRefreshKind::nothing(),
     );
-    if let Some(process) = sys.process(pid) {
-        if let Some(cg) = process.cgroup_limits() {
-            return cg.total_memory;
-        }
+    if let Some(cg) = sys.process(pid).and_then(|p| p.cgroup_limits()) {
+        return cg.total_memory;
     }
 
     // Fallback to total system memory
@@ -224,7 +222,7 @@ mod tests {
         sys.refresh_processes_specifics(
             sysinfo::ProcessesToUpdate::Some(&[pid]),
             false,
-            sysinfo::ProcessRefreshKind::nothing()
+            sysinfo::ProcessRefreshKind::nothing(),
         );
         if sys.process(pid).and_then(|p| p.cgroup_limits()).is_some() {
             // A cgroup limit is active on this machine — the fallback path

--- a/mountpoint-s3-fs/src/mem_limiter.rs
+++ b/mountpoint-s3-fs/src/mem_limiter.rs
@@ -181,7 +181,11 @@ pub fn effective_total_memory() -> u64 {
         return cg.total_memory;
     }
 
-    // Fallback to total system memory
+    // Fallback to system-level cgroup detection
+    if let Some(cg) = sys.cgroup_limits() {
+        return cg.total_memory;
+    }
+
     sys.total_memory()
 }
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased (v1.23.1)
 
+* Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
+
 ## v1.23.0 (July 20, 2026)
 
 * Add `--ca-bundle` flag (and `AWS_CA_BUNDLE` environment variable fallback) for trusting a custom certificate authority when Mountpoint makes HTTPS calls. ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834) by @yerzhan7)


### PR DESCRIPTION
mount-s3 doesn't detect `cgroup` memory limits set on parent slices. A customer has a 20GB limit on the parent, but mount-s3 doesn't see it, so it falls back to using the host's total RAM (200GB). It oversizes buffers which hits the limit and stalls completely. We use `System::cgroup_limits()` which only checks `/sys/fs/cgroup` (root). In cgroup v2, when a parent has a memory limit, children inherit it but if you only read the child's `memory.max` file, it shows "max" (meaning no limit set at this level). The actual limit is on the parent. We need to walk up the tree to find it. 

  Switched to `Process::cgroup_limits()`:
  - Reads `/proc/self/cgroup` to find the process's actual cgroup
  - Walks up ancestors checking each `memory.max`
  - Returns the smallest limit found

 ### Testing

Added a CI test that creates a cgroup hierarchy with `memory.max` set on a parent slice (1 GiB) and verifies the process detects the inherited limit rather than the container's own limit (2 GiB).
Without fix (fails):  https://github.com/awslabs/mountpoint-s3/actions/runs/32240451777/job/96029623759

With fix (passes): https://github.com/awslabs/mountpoint-s3/actions/runs/32267673710/job/96116060108
  
### Does this change impact existing behavior?

No breaking changes.

### Does this change need a changelog entry? Does it require a version change?

Yes - fixes customer issue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
