### PR TITLE
Let incremental upload drain its own pipeline before queueing for memory

### DIFF
--- a/mountpoint-s3-fs/src/memory/pool.rs
+++ b/mountpoint-s3-fs/src/memory/pool.rs
@@ -125,6 +125,26 @@ impl PagedPool {
         PoolBufferMut::new(buffer)
     }
 
+    /// Take a buffer from the pool, but only if it can be served *right now* without queueing.
+    ///
+    /// Returns `None` when the allocation queue is non-empty — so an opportunistic caller can never
+    /// jump ahead of a reader or writer already parked in either lane — or when serving the request
+    /// would exceed the memory limit. Unlike [Self::get_buffer_mut] this never forces an over-limit
+    /// allocation, and unlike [Self::get_buffer_mut_async] it never parks the caller.
+    pub fn try_get_buffer_mut(
+        &self,
+        capacity: usize,
+        kind: BufferKind,
+        cursor_id: Option<CursorId>,
+    ) -> Option<PoolBufferMut> {
+        if self.inner.is_memory_pressure() {
+            return None;
+        }
+        self.inner
+            .try_get_buffer(capacity, kind, cursor_id, false)
+            .map(PoolBufferMut::new)
+    }
+
     fn get_buffer(&self, size: usize, kind: BufferKind, cursor_id: Option<CursorId>) -> PoolBuffer {
         self.inner
             .try_get_buffer(size, kind, cursor_id, true)
@@ -341,7 +361,7 @@ impl PagedPoolInner {
     ///     - Return a buffer from the new page if successful.
     /// - In all other cases:
     ///   - Try to allocate and return a single buffer.
-    ///     
+    ///
     /// Returns `None` if allocating the required memory would exceed the memory limit.
     ///
     /// **NOTE:** guarantees to return `Some` if invoked with `ignore_limit == true`.

--- a/mountpoint-s3-fs/src/upload/incremental.rs
+++ b/mountpoint-s3-fs/src/upload/incremental.rs
@@ -162,6 +162,8 @@ struct AppendUploadQueue<Client: ObjectClient> {
     checksum_algorithm: Option<Option<ChecksumAlgorithm>>,
     /// Stores the last successful result to return in [join].
     last_known_result: Option<PutObjectResult>,
+    /// Tracks the requests pushed to the queue but still pending a response.
+    requests_in_queue: usize,
 }
 
 impl<Client> AppendUploadQueue<Client>
@@ -196,6 +198,7 @@ where
             buffer_sender,
             event_receiver,
             last_known_result: None,
+            requests_in_queue: 0,
             checksum_algorithm: None,
             pool,
             _task_handle: task_handle,
@@ -210,6 +213,7 @@ where
             while self.consume_next_response().await? {}
             return Err(UploadError::UploadAlreadyTerminated);
         }
+        self.requests_in_queue += 1;
         Ok(())
     }
 
@@ -253,8 +257,31 @@ where
             }
         };
         let hasher = ChecksumHasher::new(&checksum_algorithm)?;
-        let data = self.pool.get_buffer_mut_async(capacity, BufferKind::Append, None).await;
-        Ok(UploadBuffer { data, hasher })
+        // Three-way decision per iteration:
+        //   1. Nothing pushed-but-not-acked → queue an urgent (high-lane) allocation. The handle
+        //      holds no buffer and has nothing of its own to wait on, so it must be served — and is:
+        //      `WriteHandleLimiter` admits `write_buffer_budget / write_part_size` handles exactly so
+        //      one filling buffer each fits, and every other claim on that budget frees without a
+        //      FUSE thread. So this waits on request completion, never on another blocked writer.
+        //   2. Spare capacity → take it without queueing. `try_get_buffer_mut` succeeds only when
+        //      nothing is pending, so slack can't jump parked readers or writers. Only this branch
+        //      lets the queue reach a depth above one.
+        //   3. Otherwise → drain one response from our own pipeline and re-evaluate. While we have
+        //      recourse, this keeps append allocations out of *both* lanes, so speculative prefetch
+        //      is never preempted by a writer that could recycle its own memory instead.
+        loop {
+            if self.requests_in_queue == 0 {
+                let data = self.pool.get_buffer_mut_async(capacity, BufferKind::Append, None).await;
+                return Ok(UploadBuffer { data, hasher });
+            }
+            if let Some(data) = self.pool.try_get_buffer_mut(capacity, BufferKind::Append, None) {
+                return Ok(UploadBuffer { data, hasher });
+            }
+            trace!("wait for the next request to be processed");
+            if !self.consume_next_response().await? {
+                return Err(UploadError::UploadAlreadyTerminated);
+            }
+        }
     }
 
     /// Wait on the response channel, updating the state of the [AppendUploadQueue] when the next response arrives.
@@ -278,6 +305,7 @@ where
                 }
                 AppendUploadEvent::PutResponse(result) => {
                     trace!(?result, "received result");
+                    self.requests_in_queue -= 1;
                     self.last_known_result = Some(result);
                     return Ok(true);
                 }


### PR DESCRIPTION
**Problem:** 2GB queue buffer for append starves readers too much as append buffers are high priority in buffer allocation queue.

**Solution:** Let incremental upload drain its own pipeline before queuing for memory (if under memory pressure)

**Verification**: Benchmark results: https://github.com/awslabs/mountpoint-s3/actions/runs/32668644417

Throughput Benchmark (S3 Express One Zone, Incremental Upload, Memory-Limited)

| Benchmark suite | Current: de2395b9dec639b44f00dcbb770b41a6d5471e42 | Previous: 58817cab2fc3020a422d8aa14049a86b296f4498 | Ratio |
|-|-|-|-|
| `sequential_read,sequential_write_four_threads` | `561.45126953125` MiB/s | `451.54580078124997` MiB/s | `0.80` |
| `sequential_read_two_threads,sequential_write_two_threads` | `480.8755859375` MiB/s | `239.08544921875` MiB/s | `0.50` |
| `sequential_read_four_threads,sequential_write` | `632.134375` MiB/s | `148.512890625` MiB/s | `0.23` |
| `sequential_write_direct_io` | `111.26708984375` MiB/s | `111.18154296875` MiB/s | `1.00` |
| `sequential_write` | `110.83740234375` MiB/s | `110.981640625` MiB/s | `1.00` |

Throughput Benchmark - Peak Memory Usage (S3 Express One Zone, Incremental Upload, Memory-Limited)

| Benchmark suite | Current: de2395b9dec639b44f00dcbb770b41a6d5471e42 | Previous: 58817cab2fc3020a422d8aa14049a86b296f4498 | Ratio |
|-|-|-|-|
| `mix_1r4w` | `467.71484375` MiB | `452.03515625` MiB | `1.03` |
| `mix_2r2w` | `446.484375` MiB | `436.89453125` MiB | `1.02` |
| `mix_4r1w` | `444.09765625` MiB | `452.53125` MiB | `0.98` |
| `seq_write_direct` | `406.1953125` MiB | `406.0859375` MiB | `1.00` |
| `seq_write` | `406.1328125` MiB | `405.96484375` MiB | `1.00` |

### Does this change impact existing behavior?

N/A - part of memory limiter feature

### Does this change need a changelog entry? Does it require a version change?

N/A - part of memory limiter feature

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
