### PR TITLE
Replace bincode with wincode in disk data cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,26 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,7 +2870,6 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "base64ct",
- "bincode 2.0.1",
  "bitflags 2.13.1",
  "bytes",
  "clap",
@@ -2947,6 +2926,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "walkdir",
+ "wincode",
  "wiremock",
 ]
 
@@ -2954,7 +2934,7 @@ dependencies = [
 name = "mountpoint-s3-fuser"
 version = "0.1.1"
 dependencies = [
- "bincode 1.3.3",
+ "bincode",
  "clap",
  "env_logger",
  "libc",
@@ -3314,6 +3294,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -4557,7 +4543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4968,12 +4954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,12 +5011,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsimd"
@@ -5191,6 +5165,31 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d582d9fc9d813264407a9e16bfa16846ccf15ef032f9bbcd700741bdc00255"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "windows"

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -17,7 +17,7 @@ async-lock = "3.4.2"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 base64ct = "1.8.3"
-wincode = { version = "0.6", features = ["derive"] }
+wincode = { version = "0.6.1", features = ["derive"] }
 bitflags = "2.13.0"
 bytes = { version = "1.12.0", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -17,7 +17,7 @@ async-lock = "3.4.2"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 base64ct = "1.8.3"
-bincode = { version = "2.0.1", features = ["std"] }
+wincode = { version = "0.6", features = ["derive"] }
 bitflags = "2.13.0"
 bytes = { version = "1.12.0", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -36,12 +36,10 @@ async fn read_cache_block(cache: &DiskDataCache, cache_key: &ObjectId) {
 
 #[inline]
 async fn write_cache_block(cache: &DiskDataCache, cache_key: ObjectId, bytes: ChecksummedBytes) {
-    _ = black_box(
-        cache
-            .put_block(cache_key, 0, 0, bytes, OBJECT_SIZE)
-            .await
-            .expect("is able to write to cache"),
-    );
+    cache
+        .put_block(cache_key, 0, 0, bytes, OBJECT_SIZE)
+        .await
+        .expect("is able to write to cache");
 }
 
 fn random_bytes(length: usize) -> Vec<u8> {
@@ -91,7 +89,7 @@ fn file_write_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Pat
     let file_path = dir_path.join("file_write");
 
     group.bench_function("write_file", |b| {
-        b.iter(|| _ = black_box(fs::write(&file_path, data).expect("is able to write file")))
+        b.iter(|| fs::write(&file_path, data).expect("is able to write file"))
     });
 }
 

--- a/mountpoint-s3-fs/benches/cache_serialization.rs
+++ b/mountpoint-s3-fs/benches/cache_serialization.rs
@@ -34,6 +34,16 @@ async fn read_cache_block(cache: &DiskDataCache, cache_key: &ObjectId) {
     );
 }
 
+#[inline]
+async fn write_cache_block(cache: &DiskDataCache, cache_key: ObjectId, bytes: ChecksummedBytes) {
+    _ = black_box(
+        cache
+            .put_block(cache_key, 0, 0, bytes, OBJECT_SIZE)
+            .await
+            .expect("is able to write to cache"),
+    );
+}
+
 fn random_bytes(length: usize) -> Vec<u8> {
     let mut rng = rand::rng();
     let mut random_bytes = vec![0u8; length];
@@ -77,6 +87,14 @@ fn file_read_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Path
     });
 }
 
+fn file_write_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Path, data: &[u8]) {
+    let file_path = dir_path.join("file_write");
+
+    group.bench_function("write_file", |b| {
+        b.iter(|| _ = black_box(fs::write(&file_path, data).expect("is able to write file")))
+    });
+}
+
 fn read_benchmark(c: &mut Criterion) {
     let temp_dir = TempDir::with_prefix("mp-cache-benchmarks").unwrap();
     let data = random_bytes(BLOCK_SIZE.try_into().unwrap());
@@ -89,5 +107,43 @@ fn read_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, read_benchmark);
+fn cache_write_benchmark(group: &mut BenchmarkGroup<'_, WallTime>, dir_path: &Path, data: &[u8]) {
+    let config = DiskDataCacheConfig {
+        cache_directory: dir_path.to_path_buf(),
+        block_size: BLOCK_SIZE,
+        limit: mountpoint_s3_fs::data_cache::CacheLimit::Unbounded,
+    };
+    let pool = PagedPool::config()
+        .with_candidate_sizes([CandidateSize::new(BLOCK_SIZE as usize)])
+        .with_no_memory_limit()
+        .build();
+    let cache = DiskDataCache::new(config, pool);
+
+    // Pre-create ChecksummedBytes once (not part of serialization benchmark)
+    let bytes = ChecksummedBytes::new(data.to_owned().into());
+
+    group.bench_function("write_cache_block", |b| {
+        let mut counter = 0u64;
+        b.to_async(FuturesExecutor).iter(|| {
+            // Use unique key per iteration to avoid temp file overwrite overhead
+            counter += 1;
+            let cache_key = ObjectId::new(format!("key-{}", counter), ETag::for_tests());
+            write_cache_block(&cache, cache_key, bytes.clone())
+        })
+    });
+}
+
+fn write_benchmark(c: &mut Criterion) {
+    let temp_dir = TempDir::with_prefix("mp-cache-benchmarks").unwrap();
+    let data = random_bytes(BLOCK_SIZE.try_into().unwrap());
+
+    let mut group = c.benchmark_group("Block Write");
+
+    file_write_benchmark(&mut group, temp_dir.path(), &data);
+    cache_write_benchmark(&mut group, temp_dir.path(), &data);
+
+    group.finish();
+}
+
+criterion_group!(benches, read_benchmark, write_benchmark);
 criterion_main!(benches);

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -7,9 +7,6 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use async_trait::async_trait;
-use bincode::config::{Configuration, Fixint, Limit, LittleEndian};
-use bincode::error::{DecodeError, EncodeError};
-use bincode::{Decode, Encode};
 use bytes::Bytes;
 use linked_hash_map::LinkedHashMap;
 use mountpoint_s3_client::checksums::crc32c::{self, Crc32c};
@@ -32,7 +29,7 @@ use crate::sync::Mutex;
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
 
 /// Disk and file-layout versioning.
-const CACHE_VERSION: &str = "V2";
+const CACHE_VERSION: &str = "V3";
 
 /// Index where hashed directory names for the cache are split to avoid FS-specific limits.
 const HASHED_DIR_SPLIT_INDEX: usize = 2;
@@ -79,7 +76,7 @@ impl Default for CacheLimit {
 ///
 /// It should be written alongside the block's data
 /// and used to verify it contains the correct contents to avoid blocks being mixed up.
-#[derive(Encode, Decode, Debug)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Debug)]
 struct DiskBlockHeader {
     block_idx: BlockIndex,
     block_offset: u64,
@@ -89,18 +86,6 @@ struct DiskBlockHeader {
     data_checksum: u32,
     header_checksum: u32,
 }
-
-/// Max size of header after encoding.
-/// 10000 should easily accommodate any block header:
-/// - S3 key should always be less than or equal to 1024
-/// - Allow 1024 for ETag, even though its always much smaller
-/// - Integers should be up to 8 bytes each
-const BINCODE_HEADER_MAX_SIZE: usize = 10000;
-
-/// Binary encoding configuration for the block header.
-const BINCODE_CONFIG: Configuration<LittleEndian, Fixint, Limit<BINCODE_HEADER_MAX_SIZE>> = bincode::config::standard()
-    .with_fixed_int_encoding()
-    .with_limit::<BINCODE_HEADER_MAX_SIZE>();
 
 /// Error during creation of a [DiskBlock]
 #[derive(Debug, Error)]
@@ -124,10 +109,8 @@ enum DiskBlockAccessError {
 enum DiskBlockReadWriteError {
     #[error("Invalid block length: {0}")]
     InvalidBlockLength(u64),
-    #[error("Error decoding the block: {0}")]
-    DecodeError(DecodeError),
-    #[error("Error encoding the block: {0}")]
-    EncodeError(EncodeError),
+    #[error("Error with serialization: {0}")]
+    SerializationError(wincode::Error),
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
 }
@@ -265,15 +248,20 @@ impl DiskBlock {
         pool: &PagedPool,
         cursor_id: Option<CursorId>,
     ) -> Result<Self, DiskBlockReadWriteError> {
-        let header: DiskBlockHeader = bincode::decode_from_std_read(reader, BINCODE_CONFIG)?;
+        // Deserialize header directly from the file reader
+        let header: DiskBlockHeader = wincode::deserialize_from(wincode::io::std_read::ReadAdapter::new(&mut *reader))?;
 
         if header.block_len > block_size {
             return Err(DiskBlockReadWriteError::InvalidBlockLength(header.block_len));
         }
 
+        // Allocate pool buffer for exactly block_len (data only)
         let size = header.block_len as usize;
         let mut buffer = pool.get_buffer_mut_async(size, BufferKind::DiskCache, cursor_id).await;
+
+        // Read data directly from file into pool buffer
         buffer.fill_from_reader(reader)?;
+
         let data = buffer.into_bytes();
 
         Ok(Self { header, data })
@@ -281,27 +269,32 @@ impl DiskBlock {
 
     /// Serialize this instance to `writer` and return the number of bytes written on success.
     fn write(&self, writer: &mut impl Write) -> Result<usize, DiskBlockReadWriteError> {
-        let header_length = bincode::encode_into_std_write(&self.header, writer, BINCODE_CONFIG)?;
+        // Calculate header size
+        let header_length = wincode::serialized_size(&self.header)? as usize;
+
+        // Serialize header directly to writer
+        wincode::serialize_into(wincode::io::std_write::WriteAdapter::new(&mut *writer), &self.header)?;
         writer.write_all(&self.data)?;
+
         Ok(header_length + self.data.len())
     }
 }
 
-impl From<DecodeError> for DiskBlockReadWriteError {
-    fn from(value: DecodeError) -> Self {
-        match value {
-            DecodeError::Io { inner, .. } => DiskBlockReadWriteError::IOError(inner),
-            value => DiskBlockReadWriteError::DecodeError(value),
-        }
+impl From<wincode::Error> for DiskBlockReadWriteError {
+    fn from(value: wincode::Error) -> Self {
+        DiskBlockReadWriteError::SerializationError(value)
     }
 }
 
-impl From<EncodeError> for DiskBlockReadWriteError {
-    fn from(value: EncodeError) -> Self {
-        match value {
-            EncodeError::Io { inner, .. } => DiskBlockReadWriteError::IOError(inner),
-            value => DiskBlockReadWriteError::EncodeError(value),
-        }
+impl From<wincode::ReadError> for DiskBlockReadWriteError {
+    fn from(value: wincode::ReadError) -> Self {
+        DiskBlockReadWriteError::SerializationError(value.into())
+    }
+}
+
+impl From<wincode::WriteError> for DiskBlockReadWriteError {
+    fn from(value: wincode::WriteError) -> Self {
+        DiskBlockReadWriteError::SerializationError(value.into())
     }
 }
 
@@ -684,7 +677,7 @@ mod tests {
         let s3_key = "a".repeat(266);
         let etag = ETag::for_tests();
         let key = ObjectId::new(s3_key, etag);
-        let expected_hash = "1cfd611a26062b33e98d48a84e967ddcc2a42957479a8abd541e29cfa3258639";
+        let expected_hash = "0f913e772ae5ddb10d982a6664d12a7cba0c4eda5803cd5c84a437283d3f174e";
         let actual_hash = hex::encode(hash_cache_key_raw(&key));
         assert_eq!(expected_hash, actual_hash);
     }
@@ -1140,10 +1133,7 @@ mod tests {
         let err = block_on(DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None))
             .expect_err("deserialization should fail");
         match length_to_corrupt {
-            "key" | "etag" => assert!(matches!(
-                err,
-                DiskBlockReadWriteError::DecodeError(DecodeError::LimitExceeded)
-            )),
+            "key" | "etag" => assert!(matches!(err, DiskBlockReadWriteError::SerializationError(_))),
             "data" => assert!(matches!(err, DiskBlockReadWriteError::InvalidBlockLength(_))),
             _ => panic!("invalid length: {length_to_corrupt}"),
         }

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -861,6 +861,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_put_get_max_size_key() {
+        let block_size = 8 * 1024 * 1024;
+        let data = ChecksummedBytes::new("Foo".into());
+        let data_size = data.len();
+
+        let cache_directory = tempfile::tempdir().unwrap();
+        let pool = PagedPool::config()
+            .with_candidate_sizes([CandidateSize::new(block_size)])
+            .with_no_memory_limit()
+            .build();
+        let cache = DiskDataCache::new(
+            DiskDataCacheConfig {
+                cache_directory: cache_directory.path().to_path_buf(),
+                block_size: block_size as u64,
+                limit: CacheLimit::Unbounded,
+            },
+            pool,
+        );
+
+        // S3 keys can be up to 1024 bytes; use a key at exactly that limit.
+        let s3_key = "k".repeat(HEADER_STRING_SIZE_LIMIT);
+        let cache_key = ObjectId::new(s3_key, ETag::for_tests());
+
+        cache
+            .put_block(cache_key.clone(), 0, 0, data.clone(), data_size)
+            .await
+            .expect("cache should be accessible");
+        let entry = cache
+            .get_block(&cache_key, 0, 0, data_size, None)
+            .await
+            .expect("cache should be accessible")
+            .expect("cache entry should be returned");
+        assert_eq!(
+            data, entry,
+            "cache entry with a max-size key should round-trip to the original bytes"
+        );
+    }
+
+    #[tokio::test]
     async fn test_checksummed_bytes_slice() {
         let data = ChecksummedBytes::new("0123456789".into());
         let slice = data.slice(1..5);

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 use thiserror::Error;
 use tracing::{trace, warn};
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::checksums::IntegrityError;
 use crate::data_cache::DataCacheError;
@@ -29,7 +30,7 @@ use crate::sync::Mutex;
 use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
 
 /// Disk and file-layout versioning.
-const CACHE_VERSION: &str = "V3";
+const CACHE_VERSION: &str = "V2";
 
 /// Index where hashed directory names for the cache are split to avoid FS-specific limits.
 const HASHED_DIR_SPLIT_INDEX: usize = 2;
@@ -76,7 +77,7 @@ impl Default for CacheLimit {
 ///
 /// It should be written alongside the block's data
 /// and used to verify it contains the correct contents to avoid blocks being mixed up.
-#[derive(wincode::SchemaWrite, wincode::SchemaRead, Debug)]
+#[derive(SchemaWrite, SchemaRead, Debug)]
 struct DiskBlockHeader {
     block_idx: BlockIndex,
     block_offset: u64,
@@ -109,8 +110,10 @@ enum DiskBlockAccessError {
 enum DiskBlockReadWriteError {
     #[error("Invalid block length: {0}")]
     InvalidBlockLength(u64),
-    #[error("Error with serialization: {0}")]
-    SerializationError(wincode::Error),
+    #[error("Error decoding the block: {0}")]
+    DecodeError(wincode::ReadError),
+    #[error("Error encoding the block: {0}")]
+    EncodeError(wincode::WriteError),
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
 }
@@ -280,21 +283,15 @@ impl DiskBlock {
     }
 }
 
-impl From<wincode::Error> for DiskBlockReadWriteError {
-    fn from(value: wincode::Error) -> Self {
-        DiskBlockReadWriteError::SerializationError(value)
-    }
-}
-
 impl From<wincode::ReadError> for DiskBlockReadWriteError {
     fn from(value: wincode::ReadError) -> Self {
-        DiskBlockReadWriteError::SerializationError(value.into())
+        DiskBlockReadWriteError::DecodeError(value)
     }
 }
 
 impl From<wincode::WriteError> for DiskBlockReadWriteError {
     fn from(value: wincode::WriteError) -> Self {
-        DiskBlockReadWriteError::SerializationError(value.into())
+        DiskBlockReadWriteError::EncodeError(value)
     }
 }
 
@@ -677,7 +674,7 @@ mod tests {
         let s3_key = "a".repeat(266);
         let etag = ETag::for_tests();
         let key = ObjectId::new(s3_key, etag);
-        let expected_hash = "0f913e772ae5ddb10d982a6664d12a7cba0c4eda5803cd5c84a437283d3f174e";
+        let expected_hash = "1cfd611a26062b33e98d48a84e967ddcc2a42957479a8abd541e29cfa3258639";
         let actual_hash = hex::encode(hash_cache_key_raw(&key));
         assert_eq!(expected_hash, actual_hash);
     }
@@ -1133,7 +1130,7 @@ mod tests {
         let err = block_on(DiskBlock::read(&mut Cursor::new(buf), MAX_LENGTH, &pool, None))
             .expect_err("deserialization should fail");
         match length_to_corrupt {
-            "key" | "etag" => assert!(matches!(err, DiskBlockReadWriteError::SerializationError(_))),
+            "key" | "etag" => assert!(matches!(err, DiskBlockReadWriteError::DecodeError(_))),
             "data" => assert!(matches!(err, DiskBlockReadWriteError::InvalidBlockLength(_))),
             _ => panic!("invalid length: {length_to_corrupt}"),
         }

--- a/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
+++ b/mountpoint-s3-fs/src/data_cache/disk_data_cache.rs
@@ -14,6 +14,9 @@ use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 use thiserror::Error;
 use tracing::{trace, warn};
+use wincode::config::Configuration;
+use wincode::io::std_read::ReadAdapter;
+use wincode::io::std_write::WriteAdapter;
 use wincode::{SchemaRead, SchemaWrite};
 
 use crate::checksums::IntegrityError;
@@ -72,6 +75,17 @@ impl Default for CacheLimit {
         }
     }
 }
+
+/// Per-sequence preallocation limit (in bytes) for dynamic fields (Strings) in
+/// the header. wincode's `with_preallocation_size_limit` applies to each
+/// sequence individually. The largest dynamic field is the S3 key, which AWS
+/// caps at 1024 bytes; ETags are much smaller. So 1024 is a tight, safe upper
+/// bound that rejects a corrupted length prefix as early as possible.
+const HEADER_STRING_SIZE_LIMIT: usize = 1024;
+
+/// Wincode configuration for the block header.
+const HEADER_CONFIG: Configuration<true, HEADER_STRING_SIZE_LIMIT> =
+    Configuration::default().with_preallocation_size_limit::<HEADER_STRING_SIZE_LIMIT>();
 
 /// Describes additional information about the data stored in the block.
 ///
@@ -252,7 +266,7 @@ impl DiskBlock {
         cursor_id: Option<CursorId>,
     ) -> Result<Self, DiskBlockReadWriteError> {
         // Deserialize header directly from the file reader
-        let header: DiskBlockHeader = wincode::deserialize_from(wincode::io::std_read::ReadAdapter::new(&mut *reader))?;
+        let header: DiskBlockHeader = wincode::config::deserialize_from(ReadAdapter::new(&mut *reader), HEADER_CONFIG)?;
 
         if header.block_len > block_size {
             return Err(DiskBlockReadWriteError::InvalidBlockLength(header.block_len));
@@ -273,10 +287,10 @@ impl DiskBlock {
     /// Serialize this instance to `writer` and return the number of bytes written on success.
     fn write(&self, writer: &mut impl Write) -> Result<usize, DiskBlockReadWriteError> {
         // Calculate header size
-        let header_length = wincode::serialized_size(&self.header)? as usize;
+        let header_length = wincode::config::serialized_size(&self.header, HEADER_CONFIG)? as usize;
 
         // Serialize header directly to writer
-        wincode::serialize_into(wincode::io::std_write::WriteAdapter::new(&mut *writer), &self.header)?;
+        wincode::config::serialize_into(WriteAdapter::new(&mut *writer), &self.header, HEADER_CONFIG)?;
         writer.write_all(&self.data)?;
 
         Ok(header_length + self.data.len())


### PR DESCRIPTION
Replace unmaintained bincode serialization library with wincode (a bincode-compatible, actively maintained library) for disk cache header serialization/deserialization in `mountpoint-s3-fs`. bincode has been permanently marked as unmaintained ([RUSTSEC-2025-0141](https://osv.dev/vulnerability/RUSTSEC-2025-0141)). 
  
Implementation:
  
- Read: Header deserialized directly from the file reader via ReadAdapter. Data read directly into pool buffer.
- Write: Header serialized directly to file via WriteAdapter (no intermediate allocation, same pattern as bincode).
- Added `write_cache_block` and `write_file` benchmarks.

Benchmark results:
- `read_cache_block`: wincode 99.3 µs vs bincode 103.6 µs (faster ✅)
- `write_cache_block`: wincode 4.02 ms vs bincode 4.02 ms (identical)
  
No performance regression. Read path is slightly faster.

Note: `mountpoint-s3-fuser `still uses bincode 1.3.1 - will be addressed in a follow-up. The advisory suppression can be reverted once both are migrated.
 
### Does this change impact existing behavior?

No user-facing changes.

### Does this change need a changelog entry? Does it require a version change?

No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
