### PR TITLE
Document overwrite decision timing and last-write-wins

### DIFF
--- a/doc/SEMANTICS.md
+++ b/doc/SEMANTICS.md
@@ -207,6 +207,7 @@ but with some limitations:
   * The existing file must be opened in truncate mode (`O_TRUNC`).
   * You cannot overwrite files that are currently being read or renamed.
   * The upload to S3 starts as soon as Mountpoint receives the first `write` request and cannot be cancelled. The data is uploaded to S3 in fixed-size parts (controlled by `--write-part-size`).
+  * Whether the file can be overwritten is decided when the file is opened, and is not re-checked before the upload completes. If another client writes to the same key while the overwrite is in progress, the last upload to complete wins, replacing the data written by the other.
 * Both for new files and overwrites:
   * Synchronization operations (`fsync`, `fdatasync`) complete the upload of the object to S3 and disallow further writes.
   * The data written to the file will be visible to other S3 clients only once the upload completes.
@@ -214,6 +215,7 @@ but with some limitations:
   * The existing file must be opened without the `O_TRUNC` flag or any existing content will be truncated.
   * Only sequential writes at the end of the file are allowed. Setting the `O_APPEND` flag on open will enforce this behavior, but is not required by Mountpoint.
   * You cannot append to files that are currently being read, renamed or overwritten.
+  * Appends to existing content are conditional on the object's ETag as of `open`, or as of the last completed append. If another client modifies the object in the meantime, subsequent writes fail rather than replacing that client's data.
   * The data is uploaded incrementally to S3 in fixed-size parts (controlled by `--write-part-size`).
   * Synchronization operations (`fsync`, `fdatasync`) trigger the upload of the appended parts and do allow to continue writing.
   * Parts successfully appended to an object are visible as the whole (appended) object to other S3 clients.


### PR DESCRIPTION
Improves clarity of two points in the "Writes" section of `doc/SEMANTICS.md`. For `--allow-overwrite`, the decision that a file may be overwritten is made at `open` and is not re-checked before the upload completes: the atomic upload path sends no conditional headers, so if another S3 client writes to the same key while the overwrite is in flight, the last upload to complete wins. For contrast, `--incremental-upload` appends are conditional on the object's ETag as of `open`, so a concurrent modification makes subsequent writes fail instead.

### Does this change impact existing behavior?

No.

### Does this change need a changelog entry? Does it require a version change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)