### PR TITLE
Update changelogs to prepare v1.24.0 release

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.22.0)
+## Unreleased
+
+## v0.22.0 (August 24, 2026)
 
 ### Breaking changes
 

--- a/mountpoint-s3-crt/CHANGELOG.md
+++ b/mountpoint-s3-crt/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.16.0)
+## Unreleased
+
+## v0.16.0 (August 24, 2026)
 
 ### Breaking changes
 

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased (v0.11.0)
+## Unreleased
+
+## v0.11.0 (August 24, 2026)
 
 * `S3FilesystemConfig::read_only` is now enforced by the file system, which refuses operations that would modify the mount with the new `InodeError::ReadOnlyMount` (`EROFS`) instead of relying on the kernel to do so. `FuseOptions::read_only` is now also accepted with a `MountPoint::FileDescriptor` mount point, where it records that the caller performed the mount read-only. `MountpointConfig::create_fuse_session` now fails if `FuseOptions::read_only` and `S3FilesystemConfig::read_only` disagree. ([#1939](https://github.com/awslabs/mountpoint-s3/pull/1939))
 * Remove the `mem_limiter` module. `MemoryLimiter` and related types now live in `memory`, and the memory limit is configured on the pool with `PagedPool::config()` rather than through `S3FilesystemConfig::mem_limit`, which has been removed. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased (v1.24.0)
+## Unreleased
+
+## v1.24.0 (August 24, 2026)
 
 ### New features
+
 * Mountpoint now supports setting a target for total memory usage via the `--memory-target` CLI argument. This target is not a guaranteed limit but Mountpoint manages the memory available for data buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. See [the configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-memory-usage). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 
 ### Breaking changes
@@ -13,7 +16,8 @@
 * Add experimental metrics for observing memory pressure: `experimental.pool.allocation_queue_depth`, `experimental.pool.allocation_queue_wait`, `experimental.mem.cursor_resets`, `experimental.mem.seek_window_resets`, and `experimental.fs.write_handle_limit_exceeded`. See [the metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 * Change memory pool metrics in logs. `pool.reserved_bytes` is replaced by `pool.acquired_bytes` and `pool.bytes_in_use`, `pool.allocated_bytes` and `pool.allocate_latency_us` are new, and the `size` dimension on `pool.allocated_pages`, `pool.empty_pages`, `pool.slack_bytes` and `pool.trim_pages` is renamed to `buffer_size`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
 * `--read-only` may now be used with a FUSE file descriptor mount point (`/dev/fd/N`), where it is accepted as a statement that the caller performed the mount read-only. Mountpoint refuses file system operations that would modify a read-only mount with `EROFS`. ([#1939](https://github.com/awslabs/mountpoint-s3/pull/1939) by @yerzhan7)
-* Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
+* Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933) by @Priyankakarumuru1)
+* Update the EC2 instance network throughput table used to auto-configure the default target throughput. ([#1895](https://github.com/awslabs/mountpoint-s3/pull/1895) by @jet-tong)
 
 ## v1.23.0 (July 20, 2026)
 


### PR DESCRIPTION
Update changelogs for all crates to prepare the v1.24.0 release.

Crate versions were already bumped in #1936

### Does this change impact existing behavior?

No, documentation only.

### Does this change need a changelog entry? Does it require a version change?

N/A — this is the changelog update for the release.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
