### PR TITLE
Fail benchmarks when a memory limit is breached

### DIFF
--- a/.github/actions/scripts/render-mem-summary.sh
+++ b/.github/actions/scripts/render-mem-summary.sh
@@ -5,7 +5,10 @@
 # (invoked with --mem-limit-mib) and appends a single Markdown table to
 # $GITHUB_STEP_SUMMARY (or prints to stdout if that variable is unset).
 #
-# Always exits 0; never fails the job even if a run breached the memory limit.
+# Also reports whether any run breached its limit as the `breached` step output, which
+# the workflow uses to fail the job after the results have been saved and published.
+#
+# Always exits 0, so the table is rendered even when a run breached the memory limit.
 set -u
 
 shopt -s nullglob
@@ -19,6 +22,7 @@ out="## Memory Breach Detection
 | Test | Peak RSS (MiB) | Memory Limit (MiB) | Status | Peak Prefetch Reserved (MiB) | Peak Upload Reserved (MiB) | Peak Pool GetObject (MiB) | Peak Pool PutObject (MiB) | Peak Pool Append (MiB) |
 |---|---|---|---|---|---|---|---|---|
 "
+breached=false
 for f in "${files[@]}"; do
   row=$(jq -r '
     (if .breached then "❌ BREACHED" else "✅ OK" end) as $status
@@ -26,12 +30,20 @@ for f in "${files[@]}"; do
   ' "$f")
   out+="${row}
 "
+  if [ "$(jq -r '.breached' "$f")" = "true" ]; then
+    echo "::error title=Memory limit breached::$(jq -r '"\(.test) peaked at \(.peak_rss_mib) MiB, above the \(.mem_limit_mib) MiB limit"' "$f")"
+    breached=true
+  fi
 done
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   printf '%s' "$out" >> "$GITHUB_STEP_SUMMARY"
 else
   printf '%s' "$out"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "breached=${breached}" >> "$GITHUB_OUTPUT"
 fi
 
 exit 0

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,6 +94,7 @@ jobs:
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
+      id: mem_summary
       if: matrix.variant == 'mem-limited'
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
@@ -144,6 +145,9 @@ jobs:
       run: |
         .github/actions/scripts/copy-static-files.sh dev/bench${{ matrix.data_path_suffix }} dev/bench${{ matrix.data_path_suffix }}/peak_mem_usage
         git push 'https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git' gh-pages:gh-pages
+    - name: Fail on memory breach
+      if: ${{ !cancelled() && steps.mem_summary.outputs.breached == 'true' }}
+      run: exit 1
 
   latency-bench:
     name: Benchmark (Latency)
@@ -268,6 +272,7 @@ jobs:
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}cache-bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_cache_bench.sh
     - name: Render memory summary
+      id: mem_summary
       if: matrix.variant == 'mem-limited'
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
@@ -317,3 +322,6 @@ jobs:
       run: |
         .github/actions/scripts/copy-static-files.sh dev/cache_bench${{ matrix.data_path_suffix }} dev/cache_bench${{ matrix.data_path_suffix }}/peak_mem_usage
         git push 'https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git' gh-pages:gh-pages
+    - name: Fail on memory breach
+      if: ${{ !cancelled() && steps.mem_summary.outputs.breached == 'true' }}
+      run: exit 1

--- a/.github/workflows/bench_s3express.yml
+++ b/.github/workflows/bench_s3express.yml
@@ -114,6 +114,7 @@ jobs:
         S3_BUCKET_TEST_PREFIX: ${{ vars.S3_BUCKET_BENCH_PREFIX || 'mountpoint-benchmark/' }}bench${{ matrix.results_subdir_suffix }}/
       run: mountpoint-s3/scripts/fs_bench.sh
     - name: Render memory summary
+      id: mem_summary
       if: matrix.memory_target_mib != ''
       run: .github/actions/scripts/render-mem-summary.sh
     - name: Save benchmark results in S3
@@ -163,6 +164,9 @@ jobs:
       run: |
         .github/actions/scripts/copy-static-files.sh dev/s3-express/bench${{ matrix.data_path_suffix }} dev/s3-express/bench${{ matrix.data_path_suffix }}/peak_mem_usage
         git push 'https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git' gh-pages:gh-pages
+    - name: Fail on memory breach
+      if: ${{ !cancelled() && steps.mem_summary.outputs.breached == 'true' }}
+      run: exit 1
 
   latency-bench:
     name: Benchmark (Latency)

--- a/mountpoint-s3/scripts/fs_bench.sh
+++ b/mountpoint-s3/scripts/fs_bench.sh
@@ -33,8 +33,8 @@ fi
 if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
   # Memory-limited variant: cap Mountpoint at the requested MiB, and ask the log
   # analyzer to additionally emit results/<job>_extra_metrics.json which is consumed
-  # only by the GitHub Actions memory summary table (render-mem-summary.sh). These
-  # files are not fed into the gh-pages benchmark charts.
+  # only by the GitHub Actions memory summary table and breach gate
+  # (render-mem-summary.sh). These files are not fed into the gh-pages benchmark charts.
   optional_args+=" --memory-target=${S3_MEMORY_TARGET_MIB}"
 fi
 

--- a/mountpoint-s3/scripts/fs_cache_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_bench.sh
@@ -43,8 +43,8 @@ fi
 if [[ -n "${S3_MEMORY_TARGET_MIB}" ]]; then
   # Memory-limited variant: cap Mountpoint at the requested MiB, and ask the log
   # analyzer to additionally emit results/<job>_extra_metrics.json which is consumed
-  # only by the GitHub Actions memory summary table (render-mem-summary.sh). These
-  # files are not fed into the gh-pages benchmark charts.
+  # only by the GitHub Actions memory summary table and breach gate
+  # (render-mem-summary.sh). These files are not fed into the gh-pages benchmark charts.
   optional_args+=" --memory-target=${S3_MEMORY_TARGET_MIB}"
 fi
 


### PR DESCRIPTION
Memory-limited benchmark jobs already report peak RSS breaches in a summary table but still pass. This makes a breach fail the job, after the results have been saved and published.

Testing:
- `render-mem-summary.sh` over 5 input shapes locally (no results, all within limit, partial breach, full breach) — correct output and exit code in each.
- Gate wiring on a real Actions run, 4 cases: a breach fails the job; `false` and a skipped render step both pass; a breach still fails when an earlier step had already failed.
- Not covered: a real breaching benchmark run, as `--memory-target` has a 512 MiB floor.

### Does this change impact existing behavior?

Yes, intentionally: memory-limited benchmark jobs now fail on a breach. Results are still saved and published first, and other variants are unaffected.

### Does this change need a changelog entry? Does it require a version change?

No, this only changes CI benchmark workflows.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
