### PR TITLE
Fix directory lookup after empty S3 list pages

### DIFF
--- a/mountpoint-s3-fs/src/superblock.rs
+++ b/mountpoint-s3-fs/src/superblock.rs
@@ -1559,10 +1559,34 @@ impl<OC: ObjectClient + Send + Sync> SuperblockInner<OC> {
             .client
             .head_object(&self.s3_path.bucket, object_key, &head_object_params)
             .fuse();
-        let mut dir_lookup = self
-            .client
-            .list_objects(&self.s3_path.bucket, None, "/", 1, directory_prefix)
-            .fuse();
+        let dir_lookup = async {
+            let mut continuation_token = None;
+            loop {
+                let result = self
+                    .client
+                    .list_objects(
+                        &self.s3_path.bucket,
+                        continuation_token.as_deref(),
+                        "/",
+                        1,
+                        directory_prefix,
+                    )
+                    .await;
+                match &result {
+                    // An empty page is not proof that the directory is absent if S3 has more pages.
+                    Ok(page)
+                        if page.objects.is_empty()
+                            && page.common_prefixes.is_empty()
+                            && page.next_continuation_token.is_some() =>
+                    {
+                        continuation_token = page.next_continuation_token.clone();
+                    }
+                    _ => return result,
+                }
+            }
+        }
+        .fuse();
+        futures::pin_mut!(dir_lookup);
 
         let mut file_state = None;
 

--- a/mountpoint-s3-fs/tests/mock_s3_tests.rs
+++ b/mountpoint-s3-fs/tests/mock_s3_tests.rs
@@ -17,6 +17,82 @@ use test_case::test_case;
 
 mod common;
 
+#[test_case(true, false; "directory after empty pages")]
+#[test_case(true, true; "directory shadows file after empty pages")]
+#[test_case(false, true; "file after exhausted listing")]
+#[test_case(false, false; "missing after exhausted listing")]
+#[tokio::test]
+async fn test_lookup_empty_list_pages(directory_exists: bool, file_exists: bool) {
+    let bucket = "bucket";
+    let key = "directory";
+    let (fs, server) = create_fs_with_mock_s3(bucket).await;
+
+    Mock::given(method("HEAD"))
+        .and(path(format!("/{bucket}/{key}")))
+        .respond_with(
+            ResponseTemplate::new(if file_exists { 200 } else { 404 }).append_headers([
+                ("ETag", "71a5b8dcb22444f1b2b899dedc1e4122"),
+                ("Last-Modified", "Tue, 10 Jan 2023 23:39:32 GMT"),
+                ("Content-Length", "1024"),
+            ]),
+        )
+        .mount(&server)
+        .await;
+
+    // S3 can return multiple empty, truncated pages before any live keys.
+    for page in 0..3 {
+        let token = (page > 0).then(|| format!("page-{page}"));
+        let mut response = list_empty_response(bucket, key);
+        if page < 2 {
+            response = response.replace(
+                "<IsTruncated>false</IsTruncated>",
+                &format!(
+                    "<IsTruncated>true</IsTruncated><NextContinuationToken>page-{}</NextContinuationToken>",
+                    page + 1
+                ),
+            );
+        } else if directory_exists {
+            response = response.replace(
+                "<KeyCount>0</KeyCount>",
+                &format!("<KeyCount>1</KeyCount><CommonPrefixes><Prefix>{key}/child/</Prefix></CommonPrefixes>"),
+            );
+        }
+
+        Mock::given(method("GET"))
+            .and(path(format!("/{bucket}/")))
+            .and(query_param("list-type", "2"))
+            .and(query_param("prefix", format!("{key}/")))
+            .and(query_param("delimiter", "/"))
+            .and(query_param("max-keys", "1"))
+            .and(move |request: &wiremock::Request| {
+                request
+                    .url
+                    .query_pairs()
+                    .find(|(name, _)| name == "continuation-token")
+                    .map(|(_, value)| value.into_owned())
+                    == token
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_string(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+
+    let result = fs.lookup(FUSE_ROOT_INODE, key.as_ref()).await;
+    if directory_exists || file_exists {
+        let entry = result.expect("lookup should find an existing entry after empty pages");
+        let expected_kind = if directory_exists {
+            fuser::FileType::Directory
+        } else {
+            fuser::FileType::RegularFile
+        };
+        assert_eq!(entry.attr.kind, expected_kind);
+    } else {
+        let err = result.expect_err("lookup should fail after exhausting the listing");
+        assert_eq!(err.to_errno(), libc::ENOENT);
+    }
+}
+
 #[test_case(true, false; "head object")]
 #[test_case(false, true; "list object")]
 #[test_case(true, true; "both list and head")]


### PR DESCRIPTION
S3 can return empty `ListObjectsV2` pages with a continuation token. Directory lookup currently treats these as evidence that the directory is missing, causing false `ENOENT` errors or exposing a file that should be shadowed by a directory.

Continue listing while both objects and common prefixes are empty and a continuation token is present. Stop once the directory is found or the listing is exhausted.

As part of testing, reproduced the failure with unpatched Mountpoint against real S3 and verified that the patched binary resolves the directory and reads a nested file matching its direct S3 download.

### Does this change impact existing behavior?

No breaking changes. Fixes incorrect lookup results after empty, truncated pages. Lookups may take longer because they now follow pagination instead of returning an incorrect result early.

### Does this change need a changelog entry? Does it require a version change?

Yes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
