### PR TITLE
Retroactively fix changelog for 1.23.0

### DIFF
--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix memory limiter ignoring container cgroup memory limits, which could cause out-of-memory issues in memory-constrained containers. ([#1806](https://github.com/awslabs/mountpoint-s3/pull/1806) by @yerzhan7)
 * Reduce peak memory usage of incremental (append) uploads by removing an unnecessary buffer copy in the internal S3 client. ([#1882](https://github.com/awslabs/mountpoint-s3/pull/1882) by @yerzhan7)
 * Add additional debug information to FUSE operation logs including the ID of the process triggering the file system operation. ([#1718](https://github.com/awslabs/mountpoint-s3/pull/1718) by @mansi153)
+* Allow mounting on top of `autofs` managed directories. ([#1762](https://github.com/awslabs/mountpoint-s3/pull/1762) by @kiron1)
 
 ## v1.22.3 (April 28, 2026)
 


### PR DESCRIPTION
We missed an entry in the changelog for Mountpoint 1.23.0: we should have included #1762.

### Does this change impact existing behavior?

N/A

### Does this change need a changelog entry? Does it require a version change?

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
