### PR TITLE
Document memory limiter configuration and troubleshooting

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -346,7 +346,7 @@ The cap depends mainly on the [memory target](#configuring-memory-usage) and the
 The cap is computed as:
 
 ```
-max_concurrent_writes = (memory_target − additional_mem_reserved − read_part_size) / write_part_size
+cap = (memory_target − overhead − read_part_size) / write_part_size
 ```
 
 where `additional_mem_reserved` is the portion of the memory target held back for Mountpoint's own overhead: `max(128 MiB, memory_target / 8)`. For example, with the minimum memory target of 512 MiB and the default 8 MiB part sizes, 128 MiB is held back for overhead and one 8 MiB read part is kept available for reads, leaving 376 MiB for write buffers — enough for 47 files open for writing.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -323,7 +323,7 @@ At mount time, Mountpoint automatically selects appropriate defaults to provide 
 
 ### Configuring memory usage
 
-Mountpoint buffers object data in memory while reading (prefetching ahead of an application's reads) and writing (holding parts to upload). The `--memory-target` command-line argument sets a target (not a guaranteed limit), in MiB, for Mountpoint's total memory usage, with a minimum of 512 MiB. Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching.
+Mountpoint buffers object data in memory while reading (prefetching ahead of an application's reads) and writing (holding parts to upload). The `--memory-target` command-line argument sets a target, in MiB, for Mountpoint's total memory usage, with a minimum of 512 MiB. The target is not a guaranteed limit but Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs, and reduces prefetching.
 
 `--memory-target` defaults to 95% of available memory, which is the cgroup limit where one applies and otherwise total system memory. A portion of the target, `max(128 MiB, memory_target / 8)`, is held back for Mountpoint's own overhead such as metadata and file handles; the rest is the budget for data buffers.
 
@@ -349,7 +349,7 @@ The cap is computed as:
 cap = (memory_target − overhead − read_part_size) / write_part_size
 ```
 
-where `additional_mem_reserved` is the portion of the memory target held back for Mountpoint's own overhead: `max(128 MiB, memory_target / 8)`. For example, with the minimum memory target of 512 MiB and the default 8 MiB part sizes, 128 MiB is held back for overhead and one 8 MiB read part is kept available for reads, leaving 376 MiB for write buffers — enough for 47 files open for writing.
+where `overhead` is the portion of the memory target held back for Mountpoint's own overhead: `max(128 MiB, memory_target / 8)`. For example, with the minimum memory target of 512 MiB and the default 8 MiB part sizes, 128 MiB is held back for overhead and one 8 MiB read part is kept available for reads, leaving 376 MiB for write buffers — enough for 47 files open for writing.
 
 ### Maximum object size
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -321,17 +321,35 @@ At mount time, Mountpoint automatically selects appropriate defaults to provide 
 * By default, Mountpoint can serve up to 16 concurrent file or directory operations, and automatically scales up to reach this limit. If your application makes more than this many concurrent reads and writes (including to the same or different files), you can improve performance by increasing this limit with the `--max-threads` command-line argument. Higher values of this flag might cause Mountpoint to use more of your instance's resources.
 * When reading or writing files to S3, Mountpoint divides them into parts and uses parallel requests to improve throughput. You can change the part size Mountpoint uses for these parallel requests using the `--read-part-size` and `--write-part-size` command-line arguments, providing a maximum number of bytes per part for reading or writing respectively. For Mountpoint v1.7.2 or earlier, use `--part-size` instead. The default value for these arguments is 8 MiB (8,306,688 bytes), which in our testing is the largest value that achieves maximum throughput. Larger values can reduce the number of billed requests Mountpoint makes, but also reduce the throughput of object reads and writes to S3.
 
+### Configuring memory usage
+
+Mountpoint buffers object data in memory while reading (prefetching ahead of an application's reads) and writing (holding parts to upload). The `--memory-target` command-line argument sets a target (not a guaranteed limit), in MiB, for Mountpoint's total memory usage, with a minimum of 512 MiB. Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching.
+
+`--memory-target` defaults to 95% of available memory, which is the cgroup limit where one applies and otherwise total system memory. A portion of the target, `max(128 MiB, memory_target / 8)`, is held back for Mountpoint's own overhead such as metadata and file handles; the rest is the budget for data buffers.
+
+The memory target and the write part size determine the maximum number of files that can be open for writing at the same time: once that maximum is reached, opening a file for writing fails with `ENOMEM`. See [Maximum number of files open for writing](#maximum-number-of-files-open-for-writing).
+
+The [read and write part sizes](#configuring-mountpoint-performance) must also fit within the data buffer budget. A read part size larger than the budget is rejected at startup when `--memory-target` is set explicitly, or reduced to fit with a warning when the target is the default.
+
+At startup, Mountpoint logs the memory target and the resulting maximum number of files that can be open for writing:
+
+```
+INFO mountpoint_s3_fs::memory::write_handle_limiter: max files concurrently open for write: 47 (memory target 512 MiB, write part size 8 MiB)
+```
+
 ### Maximum number of files open for writing
 
-Mountpoint enforces a cap on the number of files that may be open for writing at the same time, to control memory usage. The cap is computed at startup from the configured memory target, the write part size, and one read part kept available for reads:
+Mountpoint caps how many files may be open for writing at the same time. Once the cap is reached, `open()` calls for write return `ENOMEM` ("Cannot allocate memory") until an existing write handle is closed. The cap exists because each file open for writing reserves a part-sized buffer for as long as it is open, and one read part is kept available for reads.
+
+The cap depends mainly on the [memory target](#configuring-memory-usage) and the [part size](#configuring-mountpoint-performance). With the default 8 MiB part sizes, a 512 MiB memory target allows 47 files open for writing, and a 4 GiB target allows 447. To raise the cap, increase `--memory-target` or decrease `--write-part-size`. Mountpoint logs the resulting maximum number of files that can be open for writing at startup.
+
+The cap is computed as:
 
 ```
 max_concurrent_writes = (memory_target − additional_mem_reserved − read_part_size) / write_part_size
 ```
 
-`memory_target` is set with `--memory-target` and defaults to 95% of total system memory with a minimum of 512 MiB. `additional_mem_reserved` is `max(128 MiB, memory_target / 8)` and is held back from data buffers for Mountpoint's own overhead. `read_part_size` and `write_part_size` are set with `--read-part-size` and `--write-part-size` (or both with `--part-size`) and each default to 8 MiB; one read part is kept available for reads. With the minimum `memory_target` of 512 MiB and the default 8 MiB part sizes, the cap is 47 concurrent writers.
-
-Once the cap is reached, `open()` calls for write return `ENOMEM` ("Cannot allocate memory") until an existing write handle is closed. To raise the cap, increase `--memory-target` or decrease `--write-part-size`.
+where `additional_mem_reserved` is the portion of the memory target held back for Mountpoint's own overhead: `max(128 MiB, memory_target / 8)`. For example, with the minimum memory target of 512 MiB and the default 8 MiB part sizes, 128 MiB is held back for overhead and one 8 MiB read part is kept available for reads, leaving 376 MiB for write buffers — enough for 47 files open for writing.
 
 ### Maximum object size
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -325,7 +325,7 @@ At mount time, Mountpoint automatically selects appropriate defaults to provide 
 
 Mountpoint buffers object data in memory while reading (prefetching ahead of an application's reads) and writing (holding parts to upload). The `--memory-target` command-line argument sets a target, in MiB, for Mountpoint's total memory usage, with a minimum of 512 MiB. The target is not a guaranteed limit but Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs, and reduces prefetching.
 
-`--memory-target` defaults to 95% of available memory, which is the cgroup limit where one applies and otherwise total system memory. A portion of the target, `max(128 MiB, memory_target / 8)`, is held back for Mountpoint's own overhead such as metadata and file handles; the rest is the budget for data buffers.
+`--memory-target` defaults to 95% of total (or cgroup-limited) memory. A portion of the target, `max(128 MiB, memory_target / 8)`, is held back for Mountpoint's own overhead such as metadata and file handles; the rest is the budget for data buffers.
 
 The memory target and the write part size determine the maximum number of files that can be open for writing at the same time: once that maximum is reached, opening a file for writing fails with `ENOMEM`. See [Maximum number of files open for writing](#maximum-number-of-files-open-for-writing).
 

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -264,9 +264,7 @@ To further debug throttling errors, see the [throttling errors section](https://
 
 ## Slow reads or writes under memory pressure
 
-Mountpoint buffers object data for reads and writes within a budget derived from `--memory-target`.
-When that budget is exhausted, Mountpoint slows I/O down: prefetch windows shrink, buffer allocations queue until memory is released, and speculatively prefetched data is discarded to serve reads that applications are waiting on.
-Throughput degrades, and any discarded data has to be fetched from S3 again.
+Mountpoint may slow down read and write operations under memory pressure, resulting in reduced throughput and increased latency. When Mountpoint reaches its memory budget, it starts issuing fewer parallel requests, reducing or stopping speculative prefetching, and even discarding data already prefetched, in order to prioritize I/O operations that applications are waiting on. 
 
 Memory pressure can be identified from Mountpoint's metrics, which you can write to logs with `--log-metrics` (see our [logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#metrics)) or export (see our [metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md)).
 If the following metrics are emitted, then Mountpoint is under memory pressure:

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -244,6 +244,8 @@ There are two recommendations for this scenario:
 
 If you're seeing slower throughput than expected (i.e. significantly slower than the network bandwidth for an EC2 instance type), there may be a few areas to investigate.
 
+Throughput may be reduced by memory pressure, especially in containers with a low memory limit: see the [memory pressure section](https://github.com/awslabs/mountpoint-s3/blob/main/doc/TROUBLESHOOTING.md#slow-reads-or-writes-under-memory-pressure).
+
 If you're only reading from one file at a given time, the network interface may not be fully saturated.
 Mountpoint supports Linux file system operations using FUSE.
 Operations on files pass through several subsystems including the Linux VFS layer as well as the Mountpoint process.
@@ -259,6 +261,27 @@ We recommend reviewing Mountpoint logs to confirm if requests may be failing and
 For example, throttled requests being retried may introduce latency to file system requests.
 Learn more about how to use Mountpoint logging in our [logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md).
 To further debug throttling errors, see the [throttling errors section](https://github.com/awslabs/mountpoint-s3/blob/main/doc/TROUBLESHOOTING.md#throttling-errors) of this page.
+
+## Slow reads or writes under memory pressure
+
+Mountpoint buffers object data for reads and writes within a budget derived from `--memory-target`.
+When that budget is exhausted, Mountpoint slows I/O down: prefetch windows shrink, buffer allocations queue until memory is released, and speculatively prefetched data is discarded to serve reads that applications are waiting on.
+Throughput degrades, and any discarded data has to be fetched from S3 again.
+
+Memory pressure can be identified from Mountpoint's metrics, which you can write to logs with `--log-metrics` (see our [logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#metrics)) or export (see our [metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md)).
+If the following metrics are emitted, then Mountpoint is under memory pressure:
+
+| Metric | Meaning |
+|--------|---------|
+| `pool.allocation_queue_wait` | Time buffer allocations spent waiting for memory to be released |
+| `pool.allocation_queue_depth` | Buffer allocations currently waiting for memory |
+| `mem.cursor_resets` | Prefetched data discarded to reclaim memory |
+| `mem.seek_window_resets` | Backward seek windows cleared to reclaim memory |
+
+These are the names as they appear in logs; exported over OTLP they are prefixed with `experimental.`.
+
+To reduce memory pressure, increase `--memory-target` if the host or container has memory to spare, reduce the number of files your application keeps open at the same time, or lower `--read-part-size` and `--write-part-size`.
+For more about the memory target, see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-memory-usage).
 
 ## Throttling Errors
 
@@ -305,6 +328,20 @@ mountpoint_s3_fs::fuse: write failed: upload error: object exceeded maximum uplo
 
 For workloads uploading files larger than 78GiB, we recommend configuring a larger part size using the `--write-part-size <MiB>` command-line argument.
 For more information, see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#maximum-object-size).
+
+## Cannot open file for writing
+
+Mountpoint caps how many files may be open for writing at the same time, because each one reserves a part-sized buffer until it is closed.
+Once the cap is reached, opening a file for writing fails with `ENOMEM` ("Cannot allocate memory") and Mountpoint logs an error:
+
+```
+WARN open{req=25 ino=2 pid=1234}:
+mountpoint_s3_fs::fuse: open failed with errno 12: cannot open file for writing: exceeded max allowed concurrent write file handles of 47 based on memory target 512MiB (part size is 8MiB). Increase --memory-target or decrease --write-part-size to allow for more concurrent writes, or close existing open-for-write file handles and retry open() operation.
+```
+
+Mountpoint logs the cap at startup, and increments the `fs.write_handle_limit_exceeded` metric each time an open is rejected.
+To resolve this, close write file handles your application no longer needs, or raise the cap by increasing `--memory-target` or decreasing `--write-part-size`.
+For how the cap is calculated, see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#maximum-number-of-files-open-for-writing).
 
 ## Credentials errors
 

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -266,8 +266,7 @@ To further debug throttling errors, see the [throttling errors section](https://
 
 Mountpoint may slow down read and write operations under memory pressure, resulting in reduced throughput and increased latency. When Mountpoint reaches its memory budget, it starts issuing fewer parallel requests, reducing or stopping speculative prefetching, and even discarding data already prefetched, in order to prioritize I/O operations that applications are waiting on. 
 
-Memory pressure can be identified from Mountpoint's metrics, which you can write to logs with `--log-metrics` (see our [logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#metrics)) or export (see our [metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md)).
-If the following metrics are emitted, then Mountpoint is under memory pressure:
+When Mountpoint is under memory pressure, the following metrics are emitted:
 
 | Metric | Meaning |
 |--------|---------|
@@ -276,7 +275,7 @@ If the following metrics are emitted, then Mountpoint is under memory pressure:
 | `mem.cursor_resets` | Prefetched data discarded to reclaim memory |
 | `mem.seek_window_resets` | Backward seek windows cleared to reclaim memory |
 
-These are the names as they appear in logs; exported over OTLP they are prefixed with `experimental.`.
+Metrics can be written to the logs (with `--log-metrics`, see our [logging documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/LOGGING.md#metrics)) or exported using OpenTelemetry (see our [metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md)). Note that the above metrics are prefixed with `experimental.` when exported.
 
 To reduce memory pressure, increase `--memory-target` if the host or container has memory to spare, reduce the number of files your application keeps open at the same time, or lower `--read-part-size` and `--write-part-size`.
 For more about the memory target, see [Mountpoint's configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-memory-usage).

--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased (v0.22.0)
 
+### Breaking changes
+
+* Redesign the experimental `MemoryPool` trait. The `get_buffer` method was removed in favor of the now required `get_buffer_async` method, which allows implementations to defer allocation when memory is not immediately available. This affects implementations passed to `S3ClientConfig::memory_pool`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+
 ### Other changes
 
 * Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased (v0.16.0)
 
+### Breaking changes
+
+* Remove `s3::pool::MemoryPool::get_buffer`. `get_buffer_async` is now a required method, so implementations can defer allocation when memory is not immediately available. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+
 ## v0.15.0 (July 20, 2026)
 
 * Add `io::tls` module with safe wrappers around `aws-c-io`'s TLS primitives (`TlsContextOptions`, `TlsContext`, `TlsConnectionOptions`). ([#1834](https://github.com/awslabs/mountpoint-s3/pull/1834))

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-* Remove `s3::pool::MemoryPool::get_buffer`. `get_buffer_async` is now a required method, so implementations can defer allocation when memory is not immediately available. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Redesign the experimental `MemoryPool` trait. The `get_buffer` method was removed in favor of the now required `get_buffer_async` method, which allows implementations to defer allocation when memory is not immediately available. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 
 ## v0.15.0 (July 20, 2026)
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,11 +1,6 @@
 ## Unreleased (v0.11.0)
 
-### Breaking changes
-
 * Remove the `mem_limiter` module. `MemoryLimiter` and related types now live in `memory`, and the memory limit is configured on the pool with `PagedPool::config()` rather than through `S3FilesystemConfig::mem_limit`, which has been removed. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
-
-### Other changes
-
 * Add `memory::WriteHandleLimiter`, which caps the number of concurrently open write file handles, and `InodeError::WriteHandleLimitExceeded`, which maps to `ENOMEM`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 * Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
 * Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased (v0.11.0)
 
+### Breaking changes
+
+* Remove the `mem_limiter` module. `MemoryLimiter` and related types now live in `memory`, and the memory limit is configured on the pool with `PagedPool::config()` rather than through `S3FilesystemConfig::mem_limit`, which has been removed. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+
+### Other changes
+
+* Add `memory::WriteHandleLimiter`, which caps the number of concurrently open write file handles, and `InodeError::WriteHandleLimitExceeded`, which maps to `ENOMEM`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 * Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
 * Bump `libgit2-sys` build dependency to 0.18.7+1.9.6 ([#1916](https://github.com/awslabs/mountpoint-s3/pull/1916))
 * Update EC2 instance network throughput table. ([#1895](https://github.com/awslabs/mountpoint-s3/pull/1895))

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Add the `--memory-target` CLI argument, which sets a target for Mountpoint's total memory usage. This target is not a guaranteed limit but Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Add the `--memory-target` CLI argument, which sets a target for Mountpoint's total memory usage. This target is not a guaranteed limit but Mountpoint manages the memory available for data buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 
 ### Breaking changes
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## Unreleased (v1.24.0)
 
 ### New features
-
-* Add the `--memory-target` CLI argument, which sets a target for Mountpoint's total memory usage. This target is not a guaranteed limit but Mountpoint manages the memory available for data buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Mountpoint now supports setting a target for total memory usage via the `--memory-target` CLI argument. This target is not a guaranteed limit but Mountpoint manages the memory available for data buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. See [the configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-memory-usage). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 
 ### Breaking changes
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased (v1.24.0)
 
+### New features
+
+* Add the `--memory-target` CLI argument, which sets a target (not a guaranteed limit) for Mountpoint's total memory usage. Mountpoint now enforces this target on both the read and write paths, queueing buffer allocations and discarding speculatively prefetched data under memory pressure. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+
+### Breaking changes
+
+* Mountpoint now limits how many files can be open for writing at the same time, derived from `--memory-target` and `--write-part-size`. Once the limit is reached, opening a file for writing fails with `ENOMEM` until an existing write file handle is closed. See [the configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#maximum-number-of-files-open-for-writing) for how the limit is calculated. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+
+### Other changes
+
+* Mountpoint now fails at startup if `--read-part-size` exceeds the memory available for data buffers and `--memory-target` was set explicitly. If the memory target is the default, the read part size is reduced to fit and a warning is logged instead. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Add experimental metrics for observing memory pressure: `experimental.pool.allocation_queue_depth`, `experimental.pool.allocation_queue_wait`, `experimental.mem.cursor_resets`, `experimental.mem.seek_window_resets`, and `experimental.fs.write_handle_limit_exceeded`. See [the metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Change memory pool metrics in logs. `pool.reserved_bytes` is replaced by `pool.acquired_bytes` and `pool.bytes_in_use`, `pool.allocated_bytes` and `pool.allocate_latency_us` are new, and the `size` dimension on `pool.allocated_pages`, `pool.empty_pages`, `pool.slack_bytes` and `pool.trim_pages` is renamed to `buffer_size`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 * Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
 
 ## v1.23.0 (July 20, 2026)

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features
 
-* Add the `--memory-target` CLI argument, which sets a target (not a guaranteed limit) for Mountpoint's total memory usage. Mountpoint now enforces this target on both the read and write paths, queueing buffer allocations and discarding speculatively prefetched data under memory pressure. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+* Add the `--memory-target` CLI argument, which sets a target for Mountpoint's total memory usage. This target is not a guaranteed limit but Mountpoint manages the memory available for these buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 
 ### Breaking changes
 

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -187,7 +187,7 @@ For FUSE file descriptors (Linux-only), it should be of the format `/dev/fd/N`.\
 
     #[clap(
         long,
-        help = "Maximum memory usage target [default: 95% of available memory, minimum: 512 MiB]",
+        help = "Maximum memory usage target [default: 95% of total (or cgroup-limited) memory, minimum: 512 MiB]",
         long_help = "\
 Target for Mountpoint's total memory usage, in MiB.
 
@@ -196,8 +196,7 @@ not a guaranteed limit. Lowering it may reduce throughput and increase latency. 
 many files can be open for writing at the same time. Once that cap is reached, opening a file for
 writing fails with ENOMEM.
 
-Defaults to 95% of available memory (the cgroup limit where one applies, otherwise total system
-memory).\
+Defaults to 95% of total (or cgroup-limited) memory.\
         ",
         value_name = "MiB",
         value_parser = value_parser!(u64).range(512..),

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -45,6 +45,9 @@ Arguments:
 #[clap(
     name = "mount-s3",
     about = "Mountpoint for Amazon S3",
+    long_about = "Mountpoint for Amazon S3\n\n\
+Learn more in Mountpoint's configuration documentation:\n\
+https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md",
     version = build_info::FULL_VERSION,
     group(
         ArgGroup::new("cache_group")
@@ -185,7 +188,18 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
 
     #[clap(
         long,
-        help = "Maximum memory usage target [default: 95% of total system memory with a minimum of 512 MiB]",
+        help = "Maximum memory usage target [default: 95% of available memory, minimum: 512 MiB]",
+        long_help = "\
+Target (not a guaranteed limit) for Mountpoint's total memory usage, in MiB.
+
+Mountpoint manages the memory used to buffer reads and writes to stay within this
+target. Lowering it can reduce throughput, and it caps how many files can be open
+for writing at the same time -- once that cap is reached, opening a file for
+writing fails with ENOMEM.
+
+Defaults to 95% of available memory (the cgroup limit where one applies, otherwise
+total system memory).\
+        ",
         value_name = "MiB",
         value_parser = value_parser!(u64).range(512..),
         help_heading = CLIENT_OPTIONS_HEADER

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -69,8 +69,7 @@ Directory or FUSE file descriptor to mount the bucket at.
 
 For directory mount points, the passed path must be an existing directory.
 
-For FUSE file descriptors (Linux-only), it should be of the format `/dev/fd/N`.
-Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
+For FUSE file descriptors (Linux-only), it should be of the format `/dev/fd/N`.\
         ",
         value_name = "DIRECTORY"
     )]
@@ -190,15 +189,15 @@ Learn more in Mountpoint's configuration documentation (CONFIGURATION.md).\
         long,
         help = "Maximum memory usage target [default: 95% of available memory, minimum: 512 MiB]",
         long_help = "\
-Target (not a guaranteed limit) for Mountpoint's total memory usage, in MiB.
+Target for Mountpoint's total memory usage, in MiB.
 
-Mountpoint manages the memory used to buffer reads and writes to stay within this
-target. Lowering it can reduce throughput, and it caps how many files can be open
-for writing at the same time -- once that cap is reached, opening a file for
+Mountpoint manages the memory used to buffer reads and writes to stay within this target but it is
+not a guaranteed limit. Lowering it may reduce throughput and increase latency. The target caps how
+many files can be open for writing at the same time. Once that cap is reached, opening a file for
 writing fails with ENOMEM.
 
-Defaults to 95% of available memory (the cgroup limit where one applies, otherwise
-total system memory).\
+Defaults to 95% of available memory (the cgroup limit where one applies, otherwise total system
+memory).\
         ",
         value_name = "MiB",
         value_parser = value_parser!(u64).range(512..),


### PR DESCRIPTION
Documents the memory limiter shipped in #1936: a new memory usage section in `CONFIGURATION.md`, expanded `--memory-target` help text, two troubleshooting sections, and `CHANGELOG.md` entries.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

Yes, added.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)