### PR TITLE
fix(metrics): poll S3 client metrics periodically

### DIFF
--- a/mountpoint-s3-client/CHANGELOG.md
+++ b/mountpoint-s3-client/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `ObjectClient::poll_client_metrics` (default no-op). `S3CrtClient` implements it to emit `s3.client.*` metrics, which are no longer sampled at meta-request creation. ([#1957](https://github.com/awslabs/mountpoint-s3/pull/1957))
+
 ## v0.22.0 (August 24, 2026)
 
 ### Breaking changes

--- a/mountpoint-s3-client/src/mock_client.rs
+++ b/mountpoint-s3-client/src/mock_client.rs
@@ -1437,6 +1437,12 @@ mod tests {
         };
     }
 
+    #[test]
+    fn poll_client_metrics_is_noop() {
+        let client = MockClient::config().bucket("test_bucket").build();
+        client.poll_client_metrics();
+    }
+
     async fn test_get_object(
         key: &str,
         size: usize,

--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -47,6 +47,13 @@ pub trait ObjectClient {
     /// does not record the stats.
     fn mem_usage_stats(&self) -> Option<BufferPoolUsageStats>;
 
+    /// Sample client-level metrics into the process metrics facade.
+    ///
+    /// The metrics publisher invokes this on each publication cycle, immediately before publishing.
+    /// The default implementation is a no-op so mock and other non-CRT clients do not need
+    /// CRT-specific behavior. CRT-backed clients override this to export `s3.client.*` gauges.
+    fn poll_client_metrics(&self) {}
+
     /// Delete a single object from the object store.
     ///
     /// DeleteObject will succeed even if the object within the bucket does not exist.

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -425,6 +425,14 @@ impl S3CrtClient {
     pub fn event_loop_group(&self) -> EventLoopGroup {
         self.inner.event_loop_group.clone()
     }
+
+    /// Sample CRT client metrics and emit them to the metrics facade.
+    ///
+    /// Intended to be invoked by the metrics publisher on each publication cycle, not when
+    /// individual meta requests are created.
+    pub fn poll_client_metrics(&self) {
+        self.inner.emit_client_metrics();
+    }
 }
 
 #[derive(Debug)]
@@ -843,7 +851,6 @@ impl S3CrtClientInner {
 
         // Issue the HTTP request using the CRT's S3 meta request API
         let meta_request = self.s3_client.make_meta_request(options)?;
-        Self::poll_client_metrics(&self.s3_client);
         Ok(CancellingMetaRequest::wrap(meta_request))
     }
 
@@ -961,7 +968,8 @@ impl S3CrtClientInner {
         })
     }
 
-    fn poll_client_metrics(s3_client: &Client) {
+    fn emit_client_metrics(&self) {
+        let s3_client = &self.s3_client;
         let metrics = s3_client.poll_client_metrics();
         metrics::gauge!("s3.client.num_requests_being_processed").set(metrics.num_requests_tracked_requests as f64);
         metrics::gauge!("s3.client.num_requests_being_prepared").set(metrics.num_requests_being_prepared as f64);
@@ -1604,6 +1612,10 @@ impl ObjectClient for S3CrtClient {
             })
     }
 
+    fn poll_client_metrics(&self) {
+        S3CrtClient::poll_client_metrics(self);
+    }
+
     async fn delete_object(
         &self,
         bucket: &str,
@@ -1876,6 +1888,125 @@ mod tests {
         let header = Header::new("Content-Range", range);
         headers.add_header(&header).unwrap();
         extract_range_header(&headers)
+    }
+
+    #[test]
+    fn poll_client_metrics_emits_s3_client_gauges() {
+        use metrics::{
+            Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString,
+            Unit, with_local_recorder,
+        };
+        use std::collections::{HashMap, HashSet};
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct CapturingRecorder {
+            inner: Arc<Mutex<Captured>>,
+        }
+
+        #[derive(Debug, Default)]
+        struct Captured {
+            gauges: HashMap<String, f64>,
+            histograms: HashSet<String>,
+        }
+
+        #[derive(Debug)]
+        struct CaptureGauge {
+            name: String,
+            inner: Arc<Mutex<Captured>>,
+        }
+
+        #[derive(Debug)]
+        struct CaptureHistogram {
+            name: String,
+            inner: Arc<Mutex<Captured>>,
+        }
+
+        #[derive(Debug)]
+        struct NoopCounter;
+
+        impl CounterFn for NoopCounter {
+            fn increment(&self, _value: u64) {}
+            fn absolute(&self, _value: u64) {}
+        }
+
+        impl GaugeFn for CaptureGauge {
+            fn increment(&self, _value: f64) {}
+            fn decrement(&self, _value: f64) {}
+            fn set(&self, value: f64) {
+                self.inner.lock().unwrap().gauges.insert(self.name.clone(), value);
+            }
+        }
+
+        impl HistogramFn for CaptureHistogram {
+            fn record(&self, _value: f64) {
+                self.inner.lock().unwrap().histograms.insert(self.name.clone());
+            }
+        }
+
+        impl Recorder for CapturingRecorder {
+            fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+            fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+            fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+            fn register_counter(&self, _key: &Key, _metadata: &Metadata<'_>) -> Counter {
+                Counter::from_arc(Arc::new(NoopCounter))
+            }
+
+            fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+                Gauge::from_arc(Arc::new(CaptureGauge {
+                    name: key.name().to_string(),
+                    inner: Arc::clone(&self.inner),
+                }))
+            }
+
+            fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+                Histogram::from_arc(Arc::new(CaptureHistogram {
+                    name: key.name().to_string(),
+                    inner: Arc::clone(&self.inner),
+                }))
+            }
+        }
+
+        let config = S3ClientConfig::new().auth_config(S3ClientAuthConfig::NoSigning);
+        let client = S3CrtClient::new(config).expect("Create test client");
+        let recorder = CapturingRecorder::default();
+
+        with_local_recorder(&recorder, || {
+            client.poll_client_metrics();
+        });
+
+        let captured = recorder.inner.lock().unwrap();
+        for name in [
+            "s3.client.num_requests_being_processed",
+            "s3.client.num_requests_being_prepared",
+            "s3.client.request_queue_size",
+            "s3.client.num_auto_default_network_io",
+            "s3.client.num_auto_ranged_get_network_io",
+            "s3.client.num_auto_ranged_put_network_io",
+            "s3.client.num_auto_ranged_copy_network_io",
+            "s3.client.num_total_network_io",
+            "s3.client.num_requests_stream_queued_waiting",
+            "s3.client.num_requests_streaming_response",
+        ] {
+            assert!(
+                captured.gauges.contains_key(name),
+                "missing gauge {name}; captured {:?}",
+                captured.gauges.keys()
+            );
+        }
+
+        // A newly constructed client still exposes buffer-pool stats; the histogram is recorded
+        // only when those stats are present.
+        if captured.gauges.keys().any(|k| k.starts_with("s3.client.buffer_pool.")) {
+            assert!(
+                captured
+                    .histograms
+                    .contains("s3.client.buffer_pool.get_usage_latency_us"),
+                "buffer pool gauges require the usage-latency histogram; got {:?}",
+                captured.histograms
+            );
+        }
     }
 
     /// Simple test to ensure the expected bucket owner can be set

--- a/mountpoint-s3-fs/CHANGELOG.md
+++ b/mountpoint-s3-fs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Sample registered client metric pollers on each metrics publication cycle, immediately before publishing, alongside process metrics. ([#1957](https://github.com/awslabs/mountpoint-s3/pull/1957))
+
 ## v0.11.0 (August 24, 2026)
 
 * `S3FilesystemConfig::read_only` is now enforced by the file system, which refuses operations that would modify the mount with the new `InodeError::ReadOnlyMount` (`EROFS`) instead of relying on the kernel to do so. `FuseOptions::read_only` is now also accepted with a `MountPoint::FileDescriptor` mount point, where it records that the caller performed the mount read-only. `MountpointConfig::create_fuse_session` now fails if `FuseOptions::read_only` and `S3FilesystemConfig::read_only` disagree. ([#1939](https://github.com/awslabs/mountpoint-s3/pull/1939))

--- a/mountpoint-s3-fs/examples/mount_from_config.rs
+++ b/mountpoint-s3-fs/examples/mount_from_config.rs
@@ -300,6 +300,7 @@ fn mount_filesystem(
     config: &ConfigOptions,
     manifest: Manifest,
     error_logger: impl ErrorLogger + Send + Sync + 'static,
+    metrics: &MetricsSinkHandle,
 ) -> Result<FuseSession> {
     // Create the Mountpoint configuration
     let fs_config = config.build_filesystem_config()?;
@@ -322,6 +323,10 @@ fn mount_filesystem(
     let client = client_config
         .create_client(pool.clone(), None)
         .context("Failed to create S3 client")?;
+    {
+        let client = client.clone();
+        metrics.register_poller(move || client.poll_client_metrics());
+    }
     let runtime = Runtime::new(client.event_loop_group());
 
     let metablock = ManifestMetablock::new(manifest)?;
@@ -359,12 +364,13 @@ fn main() -> Result<()> {
     })
     .context("Failed to create an event log")?;
     // Set up logging
-    let (_logging, _metrics) = setup_logging(&config).context("Failed to setup logging")?;
+    let (_logging, metrics) = setup_logging(&config).context("Failed to setup logging")?;
     // Process manifests if needed
     let temporary_dir = tempdir_in(&config.metadata_store_dir).context("Failed to create manifest")?;
     let manifest = process_manifests(&config, temporary_dir.path()).context("Failed to create manifest")?;
     // Build all configurations
-    let fuse_session = mount_filesystem(&config, manifest, error_logger).context("Failed to mount filesystem")?;
+    let fuse_session =
+        mount_filesystem(&config, manifest, error_logger, &metrics).context("Failed to mount filesystem")?;
     // Join the session and wait until it completes
     fuse_session.join().context("Failed to join session")?;
     Ok(())

--- a/mountpoint-s3-fs/examples/prefetch_benchmark.rs
+++ b/mountpoint-s3-fs/examples/prefetch_benchmark.rs
@@ -170,7 +170,7 @@ impl CliArgs {
 
 fn main() -> anyhow::Result<()> {
     init_tracing_subscriber();
-    let _metrics_handle = mountpoint_s3_fs::metrics::install(None);
+    let metrics_handle = mountpoint_s3_fs::metrics::install(None);
 
     let args = CliArgs::parse();
 
@@ -181,6 +181,10 @@ fn main() -> anyhow::Result<()> {
         .build();
     let client_config = args.s3_client_config().memory_pool(pool.clone());
     let client = S3CrtClient::new(client_config).context("failed to create S3 CRT client")?;
+    if let Ok(metrics_handle) = &metrics_handle {
+        let client = client.clone();
+        metrics_handle.register_poller(move || client.poll_client_metrics());
+    }
     let runtime = Runtime::new(client.event_loop_group());
 
     // Verify if all objects exist and collect metadata

--- a/mountpoint-s3-fs/src/metrics.rs
+++ b/mountpoint-s3-fs/src/metrics.rs
@@ -15,8 +15,10 @@ use defs::PROCESS_MEMORY_USAGE;
 use metrics::{Key, Metadata, Recorder};
 use sysinfo::{MemoryRefreshKind, ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
 
-use crate::sync::Arc;
+#[cfg(test)]
+use crate::sync::Mutex;
 use crate::sync::mpsc::{RecvTimeoutError, Sender, channel};
+use crate::sync::{Arc, RwLock};
 
 mod data;
 use data::Metric;
@@ -33,6 +35,38 @@ const AGGREGATION_PERIOD: Duration = Duration::from_secs(5);
 /// The log target to use for emitted metrics
 pub const TARGET_NAME: &str = "mountpoint_s3_fs::metrics";
 
+/// A callback invoked on each metrics publication cycle, immediately before publishing.
+type MetricPoller = Arc<dyn Fn() + Send + Sync + 'static>;
+
+/// Thread-safe list of metric pollers sampled by the publisher thread.
+///
+/// Registration writes this list directly and does **not** go through the publisher's
+/// shutdown/`recv_timeout` channel, so it does not reset or delay the aggregation period.
+#[derive(Default)]
+struct MetricPollers {
+    inner: RwLock<Vec<MetricPoller>>,
+}
+
+impl std::fmt::Debug for MetricPollers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let count = self.inner.read().map(|p| p.len()).unwrap_or(0);
+        f.debug_struct("MetricPollers").field("count", &count).finish()
+    }
+}
+
+impl MetricPollers {
+    fn register(&self, poller: MetricPoller) {
+        self.inner.write().unwrap().push(poller);
+    }
+
+    fn run(&self) {
+        let snapshot = self.inner.read().unwrap().clone();
+        for poller in snapshot {
+            poller();
+        }
+    }
+}
+
 /// Configuration for metrics collection
 pub enum MetricsConfig {
     /// OpenTelemetry configuration
@@ -45,41 +79,59 @@ pub enum MetricsConfig {
 ///
 /// Panics if a sink has already been installed.
 pub fn install(config: Option<MetricsConfig>) -> anyhow::Result<MetricsSinkHandle> {
+    install_with_period(config, AGGREGATION_PERIOD)
+}
+
+fn install_with_period(
+    config: Option<MetricsConfig>,
+    aggregation_period: Duration,
+) -> anyhow::Result<MetricsSinkHandle> {
     let sink = Arc::new(MetricsSink::new(config)?);
-    let mut sys = System::new();
-
-    let (tx, rx) = channel();
-
-    let publisher_thread = {
-        let inner = Arc::clone(&sink);
-        thread::spawn(move || {
-            loop {
-                match rx.recv_timeout(AGGREGATION_PERIOD) {
-                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
-                    Err(RecvTimeoutError::Timeout) => {
-                        poll_process_metrics(&mut sys);
-                        inner.publish()
-                    }
-                }
-            }
-            // Drain metrics one more time before shutting down. This has a chance of missing
-            // any new metrics data after the sink shuts down, but we assume a clean shutdown
-            // stops generating new metrics before shutting down the sink.
-            poll_process_metrics(&mut sys);
-            inner.publish();
-        })
-    };
-
-    let handle = MetricsSinkHandle {
-        shutdown: tx,
-        handle: Some(publisher_thread),
-    };
+    let handle = spawn_publisher(Arc::clone(&sink), aggregation_period);
 
     let recorder = MetricsRecorder { sink };
     metrics::set_global_recorder(recorder)
         .map_err(|e| anyhow::anyhow!("Failed to set global metrics recorder: {}", e))?;
 
     Ok(handle)
+}
+
+/// Spawn the periodic publisher thread. The aggregation period is the only wait; poller
+/// registration does not use this channel and therefore cannot restart the wait.
+fn spawn_publisher(sink: Arc<MetricsSink>, aggregation_period: Duration) -> MetricsSinkHandle {
+    let mut sys = System::new();
+    let (tx, rx) = channel();
+    let pollers = Arc::new(MetricPollers::default());
+
+    let publisher_thread = {
+        let inner = Arc::clone(&sink);
+        let pollers = Arc::clone(&pollers);
+        thread::spawn(move || {
+            loop {
+                match rx.recv_timeout(aggregation_period) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
+                    Err(RecvTimeoutError::Timeout) => collect_and_publish(&inner, &pollers, &mut sys),
+                }
+            }
+            // Drain metrics one more time before shutting down. This has a chance of missing
+            // any new metrics data after the sink shuts down, but we assume a clean shutdown
+            // stops generating new metrics before shutting down the sink.
+            collect_and_publish(&inner, &pollers, &mut sys);
+        })
+    };
+
+    MetricsSinkHandle {
+        shutdown: tx,
+        handle: Some(publisher_thread),
+        pollers,
+    }
+}
+
+/// Sample process metrics and any registered client pollers, then publish.
+fn collect_and_publish(sink: &MetricsSink, pollers: &MetricPollers, sys: &mut System) {
+    poll_process_metrics(sys);
+    pollers.run();
+    sink.publish();
 }
 
 /// Report process level metrics
@@ -106,16 +158,16 @@ fn poll_process_metrics(sys: &mut System) {
 struct MetricsSink {
     metrics: DashMap<Key, Metric>,
     otlp_exporter: Option<OtlpMetricsExporter>,
+    /// Test-only log of `publish()` calls, used to assert poll-before-publish ordering.
+    #[cfg(test)]
+    test_events: Arc<Mutex<Vec<&'static str>>>,
 }
 
 impl MetricsSink {
     fn new(config: Option<MetricsConfig>) -> anyhow::Result<Self> {
         // Match on the config to determine what kind of metrics sink to create
         match config {
-            None => Ok(Self {
-                metrics: DashMap::with_capacity(64),
-                otlp_exporter: None,
-            }),
+            None => Ok(Self::with_exporter(None)),
 
             // OTLP configuration
             Some(MetricsConfig::Otlp(config)) => {
@@ -129,10 +181,7 @@ impl MetricsSink {
                 match OtlpMetricsExporter::new(&config) {
                     Ok(exporter) => {
                         tracing::info!("OpenTelemetry metrics export enabled to {}", config.endpoint);
-                        Ok(Self {
-                            metrics: DashMap::with_capacity(64),
-                            otlp_exporter: Some(exporter),
-                        })
+                        Ok(Self::with_exporter(Some(exporter)))
                     }
                     Err(e) => {
                         tracing::error!("Failed to initialize OTLP exporter: {}", e);
@@ -143,6 +192,15 @@ impl MetricsSink {
                     }
                 }
             }
+        }
+    }
+
+    fn with_exporter(otlp_exporter: Option<OtlpMetricsExporter>) -> Self {
+        Self {
+            metrics: DashMap::with_capacity(64),
+            otlp_exporter,
+            #[cfg(test)]
+            test_events: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -189,6 +247,9 @@ impl MetricsSink {
 impl MetricsSink {
     /// Publish all this sink's metrics to `tracing` log messages
     fn publish(&self) {
+        #[cfg(test)]
+        self.test_events.lock().unwrap().push("publish");
+
         // Collect the output lines so we can sort them to make reading easier
         let mut metrics = vec![];
 
@@ -277,6 +338,21 @@ impl Recorder for MetricsRecorder {
 pub struct MetricsSinkHandle {
     shutdown: Sender<()>,
     handle: Option<JoinHandle<()>>,
+    pollers: Arc<MetricPollers>,
+}
+
+impl MetricsSinkHandle {
+    /// Register a callback invoked on every metrics publication cycle, immediately before
+    /// publishing, alongside process metrics.
+    ///
+    /// Registration does not reset or delay the publisher's aggregation period: pollers are stored
+    /// in a shared list the publisher reads after each timeout, not sent on the shutdown channel.
+    ///
+    /// The callback must be cheap, thread-safe, and safe to run after the FUSE session has ended so
+    /// the final drain can still sample client metrics.
+    pub fn register_poller(&self, poller: impl Fn() + Send + Sync + 'static) {
+        self.pollers.register(Arc::new(poller));
+    }
 }
 
 impl Drop for MetricsSinkHandle {
@@ -292,10 +368,55 @@ impl Drop for MetricsSinkHandle {
 mod tests {
     use super::*;
     use metrics::{Label, with_local_recorder};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
 
     const TEST_COUNTER: &str = "test_counter";
     const TEST_GAUGE: &str = "test_gauge";
     const TEST_HISTOGRAM: &str = "test_histogram";
+
+    fn start_test_publisher(aggregation_period: Duration) -> (Arc<MetricsSink>, MetricsSinkHandle) {
+        let sink = Arc::new(MetricsSink::new(None).unwrap());
+        let handle = spawn_publisher(Arc::clone(&sink), aggregation_period);
+        (sink, handle)
+    }
+
+    fn wait_for_event_count(
+        events: &Mutex<Vec<&'static str>>,
+        event: &'static str,
+        n: usize,
+        timeout: Duration,
+    ) -> Vec<&'static str> {
+        let start = Instant::now();
+        loop {
+            let snapshot = events.lock().unwrap().clone();
+            let count = snapshot.iter().filter(|e| **e == event).count();
+            if count >= n {
+                return snapshot;
+            }
+            if start.elapsed() > timeout {
+                panic!(
+                    "timed out waiting for {n} {event} events; have {count}: {snapshot:?} after {:?}",
+                    start.elapsed()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn assert_poll_before_each_publish(events: &[&'static str]) {
+        assert!(
+            !events.is_empty() && events.len().is_multiple_of(2),
+            "expected poll/publish pairs, got {events:?}"
+        );
+        for pair in events.chunks(2) {
+            assert_eq!(
+                pair,
+                &["poll", "publish"],
+                "poll must run immediately before publish: {events:?}"
+            );
+        }
+    }
 
     #[test]
     fn basic_metrics() {
@@ -389,6 +510,126 @@ mod tests {
                 assert!(inner.load_if_changed().is_none());
             }
         });
+    }
+
+    #[test]
+    fn production_aggregation_period_is_five_seconds() {
+        assert_eq!(AGGREGATION_PERIOD, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn registered_poller_runs_on_repeated_ticks_before_publish_and_on_shutdown() {
+        let interval = Duration::from_millis(50);
+        let (sink, handle) = start_test_publisher(interval);
+        let events = Arc::clone(&sink.test_events);
+
+        handle.register_poller({
+            let events = Arc::clone(&events);
+            move || events.lock().unwrap().push("poll")
+        });
+
+        // Two publisher timeouts, with no meta requests at all.
+        wait_for_event_count(&events, "publish", 2, Duration::from_secs(2));
+
+        // Shutdown must join the publisher after one final poll then publish.
+        drop(handle);
+        let events = events.lock().unwrap().clone();
+        assert!(
+            events.len() >= 6,
+            "expected at least two periodic cycles plus shutdown, got {events:?}"
+        );
+        assert_poll_before_each_publish(&events);
+    }
+
+    #[test]
+    fn registering_a_poller_does_not_reset_or_stop_the_publisher() {
+        let interval = Duration::from_millis(80);
+        let (sink, handle) = start_test_publisher(interval);
+        let events = Arc::clone(&sink.test_events);
+
+        handle.register_poller({
+            let events = Arc::clone(&events);
+            move || events.lock().unwrap().push("poll")
+        });
+
+        // If registration rode the shutdown/`recv_timeout` channel, each register would either
+        // shut the publisher down or restart the wait. Repeated registration during the wait
+        // must not prevent periodic ticks.
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_millis(350) {
+            handle.register_poller(|| {});
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        // Check *during* the registration storm. Waiting after it stops would hide a reset, because
+        // the cadence could recover once we stop restarting the wait.
+        let during = events.lock().unwrap().clone();
+        let publishes_during = during.iter().filter(|e| **e == "publish").count();
+        assert!(
+            publishes_during >= 2,
+            "repeated registration during the wait must not reset the {interval:?} cadence or shut the publisher down; after {:?} got {during:?}",
+            start.elapsed()
+        );
+
+        drop(handle);
+
+        let events = events.lock().unwrap().clone();
+        let publishes = events.iter().filter(|e| **e == "publish").count();
+        assert!(
+            publishes >= 3,
+            "repeated registration must not delay ticks indefinitely or shut the publisher down; got {events:?}"
+        );
+        assert_poll_before_each_publish(&events);
+    }
+
+    #[test]
+    fn register_poller_does_not_trigger_immediate_publish() {
+        // A long interval means a correctly implemented register cannot produce a tick of its own.
+        let (sink, handle) = start_test_publisher(Duration::from_secs(30));
+        let events = Arc::clone(&sink.test_events);
+
+        handle.register_poller({
+            let events = Arc::clone(&events);
+            move || events.lock().unwrap().push("poll")
+        });
+        std::thread::sleep(Duration::from_millis(80));
+        assert!(
+            events.lock().unwrap().is_empty(),
+            "registration must not wake the publisher channel: {:?}",
+            events.lock().unwrap()
+        );
+
+        drop(handle);
+        let events = events.lock().unwrap().clone();
+        assert_eq!(events, ["poll", "publish"]);
+    }
+
+    #[test]
+    fn dropping_handle_drops_registered_pollers() {
+        #[derive(Debug)]
+        struct DropMarker(Arc<AtomicBool>);
+
+        impl Drop for DropMarker {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        // Keep the sink alive after the handle is dropped, as the process-global recorder does.
+        // Pollers belong to the publisher lifecycle and must not be retained by that sink.
+        let (_sink, handle) = start_test_publisher(Duration::from_secs(30));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let marker = DropMarker(Arc::clone(&dropped));
+        handle.register_poller(move || {
+            let _ = &marker;
+        });
+
+        drop(handle);
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "dropping the publisher handle must release registered pollers"
+        );
     }
 }
 

--- a/mountpoint-s3/CHANGELOG.md
+++ b/mountpoint-s3/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix S3 CRT client metrics (`s3.client.*`) not updating on every metrics publication cycle for requests lasting longer than five seconds. These gauges are now sampled when metrics are published, rather than only when a new S3 request starts. ([#1957](https://github.com/awslabs/mountpoint-s3/pull/1957))
+
 ## v1.24.0 (August 24, 2026)
 
 ### New features

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -11,7 +11,7 @@ use mountpoint_s3_fs::data_cache::{DataCacheConfig, ManagedCacheDir};
 use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::logging::init_logging;
 use mountpoint_s3_fs::memory::{CandidateSize, PagedPool};
-use mountpoint_s3_fs::metrics::MetricsConfig;
+use mountpoint_s3_fs::metrics::{MetricsConfig, MetricsSinkHandle};
 use mountpoint_s3_fs::s3::config::ClientConfig;
 use mountpoint_s3_fs::s3::{S3Path, S3Personality};
 use mountpoint_s3_fs::{MountpointConfig, Runtime, Superblock, SuperblockConfig, metrics};
@@ -26,7 +26,7 @@ use crate::{build_info, parse_cli_args};
 fn init_metrics(
     log_metrics_otlp: &Option<String>,
     log_metrics_otlp_interval: Option<u64>,
-) -> anyhow::Result<impl Drop> {
+) -> anyhow::Result<MetricsSinkHandle> {
     let otlp_config = log_metrics_otlp.as_deref().map(|endpoint| {
         let mut config = mountpoint_s3_fs::metrics::OtlpConfig::new(endpoint);
         if let Some(interval) = log_metrics_otlp_interval {
@@ -52,12 +52,12 @@ pub fn run(client_builder: impl ClientBuilder, args: CliArgs) -> anyhow::Result<
     if args.foreground {
         let _logging = init_logging(args.make_logging_config()).context("failed to initialize logging")?;
         let otlp_endpoint = args.otlp_endpoint.clone();
-        let _metrics = init_metrics(&otlp_endpoint, args.otlp_export_interval)?;
+        let metrics = init_metrics(&otlp_endpoint, args.otlp_export_interval)?;
 
         create_pid_file()?;
 
         // mount file system as a foreground process
-        let session = mount(args, client_builder)?;
+        let session = mount(args, client_builder, &metrics)?;
 
         println!("{successful_mount_msg}");
 
@@ -84,11 +84,11 @@ pub fn run(client_builder: impl ClientBuilder, args: CliArgs) -> anyhow::Result<
                 let args = parse_cli_args(false);
                 let _logging = init_logging(logging_config).context("failed to initialize logging")?;
                 let otlp_endpoint = args.otlp_endpoint.clone();
-                let _metrics = init_metrics(&otlp_endpoint, args.otlp_export_interval)?;
+                let metrics = init_metrics(&otlp_endpoint, args.otlp_export_interval)?;
 
                 create_pid_file()?;
 
-                let session = mount(args, client_builder);
+                let session = mount(args, client_builder, &metrics);
 
                 // close unused file descriptor, we only write from this end.
                 drop(read_fd);
@@ -187,7 +187,11 @@ pub fn run(client_builder: impl ClientBuilder, args: CliArgs) -> anyhow::Result<
     Ok(())
 }
 
-fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<FuseSession> {
+fn mount(
+    args: CliArgs,
+    client_builder: impl ClientBuilder,
+    metrics: &MetricsSinkHandle,
+) -> anyhow::Result<FuseSession> {
     tracing::info!("mount-s3 {}", build_info::FULL_VERSION);
     tracing::debug!("{:?}", args);
 
@@ -211,6 +215,11 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let s3_path = args.s3_path()?;
     let (client, runtime, s3_personality) =
         client_builder.build(client_config, pool.clone(), &s3_path, args.personality())?;
+
+    {
+        let client = client.clone();
+        metrics.register_poller(move || client.poll_client_metrics());
+    }
 
     let bucket_description = args.bucket_description()?;
     tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");


### PR DESCRIPTION
**What changed and why?**

S3 CRT client gauges (`s3.client.*`) were sampled only when `make_meta_request()` ran. The metrics publisher still flushed every five seconds, but it only refreshed process metrics before `publish()`. For meta requests that last longer than that interval, the CRT gauges were therefore frozen after the first sample.

This change moves sampling onto the existing publisher cycle:

1. `MetricsSinkHandle::register_poller` stores a `Send + Sync` callback in a publisher-lifecycle registry. Registration does **not** go through the shutdown/`recv_timeout` channel, so it cannot reset or delay the five-second wait.
2. On each timeout and on shutdown, the publisher runs `poll_process_metrics()`, then the registered client pollers, then `publish()`.
3. After the object client is built, `run` and the FS examples that install metrics register a clone of the client. `S3CrtClient` is `Clone` via `Arc`, so the final drain can safely sample after the FUSE session ends.
4. The poller registry is shared only by the publisher thread and `MetricsSinkHandle`. Dropping the handle joins the final publication and then releases the callbacks and captured client clones; the process-global metrics recorder does not retain them.
5. `ObjectClient::poll_client_metrics` is a default no-op, overridden by `S3CrtClient`. Mock and other non-CRT clients keep working without CRT-specific behavior.
6. The polling call immediately after `make_meta_request()` is removed. Metric names, gauge/histogram types, and changed-value emission behavior are unchanged.

Fixes #1410

### Does this change impact existing behavior?

Yes, in the intended way: `s3.client.*` gauges now update on every five-second publication cycle even when no new meta request is created. Long-running requests no longer leave those gauges stuck at the value from request start. Existing `ObjectClient` implementations inherit the new no-op method and do not need to override it.

### Does this change need a changelog entry? Does it require a version change?

Yes. Unreleased notes were added for `mountpoint-s3`, `mountpoint-s3-fs`, and `mountpoint-s3-client`. Version numbers are left for the next release cut.

### Tests

Deterministic unit tests require no AWS credentials, network access, or real S3 service:

- A registered poller runs on repeated publisher timeouts with no meta requests, each poll occurs before the matching `publish()`, and shutdown performs one final poll and publication.
- Registering pollers during the wait does not reset or stop the cadence and does not trigger an immediate publication.
- Dropping `MetricsSinkHandle` releases registered callbacks even while the metrics sink remains alive.
- `S3CrtClient::poll_client_metrics`, constructed with `NoSigning`, emits the existing `s3.client.*` gauges under a local recorder.
- Mock `ObjectClient::poll_client_metrics` remains a no-op.

After rebasing onto current upstream `main`, `make pre-pr-check` succeeded: formatting, `cargo check --all-targets --all-features`, repository-standard clippy with warnings denied, and 941 nextest tests passed with 1 skipped. This PR does **not** include an end-to-end AWS/`--log-metrics` mount run.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).