### PR TITLE
Drop stale prefetch cursor before creating a new one

### DIFF
--- a/mountpoint-s3-fs/src/prefetch.rs
+++ b/mountpoint-s3-fs/src/prefetch.rs
@@ -318,6 +318,8 @@ where
             Ok(result)
         } else {
             // Otherwise, create a new cursor at `offset` and read from it.
+            // Drop the stale cursor first to cancel its inflight requests and release its buffers.
+            self.cursor = None;
             let (cursor, result) = self.read_from_new_cursor(offset, length).await?;
             self.cursor = Some(cursor);
             Ok(result)


### PR DESCRIPTION
**Problem:** When a read cannot be served by the current cursor, `try_read` created the replacement cursor and awaited its first read while the stale cursor was still held in `self.cursor`. The stale cursor keeps its inflight GetObject, queued parts, backward seek window, and pool reservation alive for that whole window, which is incorrect.

**Solution**: Drop stale cursor first before creating new cursor and awaiting.

### Does this change impact existing behavior?

N/A - part of memory limiter feature

### Does this change need a changelog entry? Does it require a version change?

N/A - part of memory limiter feature

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
